### PR TITLE
fix(indexing): NULL embedding 영구 skip 버그 + 자동 백필 [P0]

### DIFF
--- a/docs/reference/knownIssues_2026-04-15.md
+++ b/docs/reference/knownIssues_2026-04-15.md
@@ -21,13 +21,16 @@ related:
 
 ## 🔴 P0 — 베타 공개 차단
 
-### I1. 인덱싱 파이프라인 3중 버그 (v32 이후 embedding 복구 실패)
+### I1. 인덱싱 파이프라인 3중 버그 (v32 이후 embedding 복구 실패) ✅ 해결
 
 - **문서**: `docs/reference/indexingPipelineBug_P0_2026-04-15.md` (상세)
 - **증상**: Vector 검색 사실상 기능 정지 — gemento 프로젝트 327 chunks 중 12개만 embedding, 문서 chunk 6877개 전부 NULL
 - **원인**: v32 migration이 embedding을 NULL로 초기화만 하고, `already_indexed` 쿼리에 `AND embedding IS NOT NULL` 누락 → 영구 skip + document 자동 재인덱싱 트리거 부재
-- **Fix**: 1+2 치명, 3+5 보조 (5개 후보 모두 문서 정리)
-- **진행 상태**: secall PR 처리 후 브랜치 `fix/indexing-pipeline-recovery` 착수 예정
+- **수정 (브랜치 `fix/indexing-pipeline-recovery`)**:
+  - Fix 1: `index_chunks_blocking` / `index_conversation_chunks` 두 함수의 `already_indexed` 쿼리에 `AND embedding IS NOT NULL` 추가 + INSERT 직전 동일 root_message_id의 NULL row 정리 (중복 방지)
+  - Fix 2 + 5: 신규 `vector_search/backfill.rs` — 앱 시작 후 15초 뒤 백그라운드로 NULL embedding 보유 conversation/project 자동 재인덱싱. 200~500ms throttle로 CPU 폭주 방지
+  - Fix 3: blocking embed 실패 로깅 추가 (async 버전과 parity)
+- **검증**: cargo test --lib 232 passed. 실측은 사용자 빌드 후 `[backfill]` 로그로 확인 예정
 
 ### I2. README "2-agent 교차 검증" 문구와 코드 불일치
 

