### PR TITLE
fix(engine): lmstudio 아이콘 매핑 + opencode 프론트엔드 제거

### DIFF
--- a/src/components/tunaflow/AgentAvatar.tsx
+++ b/src/components/tunaflow/AgentAvatar.tsx
@@ -6,7 +6,11 @@ const ENGINE_ICONS: Record<string, string> = {
   claude: "/_resource/claude.png",
   codex: "/_resource/gpt.png",
   gemini: "/_resource/gemini.png",
-  opencode: "/_resource/opencode.png",
+};
+
+const ENGINE_INITIALS: Record<string, string> = {
+  ollama: "O",
+  lmstudio: "L",
 };
 
 interface AgentAvatarProps {
@@ -38,6 +42,15 @@ export function AgentAvatar({ engine, isUser, size = "md", className }: AgentAva
         needsBg ? "bg-white" : "", className)}>
         <img src={iconSrc} alt={normalized ?? "agent"}
           className={cn(needsBg ? "w-[70%] h-[70%]" : "w-full h-full", "object-contain")} />
+      </div>
+    );
+  }
+
+  const initial = normalized ? ENGINE_INITIALS[normalized] : null;
+  if (initial) {
+    return (
+      <div className={cn(dim, "rounded-full bg-accent flex items-center justify-center shrink-0 text-foreground/70 text-[11px] font-semibold", className)}>
+        {initial}
       </div>
     );
   }

