### PR TITLE
fix: AGENTS 초기 아이콘 + LM Studio 모델 discovery

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1483,6 +1483,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -4056,6 +4057,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -34,7 +34,7 @@ chrono = { version = "0.4.44", features = ["serde"] }
 regex = "1"
 sha2 = "0.10"
 toml = "0.8"
-reqwest = { version = "0.12", features = ["json", "stream"] }
+reqwest = { version = "0.12", features = ["json", "stream", "blocking"] }
 futures-util = "0.3"
 tokio = { version = "1.50.0", features = ["rt-multi-thread", "sync", "time", "process", "macros"] }
 parking_lot = "0.12"

--- a/src-tauri/src/commands/model_discovery.rs
+++ b/src-tauri/src/commands/model_discovery.rs
@@ -69,16 +69,13 @@ fn fallback_models(engine: &str) -> Vec<(&'static str, &'static str, bool)> {
             ("gemini-3.1-pro-preview", "Gemini 3.1 Pro (preview, 용량 미보장)", false),
             ("gemini-3.1-flash-lite-preview", "Gemini 3.1 Flash Lite (preview, 용량 미보장)", false),
         ],
-        "opencode" => vec![
-            ("anthropic:claude-sonnet-4-6", "Claude Sonnet 4.6", true),
-            ("openai:gpt-4.1", "GPT-4.1", false),
-        ],
         "ollama" => vec![
             ("qwen3:8b", "Qwen 3 8B", true),
             ("llama3.3:latest", "Llama 3.3", false),
             ("gemma3:12b", "Gemma 3 12B", false),
             ("phi-4:latest", "Phi-4", false),
         ],
+        "lmstudio" => vec![],  // LM Studio models are always discovered live
         _ => vec![],
     }
 }
@@ -184,63 +181,34 @@ fn discover_claude() -> Option<Vec<String>> {
     None
 }
 
-/// OpenCode: run `opencode models` and parse provider/model lines.
-fn discover_opencode() -> Option<Vec<String>> {
-    // Find opencode binary — same search order as agents/opencode.rs
-    let bin = {
-        let mut found: Option<std::path::PathBuf> = None;
-        #[cfg(not(target_os = "windows"))]
-        {
-            // Check ~/.opencode/bin first (official installer default)
-            if let Ok(home) = std::env::var("HOME") {
-                let c = std::path::PathBuf::from(&home).join(".opencode").join("bin").join("opencode");
-                if c.exists() { found = Some(c); }
-            }
-            if found.is_none() {
-                for prefix in &["/usr/local/bin", "/usr/bin", "/opt/homebrew/bin"] {
-                    let c = std::path::PathBuf::from(prefix).join("opencode");
-                    if c.exists() { found = Some(c); break; }
-                }
-            }
-            if found.is_none() {
-                if let Ok(home) = std::env::var("HOME") {
-                    let c = std::path::PathBuf::from(&home).join(".npm-global").join("bin").join("opencode");
-                    if c.exists() { found = Some(c); }
-                }
-            }
-        }
-        #[cfg(target_os = "windows")]
-        {
-            if let Ok(appdata) = std::env::var("APPDATA") {
-                let c = std::path::PathBuf::from(&appdata).join("npm").join("opencode.cmd");
-                if c.exists() { found = Some(c); }
-            }
-        }
-        found.unwrap_or_else(|| std::path::PathBuf::from("opencode"))
-    };
+/// LMStudio: query OpenAI-compatible `/v1/models` endpoint.
+fn discover_lmstudio() -> Option<Vec<String>> {
+    let endpoint = std::env::var("LMSTUDIO_ENDPOINT")
+        .unwrap_or_else(|_| "http://localhost:1234".into());
+    let url = format!("{}/v1/models", endpoint.trim_end_matches('/'));
 
-    let output = std::process::Command::new(&bin)
-        .arg("models")
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::null())
-        .output()
+    let client = reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(3))
+        .build()
         .ok()?;
 
