### PR TITLE
fix(build): TAURI_ARGS 빈 배열 unbound variable

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -280,10 +280,13 @@ fi
 
 step "5/6  Tauri build (release — this may take 5~10 minutes on first run)"
 
-TAURI_ARGS=()
-[[ $NO_BUNDLE -eq 1 ]] && TAURI_ARGS+=(-- --no-bundle)
-
-run npm run tauri build "${TAURI_ARGS[@]}"
+# Keep expansion explicit — macOS bash 3.2 + `set -u` trips on an empty
+# array expansion ("${arr[@]}: unbound variable").
+if [[ $NO_BUNDLE -eq 1 ]]; then
+  run npm run tauri build -- --no-bundle
+else
+  run npm run tauri build
+fi
 
 # ─── 6. Verify output ───────────────────────────────────────────────────────
 


### PR DESCRIPTION
bash 3.2 + set -u 에서 `"${TAURI_ARGS[@]}"` 빈 배열 expansion 차단 → if 분기로 수정. 이전 PR #13에서 도입한 버그.