### PR TITLE
feat(onboarding): 메타에이전트 선택 UX + Ollama/LMStudio 지원

### DIFF
--- a/src-tauri/src/commands/agent_detect.rs
+++ b/src-tauri/src/commands/agent_detect.rs
@@ -1,0 +1,189 @@
+//! Detect which AI agents are available on this machine.
+//!
+//! Used by the Meta Agent Selector modal shown during project onboarding.
+//! - CLI agents (claude / codex / gemini): probe via `which` + `--version`
+//! - HTTP agents (ollama / lmstudio): probe endpoint + list models live
+//! - 모든 탐지는 병렬로 수행. 각 항목은 1.5s timeout.
+
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+use tokio::process::Command;
+use tokio::time::timeout;
+
+const PROBE_TIMEOUT_MS: u64 = 1500;
+
+#[derive(Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentDetection {
+    pub engine: String,
+    pub kind: &'static str,        // "cli" or "http"
+    pub installed: bool,
+    pub version: Option<String>,   // CLI 에이전트의 `<cmd> --version`
+    pub path: Option<String>,      // CLI: `which` 결과
+    pub endpoint: Option<String>,  // HTTP: 확인/호출된 베이스 URL
+    pub models: Vec<String>,       // HTTP: /api/tags / /v1/models
+    pub note: Option<String>,      // 실패/에러 요약 (사용자에게 보여줄 수 있음)
+}
+
+// ─── CLI probing ─────────────────────────────────────────────────────────────
+
+async fn probe_cli(engine: &str, bin: &str, version_args: &[&str]) -> AgentDetection {
+    let mut det = AgentDetection {
+        engine: engine.to_string(),
+        kind: "cli",
+        installed: false,
+        version: None,
+        path: None,
+        endpoint: None,
+        models: vec![],
+        note: None,
+    };
+
+    // `which <bin>`
+    let which_fut = Command::new("which").arg(bin).output();
+    let which_out = match timeout(Duration::from_millis(PROBE_TIMEOUT_MS), which_fut).await {
+        Ok(Ok(out)) => out,
+        Ok(Err(e)) => { det.note = Some(format!("which error: {e}")); return det; }
+        Err(_) => { det.note = Some("which timeout".into()); return det; }
+    };
+    if !which_out.status.success() {
+        det.note = Some("not found in PATH".into());
+        return det;
+    }
+    let path = String::from_utf8_lossy(&which_out.stdout).trim().to_string();
+    if path.is_empty() {
+        det.note = Some("which returned empty".into());
+        return det;
+    }
+    det.path = Some(path.clone());
+    det.installed = true;
+
+    // `<bin> --version` (optional — 실패해도 installed 유지)
+    let ver_fut = Command::new(&path).args(version_args).output();
+    if let Ok(Ok(out)) = timeout(Duration::from_millis(PROBE_TIMEOUT_MS), ver_fut).await {
+        if out.status.success() {
+            let v = String::from_utf8_lossy(&out.stdout).lines().next().unwrap_or("").trim().to_string();
+            if !v.is_empty() { det.version = Some(v); }
+        }
+    }
+    det
+}
+
+// ─── HTTP probing ────────────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct OllamaTagsResponse {
+    #[serde(default)]
+    models: Vec<OllamaTagModel>,
+}
+#[derive(Deserialize)]
+struct OllamaTagModel { name: String }
+
+#[derive(Deserialize)]
+struct OpenAiModelsResponse {
+    #[serde(default)]
+    data: Vec<OpenAiModel>,
+}
+#[derive(Deserialize)]
+struct OpenAiModel { id: String }
+
+async fn probe_ollama(endpoint: &str) -> AgentDetection {
+    let base = endpoint.trim_end_matches('/');
+    let url = format!("{}/api/tags", base);
+    let mut det = AgentDetection {
+        engine: "ollama".into(),
+        kind: "http",
+        installed: false,
+        version: None,
+        path: None,
+        endpoint: Some(base.to_string()),
+        models: vec![],
+        note: None,
+    };
+
+    let client = match reqwest::Client::builder()
+        .timeout(Duration::from_millis(PROBE_TIMEOUT_MS))
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => { det.note = Some(format!("reqwest build error: {e}")); return det; }
+    };
+
+    match client.get(&url).send().await {
+        Ok(resp) if resp.status().is_success() => {
+            match resp.json::<OllamaTagsResponse>().await {
+                Ok(body) => {
+                    det.installed = true;
+                    det.models = body.models.into_iter().map(|m| m.name).collect();
+                }
+                Err(e) => det.note = Some(format!("parse error: {e}")),
+            }
+        }
+        Ok(resp) => det.note = Some(format!("status {}", resp.status())),
+        Err(_) => det.note = Some("not reachable".into()),
+    }
+    det
+}
+
+async fn probe_lmstudio(endpoint: &str) -> AgentDetection {
+    // LMStudio는 보통 .../v1 로 base. 끝에 /v1 붙어있지 않으면 붙여서 접근.
+    let base_raw = endpoint.trim_end_matches('/');
+    let base = if base_raw.ends_with("/v1") { base_raw.to_string() } else { format!("{}/v1", base_raw) };
+    let url = format!("{}/models", base);
+
+    let mut det = AgentDetection {
+        engine: "lmstudio".into(),
+        kind: "http",
+        installed: false,
+        version: None,
+        path: None,
+        endpoint: Some(base.clone()),
+        models: vec![],
+        note: None,
+    };
+
+    let client = match reqwest::Client::builder()
+        .timeout(Duration::from_millis(PROBE_TIMEOUT_MS))
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => { det.note = Some(format!("reqwest build error: {e}")); return det; }
+    };
+
+    match client.get(&url).send().await {
+        Ok(resp) if resp.status().is_success() => {
+            match resp.json::<OpenAiModelsResponse>().await {
+                Ok(body) => {
+                    det.installed = true;
+                    det.models = body.data.into_iter().map(|m| m.id).collect();
+                }
+                Err(e) => det.note = Some(format!("parse error: {e}")),
+            }
+        }
+        Ok(resp) => det.note = Some(format!("status {}", resp.status())),
+        Err(_) => det.note = Some("not reachable".into()),
+    }
+    det
+}
+
+// ─── Tauri command ───────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub async fn detect_available_agents(
+    ollama_endpoint: Option<String>,
+    lmstudio_endpoint: Option<String>,
+) -> Vec<AgentDetection> {
+    let ollama_ep = ollama_endpoint.unwrap_or_else(|| "http://localhost:11434".into());
+    let lmstudio_ep = lmstudio_endpoint.unwrap_or_else(|| "http://localhost:1234/v1".into());
+
+    // CLI probes — 병렬
+    let (claude, codex, gemini, ollama, lmstudio) = tokio::join!(
+        probe_cli("claude", "claude", &["--version"]),
+        probe_cli("codex",  "codex",  &["--version"]),
+        probe_cli("gemini", "gemini", &["--version"]),
+        probe_ollama(&ollama_ep),
+        probe_lmstudio(&lmstudio_ep),
+    );
+
+    vec![claude, codex, gemini, ollama, lmstudio]
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod agent_detect;
 pub mod agents;
 pub mod agents_helpers;
 pub mod artifacts;

--- a/src-tauri/src/commands/project_onboarding.rs
+++ b/src-tauri/src/commands/project_onboarding.rs
@@ -214,18 +214,14 @@ fn extract_between<'a>(text: &'a str, start: &str, end: &str) -> Option<&'a str>
     Some(&text[s..e])
 }
 
