### PR TITLE
fix: LMStudio timeout + 마커 플래시 + md 렌더 + 빌드 번호 + 엔진 드롭다운

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -321,6 +321,25 @@ else
   run npm run tauri build
 fi
 
+# ─── 5b. Stamp build number into .app Info.plist ───────────────────────────
+
+# Persistent build counter, incremented every successful build. CFBundleVersion
+# in macOS bundles accepts any numeric string, so we tack it onto the release
+# version ("0.1.0" → "0.1.0.<N>"). CFBundleShortVersionString stays clean.
+BUILD_COUNTER_FILE="$ROOT_DIR/scripts/.build-number"
+if [[ -f "$ROOT_DIR/src-tauri/target/release/bundle/macos/tunaFlow.app/Contents/Info.plist" ]]; then
+  step "5b/6  Stamp build number"
+  BN=$(cat "$BUILD_COUNTER_FILE" 2>/dev/null || echo 0)
+  BN=$((BN + 1))
+  PLIST="$ROOT_DIR/src-tauri/target/release/bundle/macos/tunaFlow.app/Contents/Info.plist"
+  SHORT=$(/usr/libexec/PlistBuddy -c "Print CFBundleShortVersionString" "$PLIST" 2>/dev/null || echo "0.1.0")
+  NEW_VER="${SHORT}.${BN}"
+  /usr/libexec/PlistBuddy -c "Set :CFBundleVersion ${NEW_VER}" "$PLIST" 2>/dev/null \
+    || /usr/libexec/PlistBuddy -c "Add :CFBundleVersion string ${NEW_VER}" "$PLIST" 2>/dev/null
+  echo "$BN" > "$BUILD_COUNTER_FILE"
+  ok "CFBundleVersion = ${NEW_VER}  (short=${SHORT}, build=#${BN})"
+fi
+
 # ─── 6. Verify output ───────────────────────────────────────────────────────
 
 step "6/6  Build output"

--- a/src-tauri/src/commands/agent_detect.rs
+++ b/src-tauri/src/commands/agent_detect.rs
@@ -10,7 +10,9 @@ use std::time::Duration;
 use tokio::process::Command;
 use tokio::time::timeout;
 
-const PROBE_TIMEOUT_MS: u64 = 1500;
+// LMStudio / Ollama 첫 응답이 모델 스캔 때문에 느릴 수 있으므로 3s 로 넉넉히.
+// CLI(`which`) 쪽은 여전히 가볍기 때문에 동일 상수로 충분.
+const PROBE_TIMEOUT_MS: u64 = 3000;
 
 #[derive(Serialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -150,18 +152,30 @@ async fn probe_lmstudio(endpoint: &str) -> AgentDetection {
         Err(e) => { det.note = Some(format!("reqwest build error: {e}")); return det; }
     };
 
+    eprintln!("[agent-detect] probe lmstudio: GET {}", url);
     match client.get(&url).send().await {
         Ok(resp) if resp.status().is_success() => {
             match resp.json::<OpenAiModelsResponse>().await {
                 Ok(body) => {
                     det.installed = true;
                     det.models = body.data.into_iter().map(|m| m.id).collect();
+                    eprintln!("[agent-detect] lmstudio ok — {} models", det.models.len());
                 }
-                Err(e) => det.note = Some(format!("parse error: {e}")),
+                Err(e) => {
+                    eprintln!("[agent-detect] lmstudio parse error: {e}");
+                    det.note = Some(format!("응답 파싱 실패: {e}"));
+                }
             }
         }
-        Ok(resp) => det.note = Some(format!("status {}", resp.status())),
-        Err(_) => det.note = Some("not reachable".into()),
+        Ok(resp) => {
+            let status = resp.status();
+            eprintln!("[agent-detect] lmstudio status {}", status);
+            det.note = Some(format!("HTTP {status}"));
+        }
+        Err(e) => {
+            eprintln!("[agent-detect] lmstudio unreachable: {e}");
+            det.note = Some(if e.is_timeout() { "timeout".into() } else { "not reachable".into() });
+        }
     }
     det
 }