--- a/src-tauri/src/commands/vector_search/backfill.rs
+++ b/src-tauri/src/commands/vector_search/backfill.rs
@@ -1,0 +1,147 @@
+//! Embedding backfill — reindex chunks whose `embedding` is NULL.
+//!
+//! Background: v32 migration cleared all 384dim embeddings to upgrade to bge-m3 1024dim,
+//! but a bug in `index_chunks_blocking` (already_indexed lacked `IS NOT NULL`) caused
+//! existing NULL chunks to be skipped forever. After Fix 1, new completions recover
+//! their own conversation. This module proactively recovers ALL conversations and
+//! documents at app startup, so users don't have to send a message in every old chat
+//! just to restore Vector search.
+//!
+//! Throttling: processes one conversation/project at a time with a short sleep between
+//! ONNX calls to avoid CPU spikes (s35 lesson on bge-m3 thread pressure).
+
+use crate::db::DbState;
+use crate::errors::AppError;
+
+/// Fire-and-forget background backfill task.
+/// Spawned from `setup` after embedder init. Logs progress; never propagates errors.
+pub fn spawn_startup_backfill(db: DbState) {
+    std::thread::spawn(move || {
+        // Wait briefly for embedder/rawq to settle before starting heavy ONNX work.
+        std::thread::sleep(std::time::Duration::from_secs(15));
+        if let Err(e) = run_backfill(&db) {
+            eprintln!("[backfill] error: {e:?}");
+        }
+    });
+}
+
+fn run_backfill(db: &DbState) -> Result<(), AppError> {
+    if !crate::agents::embedder::is_available() {
+        eprintln!("[backfill] skipped — bge-m3 embedder not available");
+        return Ok(());
+    }
+
+    backfill_conversations(db);
+    backfill_documents(db);
+    Ok(())
+}
+
+// ─── Conversation chunks ─────────────────────────────────────────────────────
+
+fn backfill_conversations(db: &DbState) {
+    let conv_ids: Vec<String> = {
+        let Ok(conn) = db.read.lock() else { return; };
+        // Conversations that have at least one NULL-embedding chunk.
+        // Exclude document sentinel conversations (handled separately).
+        conn.prepare(
+            "SELECT DISTINCT conversation_id FROM conversation_chunks
+             WHERE embedding IS NULL
+               AND (source_type IS NULL OR source_type = 'conversation')
+             LIMIT 200",
+        )
+        .and_then(|mut s| {
+            s.query_map([], |r| r.get::<_, String>(0))
+                .map(|rows| rows.filter_map(|r| r.ok()).collect())
+        })
+        .unwrap_or_default()
+    };
+
+    if conv_ids.is_empty() {
+        return;
+    }
+
+    eprintln!("[backfill] {} conversations with NULL embeddings — starting recovery", conv_ids.len());
+
+    let mut total_recovered = 0usize;
+    for (i, cid) in conv_ids.iter().enumerate() {
+        match super::index::index_chunks_blocking(db, cid) {
+            Ok(n) if n > 0 => {
+                total_recovered += n;
+                eprintln!("[backfill] {}/{}: {} chunks recovered for {}",
+                    i + 1, conv_ids.len(), n, &cid[..cid.len().min(12)]);
+            }
+            Ok(_) => {}
+            Err(e) => eprintln!("[backfill] {}/{}: error for {}: {:?}",
+                i + 1, conv_ids.len(), &cid[..cid.len().min(12)], e),
+        }
+        // Throttle: ~200ms between conversations to keep CPU sane.
+        std::thread::sleep(std::time::Duration::from_millis(200));
+    }
+
+    eprintln!("[backfill] conversations done — {} chunks recovered total", total_recovered);
+}
+
+// ─── Document chunks ─────────────────────────────────────────────────────────
+
+fn backfill_documents(db: &DbState) {
+    // Gather projects that have at least one NULL-embedding document chunk.
+    // Resolve each project's filesystem path via `projects` table.
+    let projects: Vec<(String, String)> = {
+        let Ok(conn) = db.read.lock() else { return; };
+        conn.prepare(
+            "SELECT DISTINCT cc.project_key, p.path
+             FROM conversation_chunks cc
+             JOIN projects p ON p.key = cc.project_key
+             WHERE cc.source_type = 'document'
+               AND cc.embedding IS NULL
+               AND p.path IS NOT NULL
+             LIMIT 50",
+        )
+        .and_then(|mut s| {
+            s.query_map([], |r| Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?)))
+                .map(|rows| rows.filter_map(|r| r.ok()).collect())
+        })
+        .unwrap_or_default()
+    };
+
+    if projects.is_empty() {
+        return;
+    }
+
+    eprintln!("[backfill] {} projects with NULL document embeddings — starting recovery", projects.len());
+
+    for (i, (pk, path)) in projects.iter().enumerate() {
+        // Wipe NULL document chunks for this project so index_project_documents'
+        // SHA-skip path doesn't re-skip them (file content unchanged → skipped
+        // unless chunks are missing).
+        let wiped = {
+            let Ok(conn) = db.write.lock() else { continue; };
+            let stale_rowids: Vec<i64> = conn.prepare(
+                "SELECT rowid FROM conversation_chunks
+                 WHERE project_key = ?1 AND source_type = 'document' AND embedding IS NULL"
+            ).and_then(|mut s| s.query_map([pk], |r| r.get(0))
+                .map(|rows| rows.filter_map(|r| r.ok()).collect::<Vec<i64>>()))
+                .unwrap_or_default();
+            for rid in &stale_rowids {
+                conn.execute("DELETE FROM vec_chunks WHERE rowid = ?1", [rid]).ok();
+            }
+            conn.execute(
+                "DELETE FROM conversation_chunks
+                 WHERE project_key = ?1 AND source_type = 'document' AND embedding IS NULL",
+                [pk],
+            ).ok();
+            stale_rowids.len()
+        };
+
+        match crate::commands::document_index::index_project_documents(db, pk, path) {
+            Ok(r) => eprintln!("[backfill] {}/{}: project={} wiped={} → {} files indexed, {} chunks",
+                i + 1, projects.len(), pk, wiped, r.files_indexed, r.chunks_created),
+            Err(e) => eprintln!("[backfill] {}/{}: project={} reindex error: {:?}",
+                i + 1, projects.len(), pk, e),
+        }
+        // Per-project throttle.
+        std::thread::sleep(std::time::Duration::from_millis(500));
+    }
+
+    eprintln!("[backfill] documents done");
+}

