### PR TITLE
ci: CI(check) 워크플로우를 self-hosted Linux runner로 이전

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,28 @@ on:
 
 jobs:
   check:
-    runs-on: macos-latest
+    # Moved off GitHub-hosted macos-latest (10× cost multiplier) to a
+    # self-hosted Linux runner — CI budget was hitting the 2000-min warning.
+    # Build / release workflow (build.yml) still targets macos-latest because
+    # Tauri app + sidecars are cross-compiled for aarch64-apple-darwin.
+    runs-on: [self-hosted, Linux]
     steps:
       - uses: actions/checkout@v5
+
+      - name: Install Linux build deps (tauri webkit2gtk)
+        # Idempotent; apt is a no-op when packages are already installed.
+        # Keep runner sudoers (NOPASSWD) pre-configured for unattended CI.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libwebkit2gtk-4.1-dev \
+            libjavascriptcoregtk-4.1-dev \
+            libsoup-3.0-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            build-essential \
+            curl wget file pkg-config
 
       - name: Setup Node
         uses: actions/setup-node@v5
@@ -30,6 +49,9 @@ jobs:
         run: npm install --no-audit --no-fund
 
       - name: Create sidecar placeholder
+        # aarch64-apple-darwin filename is retained so Tauri's bundleResource
+        # path resolution doesn't complain at config load. Content is a stub
+        # and never executed on this Linux-only check job.
         run: |
           mkdir -p src-tauri/binaries
           touch src-tauri/binaries/rawq-aarch64-apple-darwin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,14 +37,22 @@ jobs:
       - name: Install frontend dependencies
         run: npm install --no-audit --no-fund
 
-      - name: Create sidecar placeholder
-        # aarch64-apple-darwin filename is retained so Tauri's bundleResource
-        # path resolution doesn't complain at config load. Content is a stub
-        # and never executed on this Linux-only check job.
+      - name: Create sidecar placeholders
+        # Tauri's build script resolves sidecar paths against the CURRENT
+        # target triple (TAURI_ENV_TARGET_TRIPLE). On Linux self-hosted CI
+        # that's x86_64-unknown-linux-gnu, not aarch64-apple-darwin — so we
+        # create stubs for both the macOS name (kept for config validation
+        # safety) and the host target. Content is never executed on this
+        # Linux-only check job; only file existence matters.
         run: |
           mkdir -p src-tauri/binaries
-          touch src-tauri/binaries/rawq-aarch64-apple-darwin
-          chmod +x src-tauri/binaries/rawq-aarch64-apple-darwin
+          TRIPLE=$(rustc -vV | sed -n 's/^host: //p')
+          for name in rawq crg chub; do
+            touch "src-tauri/binaries/${name}-aarch64-apple-darwin"
+            chmod +x "src-tauri/binaries/${name}-aarch64-apple-darwin"
+            touch "src-tauri/binaries/${name}-${TRIPLE}"
+            chmod +x "src-tauri/binaries/${name}-${TRIPLE}"
+          done
 
       - name: Cargo check
         working-directory: src-tauri

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,23 +13,12 @@ jobs:
     # Build / release workflow (build.yml) still targets macos-latest because
     # Tauri app + sidecars are cross-compiled for aarch64-apple-darwin.
     runs-on: [self-hosted, Linux]
+    # Runner prerequisite: Tauri 2 Linux build deps pre-installed on host
+    # (libwebkit2gtk-4.1-dev, libjavascriptcoregtk-4.1-dev, libsoup-3.0-dev,
+    # libappindicator3-dev, librsvg2-dev, patchelf, build-essential, pkg-config).
+    # Avoids per-run sudo/apt and keeps the runner user without elevated rights.
     steps:
       - uses: actions/checkout@v5
-
-      - name: Install Linux build deps (tauri webkit2gtk)
-        # Idempotent; apt is a no-op when packages are already installed.
-        # Keep runner sudoers (NOPASSWD) pre-configured for unattended CI.
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            libwebkit2gtk-4.1-dev \
-            libjavascriptcoregtk-4.1-dev \
-            libsoup-3.0-dev \
-            libappindicator3-dev \
-            librsvg2-dev \
-            patchelf \
-            build-essential \
-            curl wget file pkg-config
 
       - name: Setup Node
         uses: actions/setup-node@v5


### PR DESCRIPTION
## Summary

GitHub-hosted macos-latest runner 사용량 2000분 경고 해결. check job을 사용자 Ubuntu 24.04 self-hosted runner로 이전.

## 변경

### \`ci.yml\`
- \`runs-on: macos-latest\` → \`[self-hosted, Linux]\`
- Tauri 2 Linux 빌드 의존성(webkit2gtk 등) apt install step 추가 (멱등)

### \`build.yml\` (변경 없음)
Tauri app + sidecar 5종 모두 \`aarch64-apple-darwin\` 크로스 컴파일 → **macos-latest 유지 필수**. 릴리즈 태그 push에만 돌기 때문에 사용량 영향 미미.

## Runner 환경

- 호스트: Ubuntu 24.04 (d9ng-u2404-docker — 호스트명만 docker, runner 자체는 systemd로 호스트 직접 설치)
- 서비스: \`actions.runner.hang-in-tunaFlow.d9ng-u2404-docker.service\` 기동 확인
- sudoers NOPASSWD 필요 (apt step)

## 기대 효과

- check job 무료 실행 (매 push/PR)
- 월 GitHub Actions 사용량 대폭 감소

## Test plan

- [ ] 이 PR 자체가 첫 실행 → 성공 시 self-hosted runner + apt 의존성 정상 작동 확증
- [ ] \`cargo check\` / \`cargo test --lib\` Linux 환경에서 통과 확인
- [ ] 실패 시 원인 (webkit2gtk 누락, sudo 권한 등)으로 분기

🤖 Generated with [Claude Code](https://claude.com/claude-code)