### PR TITLE
chore: 로컬 빌드 올인원 스크립트 (scripts/build.sh)

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+#
+# tunaFlow all-in-one build script (macOS)
+#
+# Checks dependencies, builds sidecar binaries (rawq / crg / context-hub),
+# installs npm deps, and runs `tauri build`. Emits a readable progress
+# trail so you can see every step.
+#
+# Usage:
+#   ./scripts/build.sh                    # full build
+#   ./scripts/build.sh --skip-sidecars    # skip sidecar rebuilds (use existing binaries)
+#   ./scripts/build.sh --no-bundle        # pass --no-bundle to tauri (skip .dmg packaging)
+#
+# Env overrides (optional, autodetected if unset):
+#   RAWQ_SRC=<path>
+#   CRG_SRC=<path>
+#   CHUB_SRC=<path>
+#
+set -euo pipefail
+
+# ─── Colors / progress helpers ───────────────────────────────────────────────
+
+if [[ -t 1 ]]; then
+  C_RESET=$'\033[0m'; C_BOLD=$'\033[1m'; C_DIM=$'\033[2m'
+  C_RED=$'\033[31m'; C_GRN=$'\033[32m'; C_YLW=$'\033[33m'; C_BLU=$'\033[34m'; C_CYN=$'\033[36m'
+else
+  C_RESET=; C_BOLD=; C_DIM=; C_RED=; C_GRN=; C_YLW=; C_BLU=; C_CYN=
+fi
+
+step()    { printf "\n${C_BOLD}${C_BLU}▶ %s${C_RESET}\n" "$*"; }
+substep() { printf "  ${C_DIM}›${C_RESET} %s\n" "$*"; }
+ok()      { printf "  ${C_GRN}✓${C_RESET} %s\n" "$*"; }
+warn()    { printf "  ${C_YLW}!${C_RESET} %s\n" "$*"; }
+fail()    { printf "  ${C_RED}✗${C_RESET} %s\n" "$*" >&2; }
+die()     { fail "$*"; exit 1; }
+
+run() {
+  # Run a command with its output streamed live (so build progress is visible).
+  substep "$*"
+  "$@"
+}
+
+# ─── Args ────────────────────────────────────────────────────────────────────
+
+SKIP_SIDECARS=0
+NO_BUNDLE=0
+for arg in "$@"; do
+  case "$arg" in
+    --skip-sidecars) SKIP_SIDECARS=1 ;;
+    --no-bundle)     NO_BUNDLE=1 ;;
+    -h|--help)
+      awk 'NR==1{next} /^#!/{next} /^#/{sub(/^# ?/,""); print; next} {exit}' "$0"
+      exit 0 ;;
+    *) die "Unknown argument: $arg  (try --help)" ;;
+  esac
+done
+
+# ─── Paths ───────────────────────────────────────────────────────────────────
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+BIN_DIR="$ROOT_DIR/src-tauri/binaries"
+
+# ─── 1. Platform check ──────────────────────────────────────────────────────
+
+step "1/6  Platform check"
+
+UNAME_S="$(uname -s)"
+if [[ "$UNAME_S" != "Darwin" ]]; then
+  warn "Non-macOS platform ($UNAME_S). Tauri build targets macOS; results may differ."
+else
+  ok "macOS $(sw_vers -productVersion) ($(uname -m))"
+fi
+
+# ─── 2. Dependency check ────────────────────────────────────────────────────
+
+step "2/6  Dependency check"
+
+need() {
+  # need <cmd> <install hint>
+  if command -v "$1" >/dev/null 2>&1; then
+    ok "$1  ($("$1" --version 2>&1 | head -1))"
+  else
+    fail "$1 not found"
+    printf "    ${C_DIM}install: %s${C_RESET}\n" "$2"
+    return 1
+  fi
+}
+
+MISSING=0
+need node "brew install node@22"        || MISSING=1
+need npm  "comes with node"             || MISSING=1
+need rustc "https://rustup.rs"          || MISSING=1
+need cargo "https://rustup.rs"          || MISSING=1
+if [[ "$UNAME_S" == "Darwin" ]]; then
+  if xcode-select -p >/dev/null 2>&1; then
+    ok "Xcode CLT ($(xcode-select -p))"
+  else
+    fail "Xcode Command Line Tools not installed"
+    printf "    ${C_DIM}install: xcode-select --install${C_RESET}\n"
+    MISSING=1
+  fi
+fi
+
+# Node version hint (package.json wants >=22)
+if command -v node >/dev/null 2>&1; then
+  NODE_MAJOR="$(node -p 'process.versions.node.split(".")[0]' 2>/dev/null || echo 0)"
+  if (( NODE_MAJOR < 22 )); then
+    warn "Node major = $NODE_MAJOR; tunaFlow targets >=22. Upgrade recommended."
+  fi
+fi
+
+[[ $MISSING -eq 0 ]] || die "Missing dependencies above. Install them and retry."
+
+# ─── 3. Sidecar binaries ────────────────────────────────────────────────────
+
+step "3/6  Sidecar binaries (rawq / crg / chub)"
+
+if [[ $SKIP_SIDECARS -eq 1 ]]; then
+  substep "--skip-sidecars set; using whatever is already in src-tauri/binaries/"
+  ls -1 "$BIN_DIR" 2>/dev/null | grep -v README || warn "no sidecar binaries present; Tauri build will fail."
+else
+  TARGET_TRIPLE="$(rustc --print host-tuple)"
+  substep "host target: $TARGET_TRIPLE"
+  mkdir -p "$BIN_DIR"
+
+  # ── 3a. rawq ── (script already exists; delegates)
+  if [[ -f "$BIN_DIR/rawq-$TARGET_TRIPLE" ]]; then
+    ok "rawq sidecar already present (skip). Remove src-tauri/binaries/rawq-$TARGET_TRIPLE to rebuild."
+  elif [[ -x "$ROOT_DIR/scripts/build-rawq.sh" ]]; then
+    substep "Building rawq sidecar via scripts/build-rawq.sh …"
+    "$ROOT_DIR/scripts/build-rawq.sh"
+    ok "rawq sidecar built"
+  else
+    warn "scripts/build-rawq.sh missing; rawq sidecar not built."
+  fi
+
+  # ── 3b. crg (code-review-graph) ──
+  build_crg() {
+    local src="$1"
+    local dest="$BIN_DIR/crg-$TARGET_TRIPLE"
+    local target_dir="$ROOT_DIR/src-tauri/target/crg-sidecar"
+    substep "Building crg from $src …"
+    cargo build --manifest-path "$src/Cargo.toml" --release --target-dir "$target_dir"
+    # crate binary name may be `crg` or `code-review-graph`; pick whichever exists.
+    if [[ -f "$target_dir/release/crg" ]]; then
+      cp "$target_dir/release/crg" "$dest"
+    elif [[ -f "$target_dir/release/code-review-graph" ]]; then
+      cp "$target_dir/release/code-review-graph" "$dest"
+    else
+      fail "crg binary not produced under $target_dir/release/"
+      return 1
+    fi
+    chmod +x "$dest"
+    ok "crg sidecar built: $dest"
+  }
+  if [[ -f "$BIN_DIR/crg-$TARGET_TRIPLE" ]]; then
+    ok "crg sidecar already present (skip)."
+  else
+    CRG_CANDIDATES=(
+      "${CRG_SRC:-}"
+      "$ROOT_DIR/vendor/code-review-graph"
+      "$ROOT_DIR/../_research/_util/code-review-graph"
+    )
+    CRG_PICKED=""
+    for c in "${CRG_CANDIDATES[@]}"; do
+      [[ -n "$c" && -f "$c/Cargo.toml" ]] && { CRG_PICKED="$c"; break; }
+    done
+    if [[ -n "$CRG_PICKED" ]]; then
+      build_crg "$CRG_PICKED"
+    else
+      warn "crg source not found. Set CRG_SRC=<path> or clone the repo. Skipping."
+    fi
+  fi
+
+  # ── 3c. context-hub (chub) ──
+  build_chub() {
+    local src="$1"
+    local dest="$BIN_DIR/chub-$TARGET_TRIPLE"
+    substep "Building chub from $src …"
+    pushd "$src" >/dev/null
+    if [[ ! -d node_modules ]]; then
+      substep "chub: npm install"
+      npm install --no-audit --no-fund
+    fi
+    npm run build 2>/dev/null || true   # build step optional
+    # pkg target triple mapping
+    local pkg_target="node18-macos-arm64"
+    if [[ "$TARGET_TRIPLE" == "x86_64-apple-darwin" ]]; then
+      pkg_target="node18-macos-x64"
+    fi
+    substep "chub: npx pkg → $pkg_target"
+    npx --yes pkg . --targets "$pkg_target" --output "$dest"
+    chmod +x "$dest"
+    popd >/dev/null
+    ok "chub sidecar built: $dest"
+  }
+  if [[ -f "$BIN_DIR/chub-$TARGET_TRIPLE" ]]; then
+    ok "chub sidecar already present (skip)."
+  else
+    CHUB_CANDIDATES=(
+      "${CHUB_SRC:-}"
+      "$ROOT_DIR/vendor/context-hub"
+      "$ROOT_DIR/../_research/_util/context-hub"
+    )
+    CHUB_PICKED=""
+    for c in "${CHUB_CANDIDATES[@]}"; do
+      [[ -n "$c" && -f "$c/package.json" ]] && { CHUB_PICKED="$c"; break; }
+    done
+    if [[ -n "$CHUB_PICKED" ]]; then
+      build_chub "$CHUB_PICKED"
+    else
+      warn "chub source not found. Set CHUB_SRC=<path> or clone the repo. Skipping."
+    fi
+  fi
+
+  # Summary
+  substep "installed sidecars:"
+  ls -lh "$BIN_DIR" 2>/dev/null | awk 'NR>1 && $NF != "README.md" {print "    "$NF"  ("$5")"}'
+fi
+
+# ─── 4. Frontend deps ───────────────────────────────────────────────────────
+
+step "4/6  Frontend dependencies (npm)"
+
+if [[ -d node_modules ]]; then
+  ok "node_modules present (skip install). Delete node_modules to force reinstall."
+else
+  run npm install --no-audit --no-fund
+  ok "npm deps installed"
+fi
+
+# ─── 5. Tauri production build ──────────────────────────────────────────────
+
+step "5/6  Tauri build (release — this may take 5~10 minutes on first run)"
+
+TAURI_ARGS=()
+[[ $NO_BUNDLE -eq 1 ]] && TAURI_ARGS+=(-- --no-bundle)
+
+run npm run tauri build "${TAURI_ARGS[@]}"
+
+# ─── 6. Verify output ───────────────────────────────────────────────────────
+
+step "6/6  Build output"
+
+BUNDLE_DIR="$ROOT_DIR/src-tauri/target/release/bundle"
+APP_PATH="$BUNDLE_DIR/macos/tunaFlow.app"
+DMG_PATH="$(ls -1t "$BUNDLE_DIR"/dmg/*.dmg 2>/dev/null | head -1 || true)"
+
+if [[ -d "$APP_PATH" ]]; then
+  ok "App bundle: $APP_PATH"
+  substep "size: $(du -sh "$APP_PATH" | awk '{print $1}')"
+else
+  fail "App bundle not found at expected path: $APP_PATH"
+fi
+
+if [[ -n "$DMG_PATH" && -f "$DMG_PATH" ]]; then
+  ok "DMG:        $DMG_PATH"
+  substep "size: $(du -sh "$DMG_PATH" | awk '{print $1}')"
+elif [[ $NO_BUNDLE -eq 1 ]]; then
+  substep "DMG skipped (--no-bundle)"
+else
+  warn "DMG not found; bundle step may have been skipped."
+fi
+
+echo
+printf "${C_BOLD}${C_GRN}Build complete.${C_RESET}\n"
+echo "  To run:       open \"$APP_PATH\""
+if [[ -n "$DMG_PATH" ]]; then
+  echo "  To install:   open \"$DMG_PATH\"   (drag into /Applications, then:"
+  echo "                xattr -cr /Applications/tunaFlow.app  # strip Gatekeeper quarantine)"
+fi


### PR DESCRIPTION
## Summary

로컬에서 \`npm run tauri build\` 한 번 돌리려면 사전 체크(Rust/Node/Xcode CLT + rawq/crg/chub 세 사이드카 빌드)가 여러 단계. 단일 스크립트로 묶음.

## 단계

1. Platform check
2. Dependency check — 누락 시 설치 힌트 + exit
3. Sidecar binaries — rawq(기존 스크립트 재사용)/crg/chub 빌드. 있으면 skip
4. npm install (node_modules 있으면 skip)
5. \`npm run tauri build\`
6. 결과물(.app/.dmg) 경로 + 크기 + 실행/설치 안내

## 사용

\`\`\`bash
./scripts/build.sh                    # 풀 빌드
./scripts/build.sh --skip-sidecars    # 기존 사이드카 재사용
./scripts/build.sh --no-bundle        # .dmg 생략
./scripts/build.sh --help
\`\`\`

Env 오버라이드: \`RAWQ_SRC\`, \`CRG_SRC\`, \`CHUB_SRC\` (자동 탐색 실패 시).

## Test plan

- [x] \`./scripts/build.sh --help\`: 도움말 정상 출력
- [ ] 사용자 환경에서 실행 후 빌드 완료 시 .app/.dmg 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)