--- a/src-tauri/src/commands/vector_search/index.rs
+++ b/src-tauri/src/commands/vector_search/index.rs
@@ -225,18 +225,22 @@ pub async fn index_conversation_chunks(
 
         if chunks.is_empty() { return Ok(0); }
 
-        // Phase 1b: find already-indexed root_message_ids (incremental — skip re-embedding)
+        // Phase 1b: find chunks that ALREADY have an embedding. NULL embeddings
+        // (e.g. from v32 migration that cleared all 384dim embeddings before bge-m3
+        // upgrade) MUST be re-embedded — without `IS NOT NULL` they were treated as
+        // "already indexed" and skipped forever.
         let already_indexed: std::collections::HashSet<String> = {
             let conn = db.read.lock().map_err(|_| AppError::Lock)?;
             let mut stmt = conn.prepare(
-                "SELECT root_message_id FROM conversation_chunks WHERE conversation_id = ?1"
+                "SELECT root_message_id FROM conversation_chunks
+                 WHERE conversation_id = ?1 AND embedding IS NOT NULL"
             ).unwrap_or_else(|_| conn.prepare("SELECT ''").unwrap());
             stmt.query_map([&conversation_id], |r| r.get::<_, String>(0))
                 .map(|rows| rows.filter_map(|r| r.ok()).collect())
                 .unwrap_or_default()
         };
 
-        // Phase 2: embed only NEW chunks (not yet indexed)
+        // Phase 2: embed only NEW chunks (not yet indexed) or chunks needing recovery (NULL embedding)
         let new_chunks: Vec<_> = chunks.iter()
             .filter(|(root_id, _, _)| !already_indexed.contains(root_id))
             .collect();
@@ -257,11 +261,33 @@ pub async fn index_conversation_chunks(
 
         if embedded.is_empty() { return Ok(0); }
 
-        // Phase 3: write only new results (short lock) — do NOT delete existing chunks
+        // Phase 3: write only new results (short lock).
+        // Delete any pre-existing NULL-embedding row for the same root_message_id first
+        // (recovery path) so we don't end up with duplicate rows after INSERT.
         let conn = db.write.lock().map_err(|_| AppError::Lock)?;
         let now = now_epoch_ms();
         let mut indexed = 0;
+        let mut recovered = 0;
         for (root_id, kind, text, blob) in &embedded {
+            // Cleanup NULL-embedding rows for this root_message_id (vec_chunks linked by rowid).
+            let stale_rowids: Vec<i64> = conn.prepare(
+                "SELECT rowid FROM conversation_chunks
+                 WHERE conversation_id = ?1 AND root_message_id = ?2 AND embedding IS NULL"
+            ).and_then(|mut s| s.query_map(rusqlite::params![conversation_id, root_id], |r| r.get(0))
+                .map(|rows| rows.filter_map(|r| r.ok()).collect()))
+                .unwrap_or_default();
+            for rid in &stale_rowids {
+                conn.execute("DELETE FROM vec_chunks WHERE rowid = ?1", [rid]).ok();
+            }
+            if !stale_rowids.is_empty() {
+                conn.execute(
+                    "DELETE FROM conversation_chunks
+                     WHERE conversation_id = ?1 AND root_message_id = ?2 AND embedding IS NULL",
+                    rusqlite::params![conversation_id, root_id],
+                )?;
+                recovered += 1;
+            }
+
             let id = Uuid::new_v4().to_string();
             conn.execute(
                 "INSERT INTO conversation_chunks (id, project_key, conversation_id, kind, root_message_id, text_preview, embedding, created_at)
@@ -280,7 +306,9 @@ pub async fn index_conversation_chunks(
             }
             indexed += 1;
         }
-        eprintln!("[vector] indexed {} new chunks for {} ({} already indexed)", indexed, conversation_id, already_indexed.len());
+        eprintln!("[vector] indexed {} new chunks for {} ({} already indexed{})",
+            indexed, conversation_id, already_indexed.len(),
+            if recovered > 0 { format!(", {} recovered from NULL", recovered) } else { String::new() });
         Ok(indexed)
     }).await.map_err(|_| AppError::Lock)?
 }
@@ -303,16 +331,18 @@ pub fn index_chunks_blocking(db: &crate::db::DbState, conversation_id: &str) -> 
     };
     if chunks.is_empty() { return Ok(0); }
 