--- a/src/components/tunaflow/BranchThreadPanel.tsx
+++ b/src/components/tunaflow/BranchThreadPanel.tsx
@@ -416,7 +416,7 @@ function PlanRevisionActions({ plan, threadMessages, threadBranchConvId }: {
   if (mode === "select") return (
     <div className="flex items-center gap-1">
       <select value={engine} onChange={(e) => setEngine(e.target.value)} className="text-[9px] bg-input border border-border rounded px-1 py-0.5 outline-none">
-        {["claude", "codex", "gemini", "opencode", "ollama"].map((e) => <option key={e} value={e}>{e}</option>)}
+        {["claude", "codex", "gemini", "ollama", "lmstudio"].map((e) => <option key={e} value={e}>{e}</option>)}
       </select>
       <button
         onClick={async () => {

--- a/src/components/tunaflow/context-panel/TraceSpanCard.tsx
+++ b/src/components/tunaflow/context-panel/TraceSpanCard.tsx
@@ -33,7 +33,7 @@ export function formatDuration(ms: number | null): string {
 
 export function formatCost(usd: number, engine?: string | null): string {
   if (usd === 0) {
-    if (engine === "gemini" || engine === "opencode") return "N/A";
+    if (engine === "gemini" || engine === "ollama" || engine === "lmstudio") return "N/A";
     return "$0";
   }
   if (usd < 0.01) return `$${usd.toFixed(4)}`;
@@ -41,7 +41,7 @@ export function formatCost(usd: number, engine?: string | null): string {
 }
 
 export function formatTokens(tokens: number, engine?: string | null): string {
-  if (tokens === 0 && engine === "opencode") return "N/A";
+  if (tokens === 0 && (engine === "ollama" || engine === "lmstudio")) return "N/A";
   return tokens.toLocaleString();
 }
 

--- a/src/components/tunaflow/context-panel/plans/constants.ts
+++ b/src/components/tunaflow/context-panel/plans/constants.ts
@@ -25,7 +25,7 @@ export const PLAN_PHASE_CFG: Record<PlanPhase, { label: string; cls: string }> =
   rework:          { label: "rework",     cls: "text-status-rejected bg-status-rejected/10 border-status-rejected/20" },
 };
 
-export const OWNER_OPTIONS = ["claude", "codex", "gemini", "opencode", "ollama"];
+export const OWNER_OPTIONS = ["claude", "codex", "gemini", "ollama", "lmstudio"];
 
 export const INPUT_CLS =
   "w-full bg-input rounded-md px-2.5 py-1.5 text-xs outline-none text-foreground " +

--- a/src/components/tunaflow/input/EngineSelector.tsx
+++ b/src/components/tunaflow/input/EngineSelector.tsx
@@ -2,14 +2,14 @@ import { useRef, useEffect, useState } from "react";
 import { cn } from "@/lib/utils";
 import { ChevronDown } from "lucide-react";
 
-type Engine = "claude" | "codex" | "gemini" | "opencode" | "ollama";
+type Engine = "claude" | "codex" | "gemini" | "ollama" | "lmstudio";
 
 const ENGINE_LIST: { id: Engine; label: string; color: string }[] = [
   { id: "claude", label: "Claude", color: "text-agent-claude" },
   { id: "codex", label: "Codex", color: "text-agent-codex" },
   { id: "gemini", label: "Gemini", color: "text-agent-gemini" },
-  { id: "opencode", label: "OpenCode", color: "text-agent-opencode" },
   { id: "ollama", label: "Ollama", color: "text-agent-ollama" },
+  { id: "lmstudio", label: "LM Studio", color: "text-agent-lmstudio" },
 ];
 
 interface EngineSelectorProps {

--- a/src/components/tunaflow/input/useSendActions.ts
+++ b/src/components/tunaflow/input/useSendActions.ts
@@ -51,12 +51,14 @@ const ENGINE_ALIASES: Record<string, string> = {
   "클로드": "claude", "클": "claude",
   "코덱스": "codex", "코": "codex",
   "제미나이": "gemini", "제미니": "gemini", "젬": "gemini",
-  "오픈코드": "opencode",
+  "올라마": "ollama",
+  "엘엠": "lmstudio",
   // 영어
   "claude": "claude",
   "codex": "codex",
   "gemini": "gemini",
-  "opencode": "opencode",
+  "ollama": "ollama",
+  "lmstudio": "lmstudio",
 };
 
 const GOAL_ALIASES: Record<string, string> = {

--- a/src/index.css
+++ b/src/index.css
@@ -31,6 +31,7 @@
   --agent-gemini: oklch(0.68 0.18 55);
   --agent-opencode: oklch(0.62 0.18 145);
   --agent-ollama: oklch(0.65 0.15 30);
+  --agent-lmstudio: oklch(0.60 0.16 180);
 
   --status-draft: oklch(0.65 0.15 55);
   --status-approved: oklch(0.62 0.18 145);
@@ -104,6 +105,7 @@
   --color-agent-gemini: var(--agent-gemini);
   --color-agent-opencode: var(--agent-opencode);
   --color-agent-ollama: var(--agent-ollama);
+  --color-agent-lmstudio: var(--agent-lmstudio);
   --color-status-draft: var(--status-draft);
   --color-status-approved: var(--status-approved);
   --color-status-rejected: var(--status-rejected);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,30 +5,30 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
-export type AgentEngine = "claude" | "codex" | "gemini" | "opencode" | "ollama";
+export type AgentEngine = "claude" | "codex" | "gemini" | "ollama" | "lmstudio";
 
 export const AGENT_COLORS: Record<AgentEngine, string> = {
   claude: "text-agent-claude border-agent-claude/30 bg-agent-claude/10",
   codex: "text-agent-codex border-agent-codex/30 bg-agent-codex/10",
   gemini: "text-agent-gemini border-agent-gemini/30 bg-agent-gemini/10",
-  opencode: "text-agent-opencode border-agent-opencode/30 bg-agent-opencode/10",
   ollama: "text-agent-ollama border-agent-ollama/30 bg-agent-ollama/10",
+  lmstudio: "text-agent-lmstudio border-agent-lmstudio/30 bg-agent-lmstudio/10",
 };
 
 export const AGENT_DOT_COLORS: Record<AgentEngine, string> = {
   claude: "bg-agent-claude",
   codex: "bg-agent-codex",
   gemini: "bg-agent-gemini",
-  opencode: "bg-agent-opencode",
   ollama: "bg-agent-ollama",
+  lmstudio: "bg-agent-lmstudio",
 };
 
 export const AGENT_DISPLAY_NAMES: Record<AgentEngine, string> = {
   claude: "Claude",
   codex: "Codex",
   gemini: "Gemini",
-  opencode: "OpenCode",
   ollama: "Ollama",
+  lmstudio: "LM Studio",
 };
 
 export function formatTimestamp(ts: number): string {
@@ -44,8 +44,8 @@ export function normalizeEngine(s: string | undefined): AgentEngine | null {
   if (s === "claude" || s === "claude-code") return "claude";
   if (s === "codex") return "codex";
   if (s === "gemini") return "gemini";
-  if (s === "opencode") return "opencode";
   if (s === "ollama" || s === "openai-compat") return "ollama";
+  if (s === "lmstudio") return "lmstudio";
   return null;
 }
 
@@ -70,6 +70,6 @@ export const AGENT_TEXT_COLORS: Record<AgentEngine, string> = {
   claude: "text-agent-claude",
   codex: "text-agent-codex",
   gemini: "text-agent-gemini",
-  opencode: "text-agent-opencode",
   ollama: "text-agent-ollama",
+  lmstudio: "text-agent-lmstudio",
 };

--- a/src/stores/slices/assetSlice.ts
+++ b/src/stores/slices/assetSlice.ts
@@ -19,7 +19,7 @@ const DEFAULT_PROFILES: AgentProfile[] = [
   { id: "architect-claude", label: "Architect Claude", engine: "claude", model: "claude-opus-4-6", defaultSkills: [], personaId: "persona_architect" },
   { id: "reviewer-codex", label: "Reviewer Codex", engine: "codex", defaultSkills: [], personaId: "persona_reviewer" },
   { id: "tester-gemini", label: "Tester Gemini", engine: "gemini", defaultSkills: [], personaId: "persona_tester" },
-  { id: "general-opencode", label: "General OpenCode", engine: "opencode", defaultSkills: [], personaId: "persona_implementer" },
+  { id: "general-ollama", label: "General Ollama", engine: "ollama", defaultSkills: [], personaId: "persona_implementer" },
 ];
 
 /** Per-conversation engine/profile snapshot */

--- a/src/tests/ui-regression.test.tsx
+++ b/src/tests/ui-regression.test.tsx
@@ -35,14 +35,14 @@ describe("TraceSpanCard — formatDuration", () => {
 describe("TraceSpanCard — formatCost", () => {
   it("returns $0 for zero cost", () => expect(formatCost(0)).toBe("$0"));
   it("returns N/A for gemini with zero cost", () => expect(formatCost(0, "gemini")).toBe("N/A"));
-  it("returns N/A for opencode with zero cost", () => expect(formatCost(0, "opencode")).toBe("N/A"));
+  it("returns N/A for ollama with zero cost", () => expect(formatCost(0, "ollama")).toBe("N/A"));
   it("formats small cost with 4 decimals", () => expect(formatCost(0.005)).toBe("$0.0050"));
   it("formats normal cost with 2 decimals", () => expect(formatCost(1.5)).toBe("$1.50"));
 });
 
 describe("TraceSpanCard — formatTokens", () => {
   it("formats with locale separators", () => expect(formatTokens(12345)).toBe("12,345"));
-  it("returns N/A for opencode with zero", () => expect(formatTokens(0, "opencode")).toBe("N/A"));
+  it("returns N/A for ollama with zero", () => expect(formatTokens(0, "ollama")).toBe("N/A"));
   it("formats zero for claude", () => expect(formatTokens(0, "claude")).toBe("0"));
 });
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -196,7 +196,7 @@ export interface SendWithClaudeInput {
 export interface RoundtableParticipant {
   name: string;
   model?: string;
-  /** "claude" | "codex" | "gemini" | "opencode" | "ollama" — defaults to "claude" on backend */
+  /** "claude" | "codex" | "gemini" | "ollama" | "lmstudio" — defaults to "claude" on backend */
   engine?: string;
   /** Blind verifier — receives topic only, no prior/current transcript */
   blind?: boolean;


### PR DESCRIPTION
## Summary
- `AgentEngine` 타입에 `lmstudio` 추가, `opencode` 제거
- ollama/lmstudio는 이미지 없으므로 이니셜(O/L) fallback 표시
- 프론트엔드 전역 엔진 목록에서 opencode → lmstudio 교체
- CSS `--agent-lmstudio` 토큰 추가
- Rust 백엔드 opencode 참조는 별도 PR에서 처리

## Test plan
- [x] `npx tsc --noEmit` 통과
- [x] `npx vitest run` 192 passed
- [ ] 설정 → AGENTS 탭에서 ollama/lmstudio 아이콘 정상 표시 확인
- [ ] 채팅 입력창 ProfileSelector에서 동일 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)