### PR TITLE
fix(db): dev / release 빌드 DB 파일 분리 (tunaflow.db vs tunaflow-sandbox.db)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -83,7 +83,19 @@ pub fn run() {
                 .app_data_dir()
                 .unwrap_or_else(|_| std::path::PathBuf::from(".tunaflow_data"));
             std::fs::create_dir_all(&data_dir)?;
-            let db_path = data_dir.join("tunaflow.db");
+            // Separate DB files for dev vs release:
+            // - `tauri dev` (debug build)  → tunaflow.db          (real working data)
+            // - `tauri build` (release)    → tunaflow-sandbox.db  (onboarding/install smoke test)
+            // Rationale: production build should not share the live dev DB so
+            // install-flow rehearsals and AppCleaner-style accidents don't clobber
+            // real conversations. settings.json / skills/ are still shared.
+            let db_filename = if cfg!(debug_assertions) {
+                "tunaflow.db"
+            } else {
+                "tunaflow-sandbox.db"
+            };
+            let db_path = data_dir.join(db_filename);
+            eprintln!("[startup] DB: {}", db_path.display());
             let (write_conn, read_conn) = db::init(db_path)?;
 
             // Cleanup stale streaming messages from previous crash/shutdown


### PR DESCRIPTION
release 빌드는 `tunaflow-sandbox.db` 를 사용해서 온보딩/설치 테스트 공간을 분리. AppCleaner 사고로 실 데이터(233 conv, 2557 msg)가 날아간 일 복구 후 운영 분리를 위한 수정. 근본 보호(AppCleaner 내성)는 perProjectDatabaseSplitPlan 에서 `~/.tunaflow/` 이전과 함께 처리.