-    // Phase 1b: find already-indexed root_message_ids (read lock, incremental skip)
+    // Phase 1b: find chunks that ALREADY have an embedding. NULL embeddings (e.g.
+    // from v32 migration) MUST be re-embedded, so we exclude them from `already_indexed`.
     let already_indexed: std::collections::HashSet<String> = {
         let conn = db.read.lock().map_err(|_| AppError::Lock)?;
-        conn.prepare("SELECT root_message_id FROM conversation_chunks WHERE conversation_id = ?1")
+        conn.prepare("SELECT root_message_id FROM conversation_chunks
+                      WHERE conversation_id = ?1 AND embedding IS NOT NULL")
             .and_then(|mut s| s.query_map([conversation_id], |r| r.get::<_, String>(0))
                 .map(|rows| rows.filter_map(|r| r.ok()).collect()))
             .unwrap_or_default()
     };
 
-    // Phase 2: embed only NEW chunks (no lock held — ONNX inference is the slow part)
+    // Phase 2: embed NEW chunks + recover NULL chunks (no lock held — ONNX inference is slow)
     let new_chunks: Vec<_> = chunks.iter()
         .filter(|(root_id, _, _)| !already_indexed.contains(root_id))
         .collect();
@@ -321,17 +351,40 @@ pub fn index_chunks_blocking(db: &crate::db::DbState, conversation_id: &str) -> 
 
     let mut embedded: Vec<(String, String, String, Vec<u8>)> = Vec::new();
     for (root_id, kind, text) in &new_chunks {
-        if let Ok(v) = crate::agents::embedder::embed_text(text, false) {
-            embedded.push((root_id.clone(), kind.clone(), text.clone(), embedding_to_blob(&v)));
+        match crate::agents::embedder::embed_text(text, false) {
+            Ok(v) => embedded.push((root_id.clone(), kind.clone(), text.clone(), embedding_to_blob(&v))),
+            // Fix 3: Parity with index_conversation_chunks — log embed failures
+            // instead of silent drop so users can see why indexing isn't progressing.
+            Err(e) => eprintln!("[vector] embed failed for chunk {}: {:?}", root_id, e),
         }
     }
     if embedded.is_empty() { return Ok(0); }
 
-    // Phase 3: insert only new results (write lock — fast)
+    // Phase 3: insert results with NULL-row recovery (write lock — fast)
     let conn = db.write.lock().map_err(|_| AppError::Lock)?;
     let now = now_epoch_ms();
     let mut indexed = 0;
+    let mut recovered = 0;
     for (root_id, kind, text, blob) in &embedded {
+        // Cleanup NULL-embedding rows for this root_message_id (recovery path).
+        let stale_rowids: Vec<i64> = conn.prepare(
+            "SELECT rowid FROM conversation_chunks
+             WHERE conversation_id = ?1 AND root_message_id = ?2 AND embedding IS NULL"
+        ).and_then(|mut s| s.query_map(rusqlite::params![conversation_id, root_id], |r| r.get(0))
+            .map(|rows| rows.filter_map(|r| r.ok()).collect()))
+            .unwrap_or_default();
+        for rid in &stale_rowids {
+            conn.execute("DELETE FROM vec_chunks WHERE rowid = ?1", [rid]).ok();
+        }
+        if !stale_rowids.is_empty() {
+            conn.execute(
+                "DELETE FROM conversation_chunks
+                 WHERE conversation_id = ?1 AND root_message_id = ?2 AND embedding IS NULL",
+                rusqlite::params![conversation_id, root_id],
+            )?;
+            recovered += 1;
+        }
+
         let id = Uuid::new_v4().to_string();
         conn.execute(
             "INSERT INTO conversation_chunks (id, project_key, conversation_id, kind, root_message_id, text_preview, embedding, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
@@ -342,7 +395,9 @@ pub fn index_chunks_blocking(db: &crate::db::DbState, conversation_id: &str) -> 
         indexed += 1;
     }
     if indexed > 0 {
-        eprintln!("[vector] indexed {} new chunks for {} ({} already indexed)", indexed, conversation_id, already_indexed.len());
+        eprintln!("[vector] indexed {} new chunks for {} ({} already indexed{})",
+            indexed, conversation_id, already_indexed.len(),
+            if recovered > 0 { format!(", {} recovered from NULL", recovered) } else { String::new() });
     }
     Ok(indexed)
 }

--- a/src-tauri/src/commands/vector_search/mod.rs
+++ b/src-tauri/src/commands/vector_search/mod.rs
@@ -9,9 +9,12 @@
 //! - `index`: sliding-window chunking + index_conversation_chunks (Tauri command)
 //! - `query`: search_similar, vec0 KNN, brute-force, search_conversation_vectors (Tauri command)
 
+mod backfill;
 mod helpers;
 mod index;
 mod query;
+
+pub use backfill::spawn_startup_backfill;
 
 // Re-export all public and proc-macro generated symbols so callers
 // use `commands::vector_search::*` unchanged.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -130,6 +130,13 @@ pub fn run() {
                 });
             }
 