--- a/src/components/tunaflow/MessageItem.tsx
+++ b/src/components/tunaflow/MessageItem.tsx
@@ -29,9 +29,30 @@ function hasMarkdownSignal(content: string): boolean {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const REMARK_PLUGINS: any[] = [[remarkGfm, { singleTilde: false }]];
 
+/**
+ * Hide partially-arrived HTML comments during streaming so the raw
+ * `<!-- tunaflow:... -->` marker text does not flash on screen before the
+ * closing `-->` token arrives and react-markdown collapses it out.
+ * Only applied while isStreaming=true; the final render goes through
+ * the normal pipeline (PlanProposalCard / vizMarkers).
+ */
+function hideTrailingIncompleteComment(text: string): string {
+  const lastOpen = text.lastIndexOf("<!--");
+  const lastClose = text.lastIndexOf("-->");
+  if (lastOpen > lastClose) {
+    // There is an unclosed comment at the tail; trim it so it never renders.
+    return text.slice(0, lastOpen);
+  }
+  return text;
+}
+
 function MarkdownBody({ content, className, conversationId, isStreaming, isUser }: { content: string; className?: string; conversationId?: string; isStreaming?: boolean; isUser?: boolean }) {
-  // Skip expensive marker processing during streaming — apply only on final render
-  const processed = useMemo(() => isStreaming ? content : vizMarkers(content), [content, isStreaming]);
+  // Skip expensive marker processing during streaming — apply only on final render.
+  // Also suppress in-flight HTML-comment markers so they don't flash as plain text.
+  const processed = useMemo(() => {
+    if (!isStreaming) return vizMarkers(content);
+    return hideTrailingIncompleteComment(content);
+  }, [content, isStreaming]);
   // Plan proposal markers are only valid in assistant messages — never parse user messages
   // (user feedback text may quote marker strings which would falsely trigger PlanProposalCard)
   const segments = useMemo(

--- a/src/components/tunaflow/ProjectOnboardingModal.tsx
+++ b/src/components/tunaflow/ProjectOnboardingModal.tsx
@@ -2,9 +2,15 @@ import { useEffect, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { CheckCircle2, Circle, Loader2, AlertCircle } from "lucide-react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 import { cn } from "@/lib/utils";
 import { useChatStore } from "@/stores/chatStore";
 import { MetaAgentSelector } from "./MetaAgentSelector";
+import { markdownComponents } from "./chat/MarkdownComponents";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const REMARK_PLUGINS: any[] = [[remarkGfm, { singleTilde: false }]];
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -252,11 +258,14 @@ export function ProjectOnboardingModal() {
               ))}
             </div>
 
-            {/* Content */}
+            {/* Content — render as Markdown so the preview matches how the
+                 file will actually look in the editor / Docs viewer. */}
             <div className="flex-1 overflow-y-auto min-h-0">
-              <pre className="px-6 py-4 text-[10px] leading-relaxed text-foreground/80 whitespace-pre-wrap font-mono">
-                {activeTab === "claude_md" ? preview.claude_md : preview.ref_index}
-              </pre>
+              <div className="prose prose-invert prose-chat prose-sm max-w-none px-6 py-4 text-[12px] leading-relaxed [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
+                <ReactMarkdown remarkPlugins={REMARK_PLUGINS} components={markdownComponents}>
+                  {activeTab === "claude_md" ? preview.claude_md : preview.ref_index}
+                </ReactMarkdown>
+              </div>
             </div>
 
             <div className="px-6 py-4 border-t border-border">

--- a/src/components/tunaflow/settings/AgentsSection.tsx
+++ b/src/components/tunaflow/settings/AgentsSection.tsx
@@ -6,7 +6,16 @@ import { DEFAULT_PERSONAS } from "@/lib/defaultPersonas";
 import { AgentAvatar } from "../AgentAvatar";
 import type { AgentProfile } from "@/types";
 
-const ENGINES = ["claude", "codex", "gemini", "opencode", "ollama"] as const;
+// Keep in sync with ENGINE_CONFIGS (src/lib/engineConfig.ts). OpenCode removed;
+// Ollama + LMStudio share the openai-compatible runtime.
+const ENGINES = ["claude", "codex", "gemini", "ollama", "lmstudio"] as const;
+const ENGINE_LABELS: Record<(typeof ENGINES)[number], string> = {
+  claude: "Claude",
+  codex: "Codex",
+  gemini: "Gemini",
+  ollama: "Ollama",
+  lmstudio: "LM Studio",
+};
 
 export function AgentsSection() {
   const profiles = useChatStore((s) => s.agentProfiles);
@@ -86,24 +95,26 @@ export function AgentsSection() {
 
             <div>
               <label className="text-tf-sm text-muted-foreground mb-1 block">Engine</label>
-              <div className="flex gap-1.5">
-                {ENGINES.map((eng) => (
-                  <button key={eng}
-                    onClick={() => {
-                      if (!selectedId) return;
-                      // Find recommended model for the new engine
-                      const recommendedModel = engineModels.find((m) => m.engine === eng && m.recommended)?.id
-                        ?? engineModels.find((m) => m.engine === eng)?.id;
-                      save(profiles.map((p) => p.id === selectedId ? { ...p, engine: eng, model: recommendedModel } : p));
-                    }}
-                    className={cn(
-                      "flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-tf-caption font-medium transition-colors border",
-                      selected.engine === eng ? "border-primary/40 bg-primary/8 text-foreground" : "border-border/20 text-muted-foreground hover:border-border/40"
-                    )}>
-                    <AgentAvatar engine={eng} size="xs" />
-                    {eng}
-                  </button>
-                ))}
+              {/* Dropdown instead of icon row — more obvious what is selected
+                   when 5+ engines share the strip. AgentAvatar next to the
+                   select mirrors the active engine. */}
+              <div className="flex items-center gap-2">
+                <AgentAvatar engine={selected.engine} size="sm" />
+                <select
+                  value={selected.engine}
+                  onChange={(e) => {
+                    if (!selectedId) return;
+                    const eng = e.target.value as (typeof ENGINES)[number];
+                    const recommendedModel = engineModels.find((m) => m.engine === eng && m.recommended)?.id
+                      ?? engineModels.find((m) => m.engine === eng)?.id;
+                    save(profiles.map((p) => p.id === selectedId ? { ...p, engine: eng, model: recommendedModel } : p));
+                  }}
+                  className="flex-1 bg-background rounded-lg px-3 py-2 text-tf-caption outline-none border border-border/30 focus:border-ring/40 cursor-pointer"
+                >
+                  {ENGINES.map((eng) => (
+                    <option key={eng} value={eng}>{ENGINE_LABELS[eng]}</option>
+                  ))}
+                </select>
               </div>
             </div>
 

--- a/src/components/tunaflow/settings/RuntimeSection.tsx
+++ b/src/components/tunaflow/settings/RuntimeSection.tsx
@@ -296,8 +296,8 @@ function InsightAgentConfig() {
             <option value="claude">Claude</option>
             <option value="codex">Codex</option>
             <option value="gemini">Gemini</option>
-            <option value="opencode">OpenCode</option>
             <option value="ollama">Ollama</option>
+            <option value="lmstudio">LM Studio</option>
           </select>
         </div>
         <div className="space-y-1 flex-1">


### PR DESCRIPTION
5 건 작은 개선 묶음. RT 고도화 sprint 전 잔이슈 정리.

- LMStudio probe 3s timeout + 디버그 로그
- 스트리밍 중 미완성 HTML 주석 숨김 (I3)
- 온보딩 preview 가 markdown 렌더
- build.sh CFBundleVersion 자동 증가 (scripts/.build-number)
- Settings 엔진 드롭다운, opencode→lmstudio

192/192 + 232/232 통과.