### PR TITLE
fix(compression): Haiku 강제 + 재압축 임계 완화 — Opus 쿼터 출혈 차단

### DIFF
--- a/src-tauri/src/commands/memory_compression.rs
+++ b/src-tauri/src/commands/memory_compression.rs
@@ -102,8 +102,11 @@ pub fn needs_compression(conn: &Connection, conversation_id: &str) -> bool {
 
     match existing {
         Some(prev_count) => {
-            // Re-compress if significantly more messages since last compression
-            msg_count - prev_count >= COMPRESSION_THRESHOLD / 2
+            // Re-compress only when a full compression window's worth of new
+            // messages has accumulated. Previously `/ 2` caused re-compression
+            // too frequently on active conversations, multiplying the Opus
+            // quota burn (see compress_memory_blocking call below).
+            msg_count - prev_count >= COMPRESSION_THRESHOLD
         }
         None => true,
     }
@@ -495,8 +498,16 @@ pub fn compress_memory_blocking(db: &crate::db::DbState, conversation_id: &str) 
         t
     };
     let prompt = format!("{}{}", SUMMARY_PROMPT, transcript);
+    // Use Haiku for memory compression — this is a background summarization
+    // task that runs after EVERY user completion. Defaulting to the user's
+    // selected chat model (often Opus) doubled quota consumption. Haiku is
+    // ~15× cheaper and fully capable of the JSON topic-extraction task here.
     let result = crate::agents::claude::run(crate::agents::claude::RunInput {
-        prompt, model: None, system_prompt: None, resume_token: None, project_path: None,
+        prompt,
+        model: Some("claude-haiku-4-5".into()),
+        system_prompt: None,
+        resume_token: None,
+        project_path: None,
     });
     let raw_output = match result {
         Ok(out) if !out.content.trim().is_empty() => out.content.trim().to_string(),


### PR DESCRIPTION
## Summary

Max 200 Opus 쿼터가 평소 대비 2.5~3배 빨리 소진되는 증상 원인 규명 및 수정.

## 증상

- 평소: 하루 종일 작업해도 15% 내외
- 현재: Opus 대화 2회 텀마다 1%, 1시간에 5% (~3배)
- ContextPack 크기는 평소와 동일 (~30k)

## 원인

\`src-tauri/src/commands/memory_compression.rs\`:

### 1. \`compress_memory_blocking\`이 매 대화 후 Opus 별도 호출 (line 498)

\`\`\`rust
let result = crate::agents::claude::run(crate::agents::claude::RunInput {
    prompt, model: None, ...  // ← 사용자 기본 모델 사용
});
\`\`\`

\`claude -p\` 실행 시 \`--model\` 미지정 → **CLI가 사용자 기본값 사용** → Opus 선택한 사용자는 요약 작업에도 Opus.
메인 대화 1회 + 요약 1회 = **매 턴 Opus 2회 호출**.

### 2. \`needs_compression\` 재압축 임계값 \`/ 2\` (line 106)

\`\`\`rust
msg_count - prev_count >= COMPRESSION_THRESHOLD / 2  // 6개
\`\`\`

활발한 대화방에서 **하루 5+회 압축 반복**. 로그 실측에서 동일 conv(\`819e8eca\`)가 반복적으로 압축.

## Fix

- **A. Haiku 강제**: \`model: Some(\"claude-haiku-4-5\".into())\`. Opus 대비 ~15× 저렴. JSON topic 추출 수준이라 Haiku 품질 충분.
- **B. 임계 완화**: \`COMPRESSION_THRESHOLD / 2\` → \`COMPRESSION_THRESHOLD\` (12개). 재압축 빈도 절반.

## 기대 효과

- 압축당 비용 ~15× ↓ + 빈도 ~2× ↓ = 이 경로 출혈 ~30× ↓
- 전체 Opus 쿼터 소모는 이전 평상시 수준으로 정상화

## Test plan

- [x] \`cargo check --lib\`: 경고 0
- [x] \`cargo test --lib memory_compression\`: 9 passed
- [ ] 머지 후 사용자 쿼터 소모 추이 관찰 — \`[memory] compressed → N topics\` 로그 빈도 감소 + 플랜 사용량 정상 범위 확인

## Follow-up

- 베타 후: Settings에 \"compression model\" 선택 옵션 추가 (Haiku 하드코딩 → 사용자 선택)

🤖 Generated with [Claude Code](https://claude.com/claude-code)