+            // Backfill NULL-embedding chunks left over from v32 (bge-m3 migration).
+            // Sleeps 15s before starting to let embedder/rawq settle, then processes
+            // one conversation/project at a time with throttling.
+            crate::commands::vector_search::spawn_startup_backfill(
+                app.state::<DbState>().inner().clone(),
+            );
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![


### PR DESCRIPTION
## Summary

v32 bge-m3 마이그레이션 후 발생한 인덱싱 파이프라인 3중 버그 수정. Vector 검색이 사실상 기능 정지 상태에서 정상화. 베타 공개 차단 P0 이슈.

상세 조사: \`docs/reference/indexingPipelineBug_P0_2026-04-15.md\`

## 증상 (DB 실측)

\`\`\`
gemento:         327 chunks /  12 embedding (3.7%)
tunaflow:       6711 chunks / 266 embedding (4.0%)
secall:          305 chunks / 274 embedding (89.8%)  ← v32 전부터 활발한 프로젝트만 정상
문서 chunk 전체: 6877 chunks /   0 embedding (0.0%)  ← 자동 트리거 부재
\`\`\`

\`\`\`
[retrieval] Vector: 1 chunks (threshold 0.3)         ← Vector가 항상 한 자리수
\`\`\`

## 근본 원인 3중

1. v32 마이그레이션이 384→1024dim 업그레이드를 위해 \`UPDATE conversation_chunks SET embedding = NULL\` 만 하고 자동 재생성 훅 없음
2. **치명**: \`index_chunks_blocking\` / \`index_conversation_chunks\`의 \`already_indexed\` 쿼리가 \`AND embedding IS NOT NULL\` 누락 → NULL chunk가 \"이미 인덱싱됨\"으로 간주되어 post-completion마다 영구 skip
3. document chunks(\`source_type='document'\`)는 SHA hash 변경 감지로만 재인덱싱 트리거 → v32 후 자동 복구 경로 없음

## 수정

### \`vector_search/index.rs\` (Fix 1+3)
- 두 함수의 \`already_indexed\` 쿼리에 \`AND embedding IS NOT NULL\` 추가
- INSERT 직전에 동일 root_message_id의 NULL row + vec_chunks rowid 삭제 (recovery path, 중복 방지)
- 로그에 \`, N recovered from NULL\` 표기 — 백필 진행 가시성
- blocking 함수에 embed 실패 \`eprintln!\` 추가 (async 버전과 parity)

### \`vector_search/backfill.rs\` (신규, Fix 2+5)
- \`spawn_startup_backfill\`: 앱 시작 15초 후 백그라운드 일회성 실행
- \`backfill_conversations\`: NULL chunk 보유 대화방 enumerate → \`index_chunks_blocking\` 호출 (200ms throttle)
- \`backfill_documents\`: NULL document chunk 보유 프로젝트 → file_path 기준 NULL row + vec_chunks 정리 후 \`index_project_documents\` 호출 (500ms throttle, SHA-skip 우회)
- 임베더 미가용 / 잠금 실패 시 silent skip (다음 시작에 재시도)

### \`lib.rs\`
- setup hook의 embedder init 직후 \`spawn_startup_backfill\` 호출 추가

## Test plan

- [x] \`cargo check --lib\`: 경고 0
- [x] \`cargo test --lib\`: 232 passed (기존 회귀 없음)
- [ ] 사용자 빌드 후 실측:
  - 시작 후 15초~1분 안에 \`[backfill] N conversations with NULL embeddings — starting recovery\` 로그 확인
  - \`[backfill] {i}/{n}: {N} chunks recovered for {conv}\` 진행 로그
  - \`[backfill] conversations done — {total} chunks recovered total\`
  - 동일 패턴으로 documents
  - 백필 완료 후 retrieval 쿼리에서 \`[retrieval] Vector: {N} chunks\` N이 의미있는 숫자(>3)로 증가 확인
  - DB 직접 확인: \`SELECT SUM(embedding IS NOT NULL)/COUNT(*) FROM conversation_chunks WHERE project_key='gemento'\` ≈ 1.0
- [ ] 백필 실행 중 일반 send/대화 경험에 영향 없는지 (200ms throttle로 충분한지) 확인

## Follow-up

- 베타 진입 전 README 수정 (I2) — 별도 PR
- 그 다음 \`feat/rt-upgrade-deep-track\` (S1+S2+S3) — \`betaRtUpgradeSprintPlan_2026-04-15.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)