### PR TITLE
chore: unused_mut 경고 제거

### DIFF
--- a/src-tauri/src/commands/project_onboarding.rs
+++ b/src-tauri/src/commands/project_onboarding.rs
@@ -217,7 +217,7 @@ fn extract_between<'a>(text: &'a str, start: &str, end: &str) -> Option<&'a str>
 // ─── AI call ─────────────────────────────────────────────────────────────────
 
 async fn call_claude(prompt: &str, cancel: &AtomicBool) -> Result<(String, String), String> {
-    let mut child = tokio::process::Command::new("claude")
+    let child = tokio::process::Command::new("claude")
         .args(["-p", prompt, "--max-turns", "1", "--output-format", "text"])
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::null())


### PR DESCRIPTION
## Summary

\`project_onboarding::call_claude\`에서 \`tokio::process::Command::spawn()\`의 반환값 \`child\`에 걸려있던 \`mut\`를 제거.

\`child.wait_with_output().await\`는 \`self\`를 소비(move-by-value)하므로 \`&mut self\`가 필요 없음. \`let mut child = ...\` 대신 \`let child = ...\`.

\`cargo check --lib\` 경고 1건 제거 → 경고 0.

## Test plan

- [x] \`cargo check --lib\` 경고 0
- [x] \`cargo test --lib\` 232 passed (사전 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)