### PR TITLE
fix: 메시지 헤더 메타 회귀 + 에러 trace 누락 복구 (I11 + I12)

### DIFF
--- a/src-tauri/src/commands/agents_helpers/send_common/persistence.rs
+++ b/src-tauri/src/commands/agents_helpers/send_common/persistence.rs
@@ -177,6 +177,14 @@ pub fn finalize_engine_run(
                 "UPDATE messages SET content=?1,status='error',timestamp=?2 WHERE id=?3",
                 params![em, now, msg_id],
             );
+            // Record error span too — without this, trace history is blind to
+            // every failed run (observed: trace_log status=err = 0 across 1058 rows).
+            insert_trace_log(conn, conversation_id, 0, 0, 0.0, now,
+                &SpanInfo {
+                    trace_id: &new_trace_id(), span_id: new_span_id(), parent_span_id: None,
+                    operation: "agent.stream", engine: engine_key,
+                    duration_ms: duration_ms as i64, status: "error",
+                });
             let _ = super::super::super::jobs::complete_job(conn, job_id, "error", Some(&em));
             let _ = app.emit("agent:error", serde_json::json!({
                 "messageId": msg_id, "conversationId": conversation_id, "engine": engine_key, "error": em

--- a/src-tauri/src/commands/messages.rs
+++ b/src-tauri/src/commands/messages.rs
@@ -66,17 +66,26 @@ pub fn list_messages(
 ) -> Result<Vec<Message>, AppError> {
     let conn = state.read.lock().map_err(|_| AppError::Lock)?;
     // Try JOIN with trace_log.message_id (v23+), fallback to plain query if column missing
+    // JOIN trace_log for run-time metadata (durationMs / tokens / cost).
+    // Previously this query referenced `m.duration_ms` via COALESCE, but the
+    // `messages` table has no such column — the prepare() failed silently and
+    // every request fell through to the fallback below, stripping all meta
+    // from message headers whenever the cache was dropped (app restart,
+    // conversation switch, HMR).
+    //
+    // Picking the latest trace row per message_id (a message may have multiple
+    // if re-run or error+retry); NOT EXISTS is cheap thanks to idx_trace_log_message_id.
     let result = conn.prepare(
         "SELECT m.id, m.conversation_id, m.role, m.content, m.timestamp, m.status,
                 (m.progress_content IS NOT NULL) as has_progress,
                 m.engine, m.model, m.persona,
-                COALESCE(t.duration_ms, m.duration_ms), t.input_tokens, t.output_tokens, t.cost_usd
+                t.duration_ms, t.input_tokens, t.output_tokens, t.cost_usd
          FROM messages m
-         LEFT JOIN (
-           SELECT message_id, duration_ms, input_tokens, output_tokens, cost_usd
-           FROM trace_log WHERE message_id IS NOT NULL
-           GROUP BY message_id
-         ) t ON t.message_id = m.id
+         LEFT JOIN trace_log t ON t.message_id = m.id
+           AND NOT EXISTS (
+             SELECT 1 FROM trace_log t2
+             WHERE t2.message_id = t.message_id AND t2.recorded_at > t.recorded_at
+           )
          WHERE m.conversation_id = ?1 ORDER BY m.timestamp ASC",
     );
     match result {


### PR DESCRIPTION
## Summary

두 회귀/누락을 같은 PR에서 처리.

## I12: 메시지 헤더 메타 사라짐

**증상**: 에이전트 답변 후 헤더에 \`duration·tokens\` 보이다가 **앱 재시작/대화 전환/HMR** 뒤 사라짐. 사용자가 여러 번 목격한 회귀성 버그.

**원인**: \`messages.rs:73\`의 JOIN 쿼리가 \`m.duration_ms\`를 COALESCE로 참조하는데, \`messages\` 테이블에 해당 컬럼이 **존재하지 않음** → \`conn.prepare()\` 실패 → fallback path로 넘어가 메타 \`None\` 반환. 프론트 state에만 merge되던 메타가 리로드마다 증발.

**Fix**: \`COALESCE(t.duration_ms, m.duration_ms)\` → \`t.duration_ms\`. 최신 trace row만 선택하도록 NOT EXISTS 서브쿼리 추가 (message_id당 복수 trace 존재 가능성 대비).

## I11: 에러 케이스 trace 누락

**증상**: \`trace_log\` status 분포가 \`ok 1058 / err 0\`. 에러로 끝난 호출은 trace에 전혀 남지 않음 → 뜨문뜨문한 trace history.

**원인**: \`persistence.rs:174-184\`의 Err 분기에 \`insert_trace_log\` 호출 없음. 성공 케이스만 기록.

**Fix**: Err 분기에서도 \`status=\"error\"\`로 span 기록. 토큰/비용은 0.

## Test plan

- [x] \`cargo check --lib\`: 경고 0
- [x] \`cargo test --lib\`: 232 passed
- [ ] 머지 후 새 메시지 send → 헤더 메타(duration/tokens) 표시 확인
- [ ] 앱 재시작 또는 다른 대화 전환 후 돌아와도 메타 유지 확인
- [ ] 다음 에러 케이스(cancel/timeout/CLI fail) 시 \`trace_log.status='error'\` row 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)