### PR TITLE
feat: sdk-url 세션 + codex app-server + conventions sync 복구 (stash)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -308,7 +308,7 @@ dependencies = [
  "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.28.0",
  "tower",
  "tower-layer",
  "tower-service",
@@ -5707,6 +5707,18 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.24.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
@@ -5714,7 +5726,7 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite",
+ "tungstenite 0.28.0",
 ]
 
 [[package]]
@@ -5988,10 +6000,29 @@ dependencies = [
  "thiserror 1.0.69",
  "tokenizers",
  "tokio",
+ "tokio-tungstenite 0.24.0",
  "toml 0.8.2",
  "tower-http",
  "uuid",
  "zerocopy 0.7.35",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -36,6 +36,7 @@ sha2 = "0.10"
 toml = "0.8"
 reqwest = { version = "0.12", features = ["json", "stream", "blocking"] }
 futures-util = "0.3"
+tokio-tungstenite = "0.24"
 tokio = { version = "1.50.0", features = ["rt-multi-thread", "sync", "time", "process", "macros"] }
 parking_lot = "0.12"
 axum = { version = "0.8", features = ["ws"] }

--- a/src-tauri/src/agents/claude_sdk_session.rs
+++ b/src-tauri/src/agents/claude_sdk_session.rs
@@ -1,0 +1,765 @@
+//! Claude `--sdk-url` 세션 모드
+//!
+//! Desktop 앱 소스 분석으로 확인한 실제 동작 방식:
+//! - claude 자식 프로세스: `--print --sdk-url ws://... --session-id ... --replay-user-messages`
+//! - **사용자 메시지 전달: stdin write** (WS TEXT 아님)
+//! - **이벤트 수신: HTTP POST `/{session_id}/events`** (stdout 병행)
+//! - WS: 연결 인증(Bearer token) + keepalive 전용
+//!
+//! 출처: claude 바이너리 내부 JS — `writeStdin(X)` 및 `w.stdout` readline 패턴
+//!
+//! 참고: `docs/plans/sdkUrlSessionModePlan.md`
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use axum::{
+    body::Bytes,
+    extract::{Path, State, WebSocketUpgrade, ws},
+    http::{HeaderMap, StatusCode},
+    response::IntoResponse,
+    Router,
+};
+use futures_util::{SinkExt, StreamExt};
+use parking_lot::Mutex as PlMutex;
+use serde::Deserialize;
+use tokio::io::AsyncWriteExt;
+use tokio::process::Command as TokioCommand;
+use tokio::sync::{broadcast, mpsc, oneshot};
+use uuid::Uuid;
+
+use crate::agents::claude::{resolve_cwd, RunInput, RunOutput};
+use crate::errors::AppError;
+
+// ─────────────────────────────── Stream JSON types ────────────────────────────
+
+/// One JSON line from claude `--output-format stream-json` via HTTP POST events.
+#[derive(Deserialize)]
+struct SdkStreamLine {
+    #[serde(rename = "type")]
+    line_type: String,
+    message: Option<SdkAssistantMsg>,
+    result: Option<String>,
+    is_error: Option<bool>,
+    cost_usd: Option<f64>,
+    total_cost_usd: Option<f64>,
+    total_input_tokens: Option<i64>,
+    total_output_tokens: Option<i64>,
+    session_id: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct SdkAssistantMsg {
+    content: Option<Vec<SdkContentBlock>>,
+    /// 토큰 사용량 — assistant 이벤트마다 포함되며 마지막 값이 최신 누적치
+    usage: Option<SdkUsage>,
+}
+
+#[derive(Deserialize)]
+struct SdkUsage {
+    input_tokens: Option<i64>,
+    output_tokens: Option<i64>,
+}
+
+#[derive(Deserialize)]
+struct SdkContentBlock {
+    #[serde(rename = "type")]
+    block_type: String,
+    text: Option<String>,
+    thinking: Option<String>,
+    name: Option<String>,
+    input: Option<serde_json::Value>,
+}
+
+// ──────────────────────────── WS Server State ─────────────────────────────────────
+
+/// axum 핸들러에 공유되는 세션 WS 서버 상태.
+///
+/// WS는 인증(Bearer) + keepalive + **tunaFlow→claude 제어 메시지** 전송 경로.
+/// 사용자 메시지는 stdin으로 전달하고, 이벤트는 HTTP POST로 수신.
+/// 모델 변경은 control_request(set_model)을 WS로 전송한다 (재스폰 없음).
+#[derive(Clone)]
+struct WsServerState {
+    auth_token: String,
+    /// claude → tunaFlow 브로드캐스트 (HTTP POST 이벤트 수신)
+    from_claude_tx: broadcast::Sender<String>,
+    /// claude가 WS 연결 시 신호 (1회만 사용)
+    connected_tx: Arc<tokio::sync::Mutex<Option<oneshot::Sender<()>>>>,
+    /// tunaFlow → claude WS 전송 채널 (control_request 등)
+    ws_send_rx: Arc<tokio::sync::Mutex<mpsc::UnboundedReceiver<String>>>,
+}
+
+// ──────────────────────────── Session Handle ──────────────────────────────────
+
+/// 하나의 conversation에 대한 활성 claude SDK 세션.
+pub struct SdkSession {
+    /// 세션 식별자 — 매 spawn마다 새로 생성됨. ContextPack freshness 판정에 사용.
+    pub session_id: String,
+    /// 사용자 메시지를 claude stdin으로 전송하는 채널
+    pub to_claude_tx: mpsc::UnboundedSender<String>,
+    /// claude 이벤트 브로드캐스트 채널
+    pub from_claude_tx: broadcast::Sender<String>,
+    /// 현재 세션의 모델 (모델 변경 가능 — 내부 가변성)
+    pub model: Arc<PlMutex<String>>,
+    /// tunaFlow→claude WS 제어 메시지 전송 채널 (set_model control_request 등)
+    pub ws_sender_tx: mpsc::UnboundedSender<String>,
+    /// claude child process가 살아있는지. monitor task가 child.wait() 후 false로 set.
+    /// stream_run_sdk가 이 값을 polling/select하여 죽었으면 즉시 에러로 끊는다.
+    /// (broadcast 채널은 SdkSession이 sender를 보유한 한 close되지 않으므로 별도 신호 필요.)
+    pub process_alive: Arc<AtomicBool>,
+    /// WS 서버 종료 신호 (Drop 시 자동 전송)
+    _shutdown_tx: oneshot::Sender<()>,
+    /// claude 자식 프로세스 모니터 태스크 핸들
+    /// Drop 시 abort() 호출 → 태스크 취소 → child drop → kill_on_drop으로 프로세스 종료
+    _monitor_abort: tokio::task::AbortHandle,
+}
+
+impl Drop for SdkSession {
+    fn drop(&mut self) {
+        // 세션이 제거될 때 모니터 태스크를 명시적으로 취소해 child 프로세스를 즉시 종료한다.
+        self._monitor_abort.abort();
+    }
+}
+
+// ──────────────────────────── Session Registry ────────────────────────────────
+
+type SessionRegistry = Arc<PlMutex<HashMap<String, Arc<SdkSession>>>>;
+/// conversation_id → 마지막 result session_id (세션 종료 후에도 --resume용으로 보존)
+type ResumeRegistry = Arc<PlMutex<HashMap<String, String>>>;
+
+lazy_static::lazy_static! {
+    static ref SESSIONS: SessionRegistry = Arc::new(PlMutex::new(HashMap::new()));
+    static ref RESUME_IDS: ResumeRegistry = Arc::new(PlMutex::new(HashMap::new()));
+}
+
+/// conversation_id에 대한 세션을 반환하거나 새로 생성한다.
+///
+/// 모델이 변경된 경우 **프로세스를 재스폰하지 않고** WS로 `control_request(set_model)`을
+/// 전송해 claude 내부 모델만 교체한다 (Claude Desktop/Claude Code 동일 방식).
+pub async fn get_or_create_session(
+    conv_id: &str,
+    project_path: Option<&str>,
+    model: Option<&str>,
+) -> Result<Arc<SdkSession>, AppError> {
+    let effective_model = match model {
+        Some(m) if !m.is_empty() => m,
+        _ => "claude-sonnet-4-6",
+    };
+
+    // 기존 세션 확인 (sync lock, await 없음)
+    let existing = {
+        let sessions = SESSIONS.lock();
+        sessions.get(conv_id).map(|s| Arc::clone(s))
+    };
+
+    if let Some(session) = existing {
+        let current_model = session.model.lock().clone();
+        if current_model == effective_model {
+            return Ok(session); // 같은 모델 — 재사용
+        }
+        // 모델 변경 — control_request(set_model)을 WS로 전송, 프로세스 유지 시도.
+        // 일부 케이스(sonnet→opus 등)에서 claude가 control_request 후 자체 종료할 수 있다.
+        // 그런 경우는 stream_run_sdk의 process_alive 감시가 즉시 에러로 끊어주므로
+        // UI는 무한 streaming 대신 명확한 에러를 받게 된다.
+        send_set_model(&session, effective_model)?;
+        *session.model.lock() = effective_model.to_string();
+        eprintln!("[sdk-session] model changed via control_request: {} → {} for conv: {}",
+            current_model, effective_model, conv_id);
+        return Ok(session);
+    }
+
+    // 기존 세션 없음 — 새로 스폰. RESUME_IDS의 prior session_id로 --resume 가능.
+    let resume_id = RESUME_IDS.lock().get(conv_id).cloned();
+    let session = spawn_session(conv_id, project_path, effective_model, resume_id.as_deref()).await?;
+    SESSIONS.lock().insert(conv_id.to_string(), Arc::clone(&session));
+    Ok(session)
+}
+
+/// WS를 통해 claude에 set_model control_request를 전송한다.
+///
+/// claude는 내부 `mainLoopModelOverride`를 즉시 업데이트하고 `control_response(success)`로 응답.
+/// 응답은 비동기로 오므로 여기서 기다리지 않는다 (다음 턴부터 새 모델이 적용되면 충분).
+fn send_set_model(session: &SdkSession, model: &str) -> Result<(), AppError> {
+    let request_id = Uuid::new_v4().to_string();
+    let msg = serde_json::json!({
+        "type": "control_request",
+        "request_id": request_id,
+        "request": {
+            "subtype": "set_model",
+            "model": model
+        }
+    })
+    .to_string();
+    session
+        .ws_sender_tx
+        .send(msg)
+        .map_err(|_| AppError::Agent("sdk-session: WS sender closed (set_model failed)".into()))
+}
+
+/// 세션을 명시적으로 종료한다.
+/// `keep_resume`: true이면 RESUME_IDS를 유지해 다음 세션에서 --resume 사용.
+///               false이면 RESUME_IDS도 제거해 다음 세션은 새로 시작.
+#[allow(dead_code)]
+pub fn kill_session(conv_id: &str) {
+    kill_session_with_resume(conv_id, true);
+}
+
+pub fn kill_session_clear_resume(conv_id: &str) {
+    kill_session_with_resume(conv_id, false);
+}
+
+fn kill_session_with_resume(conv_id: &str, keep_resume: bool) {
+    SESSIONS.lock().remove(conv_id);
+    if !keep_resume {
+        RESUME_IDS.lock().remove(conv_id);
+    }
+    // ContextPack freshness: 세션이 죽으면 LAST_DELIVERED도 무효화 — 다음 send는 full로 강제
+    crate::commands::agents_helpers::send_common::session_freshness::clear_delivered_key(conv_id);
+    // SdkSession Drop → _shutdown_tx 전송 → axum 서버 종료 → _monitor_abort 취소
+}
+
+/// 해당 conversation에 활성 SDK 세션이 있는지 확인한다.
+/// UI send-guard용 (WS 연결 전 send 시도 차단).
+pub fn has_active_session(conv_id: &str) -> bool {
+    SESSIONS.lock().contains_key(conv_id)
+}
+
+/// ContextPack freshness 판정용 — 현재 활성 세션의 식별 키.
+/// 매 spawn마다 새로운 session_id가 생기므로, 같은 키 = 같은 에이전트 프로세스.
+/// 세션이 없으면 None 반환 (=> ContextPack은 full로 보내야 함).
+pub fn current_session_key(conv_id: &str) -> Option<String> {
+    SESSIONS.lock().get(conv_id).map(|s| format!("claude-ws:{}", s.session_id))
+}
+
+/// conversation이 로드될 때 미리 세션을 초기화한다.
+///
+/// claude 자식 프로세스 + MCP 초기화(26-60s)를 사전에 완료해
+/// 사용자가 첫 메시지를 보낼 때 즉시 응답받을 수 있도록 한다.
+/// 세션이 이미 존재하면 no-op.
+pub async fn prewarm_session(
+    conv_id: &str,
+    project_path: Option<&str>,
+    model: Option<&str>,
+) {
+    // 이미 세션이 있으면 스킵
+    let exists = SESSIONS.lock().contains_key(conv_id);
+    if exists { return; }
+
+    match get_or_create_session(conv_id, project_path, model).await {
+        Ok(_) => eprintln!("[sdk-session] prewarmed conv={}", conv_id),
+        Err(e) => eprintln!("[sdk-session] prewarm failed conv={}: {}", conv_id, e),
+    }
+}
+
+// ──────────────────────────── Session Spawn ───────────────────────────────────
+
+async fn spawn_session(
+    conv_id: &str,
+    project_path: Option<&str>,
+    model: &str,
+    resume_session_id: Option<&str>,
+) -> Result<Arc<SdkSession>, AppError> {
+    // 랜덤 포트 바인딩
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .map_err(|e| AppError::Agent(format!("sdk-session: bind failed: {}", e)))?;
+    let port = listener
+        .local_addr()
+        .map_err(|e| AppError::Agent(format!("sdk-session: local_addr failed: {}", e)))?
+        .port();
+
+    let session_id = Uuid::new_v4().to_string();
+    let auth_token = Uuid::new_v4().to_string();
+
+    // 채널 생성
+    // to_claude: tunaFlow → claude stdin (사용자 메시지)
+    let (to_claude_tx, mut to_claude_rx) = mpsc::unbounded_channel::<String>();
+    // from_claude: claude → tunaFlow (이벤트 브로드캐스트)
+    let (from_claude_tx, _) = broadcast::channel::<String>(512);
+    let (connected_tx, connected_rx) = oneshot::channel::<()>();
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+    // ws_sender: tunaFlow → claude WS (control_request: set_model 등)
+    let (ws_sender_tx, ws_send_rx) = mpsc::unbounded_channel::<String>();
+
+    let ws_state = WsServerState {
+        auth_token: auth_token.clone(),
+        from_claude_tx: from_claude_tx.clone(),
+        connected_tx: Arc::new(tokio::sync::Mutex::new(Some(connected_tx))),
+        ws_send_rx: Arc::new(tokio::sync::Mutex::new(ws_send_rx)),
+    };
+
+    // axum 라우터: WS 연결(keepalive/auth) + HTTP POST 이벤트 수신
+    let router = Router::new()
+        .route("/{session_id}", axum::routing::get(ws_handler))
+        .route("/{session_id}/events", axum::routing::post(events_handler))
+        .with_state(ws_state);
+
+    // axum 서버 태스크
+    tokio::spawn(async move {
+        axum::serve(listener, router)
+            .with_graceful_shutdown(async move {
+                let _ = shutdown_rx.await;
+            })
+            .await
+            .ok();
+    });
+
+    // claude 자식 프로세스 스폰
+    // sdk_url: WS 연결 + HTTP POST 이벤트 경로 기반 URL
+    // ws://127.0.0.1:{port}/{session_id} → POST http://127.0.0.1:{port}/{session_id}/events
+    let sdk_url = format!("ws://127.0.0.1:{}/{}", port, session_id);
+    let cwd = resolve_cwd(project_path);
+
+    let mut cmd = TokioCommand::new("claude");
+    cmd.arg("--print")
+        .arg("--sdk-url").arg(&sdk_url)
+        .arg("--session-id").arg(&session_id)
+        .arg("--model").arg(model)
+        .arg("--input-format").arg("stream-json")
+        .arg("--output-format").arg("stream-json")
+        .arg("--replay-user-messages")
+        .arg("--permission-mode").arg("bypassPermissions")
+        .env("CLAUDE_CODE_ENVIRONMENT_KIND", "bridge")
+        .env("CLAUDE_CODE_SESSION_ACCESS_TOKEN", &auth_token)
+        // HybridTransport: 이벤트를 HTTP POST로 전송 (Desktop 앱 동일 패턴)
+        .env("CLAUDE_CODE_POST_FOR_SESSION_INGRESS_V2", "1")
+        .env_remove("CLAUDE_CODE_OAUTH_TOKEN")
+        .current_dir(&cwd)
+        // stdin/stdout piped — stdin: 메시지 전달, stdout: 이벤트 수신(HTTP POST 병행)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .kill_on_drop(true);
+
+    // 이전 대화 이력이 있으면 --resume으로 이어받기
+    if let Some(resume_id) = resume_session_id {
+        cmd.arg("--resume").arg(resume_id);
+        eprintln!("[sdk-session] resuming with session_id={} model={}", resume_id, model);
+    }
+
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| AppError::Agent(format!("sdk-session: spawn failed: {}", e)))?;
+
+    // stdin 핸들 추출 — 메시지 전달 채널로 사용
+    let mut child_stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| AppError::Agent("sdk-session: could not get child stdin".into()))?;
+
+    // stdout 핸들 추출 — 이벤트 수신 (HTTP POST와 병행)
+    let child_stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| AppError::Agent("sdk-session: could not get child stdout".into()))?;
+
+    // claude WS 연결 대기 (최대 30초)
+    tokio::time::timeout(
+        std::time::Duration::from_secs(30),
+        connected_rx,
+    )
+    .await
+    .map_err(|_| AppError::Agent("sdk-session: claude did not connect within 30s".into()))?
+    .map_err(|_| AppError::Agent("sdk-session: connected signal dropped".into()))?;
+
+    eprintln!("[sdk-session] claude connected on port {} model={} for conv: {}", port, model, conv_id);
+
+    // stdin 쓰기 태스크: to_claude_rx → child stdin
+    // 각 메시지는 JSON 한 줄 + newline
+    tokio::spawn(async move {
+        while let Some(msg) = to_claude_rx.recv().await {
+            let line = format!("{}\n", msg);
+            if child_stdin.write_all(line.as_bytes()).await.is_err() {
+                eprintln!("[sdk-session] stdin write failed, channel closed");
+                break;
+            }
+        }
+        // 채널이 닫히면 stdin EOF → claude가 정상 종료
+        drop(child_stdin);
+    });
+
+    // stdout 읽기 태스크: 이벤트를 from_claude_tx로 브로드캐스트 (HTTP POST 병행)
+    let from_claude_tx_stdout = from_claude_tx.clone();
+    tokio::spawn(async move {
+        use tokio::io::{AsyncBufReadExt, BufReader};
+        let mut lines = BufReader::new(child_stdout).lines();
+        while let Ok(Some(line)) = lines.next_line().await {
+            if line.trim().is_empty() { continue; }
+            let _ = from_claude_tx_stdout.send(line);
+        }
+    });
+
+    // 자식 프로세스 모니터 태스크
+    let conv_id_owned = conv_id.to_string();
+    let process_alive = Arc::new(AtomicBool::new(true));
+    let alive_for_monitor = process_alive.clone();
+    let monitor_task = tokio::spawn(async move {
+        let _ = child.wait().await;
+        eprintln!("[sdk-session] claude subprocess exited for conv: {}", conv_id_owned);
+        // alive flag를 가장 먼저 false로 — stream_run_sdk가 즉시 감지하도록.
+        alive_for_monitor.store(false, Ordering::SeqCst);
+        // 세션 레지스트리에서 제거 (좀비 방지)
+        SESSIONS.lock().remove(&conv_id_owned);
+        // ContextPack freshness: 프로세스가 죽었으면 다음 send는 새 세션이므로 full 필요
+        crate::commands::agents_helpers::send_common::session_freshness::clear_delivered_key(&conv_id_owned);
+    });
+
+    Ok(Arc::new(SdkSession {
+        session_id: session_id.clone(),
+        to_claude_tx,
+        from_claude_tx,
+        model: Arc::new(PlMutex::new(model.to_string())),
+        ws_sender_tx,
+        process_alive,
+        _shutdown_tx: shutdown_tx,
+        _monitor_abort: monitor_task.abort_handle(),
+    }))
+}
+
+// ──────────────────────────── WS Handler ─────────────────────────────────────
+
+async fn ws_handler(
+    Path(_sid): Path<String>,
+    State(state): State<WsServerState>,
+    headers: HeaderMap,
+    ws_upgrade: WebSocketUpgrade,
+) -> impl IntoResponse {
+    // Bearer 토큰 검증
+    let token = headers
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+        .unwrap_or("");
+
+    if token != state.auth_token {
+        return (StatusCode::UNAUTHORIZED, "invalid token").into_response();
+    }
+
+    ws_upgrade
+        .on_upgrade(move |socket| handle_claude_ws(socket, state))
+        .into_response()
+}
+
+/// WS 양방향 핸들러.
+///
+/// - **수신 (claude → 서버)**: keepalive 및 control_response 처리
+/// - **전송 (서버 → claude)**: ws_send_rx 채널로 들어온 control_request 전송
+///   예: `{"type":"control_request","request":{"subtype":"set_model","model":"..."}}`
+///
+/// 메시지 전달은 stdin, 이벤트 수신은 HTTP POST + stdout으로 처리.
+async fn handle_claude_ws(socket: ws::WebSocket, state: WsServerState) {
+    let (mut ws_sender, mut ws_receiver) = socket.split();
+
+    // 연결 신호 발송 (spawn_session의 connected_rx 해제)
+    if let Some(tx) = state.connected_tx.lock().await.take() {
+        let _ = tx.send(());
+    }
+
+    // ws_send_rx 잠금 — 이 핸들러가 유일한 소비자
+    let mut ws_send_rx = state.ws_send_rx.lock().await;
+
+    loop {
+        tokio::select! {
+            // claude → 서버: keepalive / control_response 수신
+            msg = ws_receiver.next() => {
+                match msg {
+                    Some(Ok(ws::Message::Close(_))) | None => break,
+                    Some(Ok(ws::Message::Text(text))) => {
+                        // control_response 로깅 (set_model 응답 등)
+                        if text.contains("control_response") {
+                            eprintln!("[sdk-session] control_response: {:.120}", text);
+                        }
+                    }
+                    _ => {} // ping/pong 등 무시
+                }
+            }
+            // 서버 → claude: control_request 전송 (set_model 등)
+            //
+            // **CRITICAL**: trailing newline 필수. claude의 RemoteIO는 WS로 받은 데이터와
+            // stdin을 같은 PassThrough inputStream으로 합친다 (claude code source: remoteIO.ts:98-103
+            // `setOnData(data => inputStream.write(data))`). newline이 없으면 다음에 오는 stdin
+            // user message와 한 줄로 합쳐져 stream-json 파서가 fail → "JSON Parse error" → 프로세스 exit.
+            // 격리 테스트(/tmp/ws_test/test_set_model.js)로 검증된 사실.
+            msg = ws_send_rx.recv() => {
+                match msg {
+                    Some(text) => {
+                        let payload = if text.ends_with('\n') { text } else { format!("{}\n", text) };
+                        if ws_sender.send(ws::Message::Text(payload.into())).await.is_err() {
+                            eprintln!("[sdk-session] WS send failed");
+                            break;
+                        }
+                    }
+                    None => break, // 채널 닫힘
+                }
+            }
+        }
+    }
+
+    eprintln!("[sdk-session] WS connection closed");
+}
+
+// ──────────────────────────── HTTP POST Events Handler ───────────────────────
+
+/// HybridTransport: claude가 `/{session_id}/events` 로 POST하는 이벤트를 수신한다.
+///
+/// 요청 본문: `{"events":[...]}` 배열 래퍼 또는 단일 JSON 객체.
+/// 각 이벤트를 `from_claude_tx`로 브로드캐스트해 `stream_run_sdk`가 소비한다.
+async fn events_handler(
+    Path(_sid): Path<String>,
+    State(state): State<WsServerState>,
+    body: Bytes,
+) -> impl IntoResponse {
+    if let Ok(text) = std::str::from_utf8(&body) {
+        // `{"events":[...]}` 래퍼 형식 처리
+        if let Ok(obj) = serde_json::from_str::<serde_json::Value>(text) {
+            if let Some(arr) = obj.get("events").and_then(|v| v.as_array()) {
+                for item in arr {
+                    let _ = state.from_claude_tx.send(item.to_string());
+                }
+            } else {
+                // 단일 이벤트 형식
+                let _ = state.from_claude_tx.send(obj.to_string());
+            }
+        } else {
+            eprintln!("[sdk-session] events_handler: failed to parse body: {:.100}", text);
+        }
+    }
+    StatusCode::OK
+}
+
+// ──────────────────────────── Stream Run ─────────────────────────────────────
+
+/// claude `--sdk-url` 세션을 통해 메시지를 전송하고 스트리밍 응답을 수집한다.
+///
+/// 기존 `claude::stream_run` 과 동일한 인터페이스.
+pub async fn stream_run_sdk<F, G, C>(
+    conv_id: &str,
+    input: RunInput,
+    mut on_progress: G,
+    mut on_chunk: F,
+    is_cancelled: C,
+) -> Result<RunOutput, AppError>
+where
+    F: FnMut(String) + Send,
+    G: FnMut(String) + Send,
+    C: Fn() -> bool + Send,
+{
+    // 세션 획득 (없으면 새로 생성, 모델 변경 시 재시작)
+    let session = get_or_create_session(
+        conv_id,
+        input.project_path.as_deref(),
+        input.model.as_deref(),
+    ).await?;
+
+    // 이벤트 구독 — 전송 전에 구독해야 이벤트를 놓치지 않음
+    let mut event_rx = session.from_claude_tx.subscribe();
+
+    // 사용자 메시지 전송 (stream-json stdin 형식)
+    let user_msg = build_user_message(&input.prompt);
+    session
+        .to_claude_tx
+        .send(user_msg)
+        .map_err(|_| AppError::Agent("sdk-session: send channel closed".into()))?;
+
+    on_progress("Agent initializing...".into());
+
+    let conv_id_owned = conv_id.to_string();
+    let mut accumulated_input_tokens: i64 = 0;
+    let mut accumulated_output_tokens: i64 = 0;
+
+    // 응답 수집
+    let alive_for_loop = session.process_alive.clone();
+    loop {
+        let line_result: Result<Result<String, broadcast::error::RecvError>, tokio::time::error::Elapsed> =
+            tokio::select! {
+                r = tokio::time::timeout(std::time::Duration::from_secs(600), event_rx.recv()) => r,
+                _ = async {
+                    loop {
+                        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                        if is_cancelled() { break; }
+                    }
+                } => {
+                    let interrupt = serde_json::json!({
+                        "type": "control_request",
+                        "request": { "subtype": "interrupt" }
+                    }).to_string();
+                    let _ = session.to_claude_tx.send(interrupt);
+                    return Err(AppError::Agent("cancelled by user".into()));
+                }
+                // claude child process가 죽었는지 100ms마다 폴링.
+                // broadcast 채널은 SdkSession Arc(stream_run_sdk가 보유)이 살아있는 한 close되지
+                // 않으므로 별도 신호가 필요. monitor_task가 child.wait() 후 false 설정.
+                _ = async {
+                    loop {
+                        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                        if !alive_for_loop.load(Ordering::SeqCst) { break; }
+                    }
+                } => {
+                    eprintln!("[sdk-session] process death detected for conv: {} — aborting stream",
+                        &conv_id_owned[..conv_id_owned.len().min(8)]);
+                    return Err(AppError::Agent(
+                        "claude 프로세스가 종료되었습니다 (모델 전환/외부 종료 추정). 다시 send하면 새 세션으로 자동 재시작됩니다.".into(),
+                    ));
+                }
+            };
+
+        let line = match line_result {
+            Ok(Ok(line)) => line,
+            Ok(Err(broadcast::error::RecvError::Lagged(n))) => {
+                eprintln!("[sdk-session] receiver lagged, skipped {} messages", n);
+                continue;
+            }
+            Ok(Err(broadcast::error::RecvError::Closed)) => {
+                return Err(AppError::Agent("sdk-session: event channel closed".into()));
+            }
+            Err(_) => {
+                return Err(AppError::Agent(
+                    "sdk-session: timeout waiting for response (10min)".into(),
+                ));
+            }
+        };
+
+        let parsed: SdkStreamLine = match serde_json::from_str(&line) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+
+        // [디버그] stream-json 라인 도착 추적 — Architect stuck 원인 파악용.
+        // 이 라인이 계속 찍히는데 result가 안 오면 → claude 자체 hang.
+        // 안 찍히면 → broadcast 채널 문제.
+        eprintln!("[sdk-session:trace] line type={} for conv={}", parsed.line_type,
+            &conv_id_owned[..conv_id_owned.len().min(8)]);
+
+        // 주의: 이전에 추가했던 `on_progress("__HEARTBEAT__:...")` 호출은
+        // architect stuck 의심 디버깅을 위해 일시 제거. watchdog은 기존 progress/chunk
+        // 이벤트만으로 동작 — 10분 timeout이 충분한 여유.
+        match parsed.line_type.as_str() {
+            "system" => {
+                on_progress("Agent initializing...".into());
+            }
+            "assistant" => {
+                if let Some(msg) = &parsed.message {
+                    if let Some(usage) = &msg.usage {
+                        if let Some(v) = usage.input_tokens { accumulated_input_tokens = v; }
+                        if let Some(v) = usage.output_tokens { accumulated_output_tokens = v; }
+                    }
+                    if let Some(blocks) = &msg.content {
+                        for block in blocks {
+                            match block.block_type.as_str() {
+                                "thinking" => {
+                                    if let Some(thinking) = &block.thinking {
+                                        let last_line = thinking
+                                            .lines()
+                                            .filter(|l| !l.trim().is_empty())
+                                            .last()
+                                            .unwrap_or("")
+                                            .trim();
+                                        if !last_line.is_empty() {
+                                            let step = serde_json::json!({
+                                                "type": "thinking",
+                                                "name": "Thinking",
+                                                "input": last_line.chars().take(120).collect::<String>(),
+                                                "status": "done"
+                                            });
+                                            on_progress(format!("__STEP__:{}", step));
+                                        }
+                                    }
+                                }
+                                "tool_use" => {
+                                    if let Some(name) = &block.name {
+                                        let input_summary =
+                                            block.input.as_ref().map(|v| {
+                                                let s = v.to_string();
+                                                if s.len() > 120 {
+                                                    let mut end = 120;
+                                                    while end > 0 && !s.is_char_boundary(end) {
+                                                        end -= 1;
+                                                    }
+                                                    format!("{}…", &s[..end])
+                                                } else {
+                                                    s
+                                                }
+                                            }).unwrap_or_default();
+                                        let step = serde_json::json!({
+                                            "type": "tool_use",
+                                            "name": name,
+                                            "input": input_summary,
+                                            "status": "running"
+                                        });
+                                        on_progress(format!("__STEP__:{}", step));
+                                    }
+                                }
+                                "text" => {
+                                    if let Some(text) = &block.text {
+                                        if !text.is_empty() {
+                                            on_chunk(text.clone());
+                                        }
+                                    }
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
+                }
+            }
+            "result" => {
+                if parsed.is_error.unwrap_or(false) {
+                    return Err(AppError::Agent(format!(
+                        "claude reported error: {}",
+                        parsed.result.as_deref().unwrap_or("unknown")
+                    )));
+                }
+
+                // 다음 모델 변경 시 --resume에 사용할 session_id를 RESUME_IDS에 보존
+                if let Some(sid) = &parsed.session_id {
+                    RESUME_IDS.lock().insert(conv_id_owned.clone(), sid.clone());
+                }
+
+                let final_input = parsed.total_input_tokens
+                    .filter(|&v| v > 0)
+                    .unwrap_or(accumulated_input_tokens);
+                let final_output = parsed.total_output_tokens
+                    .filter(|&v| v > 0)
+                    .unwrap_or(accumulated_output_tokens);
+                eprintln!("[sdk-session] result tokens: in={} out={} (from_result={}/{})",
+                    final_input, final_output,
+                    parsed.total_input_tokens.unwrap_or(0),
+                    parsed.total_output_tokens.unwrap_or(0));
+
+                return Ok(RunOutput {
+                    content: parsed.result.unwrap_or_default(),
+                    cost_usd: parsed.total_cost_usd.or(parsed.cost_usd).unwrap_or(0.0),
+                    input_tokens: final_input,
+                    output_tokens: final_output,
+                    session_id: parsed.session_id,
+                });
+            }
+            "control_request" => {
+                eprintln!("[sdk-session] control_request received (unhandled in Phase 1)");
+            }
+            _ => {}
+        }
+    }
+}
+
+// ──────────────────────────── Helpers ────────────────────────────────────────
+
+/// stream-json stdin 형식의 사용자 메시지를 생성한다.
+fn build_user_message(content: &str) -> String {
+    serde_json::json!({
+        "type": "user",
+        "message": {
+            "role": "user",
+            "content": content
+        }
+    })
+    .to_string()
+}
+
+/// 모든 활성 SDK 세션을 종료한다 (앱 종료 시 호출).
+#[allow(dead_code)]
+pub fn shutdown_all_sessions() {
+    SESSIONS.lock().clear();
+    RESUME_IDS.lock().clear();
+}

--- a/src-tauri/src/agents/codex_app_server.rs
+++ b/src-tauri/src/agents/codex_app_server.rs
@@ -1,0 +1,645 @@
+//! Codex `app-server` 지속 세션 모드
+//!
+//! `codex app-server --listen ws://127.0.0.1:PORT` 를 글로벌 프로세스로 스폰하고
+//! WebSocket 클라이언트로 연결해 멀티턴 대화를 유지한다.
+//!
+//! 프로토콜: JSON-RPC 2.0 over WebSocket
+//! 소스 참조: `_util/codex/codex-rs/app-server-protocol/src/`
+//!
+//! # 구조
+//! - **글로벌 AppServer**: 하나의 codex 프로세스 + 하나의 WS 연결
+//! - **스레드 레지스트리**: conv_id → thread_id 매핑 (conversation당 하나의 codex thread)
+//! - **RPC 호출**: ID 기반 요청/응답 매칭 (broadcast 채널 필터링)
+//! - **스트리밍**: `agentMessageDelta` 알림으로 실시간 텍스트 스트리밍
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use futures_util::{SinkExt, StreamExt};
+use parking_lot::Mutex as PlMutex;
+use serde_json::{Value, json};
+use tokio::sync::{broadcast, mpsc};
+use tokio_tungstenite::{connect_async, tungstenite::protocol::Message};
+
+use crate::agents::claude::{RunInput, RunOutput, resolve_cwd};
+use crate::agents::resolve::{NpmCliConfig, resolve_npm_cli};
+use crate::errors::AppError;
+
+// ─────────────────────────── Types ────────────────────────────────────────────
+
+struct AppServer {
+    /// codex app-server가 리스닝하는 포트 (디버깅용)
+    #[allow(dead_code)]
+    port: u16,
+    /// tunaFlow → codex: JSON 문자열 전송
+    ws_tx: mpsc::UnboundedSender<String>,
+    /// codex → tunaFlow: 모든 서버 메시지 브로드캐스트
+    from_server_tx: broadcast::Sender<String>,
+    /// 다음 JSON-RPC 요청 ID (자동 증가)
+    next_id: AtomicU64,
+    /// codex 프로세스 모니터 태스크 핸들 (Drop 시 abort → 프로세스 종료)
+    _process_abort: tokio::task::AbortHandle,
+}
+
+struct ConvThread {
+    thread_id: String,
+    model: String,
+}
+
+// ─────────────────────────── Global State ─────────────────────────────────────
+
+lazy_static::lazy_static! {
+    /// 글로벌 codex app-server (하나의 프로세스, 여러 conversation 공유)
+    static ref SERVER: PlMutex<Option<Arc<AppServer>>> = PlMutex::new(None);
+    /// conv_id → ConvThread (thread_id, model)
+    static ref CONV_THREADS: PlMutex<HashMap<String, ConvThread>> = PlMutex::new(HashMap::new());
+    /// 서버 시작 중복 방지 뮤텍스
+    static ref SERVER_INIT: tokio::sync::Mutex<()> = tokio::sync::Mutex::new(());
+}
+
+// ─────────────────────────── Public API ───────────────────────────────────────
+
+/// codex 바이너리가 설치되어 있으면 app-server 모드를 사용할 수 있다.
+pub fn is_available() -> bool {
+    let resolved = resolve_npm_cli(&NpmCliConfig {
+        bin_name: "codex",
+        npm_package: "@openai/codex",
+        npm_entry: "bin/codex.js",
+    });
+    // 절대 경로면 파일 존재 여부 확인, 아니면 PATH에서 탐색
+    let cmd = &resolved.command;
+    if std::path::Path::new(cmd).is_absolute() {
+        std::path::Path::new(cmd).exists()
+    } else {
+        // PATH에서 바이너리 탐색
+        std::env::var("PATH")
+            .unwrap_or_default()
+            .split(':')
+            .any(|dir| std::path::Path::new(dir).join(cmd).exists())
+    }
+}
+
+/// ContextPack freshness 판정용 — 현재 활성 thread의 식별 키.
+/// 같은 키 = 같은 codex thread (replay 히스토리 보유). 없으면 None (=> full ContextPack 필요).
+pub fn current_thread_key(conv_id: &str) -> Option<String> {
+    CONV_THREADS.lock().get(conv_id).map(|t| format!("codex-app:{}", t.thread_id))
+}
+
+/// conversation이 제거될 때 해당 thread를 레지스트리에서 제거한다.
+/// 서버 자체는 계속 실행된다.
+#[allow(dead_code)]
+pub fn kill_thread(conv_id: &str) {
+    CONV_THREADS.lock().remove(conv_id);
+}
+
+/// app-server 세션을 통해 메시지를 전송하고 스트리밍 응답을 수집한다.
+///
+/// Claude의 `claude_sdk_session::stream_run_sdk`와 동일한 인터페이스.
+pub async fn stream_run_app_server<F, G, C>(
+    conv_id: &str,
+    input: RunInput,
+    mut on_progress: G,
+    mut on_chunk: F,
+    is_cancelled: C,
+) -> Result<RunOutput, AppError>
+where
+    F: FnMut(String) + Send,
+    G: FnMut(String) + Send,
+    C: Fn() -> bool + Send,
+{
+    // 빈 문자열 model 가드 — Some("")이 들어오면 unwrap_or가 발동하지 않아
+    // codex API에 빈 model 필드가 전달되어 RPC 에러가 발생한다 (claude와 동일 패턴).
+    //
+    // default = "gpt-5-codex": ChatGPT account/Codex 사용자 모두 호환되는 안전한 default.
+    // 이전 default였던 "o4-mini"는 OpenAI Platform API 전용 — ChatGPT account에선
+    // 400 "model is not supported" 에러 발생 (실측 확인됨).
+    let model = input.model
+        .as_deref()
+        .filter(|m| !m.is_empty())
+        .unwrap_or("gpt-5-codex")
+        .to_string();
+
+    let server = get_or_start_server().await?;
+    let thread_id =
+        get_or_create_thread(&server, conv_id, &model, input.project_path.as_deref()).await?;
+
+    // turn/start 전에 구독 → 초기 이벤트 누락 방지
+    let mut event_rx = server.from_server_tx.subscribe();
+
+    // turn/start RPC 호출 → turn_id 획득
+    let turn_result = rpc_call(&server, "turn/start", json!({
+        "threadId": thread_id,
+        "input": [{ "type": "text", "text": input.prompt }]
+    }))
+    .await?;
+
+    let turn_id = turn_result
+        .get("turn")
+        .and_then(|t| t.get("id"))
+        .and_then(|id| id.as_str())
+        .ok_or_else(|| AppError::Agent("codex app-server: turn/start returned no turn.id".into()))?
+        .to_string();
+
+    on_progress("Agent thinking...".into());
+
+    let mut accumulated_text = String::new();
+    let input_tokens: i64 = 0;
+    let output_tokens: i64 = 0;
+    let total_cost: f64 = 0.0;
+
+    // 스트리밍 이벤트 수신 루프
+    loop {
+        let line_result = tokio::select! {
+            r = tokio::time::timeout(
+                std::time::Duration::from_secs(600),
+                event_rx.recv()
+            ) => r,
+            _ = async {
+                loop {
+                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                    if is_cancelled() { break; }
+                }
+            } => {
+                // 취소 요청 → turn/interrupt 전송
+                let id = server.next_id.fetch_add(1, Ordering::Relaxed).to_string();
+                let _ = server.ws_tx.send(json!({
+                    "id": id,
+                    "method": "turn/interrupt",
+                    "params": { "threadId": thread_id }
+                }).to_string());
+                return Err(AppError::Agent("cancelled by user".into()));
+            }
+        };
+
+        let line = match line_result {
+            Ok(Ok(line)) => line,
+            Ok(Err(broadcast::error::RecvError::Lagged(n))) => {
+                eprintln!("[codex-app-server] receiver lagged by {} messages", n);
+                continue;
+            }
+            Ok(Err(broadcast::error::RecvError::Closed)) => {
+                return Err(AppError::Agent("codex app-server: event channel closed".into()));
+            }
+            Err(_) => {
+                return Err(AppError::Agent(
+                    "codex app-server: timeout waiting for response (10min)".into(),
+                ));
+            }
+        };
+
+        let Ok(v) = serde_json::from_str::<Value>(&line) else { continue };
+
+        // RPC 응답(id 있음)은 건너뜀 — rpc_call 내부에서 처리
+        if v.get("id").is_some() {
+            continue;
+        }
+
+        let method = v.get("method").and_then(|m| m.as_str()).unwrap_or("");
+        let params = v.get("params").unwrap_or(&Value::Null);
+
+        // 현재 thread_id 필터링
+        let msg_thread_id = params.get("threadId").and_then(|t| t.as_str()).unwrap_or("");
+        if !thread_id.is_empty() && msg_thread_id != thread_id {
+            continue;
+        }
+
+        match method {
+            "item/agentMessage/delta" => {
+                let delta = params.get("delta").and_then(|d| d.as_str()).unwrap_or("");
+                if !delta.is_empty() {
+                    accumulated_text.push_str(delta);
+                    on_chunk(accumulated_text.clone());
+                }
+            }
+            "item/started" => {
+                if let Some(item) = params.get("item") {
+                    let item_type = item.get("type").and_then(|t| t.as_str()).unwrap_or("");
+                    match item_type {
+                        "command_execution" => {
+                            let cmd = item
+                                .get("command")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("bash");
+                            let truncated = &cmd[..cmd.len().min(120)];
+                            let step = json!({
+                                "type": "command",
+                                "name": "Bash",
+                                "input": truncated,
+                                "status": "running"
+                            });
+                            on_progress(format!("__STEP__:{}", step));
+                        }
+                        "file_change" => {
+                            let file = item
+                                .get("file")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("file");
+                            let step = json!({
+                                "type": "file_change",
+                                "name": "Edit",
+                                "input": file,
+                                "status": "running"
+                            });
+                            on_progress(format!("__STEP__:{}", step));
+                        }
+                        "reasoning" => {
+                            let step = json!({
+                                "type": "thinking",
+                                "name": "Reasoning",
+                                "input": "",
+                                "status": "running"
+                            });
+                            on_progress(format!("__STEP__:{}", step));
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            "item/completed" => {
+                if let Some(item) = params.get("item") {
+                    let item_type = item.get("type").and_then(|t| t.as_str()).unwrap_or("");
+                    match item_type {
+                        "command_execution" => {
+                            let cmd = item
+                                .get("command")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("bash");
+                            let truncated = &cmd[..cmd.len().min(120)];
+                            let status = item
+                                .get("status")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("done");
+                            let step = json!({
+                                "type": "command",
+                                "name": "Bash",
+                                "input": truncated,
+                                "status": if status == "failed" { "error" } else { "done" }
+                            });
+                            on_progress(format!("__STEP__:{}", step));
+                        }
+                        "file_change" => {
+                            let file = item
+                                .get("file")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("file");
+                            let step = json!({
+                                "type": "file_change",
+                                "name": "Edit",
+                                "input": file,
+                                "status": "done"
+                            });
+                            on_progress(format!("__STEP__:{}", step));
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            "turn/completed" => {
+                let turn = params.get("turn").unwrap_or(&Value::Null);
+                let completed_turn_id = turn
+                    .get("id")
+                    .and_then(|id| id.as_str())
+                    .unwrap_or("");
+                // 다른 turn의 완료 이벤트는 건너뜀
+                if completed_turn_id != turn_id {
+                    continue;
+                }
+
+                let content = accumulated_text.trim().to_string();
+                return Ok(RunOutput {
+                    content,
+                    cost_usd: total_cost,
+                    input_tokens,
+                    output_tokens,
+                    session_id: Some(thread_id),
+                });
+            }
+            // wire format: "error" (NOT "errorNotification"; codex v2 protocol common.rs:978)
+            // payload: { error: { message, codexErrorInfo, additionalDetails }, willRetry, threadId, turnId }
+            "error" => {
+                let error_msg = params
+                    .get("error")
+                    .and_then(|e| e.get("message"))
+                    .and_then(|m| m.as_str())
+                    .unwrap_or("unknown error");
+                let will_retry = params.get("willRetry").and_then(|v| v.as_bool()).unwrap_or(false);
+                eprintln!("[codex-app-server] error: {} (willRetry={})", error_msg, will_retry);
+                // willRetry=false이면 turn이 interrupt되어 turn/completed가 오지 않으므로
+                // 즉시 Err로 끊어 finalize에서 ok=false 표시. willRetry=true면 turn 계속.
+                if !will_retry {
+                    return Err(AppError::Agent(format!(
+                        "codex app-server error: {}",
+                        error_msg
+                    )));
+                }
+            }
+            _ => {
+                // threadStarted/turnStarted/planDelta/hookStarted/command-exec-outputDelta/
+                // reasoning-textDelta 등 — UI에 표시할 step은 아니지만 watchdog 유지를 위한
+                // heartbeat은 보낸다. __HEARTBEAT__ 접두는 frontend에서 timer reset만 하고
+                // tool-step 파싱은 스킵한다.
+                if !method.is_empty() {
+                    on_progress(format!("__HEARTBEAT__:{}", method));
+                    eprintln!("[codex-app-server] notification: {}", method);
+                }
+            }
+        }
+    }
+}
+
+// ─────────────────────────── Server Management ────────────────────────────────
+
+async fn get_or_start_server() -> Result<Arc<AppServer>, AppError> {
+    // 빠른 경로: 서버가 이미 실행 중
+    if let Some(s) = SERVER.lock().clone() {
+        return Ok(s);
+    }
+
+    // 중복 시작 방지 락 획득
+    let _guard = SERVER_INIT.lock().await;
+
+    // 락 획득 후 재확인 (double-checked locking)
+    if let Some(s) = SERVER.lock().clone() {
+        return Ok(s);
+    }
+
+    let server = start_server().await?;
+    *SERVER.lock() = Some(Arc::clone(&server));
+    Ok(server)
+}
+
+async fn start_server() -> Result<Arc<AppServer>, AppError> {
+    // 여유 포트 탐색 (잠시 바인딩 후 해제 — codex가 해당 포트를 사용)
+    let port = find_free_port().await?;
+
+    let resolved = resolve_npm_cli(&NpmCliConfig {
+        bin_name: "codex",
+        npm_package: "@openai/codex",
+        npm_entry: "bin/codex.js",
+    });
+
+    let ws_url = format!("ws://127.0.0.1:{}", port);
+
+    let mut cmd = tokio::process::Command::new(&resolved.command);
+    if let Some(ref script) = resolved.script_arg {
+        cmd.arg(script);
+    }
+    cmd.arg("app-server")
+        .arg("--listen")
+        .arg(&ws_url)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .kill_on_drop(true);
+
+    let mut child = cmd.spawn().map_err(|e| {
+        AppError::Agent(format!(
+            "codex app-server: spawn failed ({}): {}",
+            resolved.command, e
+        ))
+    })?;
+
+    // codex가 바인딩할 때까지 재시도 (최대 10초)
+    let ws_connect_url = format!("ws://127.0.0.1:{}", port);
+    let ws_stream = retry_connect(&ws_connect_url, 20, 500).await.map_err(|e| {
+        AppError::Agent(format!("codex app-server: WS connect failed: {}", e))
+    })?;
+
+    let (mut ws_sink, mut ws_source) = ws_stream.split();
+    let (ws_tx, mut ws_rx) = mpsc::unbounded_channel::<String>();
+    let (from_server_tx, _) = broadcast::channel::<String>(512);
+    let from_server_tx_clone = from_server_tx.clone();
+
+    // WS 전송 태스크: ws_rx → ws_sink
+    tokio::spawn(async move {
+        while let Some(msg) = ws_rx.recv().await {
+            if ws_sink.send(Message::Text(msg.into())).await.is_err() {
+                eprintln!("[codex-app-server] WS send error, sender loop exiting");
+                break;
+            }
+        }
+    });
+
+    // WS 수신 태스크: ws_source → from_server_tx
+    tokio::spawn(async move {
+        while let Some(Ok(msg)) = ws_source.next().await {
+            if let Message::Text(text) = msg {
+                let _ = from_server_tx_clone.send(text.to_string());
+            }
+        }
+        eprintln!("[codex-app-server] WS connection closed — clearing server");
+        *SERVER.lock() = None;
+    });
+
+    // 프로세스 모니터 태스크 (종료 시 레지스트리 초기화)
+    let process_task = tokio::spawn(async move {
+        let _ = child.wait().await;
+        eprintln!("[codex-app-server] process exited — clearing server & threads");
+        *SERVER.lock() = None;
+        CONV_THREADS.lock().clear();
+    });
+
+    let server = Arc::new(AppServer {
+        port,
+        ws_tx,
+        from_server_tx,
+        next_id: AtomicU64::new(1),
+        _process_abort: process_task.abort_handle(),
+    });
+
+    // initialize RPC 호출
+    rpc_call(
+        &server,
+        "initialize",
+        json!({
+            "clientInfo": { "name": "tunaflow", "version": "0.1.0" },
+            "capabilities": { "experimentalApi": false }
+        }),
+    )
+    .await?;
+
+    eprintln!("[codex-app-server] started on port {}", port);
+    Ok(server)
+}
+
+// ─────────────────────────── Thread Management ────────────────────────────────
+
+async fn get_or_create_thread(
+    server: &AppServer,
+    conv_id: &str,
+    model: &str,
+    project_path: Option<&str>,
+) -> Result<String, AppError> {
+    // 기존 스레드 확인
+    let existing = CONV_THREADS
+        .lock()
+        .get(conv_id)
+        .map(|t| (t.thread_id.clone(), t.model.clone()));
+
+    if let Some((thread_id, current_model)) = existing {
+        if current_model == model {
+            return Ok(thread_id);
+        }
+        // 모델 변경 — 기존 스레드 폐기, 새 스레드 시작
+        eprintln!(
+            "[codex-app-server] model changed ({} → {}), starting new thread for conv={}",
+            current_model, model, conv_id
+        );
+        CONV_THREADS.lock().remove(conv_id);
+    }
+
+    let cwd = resolve_cwd(project_path);
+    // sandbox=danger-full-access는 claude의 --permission-mode bypassPermissions와 등가.
+    // 이게 없으면 codex는 default sandbox(workspace-write, network 차단)에서 동작하여
+    // gh/curl 등 네트워크 도구가 모두 실패한다.
+    // persistExtendedHistory/experimentalRawEvents는 experimentalApi capability가 있어야
+    // 허용되므로 필드 자체를 생략.
+    let result = rpc_call(
+        server,
+        "thread/start",
+        json!({
+            "model": model,
+            "cwd": cwd.to_string_lossy(),
+            "approvalPolicy": "never",
+            "sandbox": "danger-full-access"
+        }),
+    )
+    .await?;
+
+    let thread_id = result
+        .get("thread")
+        .and_then(|t| t.get("id"))
+        .and_then(|id| id.as_str())
+        .ok_or_else(|| {
+            AppError::Agent("codex app-server: thread/start returned no thread.id".into())
+        })?
+        .to_string();
+
+    CONV_THREADS.lock().insert(
+        conv_id.to_string(),
+        ConvThread {
+            thread_id: thread_id.clone(),
+            model: model.to_string(),
+        },
+    );
+
+    eprintln!(
+        "[codex-app-server] created thread {} for conv={}",
+        thread_id, conv_id
+    );
+    Ok(thread_id)
+}
+
+// ─────────────────────────── RPC Helper ───────────────────────────────────────
+
+/// JSON-RPC 2.0 요청을 전송하고 매칭 응답을 기다린다.
+///
+/// 전송 전에 broadcast를 구독하므로 응답을 놓치지 않는다.
+/// 알림(notifications)은 id가 없어서 자동으로 필터링된다.
+async fn rpc_call(server: &AppServer, method: &str, params: Value) -> Result<Value, AppError> {
+    let id = server.next_id.fetch_add(1, Ordering::Relaxed).to_string();
+    let request = json!({ "id": id, "method": method, "params": params });
+
+    // 전송 전 구독
+    let mut rx = server.from_server_tx.subscribe();
+
+    server
+        .ws_tx
+        .send(request.to_string())
+        .map_err(|_| AppError::Agent("codex app-server: WS send channel closed".into()))?;
+
+    let id_str = id.clone();
+    let method_str = method.to_string();
+
+    tokio::time::timeout(
+        std::time::Duration::from_secs(30),
+        async move {
+            loop {
+                match rx.recv().await {
+                    Ok(line) => {
+                        let Ok(v) = serde_json::from_str::<Value>(&line) else { continue };
+                        // ID 매칭: 문자열 또는 정수 ID 모두 지원
+                        let v_id = v.get("id").and_then(|i| match i {
+                            Value::String(s) => Some(s.clone()),
+                            Value::Number(n) => n.as_i64().map(|n| n.to_string()),
+                            _ => None,
+                        });
+                        if v_id.as_deref() != Some(&id_str) {
+                            continue;
+                        }
+                        if let Some(error) = v.get("error") {
+                            return Err(AppError::Agent(format!(
+                                "codex RPC error ({}): {}",
+                                method_str, error
+                            )));
+                        }
+                        return Ok(v.get("result").cloned().unwrap_or(Value::Null));
+                    }
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        eprintln!("[codex-app-server] rpc_call lagged by {} messages", n);
+                    }
+                    Err(broadcast::error::RecvError::Closed) => {
+                        return Err(AppError::Agent(
+                            "codex app-server: broadcast closed during RPC".into(),
+                        ));
+                    }
+                }
+            }
+        },
+    )
+    .await
+    .map_err(|_| {
+        AppError::Agent(format!(
+            "codex app-server: RPC timeout for method={}",
+            method
+        ))
+    })?
+}
+
+// ─────────────────────────── Utilities ────────────────────────────────────────
+
+/// 임시 바인딩으로 여유 포트를 찾는다.
+async fn find_free_port() -> Result<u16, AppError> {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .map_err(|e| AppError::Agent(format!("codex app-server: find_free_port: {}", e)))?;
+    let port = listener
+        .local_addr()
+        .map_err(|e| AppError::Agent(format!("codex app-server: local_addr: {}", e)))?
+        .port();
+    drop(listener); // codex가 사용할 포트를 해제
+    Ok(port)
+}
+
+/// WS 연결을 재시도한다. codex 프로세스가 바인딩할 때까지 폴링.
+async fn retry_connect(
+    url: &str,
+    max_attempts: u32,
+    delay_ms: u64,
+) -> Result<
+    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
+    String,
+> {
+    let mut last_err = String::from("no attempts made");
+    for attempt in 1..=max_attempts {
+        tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+        match connect_async(url).await {
+            Ok((stream, _)) => {
+                eprintln!(
+                    "[codex-app-server] WS connected after {} attempt(s)",
+                    attempt
+                );
+                return Ok(stream);
+            }
+            Err(e) => {
+                last_err = e.to_string();
+                eprintln!(
+                    "[codex-app-server] WS connect attempt {}/{} failed: {}",
+                    attempt, max_attempts, e
+                );
+            }
+        }
+    }
+    Err(last_err)
+}

--- a/src-tauri/src/agents/mod.rs
+++ b/src-tauri/src/agents/mod.rs
@@ -1,6 +1,8 @@
 pub mod anthropic_sdk;
 pub mod claude;
+pub mod claude_sdk_session;
 pub mod codex;
+pub mod codex_app_server;
 pub mod context_hub;
 pub mod crg;
 pub mod embedder;

--- a/src-tauri/src/commands/agents.rs
+++ b/src-tauri/src/commands/agents.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, State};
 
-use crate::agents::{anthropic_sdk, claude, codex, gemini, gemini_sdk, openai_compat, openai_sdk, opencode};
+use crate::agents::{anthropic_sdk, claude, claude_sdk_session, codex, codex_app_server, gemini, gemini_sdk, openai_compat, openai_sdk, opencode};
 use crate::db::DbState;
 use crate::errors::AppError;
 use crate::guardrail;
@@ -58,6 +58,53 @@ fn identity_fragment(input: &SendWithClaudeInput, engine: &str) -> Option<String
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
+// Mode query
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// 현재 conversation에 적용될 claude 전송 모드를 반환한다.
+/// - "sdk-url" : --sdk-url WS 세션 (기본)
+/// - "cli"     : -p stream-json (TUNAFLOW_DISABLE_SDK_URL=1 시)
+/// - "sdk"     : Anthropic SDK 직접 (API 키 + branch)
+fn resolve_claude_mode(conversation_id: &str) -> &'static str {
+    let is_branch = conversation_id.starts_with("branch:");
+    if anthropic_sdk::is_available() && is_branch {
+        "sdk"
+    } else if std::env::var("TUNAFLOW_DISABLE_SDK_URL").as_deref() != Ok("1") {
+        "sdk-url"
+    } else {
+        "cli"
+    }
+}
+
+#[tauri::command]
+pub fn get_claude_mode(conversation_id: String) -> String {
+    resolve_claude_mode(&conversation_id).to_string()
+}
+
+#[tauri::command]
+pub fn restart_sdk_session(conversation_id: String) {
+    if resolve_claude_mode(&conversation_id) == "sdk-url" {
+        claude_sdk_session::kill_session_clear_resume(&conversation_id);
+    }
+}
+
+#[tauri::command]
+pub async fn prewarm_sdk_session(conversation_id: String, project_path: Option<String>, model: Option<String>) {
+    if resolve_claude_mode(&conversation_id) == "sdk-url" {
+        claude_sdk_session::prewarm_session(
+            &conversation_id,
+            project_path.as_deref(),
+            model.as_deref(),
+        ).await;
+    }
+}
+
+#[tauri::command]
+pub fn has_active_sdk_session(conversation_id: String) -> bool {
+    claude_sdk_session::has_active_session(&conversation_id)
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
 // Background start_* commands — async, DB work runs off main thread
 // ═══════════════════════════════════════════════════════════════════════════
 
@@ -111,12 +158,16 @@ pub async fn start_claude_stream(
     }).await.map_err(|_| AppError::Lock)??;
 
     let ret = prep.msg_id.clone();
+    let ep = prep.enriched_prompt.clone();
     let PreparedRun { msg_id, job_id, project_path, ctx_meta, .. } = prep;
     let plen = pr.len() + system_prompt.as_ref().map_or(0, |s| s.len());
 
-    // Claude: CLI preferred (file editing, MCP, terminal).
-    // SDK only when ANTHROPIC_API_KEY is set AND conversation is a branch (Developer/Reviewer).
+    // Claude 실행 경로 선택:
+    // 1. ANTHROPIC_API_KEY + branch → Anthropic SDK 직접 호출
+    // 2. 기본 → --sdk-url WS 세션 (슬래시 커맨드 + 구조화 JSON)
+    // 3. TUNAFLOW_DISABLE_SDK_URL=1 → CLI -p stream-json (fallback)
     let use_sdk = anthropic_sdk::is_available() && cid.starts_with("branch:");
+    let use_sdk_url = !use_sdk && std::env::var("TUNAFLOW_DISABLE_SDK_URL").as_deref() != Ok("1");
 
     if use_sdk {
         let sp = system_prompt;
@@ -138,15 +189,35 @@ pub async fn start_claude_stream(
             }
             if rr.is_ok() { spawn_post_completion_tasks(db_p, cid); }
         });
+    } else if use_sdk_url {
+        // --sdk-url WS 세션: 구조화 JSON + 슬래시 커맨드 지원
+        let cid2 = cid.clone();
+        let db_p = db_post.clone();
+        tokio::spawn(async move {
+            let pa = app.clone(); let pi = msg_id.clone(); let pc = cid2.clone();
+            let c2 = app.clone(); let ci = msg_id.clone(); let cc = cid2.clone();
+            let t0 = std::time::Instant::now();
+            let rr = claude_sdk_session::stream_run_sdk(
+                &cid2,
+                claude::RunInput { prompt: ep, model: mo.clone(), system_prompt: None, resume_token: None, project_path },
+                move |t| { let _ = pa.emit("claude:progress", ChunkPayload { message_id: pi.clone(), conversation_id: pc.clone(), text: t }); },
+                move |t| { let _ = c2.emit("claude:chunk", ChunkPayload { message_id: ci.clone(), conversation_id: cc.clone(), text: t }); },
+                { let c = cid2.clone(); let r = cancel_arc; move || { r.lock().remove(&c) } },
+            ).await;
+            let dur = t0.elapsed().as_millis();
+            guardrail::log_run("claude-sdk-url", mo.as_deref(), dur, plen, rr.is_ok());
+            if let Ok(conn) = write_arc.lock() {
+                finalize_engine_run(&conn, "claude-code", &msg_id, &cid, &job_id, &rr, dur, &ctx_meta, &app);
+            }
+            if rr.is_ok() { spawn_post_completion_tasks(db_p, cid); }
+        });
     } else {
-        // CLI path — full Claude Code features
+        // CLI -p fallback (TUNAFLOW_DISABLE_SDK_URL=1)
         std::thread::spawn(move || {
             let pa = app.clone(); let pi = msg_id.clone(); let pc = cid.clone();
             let c2 = app.clone(); let ci = msg_id.clone(); let cc = cid.clone();
             let t0 = std::time::Instant::now();
             let rr = claude::stream_run(
-                // resume_token intentionally omitted: ContextPack includes full conversation history.
-                // PTY mode owns the resume_token for interactive session continuity.
                 claude::RunInput { prompt: pr, model: mo.clone(), system_prompt, resume_token: None, project_path },
                 move |t| { let _ = pa.emit("claude:progress", ChunkPayload { message_id: pi.clone(), conversation_id: pc.clone(), text: t }); },
                 move |t| { let _ = c2.emit("claude:chunk", ChunkPayload { message_id: ci.clone(), conversation_id: cc.clone(), text: t }); },
@@ -264,6 +335,26 @@ pub async fn start_codex_run(
                 finalize_engine_run(&conn, "codex", &msg_id, &cid, &job_id, &rr, dur, &ctx_meta, &app);
             }
             if rr.is_ok() { spawn_post_completion_tasks(db_p, cid); }
+        });
+    } else if codex_app_server::is_available() {
+        // Codex app-server 지속 세션 (매번 재스폰 없음)
+        let cid2 = cid.clone();
+        tokio::spawn(async move {
+            let pa = app.clone(); let pi = msg_id.clone(); let pc = cid2.clone();
+            let c2 = app.clone(); let ci = msg_id.clone(); let cc = cid2.clone();
+            let t0 = std::time::Instant::now();
+            let rr = codex_app_server::stream_run_app_server(
+                &cid,
+                claude::RunInput { prompt: enriched_prompt, model: mo.clone(), system_prompt: None, resume_token: None, project_path },
+                move |t| { let _ = pa.emit("codex:progress", ChunkPayload { message_id: pi.clone(), conversation_id: pc.clone(), text: t }); },
+                move |t| { let _ = c2.emit("codex:chunk", ChunkPayload { message_id: ci.clone(), conversation_id: cc.clone(), text: t }); },
+                || false,
+            ).await;
+            let dur = t0.elapsed().as_millis();
+            if let Ok(conn) = write_arc.lock() {
+                finalize_engine_run(&conn, "codex", &msg_id, &cid2, &job_id, &rr, dur, &ctx_meta, &app);
+            }
+            if rr.is_ok() { spawn_post_completion_tasks(db_post, cid2); }
         });
     } else {
         // Codex CLI fallback

--- a/src-tauri/src/commands/agents_helpers/send_common/mod.rs
+++ b/src-tauri/src/commands/agents_helpers/send_common/mod.rs
@@ -1,6 +1,7 @@
 mod context_loading;
 mod prompt_assembly;
 mod persistence;
+pub mod session_freshness;
 
 // Re-export everything so external `use crate::commands::agents_helpers::send_common::*` still works
 #[allow(unused_imports)]

--- a/src-tauri/src/commands/agents_helpers/send_common/session_freshness.rs
+++ b/src-tauri/src/commands/agents_helpers/send_common/session_freshness.rs
@@ -1,0 +1,163 @@
+//! ContextPack 세션 신선도(freshness) 판정.
+//!
+//! 핵심 규칙: 같은 (engine, session_id) 튜플로 연속 send → 에이전트가 이미
+//! `--replay-user-messages`/codex thread 내부에 히스토리를 가지고 있으므로
+//! ContextPack은 minimal(user prompt 위주)로 충분.
+//!
+//! 다른 튜플 → 새 에이전트 프로세스(엔진 전환, 세션 crash, 첫 send) → full ContextPack.
+//!
+//! 적용 대상:
+//! - claude `--sdk-url` (claude_sdk_session::SESSIONS)
+//! - codex app-server (codex_app_server::CONV_THREADS)
+//!
+//! 적용 제외 (항상 full):
+//! - claude `-p` CLI 모드 (start_claude_stream의 비-sdk 경로)
+//! - codex CLI exec fallback
+//! - gemini, opencode (one-shot)
+//! - Roundtable participants
+//! - Branch shadow conversation의 첫 send (LAST_DELIVERED 비어있어 자동으로 full)
+
+use std::collections::HashMap;
+use parking_lot::Mutex as PlMutex;
+
+lazy_static::lazy_static! {
+    /// conv_id → 마지막으로 full ContextPack을 전달한 세션 키.
+    /// 같은 키가 다시 등장하면 minimal로 보낼 수 있다.
+    static ref LAST_DELIVERED_KEY: PlMutex<HashMap<String, String>> = PlMutex::new(HashMap::new());
+
+    /// msg_id → prepare 시점에 capture한 세션 키 (in-flight send용).
+    /// finalize 성공 시 LAST_DELIVERED_KEY로 promote 후 제거. 실패/타임아웃 시 그냥 제거.
+    /// prepare 시점의 키를 보존해 prepare↔finalize 사이의 SESSIONS 변경(monitor task crash 등)에 영향받지 않게 함.
+    static ref PENDING_DELIVERY: PlMutex<HashMap<String, String>> = PlMutex::new(HashMap::new());
+}
+
+/// prepare 시점에 호출 — capture된 키를 msg_id 기준으로 in-flight 보관.
+pub fn stash_pending(msg_id: &str, key: &str) {
+    PENDING_DELIVERY.lock().insert(msg_id.to_string(), key.to_string());
+}
+
+/// finalize 성공 시 호출 — pending → LAST_DELIVERED로 승격.
+/// pending이 없으면(=session_key가 prepare 시점엔 없었음) finalize 시점의 conv/engine으로 fallback 조회.
+/// 둘 다 없으면 기록하지 않음 (예: -p one-shot 모드).
+pub fn promote_pending_to_delivered(msg_id: &str, conv_id: &str, engine: &str) {
+    let from_pending = PENDING_DELIVERY.lock().remove(msg_id);
+    let key = from_pending.or_else(|| current_session_key(conv_id, engine));
+    if let Some(k) = key {
+        LAST_DELIVERED_KEY.lock().insert(conv_id.to_string(), k);
+    }
+}
+
+/// finalize 실패 시 호출 — pending 키만 정리. LAST_DELIVERED는 건드리지 않음.
+pub fn discard_pending(msg_id: &str) {
+    PENDING_DELIVERY.lock().remove(msg_id);
+}
+
+/// 현재 conversation에 대해 활성화된 세션 키를 반환.
+/// WS/app-server 지속 세션을 사용하지 않는 엔진은 None을 반환하며,
+/// 이 경우 호출자는 항상 full ContextPack 경로를 사용해야 한다.
+pub fn current_session_key(conv_id: &str, engine: &str) -> Option<String> {
+    match engine {
+        "claude" => crate::agents::claude_sdk_session::current_session_key(conv_id),
+        "codex" => {
+            // codex는 OpenAI SDK > app-server > CLI 순으로 fallback.
+            // app-server 모드일 때만 thread key 존재.
+            crate::agents::codex_app_server::current_thread_key(conv_id)
+        }
+        _ => None,
+    }
+}
+
+/// 마지막으로 기록된 전달 키.
+pub fn last_delivered_key(conv_id: &str) -> Option<String> {
+    LAST_DELIVERED_KEY.lock().get(conv_id).cloned()
+}
+
+/// send 완료 시 현재 세션 키를 기록.
+/// 다음 send에서 같은 키면 minimal로 흐른다.
+pub fn record_delivered_key(conv_id: &str, key: &str) {
+    LAST_DELIVERED_KEY.lock().insert(conv_id.to_string(), key.to_string());
+}
+
+/// 같은 세션이 연속되는 상황인지 판정.
+/// true → minimal ContextPack 가능, false → full 필수.
+pub fn is_session_continuation(conv_id: &str, engine: &str) -> bool {
+    let current = current_session_key(conv_id, engine);
+    let last = last_delivered_key(conv_id);
+    matches!((current.as_deref(), last.as_deref()), (Some(c), Some(l)) if c == l)
+}
+
+/// 세션이 명시적으로 종료되거나 conversation이 reset될 때 호출.
+/// 다음 send는 full로 강제된다.
+/// 호출처: `branches::open_branch_stream` (브랜치 재open 시), `claude_sdk_session::kill_session_*`,
+/// 향후 conversation reset/clear 시.
+pub fn clear_delivered_key(conv_id: &str) {
+    LAST_DELIVERED_KEY.lock().remove(conv_id);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // 테스트는 글로벌 lazy_static 레지스트리를 공유하므로 각 테스트는 고유 conv_id를
+    // 사용해야 한다. UUID 같은 고유 prefix로 격리.
+    fn unique_conv(prefix: &str) -> String {
+        format!("{}-{}", prefix, uuid::Uuid::new_v4())
+    }
+
+    #[test]
+    fn record_then_compare_same_key_returns_true_via_helper() {
+        let conv = unique_conv("rec-eq");
+        record_delivered_key(&conv, "claude-ws:abc");
+        assert_eq!(last_delivered_key(&conv).as_deref(), Some("claude-ws:abc"));
+    }
+
+    #[test]
+    fn discard_pending_does_not_promote() {
+        let conv = unique_conv("disc");
+        let msg = "msg-disc-1";
+        stash_pending(msg, "claude-ws:xyz");
+        discard_pending(msg);
+        // promote 호출해도 pending이 비었고 current_session_key도 None(모듈 외 의존성 없음)
+        // → LAST_DELIVERED_KEY는 갱신되지 않아야 함.
+        promote_pending_to_delivered(msg, &conv, "unknown-engine");
+        assert!(last_delivered_key(&conv).is_none(),
+            "discard 후 promote는 LAST_DELIVERED를 변경하지 않아야 함");
+    }
+
+    #[test]
+    fn promote_uses_pending_value_not_live_lookup() {
+        // race A2 시나리오 회귀 테스트: prepare 시점에 stash한 키가 promote에 사용되어야 함.
+        // (current_session_key가 None을 반환하더라도 stashed 값이 우선)
+        let conv = unique_conv("promote-race");
+        let msg = "msg-promote-1";
+        stash_pending(msg, "claude-ws:captured-at-prepare");
+        // engine="nonexistent" → current_session_key는 None을 반환 (race 시뮬레이션)
+        promote_pending_to_delivered(msg, &conv, "nonexistent");
+        assert_eq!(
+            last_delivered_key(&conv).as_deref(),
+            Some("claude-ws:captured-at-prepare"),
+            "stashed 키가 promote에 사용되어야 함 (live lookup fallback이 None이어도)"
+        );
+    }
+
+    #[test]
+    fn clear_delivered_forces_full_next_time() {
+        let conv = unique_conv("clear");
+        record_delivered_key(&conv, "claude-ws:abc");
+        clear_delivered_key(&conv);
+        // is_session_continuation은 last가 비어있으면 false → 다음 send는 full
+        // (current_session_key가 Some이라도 last가 None이면 매치 안 됨)
+        assert!(last_delivered_key(&conv).is_none());
+    }
+
+    #[test]
+    fn is_session_continuation_requires_both_present_and_equal() {
+        let conv = unique_conv("cont");
+        // last가 없으면 false
+        assert!(!is_session_continuation(&conv, "claude"));
+        // last 기록 후에도 current_session_key가 None이면 false (-p engine 같은 경우)
+        record_delivered_key(&conv, "claude-ws:xyz");
+        assert!(!is_session_continuation(&conv, "unknown-engine"),
+            "current_session_key가 None인 엔진은 continuation 판정 false여야 함");
+    }
+}

--- a/src-tauri/src/commands/conventions_sync.rs
+++ b/src-tauri/src/commands/conventions_sync.rs
@@ -1,0 +1,595 @@
+//! Conventions Context Sync (Phase 1).
+//!
+//! ContextPack의 정적 layer를 conventions 파일(CLAUDE.md/AGENTS.md/GEMINI.md)로
+//! 영속화한다. DB(`project_conventions` 테이블)가 SSOT이고 파일은 derived/cache.
+//!
+//! # 마커 컨벤션
+//!
+//! ```markdown
+//! <!-- tunaflow:managed:start -->
+//! @.tunaflow/conventions/platform.md
+//! @.tunaflow/conventions/persona-architect.md
+//! ...
+//! <!-- tunaflow:managed:end -->
+//!
+//! [사용자 영역 — tunaflow가 절대 건드리지 않음]
+//! ```
+//!
+//! 마커 사이만 우리가 갱신. 마커가 없으면 파일 끝에 추가. 사용자 영역은 보존.
+//!
+//! # 파일 구조
+//!
+//! - `<project_root>/CLAUDE.md` — claude용 진입점 (마커 영역만)
+//! - `<project_root>/AGENTS.md` — codex/opencode 공유 진입점
+//! - `<project_root>/GEMINI.md` — gemini용 진입점
+//! - `<project_root>/.tunaflow/conventions/<layer>[-<persona>].md` — 실제 본문
+//!   - 진입점에서 `@` 임포트로 인라인됨 (claude/codex 모두 지원)
+//!
+//! # 크기 가드
+//!
+//! 각 split 파일 max ~10k chars. 초과 시 truncate + warning. 진입점 자체는 50줄 미만
+//! (포인터만).
+//!
+//! # 호출 시점
+//!
+//! - 명시 (set_convention API): UI 설정 변경 시 즉시 sync
+//! - lazy (send 직전): prepare_engine_run에서 cheap check (`is_dirty`) 후 sync 필요 시만
+
+use std::path::{Path, PathBuf};
+use std::fs;
+use std::io::Write;
+
+use rusqlite::{params, Connection};
+use serde::Serialize;
+use tauri::State;
+
+use crate::errors::AppError;
+use crate::db::DbState;
+
+const MARKER_START: &str = "<!-- tunaflow:managed:start -->";
+const MARKER_END: &str = "<!-- tunaflow:managed:end -->";
+const MAX_LAYER_FILE_CHARS: usize = 10_000;
+const SPLIT_DIR: &str = ".tunaflow/conventions";
+
+// ─── DB layer ───────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConventionRow {
+    pub id: i64,
+    pub layer: String,
+    pub persona_label: Option<String>,
+    pub content: String,
+    pub source_id: Option<String>,
+    pub revision: i64,
+    pub updated_at: i64,
+}
+
+/// 특정 project + (선택) persona에 적용될 conventions 행들을 반환.
+/// persona가 Some이면 (공통 row) + (해당 persona row) 둘 다 가져옴.
+/// DB 저장 형태는 빈 문자열 sentinel — 반환 시 None으로 환원.
+pub fn list_conventions(
+    conn: &Connection,
+    project_key: &str,
+    persona_label: Option<&str>,
+) -> Result<Vec<ConventionRow>, AppError> {
+    let sql = match persona_label {
+        Some(_) => "SELECT id, layer, persona_label, content, source_id, revision, updated_at
+                    FROM project_conventions
+                    WHERE project_key = ?1 AND (persona_label = '' OR persona_label = ?2)
+                    ORDER BY layer, persona_label, source_id, id",
+        None => "SELECT id, layer, persona_label, content, source_id, revision, updated_at
+                 FROM project_conventions
+                 WHERE project_key = ?1 AND persona_label = ''
+                 ORDER BY layer, source_id, id",
+    };
+    let mut stmt = conn.prepare(sql)?;
+    let rows = if let Some(p) = persona_label {
+        stmt.query_map(params![project_key, p], row_to_convention)?
+            .collect::<Result<Vec<_>, _>>()?
+    } else {
+        stmt.query_map(params![project_key], row_to_convention)?
+            .collect::<Result<Vec<_>, _>>()?
+    };
+    Ok(rows)
+}
+
+fn row_to_convention(row: &rusqlite::Row) -> rusqlite::Result<ConventionRow> {
+    let pl: String = row.get(2)?;
+    let sid: String = row.get(4)?;
+    Ok(ConventionRow {
+        id: row.get(0)?,
+        layer: row.get(1)?,
+        persona_label: if pl.is_empty() { None } else { Some(pl) },
+        content: row.get(3)?,
+        source_id: if sid.is_empty() { None } else { Some(sid) },
+        revision: row.get(5)?,
+        updated_at: row.get(6)?,
+    })
+}
+
+/// upsert — (project_key, layer, persona_label, source_id) 키 기준으로 갱신.
+/// revision이 더 작거나 같으면 갱신 안 함 (idempotent).
+/// None ↔ "" 변환은 여기서 처리.
+pub fn upsert_convention(
+    conn: &Connection,
+    project_key: &str,
+    layer: &str,
+    persona_label: Option<&str>,
+    source_id: Option<&str>,
+    content: &str,
+    revision: i64,
+) -> Result<(), AppError> {
+    let now = crate::db::migrations::now_epoch_ms();
+    let pl = persona_label.unwrap_or("");
+    let sid = source_id.unwrap_or("");
+    conn.execute(
+        "INSERT INTO project_conventions
+            (project_key, layer, persona_label, content, source_id, revision, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+         ON CONFLICT(project_key, layer, persona_label, source_id) DO UPDATE SET
+            content = excluded.content,
+            revision = excluded.revision,
+            updated_at = excluded.updated_at
+         WHERE excluded.revision >= project_conventions.revision",
+        params![project_key, layer, pl, content, sid, revision, now],
+    )?;
+    Ok(())
+}
+
+/// 특정 (project, layer, persona, source) 행 삭제.
+pub fn delete_convention(
+    conn: &Connection,
+    project_key: &str,
+    layer: &str,
+    persona_label: Option<&str>,
+    source_id: Option<&str>,
+) -> Result<(), AppError> {
+    let pl = persona_label.unwrap_or("");
+    let sid = source_id.unwrap_or("");
+    conn.execute(
+        "DELETE FROM project_conventions
+         WHERE project_key = ?1 AND layer = ?2 AND persona_label = ?3 AND source_id = ?4",
+        params![project_key, layer, pl, sid],
+    )?;
+    Ok(())
+}
+
+/// project의 conventions 갱신 시각 중 최댓값. file sync 필요성 판단(dirty check)에 사용.
+pub fn last_updated(conn: &Connection, project_key: &str) -> Result<i64, AppError> {
+    let v: i64 = conn
+        .query_row(
+            "SELECT COALESCE(MAX(updated_at), 0) FROM project_conventions WHERE project_key = ?1",
+            params![project_key],
+            |row| row.get(0),
+        )
+        .unwrap_or(0);
+    Ok(v)
+}
+
+// ─── File sync layer ────────────────────────────────────────────────────────
+
+/// 엔진별 conventions 진입점 파일명.
+fn entry_file_for_engine(engine: &str) -> &'static str {
+    match engine {
+        "claude" | "claude-code" => "CLAUDE.md",
+        "gemini" => "GEMINI.md",
+        // codex, opencode 등은 AGENTS.md 공유
+        _ => "AGENTS.md",
+    }
+}
+
+/// project 내 split 파일 디렉토리 절대 경로.
+fn split_dir(project_root: &Path) -> PathBuf {
+    project_root.join(SPLIT_DIR)
+}
+
+/// 한 layer의 split 파일 경로. persona가 있으면 `<layer>-<persona>.md`.
+fn layer_file_path(project_root: &Path, layer: &str, persona: Option<&str>) -> PathBuf {
+    let name = match persona {
+        Some(p) => format!("{}-{}.md", layer, sanitize_segment(p)),
+        None => format!("{}.md", layer),
+    };
+    split_dir(project_root).join(name)
+}
+
+/// 파일명에 안전한 segment로 변환 (공백 → -, 영숫자/하이픈/_ 외 제거).
+fn sanitize_segment(s: &str) -> String {
+    s.chars()
+        .map(|c| {
+            if c.is_alphanumeric() || c == '-' || c == '_' { c }
+            else if c.is_whitespace() { '-' }
+            else { '_' }
+        })
+        .collect::<String>()
+        .to_lowercase()
+}
+
+/// 사용자 영역을 보존하면서 진입점 파일의 마커 영역만 교체한다.
+/// 마커가 없으면 파일 끝에 새 마커 블록을 추가.
+pub fn write_managed_section(file_path: &Path, managed_body: &str) -> Result<(), AppError> {
+    let original = fs::read_to_string(file_path).unwrap_or_default();
+    let new_block = format!("{}\n{}\n{}", MARKER_START, managed_body.trim(), MARKER_END);
+
+    let updated = if let (Some(start), Some(end)) = (original.find(MARKER_START), original.find(MARKER_END)) {
+        // 마커 끝 위치를 marker_end 다음 줄까지 포함해야 깨끗 — end는 marker 시작 인덱스이므로 + len.
+        let end_full = end + MARKER_END.len();
+        let mut s = String::with_capacity(original.len() + new_block.len());
+        s.push_str(&original[..start]);
+        s.push_str(&new_block);
+        s.push_str(&original[end_full..]);
+        s
+    } else {
+        // 마커 없음 — 파일 끝에 추가. 기존 trailing newline 정리.
+        let trimmed = original.trim_end();
+        if trimmed.is_empty() {
+            new_block + "\n"
+        } else {
+            format!("{}\n\n{}\n", trimmed, new_block)
+        }
+    };
+
+    // atomic write — temp file → rename
+    if let Some(parent) = file_path.parent() {
+        if !parent.exists() {
+            fs::create_dir_all(parent).map_err(|e| AppError::Agent(format!("conventions: mkdir {}: {}", parent.display(), e)))?;
+        }
+    }
+    let tmp = file_path.with_extension(format!(
+        "{}.tmp",
+        file_path.extension().and_then(|s| s.to_str()).unwrap_or("md")
+    ));
+    {
+        let mut f = fs::File::create(&tmp)
+            .map_err(|e| AppError::Agent(format!("conventions: create tmp {}: {}", tmp.display(), e)))?;
+        f.write_all(updated.as_bytes())
+            .map_err(|e| AppError::Agent(format!("conventions: write tmp: {}", e)))?;
+        f.sync_all().ok();
+    }
+    fs::rename(&tmp, file_path)
+        .map_err(|e| AppError::Agent(format!("conventions: rename {}→{}: {}", tmp.display(), file_path.display(), e)))?;
+    Ok(())
+}
+
+/// split 파일 작성. 크기 가드 적용 (max 10k chars 초과 시 truncate + 경고).
+fn write_split_file(file_path: &Path, body: &str) -> Result<bool, AppError> {
+    let (final_body, truncated) = if body.len() > MAX_LAYER_FILE_CHARS {
+        let mut end = MAX_LAYER_FILE_CHARS;
+        while end > 0 && !body.is_char_boundary(end) {
+            end -= 1;
+        }
+        let truncated_body = format!(
+            "{}\n\n<!-- tunaflow: truncated — {} chars exceeded {} limit -->\n",
+            &body[..end], body.len(), MAX_LAYER_FILE_CHARS
+        );
+        (truncated_body, true)
+    } else {
+        (body.to_string(), false)
+    };
+
+    if let Some(parent) = file_path.parent() {
+        if !parent.exists() {
+            fs::create_dir_all(parent)
+                .map_err(|e| AppError::Agent(format!("conventions: mkdir {}: {}", parent.display(), e)))?;
+        }
+    }
+    let tmp = file_path.with_extension("md.tmp");
+    {
+        let mut f = fs::File::create(&tmp)
+            .map_err(|e| AppError::Agent(format!("conventions: create split tmp {}: {}", tmp.display(), e)))?;
+        f.write_all(final_body.as_bytes())
+            .map_err(|e| AppError::Agent(format!("conventions: write split tmp: {}", e)))?;
+        f.sync_all().ok();
+    }
+    fs::rename(&tmp, file_path)
+        .map_err(|e| AppError::Agent(format!("conventions: rename split {}→{}: {}", tmp.display(), file_path.display(), e)))?;
+    Ok(truncated)
+}
+
+/// project + persona에 대해 conventions 파일 전부를 sync한다.
+/// - DB에서 활성 행을 layer/persona별로 그룹화
+/// - 각 그룹을 split 파일로 write
+/// - 진입점 파일(CLAUDE.md/AGENTS.md/GEMINI.md)의 마커 영역에 `@` 임포트 라인을 채움
+///
+/// engines: 진입점 파일을 만들 엔진 목록 (예: ["claude", "codex", "gemini"])
+/// 일반적으로 활성화된 모든 엔진을 포함하지만, 비용 절약을 위해 호출자가 좁힐 수 있다.
+pub fn sync_to_files(
+    conn: &Connection,
+    project_root: &Path,
+    project_key: &str,
+    persona_label: Option<&str>,
+    engines: &[&str],
+) -> Result<SyncReport, AppError> {
+    let rows = list_conventions(conn, project_key, persona_label)?;
+
+    // (layer, persona, source_id) 단위로 합쳐 split 파일을 쓰지만,
+    // 진입점에서는 layer + persona 단위로 단일 import만 노출 (source는 같은 파일에 합침).
+    use std::collections::BTreeMap;
+    type Key = (String, Option<String>); // (layer, persona)
+    let mut groups: BTreeMap<Key, Vec<&ConventionRow>> = BTreeMap::new();
+    for r in &rows {
+        groups.entry((r.layer.clone(), r.persona_label.clone()))
+            .or_default()
+            .push(r);
+    }
+
+    let mut split_paths: Vec<PathBuf> = Vec::new();
+    let mut truncated_files: Vec<PathBuf> = Vec::new();
+
+    for ((layer, persona), items) in &groups {
+        // 같은 (layer, persona)의 모든 source를 한 파일에 합침. source_id별로 섹션 분리.
+        let mut body = String::new();
+        body.push_str(&format!("<!-- tunaflow auto-managed: layer={} persona={} -->\n",
+            layer, persona.as_deref().unwrap_or("(common)")));
+        for item in items {
+            if let Some(sid) = &item.source_id {
+                body.push_str(&format!("\n<!-- source_id={} revision={} -->\n", sid, item.revision));
+            }
+            body.push_str(item.content.trim());
+            body.push_str("\n");
+        }
+
+        let split_path = layer_file_path(project_root, layer, persona.as_deref());
+        let truncated = write_split_file(&split_path, &body)?;
+        if truncated { truncated_files.push(split_path.clone()); }
+        split_paths.push(split_path);
+    }
+
+    // 진입점 파일에 `@` 임포트 라인 작성. claude code의 `@path` 임포트와 호환.
+    let managed_body = if split_paths.is_empty() {
+        String::from("<!-- tunaflow: no conventions configured for this project -->")
+    } else {
+        let mut s = String::from("## Project conventions (managed by tunaFlow)\n\n");
+        s.push_str("> 이 영역은 tunaFlow가 자동 갱신합니다. Settings에서 편집하세요.\n\n");
+        for p in &split_paths {
+            // 진입점 파일 기준 상대 경로
+            if let Ok(rel) = p.strip_prefix(project_root) {
+                s.push_str(&format!("@{}\n", rel.display()));
+            }
+        }
+        s
+    };
+
+    let mut written_entries: Vec<PathBuf> = Vec::new();
+    for engine in engines {
+        let entry = project_root.join(entry_file_for_engine(engine));
+        // codex와 opencode가 같은 AGENTS.md 공유 — 중복 방지
+        if written_entries.contains(&entry) { continue; }
+        write_managed_section(&entry, &managed_body)?;
+        written_entries.push(entry);
+    }
+
+    Ok(SyncReport {
+        rows_written: rows.len(),
+        split_files: split_paths.len(),
+        entry_files: written_entries.len(),
+        truncated: truncated_files,
+    })
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SyncReport {
+    pub rows_written: usize,
+    pub split_files: usize,
+    pub entry_files: usize,
+    pub truncated: Vec<PathBuf>,
+}
+
+// ─── Tauri commands ─────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub fn list_project_conventions(
+    state: State<DbState>,
+    project_key: String,
+    persona_label: Option<String>,
+) -> Result<Vec<ConventionRow>, AppError> {
+    let conn = state.read.lock().map_err(|_| AppError::Lock)?;
+    list_conventions(&conn, &project_key, persona_label.as_deref())
+}
+
+#[tauri::command]
+pub fn set_project_convention(
+    state: State<DbState>,
+    project_key: String,
+    layer: String,
+    persona_label: Option<String>,
+    source_id: Option<String>,
+    content: String,
+    revision: Option<i64>,
+) -> Result<(), AppError> {
+    let conn = state.write.lock().map_err(|_| AppError::Lock)?;
+    upsert_convention(
+        &conn, &project_key, &layer,
+        persona_label.as_deref(), source_id.as_deref(),
+        &content, revision.unwrap_or(0),
+    )
+}
+
+#[tauri::command]
+pub fn delete_project_convention(
+    state: State<DbState>,
+    project_key: String,
+    layer: String,
+    persona_label: Option<String>,
+    source_id: Option<String>,
+) -> Result<(), AppError> {
+    let conn = state.write.lock().map_err(|_| AppError::Lock)?;
+    delete_convention(&conn, &project_key, &layer,
+        persona_label.as_deref(), source_id.as_deref())
+}
+
+/// 진입점 파일 + split 파일들을 즉시 sync. UI에서 명시 트리거.
+/// engines: ["claude", "codex", "gemini"] 등. 지정 안 하면 4종 모두.
+#[tauri::command]
+pub fn sync_project_conventions(
+    state: State<DbState>,
+    project_key: String,
+    project_path: String,
+    persona_label: Option<String>,
+    engines: Option<Vec<String>>,
+) -> Result<SyncReport, AppError> {
+    let conn = state.read.lock().map_err(|_| AppError::Lock)?;
+    let default_engines = vec!["claude".to_string(), "codex".to_string(), "gemini".to_string()];
+    let eng_list = engines.unwrap_or(default_engines);
+    let eng_refs: Vec<&str> = eng_list.iter().map(|s| s.as_str()).collect();
+    sync_to_files(&conn, Path::new(&project_path), &project_key,
+        persona_label.as_deref(), &eng_refs)
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    /// vec0 등 외부 extension 없이 conventions 테이블만 만든 in-memory DB.
+    /// migrations::run을 쓰지 않아 격리 빠름.
+    fn test_db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE project_conventions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                project_key TEXT NOT NULL,
+                layer TEXT NOT NULL,
+                persona_label TEXT NOT NULL DEFAULT '',
+                content TEXT NOT NULL,
+                source_id TEXT NOT NULL DEFAULT '',
+                revision INTEGER NOT NULL DEFAULT 0,
+                updated_at INTEGER NOT NULL,
+                UNIQUE(project_key, layer, persona_label, source_id)
+            );"
+        ).unwrap();
+        conn
+    }
+
+    #[test]
+    fn sanitize_segment_basic() {
+        assert_eq!(sanitize_segment("Architect"), "architect");
+        assert_eq!(sanitize_segment("Code Review"), "code-review");
+        assert_eq!(sanitize_segment("Special!@#"), "special___");
+    }
+
+    #[test]
+    fn entry_file_mapping() {
+        assert_eq!(entry_file_for_engine("claude"), "CLAUDE.md");
+        assert_eq!(entry_file_for_engine("claude-code"), "CLAUDE.md");
+        assert_eq!(entry_file_for_engine("gemini"), "GEMINI.md");
+        assert_eq!(entry_file_for_engine("codex"), "AGENTS.md");
+        assert_eq!(entry_file_for_engine("opencode"), "AGENTS.md");
+        assert_eq!(entry_file_for_engine("unknown"), "AGENTS.md");
+    }
+
+    #[test]
+    fn write_managed_section_creates_when_no_marker() {
+        let tmp = TempDir::new().unwrap();
+        let f = tmp.path().join("CLAUDE.md");
+        write_managed_section(&f, "@test").unwrap();
+        let s = fs::read_to_string(&f).unwrap();
+        assert!(s.contains(MARKER_START));
+        assert!(s.contains("@test"));
+        assert!(s.contains(MARKER_END));
+    }
+
+    #[test]
+    fn write_managed_section_preserves_user_area() {
+        let tmp = TempDir::new().unwrap();
+        let f = tmp.path().join("CLAUDE.md");
+        let initial = format!(
+            "# 사용자 헤더\n\nuser-text\n\n{}\nold-managed\n{}\n\n[사용자 footer]\n",
+            MARKER_START, MARKER_END
+        );
+        fs::write(&f, &initial).unwrap();
+        write_managed_section(&f, "@new-import").unwrap();
+        let s = fs::read_to_string(&f).unwrap();
+        assert!(s.contains("# 사용자 헤더"), "헤더 보존");
+        assert!(s.contains("user-text"), "본문 보존");
+        assert!(s.contains("[사용자 footer]"), "footer 보존");
+        assert!(s.contains("@new-import"), "새 managed 영역 적용");
+        assert!(!s.contains("old-managed"), "이전 managed 영역 교체됨");
+    }
+
+    #[test]
+    fn write_split_file_truncates_oversized() {
+        let tmp = TempDir::new().unwrap();
+        let f = tmp.path().join("layer.md");
+        let big = "x".repeat(MAX_LAYER_FILE_CHARS + 1000);
+        let truncated = write_split_file(&f, &big).unwrap();
+        assert!(truncated);
+        let s = fs::read_to_string(&f).unwrap();
+        assert!(s.contains("truncated"));
+        assert!(s.len() < big.len() + 200); // 경고 푸터 고려
+    }
+
+    #[test]
+    fn sync_to_files_full_flow() {
+        let tmp = TempDir::new().unwrap();
+        let conn = test_db();
+
+        let pk = "test-project";
+        upsert_convention(&conn, pk, "platform", None, None,
+            "## Platform\nbuild: cargo, npm", 1).unwrap();
+        upsert_convention(&conn, pk, "agent_role", Some("Architect"), None,
+            "## Architect role\nplan first.", 1).unwrap();
+
+        let report = sync_to_files(&conn, tmp.path(), pk, Some("Architect"),
+            &["claude", "codex", "gemini"]).unwrap();
+        assert_eq!(report.rows_written, 2);
+        assert_eq!(report.split_files, 2);
+        assert_eq!(report.entry_files, 3);
+
+        // 진입점 파일들 생성 확인
+        assert!(tmp.path().join("CLAUDE.md").exists());
+        assert!(tmp.path().join("AGENTS.md").exists());
+        assert!(tmp.path().join("GEMINI.md").exists());
+
+        // split 파일 생성 확인
+        assert!(tmp.path().join(".tunaflow/conventions/platform.md").exists());
+        assert!(tmp.path().join(".tunaflow/conventions/agent_role-architect.md").exists());
+
+        // 진입점에 @ 임포트 포함 확인
+        let claude_md = fs::read_to_string(tmp.path().join("CLAUDE.md")).unwrap();
+        assert!(claude_md.contains("@.tunaflow/conventions/platform.md"));
+        assert!(claude_md.contains("@.tunaflow/conventions/agent_role-architect.md"));
+    }
+
+    #[test]
+    fn upsert_idempotent_lower_revision_ignored() {
+        let conn = test_db();
+        upsert_convention(&conn, "p", "platform", None, None, "v2", 2).unwrap();
+        upsert_convention(&conn, "p", "platform", None, None, "v1-shouldnt-overwrite", 1).unwrap();
+        let rows = list_conventions(&conn, "p", None).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].content, "v2");
+        assert_eq!(rows[0].revision, 2);
+    }
+
+    #[test]
+    fn list_conventions_persona_filter() {
+        let conn = test_db();
+        upsert_convention(&conn, "p", "platform", None, None, "common", 1).unwrap();
+        upsert_convention(&conn, "p", "agent_role", Some("Architect"), None, "arch", 1).unwrap();
+        upsert_convention(&conn, "p", "agent_role", Some("Reviewer"), None, "rev", 1).unwrap();
+
+        // persona=Architect → 공통 + Architect만
+        let rows = list_conventions(&conn, "p", Some("Architect")).unwrap();
+        assert_eq!(rows.len(), 2);
+        assert!(rows.iter().any(|r| r.persona_label.is_none()));
+        assert!(rows.iter().any(|r| r.persona_label.as_deref() == Some("Architect")));
+        assert!(!rows.iter().any(|r| r.persona_label.as_deref() == Some("Reviewer")));
+
+        // persona=None → 공통만
+        let rows_common = list_conventions(&conn, "p", None).unwrap();
+        assert_eq!(rows_common.len(), 1);
+    }
+
+    #[test]
+    fn delete_convention_works() {
+        let conn = test_db();
+        upsert_convention(&conn, "p", "platform", None, None, "x", 1).unwrap();
+        delete_convention(&conn, "p", "platform", None, None).unwrap();
+        let rows = list_conventions(&conn, "p", None).unwrap();
+        assert_eq!(rows.len(), 0);
+    }
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod branches;
 pub mod capabilities;
 pub mod context_hub;
 pub mod context_queries;
+pub mod conventions_sync;
 pub mod conversation_memory;
 pub mod memory_topics;
 pub mod memory_compression;

--- a/src/components/tunaflow/settings/ConventionsSection.tsx
+++ b/src/components/tunaflow/settings/ConventionsSection.tsx
@@ -1,0 +1,280 @@
+/**
+ * ConventionsSection.tsx — Phase 1 (feat/conventions-context-sync 브랜치)
+ *
+ * project별 + persona별 conventions(static ContextPack layer)를 편집하는 UI.
+ * 저장된 내용은 sync_project_conventions로 CLAUDE.md/AGENTS.md/GEMINI.md에 반영된다.
+ *
+ * env TUNAFLOW_CONVENTIONS_SYNC=1 일 때만 ContextPack에서 정적 layer가 생략되고
+ * 이 파일들이 진짜로 적용된다. (env 안 켜져 있어도 편집/sync는 가능)
+ */
+import { useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { useChatStore } from "@/stores/chatStore";
+import { Loader2, RefreshCw, Trash2, Plus } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface ConventionRow {
+  id: number;
+  layer: string;
+  personaLabel: string | null;
+  content: string;
+  sourceId: string | null;
+  revision: number;
+  updatedAt: number;
+}
+
+interface SyncReport {
+  rowsWritten: number;
+  splitFiles: number;
+  entryFiles: number;
+  truncated: string[];
+}
+
+const LAYER_OPTIONS = [
+  { id: "platform", label: "Platform / Project meta", hint: "프로젝트 path, 빌드 명령어, 언어 등" },
+  { id: "agent_role", label: "Agent role", hint: "에이전트 역할 지침 (architect/coder/reviewer 등)" },
+  { id: "persona", label: "Persona", hint: "페르소나 행동 지침" },
+  { id: "user_profile", label: "User profile", hint: "사용자 정보, 선호" },
+  { id: "plan_doc", label: "Plan document", hint: "현재 진행 중인 plan 본문 (revision 기반)" },
+  { id: "findings", label: "Findings", hint: "이전 review verdict의 findings 본문" },
+  { id: "artifact", label: "Artifact", hint: "참고 산출물 (result.md 등)" },
+];
+
+export function ConventionsSection() {
+  const projects = useChatStore((s) => s.projects);
+  const selectedProjectKey = useChatStore((s) => s.selectedProjectKey);
+  const [projectKey, setProjectKey] = useState<string>(selectedProjectKey ?? "");
+  const [personaFilter, setPersonaFilter] = useState<string>("");
+  const [rows, setRows] = useState<ConventionRow[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [syncing, setSyncing] = useState(false);
+  const [report, setReport] = useState<SyncReport | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // 새 행 폼
+  const [newLayer, setNewLayer] = useState<string>("platform");
+  const [newPersona, setNewPersona] = useState<string>("");
+  const [newSource, setNewSource] = useState<string>("");
+  const [newContent, setNewContent] = useState<string>("");
+
+  const project = projects.find((p) => p.key === projectKey);
+
+  const reload = async () => {
+    if (!projectKey) { setRows([]); return; }
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await invoke<ConventionRow[]>("list_project_conventions", {
+        projectKey,
+        personaLabel: personaFilter || null,
+      });
+      setRows(result);
+    } catch (e) {
+      setError(String(e));
+    }
+    setLoading(false);
+  };
+
+  useEffect(() => { reload(); /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, [projectKey, personaFilter]);
+
+  const handleAdd = async () => {
+    if (!projectKey || !newContent.trim()) return;
+    setError(null);
+    try {
+      await invoke("set_project_convention", {
+        projectKey,
+        layer: newLayer,
+        personaLabel: newPersona.trim() || null,
+        sourceId: newSource.trim() || null,
+        content: newContent,
+        revision: 1,
+      });
+      setNewContent("");
+      setNewSource("");
+      await reload();
+    } catch (e) {
+      setError(String(e));
+    }
+  };
+
+  const handleDelete = async (row: ConventionRow) => {
+    setError(null);
+    try {
+      await invoke("delete_project_convention", {
+        projectKey,
+        layer: row.layer,
+        personaLabel: row.personaLabel,
+        sourceId: row.sourceId,
+      });
+      await reload();
+    } catch (e) {
+      setError(String(e));
+    }
+  };
+
+  const handleSync = async () => {
+    if (!projectKey || !project?.path) {
+      setError("project 경로가 없습니다");
+      return;
+    }
+    setSyncing(true);
+    setError(null);
+    setReport(null);
+    try {
+      const result = await invoke<SyncReport>("sync_project_conventions", {
+        projectKey,
+        projectPath: project.path,
+        personaLabel: personaFilter || null,
+        engines: ["claude", "codex", "gemini"],
+      });
+      setReport(result);
+    } catch (e) {
+      setError(String(e));
+    }
+    setSyncing(false);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-[14px] font-[550] text-foreground mb-1">Conventions Context Sync</h2>
+        <p className="text-[12px] text-muted-foreground mb-2">
+          정적 ContextPack layer를 CLAUDE.md / AGENTS.md / GEMINI.md로 sync합니다.
+          편집 후 "Sync Now" 버튼으로 파일 갱신.
+        </p>
+        <p className="text-[11px] text-amber-600/80">
+          ⚠️ Phase 1 실험. ContextPack에서 정적 layer가 실제로 생략되려면
+          앱을 <code className="px-1 bg-card rounded">TUNAFLOW_CONVENTIONS_SYNC=1</code> 환경변수로 실행하세요.
+        </p>
+      </div>
+
+      {/* Project + persona filter */}
+      <div className="flex items-center gap-2">
+        <select
+          value={projectKey}
+          onChange={(e) => setProjectKey(e.target.value)}
+          className="text-[12px] bg-input border border-border rounded px-2 py-1 outline-none"
+        >
+          <option value="">— Project 선택 —</option>
+          {projects.map((p) => (
+            <option key={p.key} value={p.key}>{p.key}</option>
+          ))}
+        </select>
+        <input
+          value={personaFilter}
+          onChange={(e) => setPersonaFilter(e.target.value)}
+          placeholder="Persona 필터 (비우면 공통 only)"
+          className="flex-1 text-[12px] bg-input border border-border rounded px-2 py-1 outline-none"
+        />
+        <button
+          onClick={reload}
+          disabled={!projectKey || loading}
+          className="px-2 py-1 rounded text-[11px] bg-card hover:bg-accent border border-border disabled:opacity-40"
+          title="다시 불러오기"
+        >
+          {loading ? <Loader2 className="w-3 h-3 animate-spin" /> : <RefreshCw className="w-3 h-3" />}
+        </button>
+        <button
+          onClick={handleSync}
+          disabled={!projectKey || !project?.path || syncing}
+          className="px-3 py-1 rounded text-[11px] font-medium bg-primary/15 text-primary hover:bg-primary/25 disabled:opacity-40"
+        >
+          {syncing ? "Syncing…" : "Sync Now"}
+        </button>
+      </div>
+
+      {error && (
+        <div className="text-[11px] text-destructive bg-destructive/10 border border-destructive/30 rounded px-2 py-1.5">
+          {error}
+        </div>
+      )}
+
+      {report && (
+        <div className="text-[11px] text-status-approved bg-status-approved/8 border border-status-approved/30 rounded px-2 py-1.5">
+          ✓ Sync 완료 — entry files: {report.entryFiles}, split files: {report.splitFiles}
+          {report.truncated.length > 0 && ` (${report.truncated.length}개 truncated)`}
+        </div>
+      )}
+
+      {/* Rows list */}
+      <div className="space-y-2">
+        {rows.length === 0 && !loading && projectKey && (
+          <p className="text-[11px] text-muted-foreground/60">아직 등록된 conventions가 없습니다. 아래에서 추가하세요.</p>
+        )}
+        {rows.map((row) => (
+          <div key={row.id} className="rounded border border-border/40 bg-card p-2 space-y-1">
+            <div className="flex items-center gap-2 text-[10px]">
+              <span className="px-1.5 py-0.5 rounded bg-primary/10 text-primary font-medium">{row.layer}</span>
+              {row.personaLabel && (
+                <span className="px-1.5 py-0.5 rounded bg-accent text-muted-foreground">persona: {row.personaLabel}</span>
+              )}
+              {row.sourceId && (
+                <span className="px-1.5 py-0.5 rounded bg-accent text-muted-foreground">src: {row.sourceId}</span>
+              )}
+              <span className="text-muted-foreground/50">rev {row.revision}</span>
+              <span className="flex-1" />
+              <button
+                onClick={() => handleDelete(row)}
+                className="p-1 text-destructive/60 hover:text-destructive hover:bg-destructive/10 rounded"
+                title="삭제"
+              >
+                <Trash2 className="w-3 h-3" />
+              </button>
+            </div>
+            <pre className={cn(
+              "text-[10px] text-foreground/80 whitespace-pre-wrap font-mono leading-snug",
+              "max-h-32 overflow-y-auto"
+            )}>{row.content}</pre>
+          </div>
+        ))}
+      </div>
+
+      {/* Add new */}
+      {projectKey && (
+        <div className="rounded border border-primary/30 bg-primary/5 p-2 space-y-2">
+          <div className="text-[11px] font-[550] text-primary">새 convention 추가</div>
+          <div className="flex items-center gap-2">
+            <select
+              value={newLayer}
+              onChange={(e) => setNewLayer(e.target.value)}
+              className="text-[11px] bg-input border border-border rounded px-2 py-1 outline-none"
+            >
+              {LAYER_OPTIONS.map((l) => (
+                <option key={l.id} value={l.id}>{l.label}</option>
+              ))}
+            </select>
+            <input
+              value={newPersona}
+              onChange={(e) => setNewPersona(e.target.value)}
+              placeholder="Persona (비우면 공통)"
+              className="flex-1 text-[11px] bg-input border border-border rounded px-2 py-1 outline-none"
+            />
+            <input
+              value={newSource}
+              onChange={(e) => setNewSource(e.target.value)}
+              placeholder="Source ID (선택)"
+              className="flex-1 text-[11px] bg-input border border-border rounded px-2 py-1 outline-none"
+            />
+          </div>
+          <p className="text-[10px] text-muted-foreground/60">{LAYER_OPTIONS.find((l) => l.id === newLayer)?.hint}</p>
+          <textarea
+            value={newContent}
+            onChange={(e) => setNewContent(e.target.value)}
+            placeholder="Markdown 본문…"
+            rows={5}
+            className="w-full text-[11px] bg-input border border-border rounded px-2 py-1.5 outline-none font-mono leading-snug"
+          />
+          <div className="flex justify-end">
+            <button
+              onClick={handleAdd}
+              disabled={!newContent.trim()}
+              className="flex items-center gap-1 px-3 py-1 rounded text-[11px] font-medium bg-status-approved/15 text-status-approved hover:bg-status-approved/25 disabled:opacity-40"
+            >
+              <Plus className="w-3 h-3" />추가
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- git stash에 묻혀있던 s36~s37 구현 코드 복구 (총 2,583줄 추가)
- `claude_sdk_session.rs`: Claude `--sdk-url` WS 세션 (Desktop 앱과 동일 방식)
- `codex_app_server.rs`: Codex `app-server` JSON-RPC 2.0 over WS
- `session_freshness.rs`: ContextPack stateful/stateless 분기 로직
- `conventions_sync.rs` + `ConventionsSection.tsx`: Conventions 자동 sync
- `agents.rs`: 3-way 경로 분기 (sdk-url / sdk / cli fallback)

## Context
s36에서 구현+테스트 완료 → stash 사고로 main 미반영 상태였음.
ContextPack 오염 문제의 근본 해결책 (session_freshness가 핵심).

## Test plan
- [x] `cargo check` 통과 (warning 0)
- [x] `npx tsc --noEmit` 통과
- [ ] `TUNAFLOW_DISABLE_SDK_URL=1`로 기존 -p 경로 정상 동작 확인
- [ ] sdk-url 모드로 Claude 세션 테스트
- [ ] codex app-server 모드 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)