-    if !output.status.success() { return None; }
+    let resp = client.get(&url).send().ok()?;
+    if !resp.status().is_success() { return None; }
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let models: Vec<String> = stdout
-        .lines()
-        .map(|l| l.trim().to_string())
-        .filter(|l| !l.is_empty() && l.contains('/'))
+    let body: serde_json::Value = resp.json().ok()?;
+    let data = body.get("data")?.as_array()?;
+    let models: Vec<String> = data.iter()
+        .filter_map(|m| m.get("id").and_then(|v| v.as_str()).map(String::from))
         .collect();
 
     if models.is_empty() { None } else { Some(models) }
 }
 
+// OpenCode discovery removed — engine dropped from active ENGINES list.
+
 // ─── Core API ───────────────────────────────────────────────────────────────
 
-const ENGINES: &[&str] = &["claude", "codex", "gemini", "opencode", "ollama"];
+const ENGINES: &[&str] = &["claude", "codex", "gemini", "ollama", "lmstudio"];
 
 fn get_models_for_engine(engine: &str, force: bool) -> (Vec<String>, String) {
     // Check cache
@@ -258,8 +226,8 @@ fn get_models_for_engine(engine: &str, force: bool) -> (Vec<String>, String) {
         "codex" => discover_codex(),
         "gemini" => discover_gemini(),
         "claude" => discover_claude(),
-        "opencode" => discover_opencode(),
         "ollama" => crate::agents::openai_compat::discover_models(),
+        "lmstudio" => discover_lmstudio(),
         _ => None,
     };
 
@@ -291,24 +259,6 @@ fn model_label(engine: &str, id: &str) -> String {
     // Check fallback registry for label
     for (fid, label, _) in fallback_models(engine) {
         if fid == id { return label.to_string(); }
-    }
-    // For opencode discovered models: "anthropic/claude-sonnet-4-6" → "Claude Sonnet 4.6 (anthropic)"
-    if engine == "opencode" && id.contains('/') {
-        let parts: Vec<&str> = id.splitn(2, '/').collect();
-        let provider = parts[0];
-        let model = parts[1];
-        // Title-case the model name: replace hyphens with spaces, capitalize words
-        let pretty: String = model.split('-')
-            .map(|w| {
-                let mut c = w.chars();
-                match c.next() {
-                    None => String::new(),
-                    Some(f) => f.to_uppercase().collect::<String>() + c.as_str(),
-                }
-            })
-            .collect::<Vec<_>>()
-            .join(" ");
-        return format!("{} ({})", pretty, provider);
     }
     id.to_string()
 }

--- a/src/components/tunaflow/settings/AgentsSection.tsx
+++ b/src/components/tunaflow/settings/AgentsSection.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { cn } from "@/lib/utils";
 import { Plus, Trash2 } from "lucide-react";
 import { useChatStore } from "@/stores/chatStore";
@@ -21,6 +21,10 @@ export function AgentsSection() {
   const profiles = useChatStore((s) => s.agentProfiles);
   const saveProfiles = useChatStore((s) => s.saveProfiles);
   const [selectedId, setSelectedId] = useState<string | null>(profiles[0]?.id ?? null);
+  // Sync selectedId when profiles load asynchronously
+  useEffect(() => {
+    if (!selectedId && profiles.length > 0) setSelectedId(profiles[0].id);
+  }, [profiles, selectedId]);
   const engineModels = useChatStore((s) => s.engineModels);
   const skills = useChatStore((s) => s.skills);
 


### PR DESCRIPTION
## Summary
- 설정 AGENTS 탭 첫 로딩 시 최상위 에이전트 `?` 아이콘 표시 수정 (profiles 비동기 로드 타이밍)
- LM Studio 모델 discovery 추가 (`/v1/models` HTTP API, `reqwest::blocking`)
- opencode 관련 discover/fallback/label dead code 제거

## Test plan
- [x] `cargo check` 통과 (warning 0)
- [x] `npx tsc --noEmit` 통과
- [ ] 설정 AGENTS 탭 진입 시 첫 번째 에이전트 아이콘 정상 표시 확인
- [ ] LM Studio 서버 실행 중일 때 엔진 모델 드롭다운에 모델 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)