### PR TITLE
feat: session_freshness 연결 — stateful 엔진 lite 모드 전환

### DIFF
--- a/src-tauri/src/commands/agents_helpers/send_common/persistence.rs
+++ b/src-tauri/src/commands/agents_helpers/send_common/persistence.rs
@@ -24,6 +24,7 @@ fn embed_semaphore() -> std::sync::Arc<tokio::sync::Semaphore> {
 use super::super::trace_log::{insert_trace_log, insert_trace_log_with_context, new_span_id, new_trace_id, SpanInfo, ContextPackMeta};
 use super::context_loading::{load_context_data, load_project_path};
 use super::prompt_assembly::assemble_prompt;
+use super::session_freshness;
 
 /// Persist a user message if no pre-existing user_message_id was provided.
 pub fn persist_user_message(
@@ -69,7 +70,7 @@ pub fn prepare_engine_run(
     state: &DbState,
 ) -> Result<PreparedRun, crate::errors::AppError> {
     // Phase A: DB operations under lock — persist user msg, load context data, pre-create streaming msg
-    let (data, project_path, msg_id) = {
+    let (mut data, project_path, msg_id) = {
         let conn = state.write.lock().map_err(|_| crate::errors::AppError::Lock)?;
         persist_user_message(&conn, &input.conversation_id, &input.prompt, &input.user_message_id)?;
         let pp = load_project_path(&conn, &input.project_key);
@@ -89,6 +90,21 @@ pub fn prepare_engine_run(
         (ctx_data, pp, mid)
         // lock released here
     };
+
+    // Session freshness: stateful 엔진(sdk-url, app-server)에서
+    // 같은 세션이 연속되면 ContextPack을 minimal(lite)로 전환.
+    let session_key = session_freshness::current_session_key(&input.conversation_id, engine_key);
+    if let Some(ref key) = session_key {
+        session_freshness::stash_pending(&msg_id, key);
+        if session_freshness::is_session_continuation(&input.conversation_id, engine_key) {
+            data.context_mode_override = Some("lite".into());
+            eprintln!("[session_freshness] continuation detected for conv={} engine={} → lite mode",
+                &input.conversation_id[..input.conversation_id.len().min(12)], engine_key);
+        } else {
+            eprintln!("[session_freshness] new session for conv={} engine={} → full mode",
+                &input.conversation_id[..input.conversation_id.len().min(12)], engine_key);
+        }
+    }
 
     // Phase B: Pure prompt assembly — no DB lock held
     let (enriched_prompt, system_context, ctx_meta) = assemble_prompt(&data, identity_frag);
@@ -119,6 +135,9 @@ pub fn finalize_engine_run(
     let now = now_epoch_ms();
     match result {
         Ok(out) => {
+            // Session freshness: 성공 시 pending → delivered 승격
+            session_freshness::promote_pending_to_delivered(msg_id, conversation_id, engine_key);
+
             let content = if out.content.is_empty() {
                 format!("({} returned no output)", engine_key)
             } else {
@@ -172,6 +191,9 @@ pub fn finalize_engine_run(
             }
         }
         Err(ref e) => {
+            // Session freshness: 실패 시 pending 정리 (delivered 승격 안 함)
+            session_freshness::discard_pending(msg_id);
+
             let em = crate::guardrail::fallback_error(engine_key, e);
             let _ = conn.execute(
                 "UPDATE messages SET content=?1,status='error',timestamp=?2 WHERE id=?3",

--- a/src/components/tunaflow/MessageItem.tsx
+++ b/src/components/tunaflow/MessageItem.tsx
@@ -17,6 +17,30 @@ import { hasPlanProposal, splitPlanProposals } from "@/lib/planProposalParser";
 import { vizMarkers } from "@/lib/vizMarkers";
 import { copyToClipboard } from "@/lib/clipboard";
 import { MessageContextMenu } from "./ContextMenu";
+import { ChevronRight } from "lucide-react";
+
+/** Collapsible display for tool-request follow-up results (auto-injected by tunaFlow). */
+function ToolResultCollapsible({ content, conversationId }: { content: string; conversationId?: string }) {
+  const [open, setOpen] = useState(false);
+  const lineCount = content.split("\n").length;
+  return (
+    <div className="rounded-lg border border-border/30 overflow-hidden text-[11px]">
+      <button
+        onClick={() => setOpen(!open)}
+        className="flex items-center gap-1.5 w-full px-3 py-1.5 text-muted-foreground/70 hover:text-foreground hover:bg-accent/30 transition-colors"
+      >
+        <ChevronRight className={cn("w-3 h-3 transition-transform", open && "rotate-90")} />
+        <span className="font-medium">도구 호출 결과</span>
+        <span className="text-muted-foreground/40 ml-1">({lineCount}줄)</span>
+      </button>
+      {open && (
+        <div className="px-3 py-2 border-t border-border/20 text-xs">
+          <MarkdownBody content={content} conversationId={conversationId} isUser />
+        </div>
+      )}
+    </div>
+  );
+}
 
 const PROSE_CLS = "prose prose-invert prose-chat max-w-none [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&>hr:last-child]:hidden [&>hr]:border-sidebar-foreground/20 [&>hr]:my-3";
 
@@ -176,9 +200,13 @@ export const MessageItem = memo(function MessageItem({ message, onBranch, onBran
           {/* Body */}
           <div className={cn("text-foreground leading-relaxed overflow-x-auto", isCompact ? "text-xs" : "text-sm")}>
             {isUser ? (
+              message.content.startsWith("### 🛠️ 도구 호출 결과") ? (
+                <ToolResultCollapsible content={message.content} conversationId={message.conversationId} />
+              ) : (
               <div className={cn("rounded-lg px-3 py-2 inline-block", isCompact && "line-clamp-3")} style={{ background: "var(--user-bubble)" }}>
                 <MarkdownBody content={message.content} conversationId={message.conversationId} isUser />
               </div>
+              )
             ) : isStreaming && !message.content ? (
               <TypingIndicator />
             ) : isStreaming ? (


### PR DESCRIPTION
## Summary
- `prepare_engine_run`에서 `session_freshness::is_session_continuation()` 판정
- 같은 (engine, session_id) 연속 → `context_mode_override = "lite"` 강제
- `finalize_engine_run` 성공/실패 시 freshness 상태 업데이트
- Claude sdk-url / Codex app-server 모드에서 첫 메시지만 full, 이후 lite

## Test plan
- [x] `cargo check` 통과
- [ ] sdk-url 모드에서 첫 메시지: `[session_freshness] new session` 로그
- [ ] 두 번째 메시지: `[session_freshness] continuation detected → lite mode` 로그
- [ ] lite 모드에서 plan/retrieval/compressed-memory 미포함 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)