### PR TITLE
chore(build): pyinstaller INFO 로그 억제

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -178,6 +178,7 @@ for f in ('__main__.py','cli.py','main.py'):
     fi
     substep "crg: pyinstaller --onefile  entry=$entry"
     ( cd "$src" && pyinstaller --onefile \
+        --log-level WARN \
         --name "crg-$TARGET_TRIPLE" \
         --distpath "$BIN_DIR" \
         "$entry" )


### PR DESCRIPTION
pyinstaller --log-level WARN 한 줄. 이번 실행은 이미 끝났고 다음 실행부터 효과.