### PR TITLE
fix(db): dev DB → ~/.tunaflow/ (AppCleaner 내성) + build.sh wipe 옵션

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -7,9 +7,11 @@
 # trail so you can see every step.
 #
 # Usage:
-#   ./scripts/build.sh                    # full build
-#   ./scripts/build.sh --skip-sidecars    # skip sidecar rebuilds (use existing binaries)
-#   ./scripts/build.sh --no-bundle        # pass --no-bundle to tauri (skip .dmg packaging)
+#   ./scripts/build.sh                       # full build
+#   ./scripts/build.sh --skip-sidecars       # skip sidecar rebuilds (use existing binaries)
+#   ./scripts/build.sh --no-bundle           # pass --no-bundle to tauri (skip .dmg packaging)
+#   ./scripts/build.sh --wipe-sandbox        # wipe release DB before build (fresh onboarding)
+#   ./scripts/build.sh --remove-previous-app # rm /Applications/tunaFlow.app before build
 #
 # Env overrides (optional, autodetected if unset):
 #   RAWQ_SRC=<path>
@@ -44,16 +46,47 @@ run() {
 
 SKIP_SIDECARS=0
 NO_BUNDLE=0
+WIPE_SANDBOX=0
+REMOVE_PREVIOUS_APP=0
 for arg in "$@"; do
   case "$arg" in
-    --skip-sidecars) SKIP_SIDECARS=1 ;;
-    --no-bundle)     NO_BUNDLE=1 ;;
+    --skip-sidecars)        SKIP_SIDECARS=1 ;;
+    --no-bundle)            NO_BUNDLE=1 ;;
+    --wipe-sandbox)         WIPE_SANDBOX=1 ;;
+    --remove-previous-app)  REMOVE_PREVIOUS_APP=1 ;;
     -h|--help)
       awk 'NR==1{next} /^#!/{next} /^#/{sub(/^# ?/,""); print; next} {exit}' "$0"
       exit 0 ;;
     *) die "Unknown argument: $arg  (try --help)" ;;
   esac
 done
+
+# ─── 0. Optional: wipe release sandbox (fresh onboarding surface) ───────────
+
+if [[ $WIPE_SANDBOX -eq 1 ]]; then
+  step "0/6  Wipe release DB sandbox (--wipe-sandbox)"
+  SANDBOX_DIR="$HOME/Library/Application Support/com.tunaflow.app"
+  if [[ -d "$SANDBOX_DIR" ]]; then
+    # Preserve settings.json + .window-state.json; only nuke DB + derived files.
+    for f in tunaflow.db tunaflow.db-wal tunaflow.db-shm tunaflow.db.bak \
+             "tunaflow-sandbox.db" "tunaflow-sandbox.db-wal" "tunaflow-sandbox.db-shm"; do
+      [[ -e "$SANDBOX_DIR/$f" ]] && rm -f "$SANDBOX_DIR/$f" && substep "removed $f"
+    done
+    ok "sandbox DB cleared — next install will run fresh onboarding"
+  else
+    substep "no sandbox dir yet (fresh install)"
+  fi
+fi
+
+if [[ $REMOVE_PREVIOUS_APP -eq 1 ]]; then
+  step "0b/6  Remove previous /Applications/tunaFlow.app (--remove-previous-app)"
+  if [[ -d "/Applications/tunaFlow.app" ]]; then
+    rm -rf "/Applications/tunaFlow.app"
+    ok "removed /Applications/tunaFlow.app"
+  else
+    substep "no previous installed app"
+  fi
+fi
 
 # ─── Paths ───────────────────────────────────────────────────────────────────
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -130,23 +130,32 @@ pub fn run() {
         .plugin(tauri_plugin_window_state::Builder::new().build())
         .setup(|app| {
             use tauri::Manager;
-            let data_dir = app
-                .path()
-                .app_data_dir()
-                .unwrap_or_else(|_| std::path::PathBuf::from(".tunaflow_data"));
-            std::fs::create_dir_all(&data_dir)?;
-            // Separate DB files for dev vs release:
-            // - `tauri dev` (debug build)  → tunaflow.db          (real working data)
-            // - `tauri build` (release)    → tunaflow-sandbox.db  (onboarding/install smoke test)
-            // Rationale: production build should not share the live dev DB so
-            // install-flow rehearsals and AppCleaner-style accidents don't clobber
-            // real conversations. settings.json / skills/ are still shared.
-            let db_filename = if cfg!(debug_assertions) {
-                "tunaflow.db"
+            // DB storage strategy:
+            // - dev     (debug build):  ~/.tunaflow/db/tunaflow.db
+            //   AppCleaner searches by bundle id (com.tunaflow.app) so anything
+            //   under Application Support/<bundle-id>/ gets wiped when the .app
+            //   is deleted. We already lost a 37M DB this way. Moving the dev
+            //   DB under ~/.tunaflow/ (dotfile, not matched by AppCleaner)
+            //   keeps real work safe across app reinstalls.
+            // - release (release build): Application Support/<bundle-id>/tunaflow.db
+            //   Intentionally inside the bundle-id folder so that AppCleaner
+            //   (and scripts/build.sh --wipe-sandbox) can reset it on every
+            //   install, giving a fresh onboarding surface every build.
+            let db_path: std::path::PathBuf = if cfg!(debug_assertions) {
+                let home = std::env::var("HOME")
+                    .map(std::path::PathBuf::from)
+                    .unwrap_or_else(|_| std::path::PathBuf::from("."));
+                let dir = home.join(".tunaflow").join("db");
+                std::fs::create_dir_all(&dir)?;
+                dir.join("tunaflow.db")
             } else {
-                "tunaflow-sandbox.db"
+                let dir = app
+                    .path()
+                    .app_data_dir()
+                    .unwrap_or_else(|_| std::path::PathBuf::from(".tunaflow_data"));
+                std::fs::create_dir_all(&dir)?;
+                dir.join("tunaflow.db")
             };
-            let db_path = data_dir.join(db_filename);
             eprintln!("[startup] DB: {}", db_path.display());
             let (write_conn, read_conn) = db::init(db_path)?;
 


### PR DESCRIPTION
AppCleaner가 `com.tunaflow.app/` 폴더째 휴지통으로 보내며 dev DB(37M) 두 번 날아간 사고에 대한 근본 수정.

- **dev**: `~/.tunaflow/db/tunaflow.db` (dotfile, AppCleaner 무시)
- **release**: `com.tunaflow.app/tunaflow.db` 유지 (의도적으로 쓸려가도 OK)
- **build.sh**: `--wipe-sandbox` (release DB 초기화), `--remove-previous-app` (이전 /Applications 제거)

dev DB는 이미 백업에서 복구 완료(projects 7 / conv 233 / msg 2557).