-// ─── AI call ─────────────────────────────────────────────────────────────────
+// ─── AI call (engine-agnostic) ───────────────────────────────────────────────
 
-async fn call_claude(prompt: &str, cancel: &AtomicBool) -> Result<(String, String), String> {
-    let child = tokio::process::Command::new("claude")
-        .args(["-p", prompt, "--max-turns", "1", "--output-format", "text"])
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::null())
-        .spawn()
-        .map_err(|e| format!("claude CLI 실행 실패: {e}. claude가 설치되어 있고 로그인되어 있는지 확인하세요."))?;
-
-    // Spawn subprocess in a background task; communicate result via channel.
-    // If cancelled we return early — the background task finishes on its own and result is dropped.
+/// Poll an already-spawned CLI subprocess with cooperative cancellation.
+async fn await_cli_with_cancel(
+    child: tokio::process::Child,
+    cancel: &AtomicBool,
+    engine: &str,
+) -> Result<String, String> {
     let (tx, mut rx) = tokio::sync::oneshot::channel::<std::io::Result<std::process::Output>>();
     tokio::spawn(async move {
         let _ = tx.send(child.wait_with_output().await);
@@ -234,23 +230,203 @@ async fn call_claude(prompt: &str, cancel: &AtomicBool) -> Result<(String, Strin
     let poll = tokio::time::Duration::from_millis(300);
     loop {
         tokio::time::sleep(poll).await;
-
-        if is_cancelled(cancel) {
-            return Err("cancelled".into());
-        }
+        if is_cancelled(cancel) { return Err("cancelled".into()); }
 
         match rx.try_recv() {
             Ok(Ok(output)) => {
                 if !output.status.success() {
-                    return Err(format!("claude 분석 실패 (exit: {:?})", output.status.code()));
+                    return Err(format!("{engine} 분석 실패 (exit: {:?})", output.status.code()));
                 }
-                return parse_output(&String::from_utf8_lossy(&output.stdout));
+                return Ok(String::from_utf8_lossy(&output.stdout).into_owned());
             }
-            Ok(Err(e)) => return Err(format!("claude 실행 오류: {e}")),
+            Ok(Err(e)) => return Err(format!("{engine} 실행 오류: {e}")),
             Err(tokio::sync::oneshot::error::TryRecvError::Empty) => continue,
             Err(_) => return Err("프로세스 채널 오류".into()),
         }
     }
+}
+
+/// Run a CLI agent with (`bin`, model-args) convention. Prompt goes on argv
+/// for claude/gemini; for codex we hand it through stdin to match existing
+/// codex agent behavior.
+async fn call_cli_agent(
+    engine: &str,
+    bin: &str,
+    prompt: &str,
+    model: Option<&str>,
+    cancel: &AtomicBool,
+) -> Result<String, String> {
+    use std::process::Stdio;
+
+    let mut cmd = tokio::process::Command::new(bin);
+    match engine {
+        "claude" => {
+            cmd.args(["-p", prompt, "--max-turns", "1", "--output-format", "text"]);
+            if let Some(m) = model { cmd.args(["--model", m]); }
+        }
+        "gemini" => {
+            cmd.args(["-p", prompt]);
+            if let Some(m) = model { cmd.args(["-m", m]); }
+        }
+        "codex" => {
+            cmd.args(["exec", "--full-auto", "-"]);
+            if let Some(m) = model { cmd.args(["--model", m]); }
+            cmd.stdin(Stdio::piped());
+        }
+        _ => return Err(format!("지원하지 않는 CLI 엔진: {engine}")),
+    }
+    cmd.stdout(Stdio::piped()).stderr(Stdio::null());
+
+    let spawn_res = cmd.spawn();
+    let mut child = spawn_res
+        .map_err(|e| format!("{engine} CLI 실행 실패: {e}. {engine}가 설치되어 있는지 확인하세요."))?;
+
+    // codex만 stdin 파이프
+    if engine == "codex" {
+        if let Some(mut stdin) = child.stdin.take() {
+            use tokio::io::AsyncWriteExt;
+            let prompt_owned = prompt.to_string();
+            tokio::spawn(async move {
+                let _ = stdin.write_all(prompt_owned.as_bytes()).await;
+                drop(stdin);
+            });
+        }
+    }
+
+    await_cli_with_cancel(child, cancel, engine).await
+}
+
+/// Call an OpenAI-compatible HTTP chat completions endpoint (LMStudio default,
+/// or Ollama which also exposes /v1/chat/completions).
+async fn call_openai_compat(
+    prompt: &str,
+    model: &str,
+    endpoint: &str,   // e.g. http://localhost:1234/v1
+    cancel: &AtomicBool,
+) -> Result<String, String> {
+    let base = endpoint.trim_end_matches('/');
+    let url = format!("{}/chat/completions", base);
+
+    let body = serde_json::json!({
+        "model": model,
+        "messages": [{ "role": "user", "content": prompt }],
+        "temperature": 0.2,
+        "stream": false,
+    });
+
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(120))
+        .build()
+        .map_err(|e| format!("HTTP 클라이언트 오류: {e}"))?;
+
+    // Spawn HTTP call in a task so we can poll cancel flag.
+    let url_c = url.clone();
+    let (tx, mut rx) = tokio::sync::oneshot::channel::<Result<String, String>>();
+    tokio::spawn(async move {
+        let res = async {
+            let resp = client.post(&url_c).json(&body).send().await
+                .map_err(|e| format!("요청 실패: {e}"))?;
+            if !resp.status().is_success() {
+                return Err(format!("HTTP {}", resp.status()));
+            }
+            let v: serde_json::Value = resp.json().await.map_err(|e| format!("응답 파싱 실패: {e}"))?;
+            v.get("choices").and_then(|c| c.get(0)).and_then(|c| c.get("message"))
+                .and_then(|m| m.get("content")).and_then(|s| s.as_str())
+                .map(|s| s.to_string())
+                .ok_or_else(|| "choices[0].message.content 필드 누락".into())
+        }.await;
+        let _ = tx.send(res);
+    });
+
+    let poll = tokio::time::Duration::from_millis(300);
+    loop {
+        tokio::time::sleep(poll).await;
+        if is_cancelled(cancel) { return Err("cancelled".into()); }
+        match rx.try_recv() {
+            Ok(Ok(text)) => return Ok(text),
+            Ok(Err(e)) => return Err(e),
+            Err(tokio::sync::oneshot::error::TryRecvError::Empty) => continue,
+            Err(_) => return Err("HTTP 채널 오류".into()),
+        }
+    }
+}
+
+/// Ollama-specific native endpoint (non-OpenAI-compat) /api/chat.
+async fn call_ollama(
+    prompt: &str,
+    model: &str,
+    endpoint: &str,   // e.g. http://localhost:11434
+    cancel: &AtomicBool,
+) -> Result<String, String> {
+    let base = endpoint.trim_end_matches('/');
+    let url = format!("{}/api/chat", base);
+
+    let body = serde_json::json!({
+        "model": model,
+        "messages": [{ "role": "user", "content": prompt }],
+        "stream": false,
+    });
+
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(180))
+        .build()
+        .map_err(|e| format!("HTTP 클라이언트 오류: {e}"))?;
+
+    let url_c = url.clone();
+    let (tx, mut rx) = tokio::sync::oneshot::channel::<Result<String, String>>();
+    tokio::spawn(async move {
+        let res = async {
+            let resp = client.post(&url_c).json(&body).send().await
+                .map_err(|e| format!("요청 실패: {e}"))?;
+            if !resp.status().is_success() {
+                return Err(format!("HTTP {}", resp.status()));
+            }
+            let v: serde_json::Value = resp.json().await.map_err(|e| format!("응답 파싱 실패: {e}"))?;
+            v.get("message").and_then(|m| m.get("content")).and_then(|s| s.as_str())
+                .map(|s| s.to_string())
+                .ok_or_else(|| "message.content 필드 누락".into())
+        }.await;
+        let _ = tx.send(res);
+    });
+
+    let poll = tokio::time::Duration::from_millis(300);
+    loop {
+        tokio::time::sleep(poll).await;
+        if is_cancelled(cancel) { return Err("cancelled".into()); }
+        match rx.try_recv() {
+            Ok(Ok(text)) => return Ok(text),
+            Ok(Err(e)) => return Err(e),
+            Err(tokio::sync::oneshot::error::TryRecvError::Empty) => continue,
+            Err(_) => return Err("HTTP 채널 오류".into()),
+        }
+    }
+}
+
+/// Top-level dispatcher: pick CLI vs HTTP path by engine name.
+async fn call_agent(
+    engine: &str,
+    model: Option<&str>,
+    endpoint: Option<&str>,
+    prompt: &str,
+    cancel: &AtomicBool,
+) -> Result<(String, String), String> {
+    let text = match engine {
+        "claude" | "codex" | "gemini" => {
+            call_cli_agent(engine, engine, prompt, model, cancel).await?
+        }
+        "ollama" => {
+            let ep = endpoint.unwrap_or("http://localhost:11434");
+            let m = model.ok_or("Ollama 모델이 지정되지 않았습니다")?;
+            call_ollama(prompt, m, ep, cancel).await?
+        }
+        "lmstudio" => {
+            let ep = endpoint.unwrap_or("http://localhost:1234/v1");
+            let m = model.ok_or("LM Studio 모델이 지정되지 않았습니다")?;
+            call_openai_compat(prompt, m, ep, cancel).await?
+        }
+        other => return Err(format!("지원하지 않는 엔진: {other}")),
+    };
+    parse_output(&text)
 }
 
 // ─── Tauri commands ──────────────────────────────────────────────────────────
@@ -259,10 +435,14 @@ async fn call_claude(prompt: &str, cancel: &AtomicBool) -> Result<(String, Strin
 pub async fn analyze_project_for_onboarding(
     project_path: String,
     project_name: String,
+    engine: Option<String>,            // default "claude" for backward compat
+    model: Option<String>,
+    endpoint: Option<String>,          // for ollama/lmstudio
     app: AppHandle,
 ) -> Result<(), String> {
     let cancel = Arc::new(AtomicBool::new(false));
     set_cancel_flag(cancel.clone());
+    let engine = engine.unwrap_or_else(|| "claude".into());
 
     let emit_step = |step: u8, label: &str, done: bool| {
         app.emit("project:onboarding:step", OnboardingStepPayload {
@@ -295,7 +475,15 @@ pub async fn analyze_project_for_onboarding(
 
     let prompt = build_prompt(&project_name, &project_path, &docs_files, &existing_claude_md);
 
-    match call_claude(&prompt, &cancel).await {
+    let agent_result = call_agent(
+        &engine,
+        model.as_deref(),
+        endpoint.as_deref(),
+        &prompt,
+        &cancel,
+    ).await;
+
+    match agent_result {
         Ok((claude_md, ref_index)) => {
             if is_cancelled(&cancel) { clear_cancel_flag(); return Ok(()); }
             emit_step(3, "분석 완료", true);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -254,6 +254,7 @@ pub fn run() {
             commands::project_tools::ensure_rawq_index,
             commands::project_tools::ensure_project_workflow_templates,
             commands::projects::refresh_project_stack_info,
+            commands::agent_detect::detect_available_agents,
             commands::project_onboarding::analyze_project_for_onboarding,
             commands::project_onboarding::cancel_project_onboarding,
             commands::project_onboarding::apply_project_onboarding,

--- a/src/components/tunaflow/MetaAgentSelector.tsx
+++ b/src/components/tunaflow/MetaAgentSelector.tsx
@@ -1,0 +1,329 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { CheckCircle2, Loader2, AlertTriangle, ChevronDown, ExternalLink } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+interface AgentDetection {
+  engine: string;                  // claude / codex / gemini / ollama / lmstudio
+  kind: "cli" | "http";
+  installed: boolean;
+  version?: string | null;
+  path?: string | null;
+  endpoint?: string | null;
+  models: string[];
+  note?: string | null;
+}
+
+interface SelectedConfig {
+  engine: string;
+  model: string;
+  endpoint?: string;
+}
+
+interface Props {
+  onProceed: (config: SelectedConfig) => void;
+  onSkip: () => void;
+  projectName: string;
+}
+
+// ─── Engine metadata (for display) ───────────────────────────────────────────
+
+const ENGINE_META: Record<string, {
+  label: string;
+  installHint: string;
+  docLink?: string;
+  defaultEndpoint?: string;
+}> = {
+  claude:   { label: "Claude",    installHint: "npm install -g @anthropic-ai/claude-code", docLink: "https://docs.claude.com/en/docs/claude-code" },
+  codex:    { label: "Codex",     installHint: "npm install -g @openai/codex-cli",        docLink: "https://openai.com/index/codex" },
+  gemini:   { label: "Gemini",    installHint: "npm install -g @google/gemini-cli",        docLink: "https://ai.google.dev/gemini-api/docs/cli" },
+  ollama:   { label: "Ollama",    installHint: "https://ollama.com/download 에서 설치 후 `ollama serve`", defaultEndpoint: "http://localhost:11434" },
+  lmstudio: { label: "LM Studio", installHint: "https://lmstudio.ai 에서 설치 후 Local Server 시작", defaultEndpoint: "http://localhost:1234/v1" },
+};
+
+// Default model candidates for CLI engines (no live enumeration).
+const CLI_DEFAULT_MODELS: Record<string, string[]> = {
+  claude: ["claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5"],
+  codex:  ["gpt-5-codex", "gpt-4o-codex"],
+  gemini: ["gemini-2.5-pro", "gemini-2.5-flash"],
+};
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export function MetaAgentSelector({ onProceed, onSkip, projectName }: Props) {
+  const [detections, setDetections] = useState<AgentDetection[] | null>(null);
+  const [ollamaEndpoint, setOllamaEndpoint] = useState("http://localhost:11434");
+  const [lmstudioEndpoint, setLmstudioEndpoint] = useState("http://localhost:1234/v1");
+
+  const [selectedEngine, setSelectedEngine] = useState<string | null>(null);
+  const [modelByEngine, setModelByEngine] = useState<Record<string, string>>({});
+
+  const [skipConfirm, setSkipConfirm] = useState(false);
+  const debounceRef = useRef<number | null>(null);
+
+  // Initial + on-endpoint-change detection
+  const runDetect = async (oEp: string, lEp: string) => {
+    setDetections(null);
+    try {
+      const result = await invoke<AgentDetection[]>("detect_available_agents", {
+        ollamaEndpoint: oEp,
+        lmstudioEndpoint: lEp,
+      });
+      setDetections(result);
+
+      // Auto-pick a default model per engine (preserve existing choice if still valid)
+      setModelByEngine((prev) => {
+        const next = { ...prev };
+        for (const d of result) {
+          if (!next[d.engine]) {
+            const list = d.models.length > 0 ? d.models : (CLI_DEFAULT_MODELS[d.engine] ?? []);
+            if (list.length > 0) next[d.engine] = list[0];
+          }
+        }
+        return next;
+      });
+    } catch (e) {
+      console.error("[agent-detect]", e);
+      setDetections([]);
+    }
+  };
+
+  useEffect(() => {
+    runDetect(ollamaEndpoint, lmstudioEndpoint);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const onEndpointChange = (engine: "ollama" | "lmstudio", value: string) => {
+    if (engine === "ollama") setOllamaEndpoint(value);
+    else setLmstudioEndpoint(value);
+
+    if (debounceRef.current) window.clearTimeout(debounceRef.current);
+    debounceRef.current = window.setTimeout(() => {
+      const o = engine === "ollama" ? value : ollamaEndpoint;
+      const l = engine === "lmstudio" ? value : lmstudioEndpoint;
+      runDetect(o, l);
+    }, 600);
+  };
+
+  const canProceed = useMemo(() => {
+    if (!selectedEngine) return false;
+    const model = modelByEngine[selectedEngine];
+    if (!model) return false;
+    const det = detections?.find((d) => d.engine === selectedEngine);
+    if (!det) return false;
+    if (det.kind === "cli") return det.installed;
+    // http: require installed (endpoint reachable) AND at least one model
+    return det.installed && det.models.length > 0;
+  }, [selectedEngine, modelByEngine, detections]);
+
+  const handleProceed = () => {
+    if (!canProceed || !selectedEngine) return;
+    const det = detections!.find((d) => d.engine === selectedEngine)!;
+    const endpoint = det.kind === "http"
+      ? (selectedEngine === "ollama" ? ollamaEndpoint : lmstudioEndpoint)
+      : undefined;
+    onProceed({
+      engine: selectedEngine,
+      model: modelByEngine[selectedEngine],
+      endpoint,
+    });
+  };
+
+  return (
+    <>
+      <div className="px-6 pt-5 pb-4 border-b border-border">
+        <h2 className="text-sm font-semibold text-foreground">메타 에이전트 선택</h2>
+        <p className="text-[11px] text-muted-foreground mt-0.5">
+          <span className="font-mono">{projectName}</span> 프로젝트 탐색과 기본 문서 생성에 사용할 에이전트를 선택하세요.
+        </p>
+      </div>
+
+      <div className="flex-1 overflow-y-auto min-h-0 px-6 py-4 space-y-3">
+        {detections === null && (
+          <div className="flex items-center gap-2 text-[11px] text-muted-foreground py-4">
+            <Loader2 className="w-3.5 h-3.5 animate-spin" />
+            사용 가능한 에이전트 감지 중...
+          </div>
+        )}
+
+        {detections !== null && detections.map((d) => {
+          const meta = ENGINE_META[d.engine];
+          const modelList = d.models.length > 0 ? d.models : (CLI_DEFAULT_MODELS[d.engine] ?? []);
+          const isSelected = selectedEngine === d.engine;
+          const selectable = d.installed && modelList.length > 0;
+
+          return (
+            <div
+              key={d.engine}
+              className={cn(
+                "rounded-lg border p-3 transition-colors",
+                isSelected ? "border-primary bg-primary/5" : "border-border hover:border-border/80",
+                !selectable && "opacity-60"
+              )}
+            >
+              <label className="flex items-start gap-3 cursor-pointer">
+                <input
+                  type="radio"
+                  name="meta-agent"
+                  checked={isSelected}
+                  disabled={!selectable}
+                  onChange={() => setSelectedEngine(d.engine)}
+                  className="mt-1 accent-primary"
+                />
+                <div className="flex-1 min-w-0 space-y-1.5">
+                  <div className="flex items-center gap-2">
+                    <span className="text-[12px] font-semibold text-foreground">{meta?.label ?? d.engine}</span>
+                    {d.installed ? (
+                      <span className="inline-flex items-center gap-1 text-[9px] px-1.5 py-0.5 rounded bg-green-500/10 text-green-500 font-medium">
+                        <CheckCircle2 className="w-2.5 h-2.5" /> detected
+                      </span>
+                    ) : (
+                      <span className="inline-flex items-center gap-1 text-[9px] px-1.5 py-0.5 rounded bg-muted/40 text-muted-foreground/70 font-medium">
+                        <AlertTriangle className="w-2.5 h-2.5" /> not found
+                      </span>
+                    )}
+                    {d.version && <span className="text-[9px] text-muted-foreground/60 font-mono">{d.version}</span>}
+                  </div>
+
+                  {/* CLI details */}
+                  {d.kind === "cli" && d.path && (
+                    <div className="text-[10px] text-muted-foreground/70 font-mono truncate">{d.path}</div>
+                  )}
+
+                  {/* HTTP endpoint editor */}
+                  {d.kind === "http" && (
+                    <div className="flex items-center gap-2">
+                      <span className="text-[10px] text-muted-foreground/60 shrink-0">Endpoint</span>
+                      <input
+                        type="text"
+                        value={d.engine === "ollama" ? ollamaEndpoint : lmstudioEndpoint}
+                        onChange={(e) => onEndpointChange(d.engine as "ollama" | "lmstudio", e.target.value)}
+                        className="flex-1 text-[10px] font-mono bg-background border border-border/60 rounded px-2 py-1 focus:outline-none focus:border-primary/60"
+                      />
+                    </div>
+                  )}
+
+                  {/* Model selector */}
+                  {selectable && modelList.length > 0 && (
+                    <div className="flex items-center gap-2">
+                      <span className="text-[10px] text-muted-foreground/60 shrink-0">Model</span>
+                      <div className="relative flex-1">
+                        <select
+                          value={modelByEngine[d.engine] ?? modelList[0]}
+                          onChange={(e) => setModelByEngine((prev) => ({ ...prev, [d.engine]: e.target.value }))}
+                          onClick={() => { if (selectable) setSelectedEngine(d.engine); }}
+                          className="w-full text-[10px] font-mono bg-background border border-border/60 rounded px-2 py-1 pr-6 appearance-none focus:outline-none focus:border-primary/60"
+                        >
+                          {modelList.map((m) => (<option key={m} value={m}>{m}</option>))}
+                        </select>
+                        <ChevronDown className="w-3 h-3 text-muted-foreground/50 absolute right-1.5 top-1/2 -translate-y-1/2 pointer-events-none" />
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Install hint when not found */}
+                  {!d.installed && meta?.installHint && (
+                    <div className="text-[10px] text-muted-foreground/70 mt-1 space-y-0.5">
+                      <div>설치: <span className="font-mono text-muted-foreground">{meta.installHint}</span></div>
+                      {meta.docLink && (
+                        <a
+                          href={meta.docLink}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="inline-flex items-center gap-1 text-primary/70 hover:text-primary"
+                        >
+                          <ExternalLink className="w-2.5 h-2.5" />
+                          설치 안내 보기
+                        </a>
+                      )}
+                    </div>
+                  )}
+
+                  {/* Failure note */}
+                  {!d.installed && d.note && d.kind === "http" && (
+                    <div className="text-[10px] text-muted-foreground/50 italic">{d.note}</div>
+                  )}
+                </div>
+              </label>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="px-6 py-4 border-t border-border flex justify-between items-center">
+        <button
+          onClick={() => setSkipConfirm(true)}
+          className="text-[11px] text-muted-foreground hover:text-foreground transition-colors"
+        >
+          건너뛰기
+        </button>
+        <button
+          onClick={handleProceed}
+          disabled={!canProceed}
+          className={cn(
+            "px-4 py-1.5 rounded-lg text-[11px] font-medium transition-colors",
+            canProceed
+              ? "bg-primary text-primary-foreground hover:bg-primary/90"
+              : "bg-muted text-muted-foreground/40 cursor-not-allowed"
+          )}
+        >
+          확인 (진행)
+        </button>
+      </div>
+
+      {skipConfirm && (
+        <SkipWithBasicOverlay
+          onBack={() => setSkipConfirm(false)}
+          onConfirm={onSkip}
+        />
+      )}
+    </>
+  );
+}
+
+// ─── Skip-with-basic-scaffold confirmation ───────────────────────────────────
+
+function SkipWithBasicOverlay({ onBack, onConfirm }: { onBack: () => void; onConfirm: () => void }) {
+  return (
+    <div className="absolute inset-0 z-20 flex items-center justify-center bg-background/80 backdrop-blur-sm rounded-xl">
+      <div className="w-[400px] bg-background border border-border rounded-lg shadow-xl p-5 space-y-4">
+        <h3 className="text-sm font-semibold text-foreground">메타에이전트 없이 진행</h3>
+
+        <div className="space-y-3 text-[11px] text-muted-foreground leading-relaxed">
+          <div>
+            <p className="text-foreground/80 font-medium mb-1">메타에이전트를 쓰면:</p>
+            <ul className="space-y-1 pl-3 list-disc list-outside marker:text-primary/50">
+              <li>프로젝트 구조를 실제로 읽고 <span className="text-foreground/70">CLAUDE.md</span>를 프로젝트 맞춤형으로 작성</li>
+              <li>docs 폴더 스캔 결과를 <span className="text-foreground/70">docs/reference/index.md</span>에 요약</li>
+            </ul>
+          </div>
+          <div>
+            <p className="text-foreground/80 font-medium mb-1">건너뛰면:</p>
+            <ul className="space-y-1 pl-3 list-disc list-outside marker:text-muted-foreground/50">
+              <li><span className="font-mono text-foreground/70">기본 스캐폴딩</span>만 생성 (빈 CLAUDE.md + docs 기본 폴더)</li>
+              <li>에이전트가 프로젝트를 처음 실행할 때 직접 코드를 탐색</li>
+              <li>나중에 Settings → Project 에서 재실행 가능</li>
+            </ul>
+          </div>
+        </div>
+
+        <div className="flex justify-between pt-1">
+          <button
+            onClick={onBack}
+            className="px-3 py-1.5 rounded text-[11px] text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors"
+          >
+            돌아가기
+          </button>
+          <button
+            onClick={onConfirm}
+            className="px-3 py-1.5 rounded text-[11px] font-medium text-foreground hover:bg-accent/50 transition-colors"
+          >
+            건너뛰고 진행
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/tunaflow/ProjectOnboardingModal.tsx
+++ b/src/components/tunaflow/ProjectOnboardingModal.tsx
@@ -4,6 +4,7 @@ import { listen } from "@tauri-apps/api/event";
 import { CheckCircle2, Circle, Loader2, AlertCircle } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useChatStore } from "@/stores/chatStore";
+import { MetaAgentSelector } from "./MetaAgentSelector";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -11,10 +12,14 @@ interface StepPayload { step: number; label: string; done: boolean; }
 interface PreviewPayload { claude_md: string; ref_index: string; has_existing_claude_md: boolean; }
 interface ErrorPayload { message: string; }
 
-type ModalState = "loading" | "preview" | "cancel_confirm" | "skip_confirm" | "done";
+// Flow: agent_select → loading → preview → done
+// Overlays (cancel_confirm / skip_confirm) render on top of the host state.
+type ModalState = "agent_select" | "loading" | "preview" | "cancel_confirm" | "skip_confirm" | "done";
 type PreviewTab = "claude_md" | "ref_index";
 
 interface Step { label: string; done: boolean; active: boolean; }
+
+interface AgentConfig { engine: string; model: string; endpoint?: string; }
 
 // ─── Component ───────────────────────────────────────────────────────────────
 
@@ -22,7 +27,7 @@ export function ProjectOnboardingModal() {
   const onboardingProject = useChatStore((s) => s.onboardingProject);
   const clearOnboardingProject = useChatStore((s) => s.clearOnboardingProject);
 
-  const [modalState, setModalState] = useState<ModalState>("loading");
+  const [modalState, setModalState] = useState<ModalState>("agent_select");
   const [steps, setSteps] = useState<Step[]>([
     { label: "프로젝트 스캔 중...", done: false, active: true },
     { label: "기존 문서 분석 중...", done: false, active: false },
@@ -33,10 +38,10 @@ export function ProjectOnboardingModal() {
   const [error, setError] = useState<string | null>(null);
   const cleanupRef = useRef<(() => void)[]>([]);
 
+  // Reset to initial "agent_select" phase when a new project arrives.
   useEffect(() => {
     if (!onboardingProject) return;
-
-    setModalState("loading");
+    setModalState("agent_select");
     setSteps([
       { label: "프로젝트 스캔 중...", done: false, active: true },
       { label: "기존 문서 분석 중...", done: false, active: false },
@@ -44,39 +49,51 @@ export function ProjectOnboardingModal() {
     ]);
     setPreview(null);
     setError(null);
-
-    const setup = async () => {
-      const unlistenStep = await listen<StepPayload>("project:onboarding:step", (e) => {
-        const { step, label, done } = e.payload;
-        setSteps((prev) => prev.map((s, i) => {
-          if (i === step - 1) return { label, done, active: !done };
-          if (i === step && !done) return { ...s, active: false }; // next step not yet active
-          return s;
-        }));
-      });
-
-      const unlistenPreview = await listen<PreviewPayload>("project:onboarding:preview", (e) => {
-        setPreview(e.payload);
-        setModalState("preview");
-      });
-
-      const unlistenError = await listen<ErrorPayload>("project:onboarding:error", (e) => {
-        setError(e.payload.message);
-      });
-
-      cleanupRef.current = [unlistenStep, unlistenPreview, unlistenError];
-
-      // Start analysis
-      invoke("analyze_project_for_onboarding", {
-        projectPath: onboardingProject.path,
-        projectName: onboardingProject.name,
-      }).catch((e) => setError(String(e)));
-    };
-
-    setup();
-
-    return () => { cleanupRef.current.forEach((u) => u()); };
+    return () => { cleanupRef.current.forEach((u) => u()); cleanupRef.current = []; };
   }, [onboardingProject]);
+
+  // Kick off analysis once the user confirms a meta-agent selection.
+  const handleProceed = async (cfg: AgentConfig) => {
+    if (!onboardingProject) return;
+    setModalState("loading");
+    setError(null);
+
+    const unlistenStep = await listen<StepPayload>("project:onboarding:step", (e) => {
+      const { step, label, done } = e.payload;
+      setSteps((prev) => prev.map((s, i) => {
+        if (i === step - 1) return { label, done, active: !done };
+        if (i === step && !done) return { ...s, active: false };
+        return s;
+      }));
+    });
+
+    const unlistenPreview = await listen<PreviewPayload>("project:onboarding:preview", (e) => {
+      setPreview(e.payload);
+      setModalState("preview");
+    });
+
+    const unlistenError = await listen<ErrorPayload>("project:onboarding:error", (e) => {
+      setError(e.payload.message);
+    });
+
+    cleanupRef.current = [unlistenStep, unlistenPreview, unlistenError];
+
+    invoke("analyze_project_for_onboarding", {
+      projectPath: onboardingProject.path,
+      projectName: onboardingProject.name,
+      engine: cfg.engine,
+      model: cfg.model,
+      endpoint: cfg.endpoint,
+    }).catch((e) => setError(String(e)));
+  };
+
+  // Skip from the selector: default scaffolding (createProject) already ran,
+  // so we just dismiss the modal.
+  const handleSkipFromSelector = () => {
+    cleanupRef.current.forEach((u) => u());
+    setModalState("done");
+    clearOnboardingProject();
+  };
 
   const handleCancel = () => {
     invoke("cancel_project_onboarding").catch(() => {});
@@ -115,7 +132,16 @@ export function ProjectOnboardingModal() {
       <div className="absolute inset-0 bg-black/50" />
 
       {/* Modal */}
-      <div className="relative z-10 w-[520px] max-h-[80vh] bg-background border border-border rounded-xl shadow-2xl flex flex-col overflow-hidden">
+      <div className="relative z-10 w-[560px] max-h-[85vh] bg-background border border-border rounded-xl shadow-2xl flex flex-col overflow-hidden">
+
+        {/* ── Agent select state (initial phase) ── */}
+        {modalState === "agent_select" && (
+          <MetaAgentSelector
+            projectName={onboardingProject.name}
+            onProceed={handleProceed}
+            onSkip={handleSkipFromSelector}
+          />
+        )}
 
         {/* ── Loading state ── */}
         {(modalState === "loading" || modalState === "cancel_confirm") && (

--- a/src/lib/engineConfig.ts
+++ b/src/lib/engineConfig.ts
@@ -6,9 +6,9 @@ export interface EngineConfig {
 }
 
 export const ENGINE_CONFIGS: Record<string, EngineConfig> = {
-  claude:   { command: "start_claude_stream", engineKey: "claude-code", label: "Claude initializing...", hasChunkEvent: true },
-  codex:    { command: "start_codex_run",     engineKey: "codex",       label: "Codex starting...",      hasChunkEvent: true },
-  gemini:   { command: "start_gemini_stream", engineKey: "gemini",      label: "Gemini initializing...", hasChunkEvent: true },
-  opencode: { command: "start_opencode_run",  engineKey: "opencode",    label: "OpenCode starting...",   hasChunkEvent: false },
-  ollama:   { command: "start_openai_compat_stream", engineKey: "ollama", label: "Ollama initializing...", hasChunkEvent: true },
+  claude:   { command: "start_claude_stream",        engineKey: "claude-code", label: "Claude initializing...",   hasChunkEvent: true },
+  codex:    { command: "start_codex_run",            engineKey: "codex",       label: "Codex starting...",        hasChunkEvent: true },
+  gemini:   { command: "start_gemini_stream",        engineKey: "gemini",      label: "Gemini initializing...",   hasChunkEvent: true },
+  ollama:   { command: "start_openai_compat_stream", engineKey: "ollama",      label: "Ollama initializing...",   hasChunkEvent: true },
+  lmstudio: { command: "start_openai_compat_stream", engineKey: "lmstudio",    label: "LM Studio initializing...", hasChunkEvent: true },
 };

--- a/src/tests/streaming-flow.test.ts
+++ b/src/tests/streaming-flow.test.ts
@@ -401,8 +401,8 @@ describe("Streaming flow — sendWithEngine", () => {
     ["claude", "start_claude_stream", "claude-code"],
     ["codex", "start_codex_run", "codex"],
     ["gemini", "start_gemini_stream", "gemini"],
-    ["opencode", "start_opencode_run", "opencode"],
     ["ollama", "start_openai_compat_stream", "ollama"],
+    ["lmstudio", "start_openai_compat_stream", "lmstudio"],
   ])("routes %s to command %s with engineKey %s", async (engine, command, engineKey) => {
     vi.mocked(invoke).mockResolvedValue({ messageId: "m1" });
 


### PR DESCRIPTION
온보딩 첫 단계에 메타에이전트 선택 UI 추가. claude/codex/gemini CLI 는 `which` + `--version` 탐지, Ollama/LMStudio 는 HTTP endpoint 라이브 탐지(모델 목록까지). OpenCode 는 UI 노출에서 제거. 건너뛰기 시 2차 확인 + 기본 스캐폴딩 유지.

- `agent_detect.rs` 신규
- `project_onboarding.rs` call_agent 일반화 (CLI 3종 + Ollama native + OpenAI 호환)
- `MetaAgentSelector.tsx` 신규 (endpoint 편집, 모델 드롭다운, 활성화 조건)
- `ProjectOnboardingModal` 에 agent_select 페이즈 추가

Plan: docs/plans/metaAgentOnboardingPlan_2026-04-16.md

Tests: 232 Rust / 192 Frontend 통과.