### PR TITLE
fix: compression 타이밍 + Architect hallucination 방지

### DIFF
--- a/src-tauri/src/commands/agents_helpers/send_common/persistence.rs
+++ b/src-tauri/src/commands/agents_helpers/send_common/persistence.rs
@@ -239,12 +239,9 @@ pub fn spawn_post_completion_tasks(db: crate::db::DbState, conversation_id: Stri
     std::thread::spawn(move || {
         let cid_short = if conversation_id.len() >= 8 { &conversation_id[..8] } else { &conversation_id };
 
-        // 1. Memory compression (conditional — needs_compression check is inside)
-        match crate::commands::conversation_memory::compress_memory_blocking(&db, &conversation_id) {
-            Ok(true) => eprintln!("[post-completion] memory compressed for {}", cid_short),
-            Ok(false) => {} // threshold not reached yet
-            Err(e) => eprintln!("[post-completion] memory compression error: {}", e),
-        }
+        // 1. Memory compression — DEFERRED to conversation switch / idle.
+        // Running claude -p here while sdk-url session is active causes exit 1 (CLI lock conflict).
+        // Compression is triggered by `compress_conversation_memory` Tauri command instead.
 
         // 2. Session link discovery — read lock for discovery, write lock only for save
         let project_key: Option<String> = {

--- a/src-tauri/src/commands/memory_compression.rs
+++ b/src-tauri/src/commands/memory_compression.rs
@@ -551,3 +551,4 @@ pub fn compress_memory_blocking(db: &crate::db::DbState, conversation_id: &str) 
     }
     Ok(true)
 }
+

--- a/src-tauri/src/commands/project_tools.rs
+++ b/src-tauri/src/commands/project_tools.rs
@@ -425,6 +425,7 @@ Include markers at the END of your response, after your main content.
 - **Write docs/plans/ files directly**: tunaFlow tracks them. Don't propose file creation — just do it.
 - **Non-goals prevent scope creep**: Always include them.
 - **Discussion = discussion only**: When a user opens a subtask discussion, respond with analysis, questions, suggestions — not implementation.
+- **Do NOT guess past work**: If the user asks about a past plan, completed task, or historical context that is not in your current context, use tool-request markers FIRST (`tool-request:plans`, `tool-request:memory`, `tool-request:rawq`) to retrieve the information. Never present uncertain information as fact. Say "I'll look that up" and emit the marker — do NOT answer and then verify after.
 "#;
 
 const DEVELOPER_TEMPLATE: &str = r#"# Developer

--- a/src/stores/slices/conversationSlice.ts
+++ b/src/stores/slices/conversationSlice.ts
@@ -233,8 +233,8 @@ export const createConversationSlice = (set: SetState, get: GetState): Conversat
     // Save current conversation's engine state before switching
     const prevConvId = get().selectedConversationId;
     if (prevConvId) {
-      // Engine state will be saved by NewMessageInput via saveConversationEngine
-      // (already handled on profile/engine change — no action needed here)
+      // Deferred memory compression for the conversation we're leaving
+      invoke("compress_conversation_memory", { conversationId: prevConvId }).catch(() => {});
     }
 
     // Close drawer/thread if open — conversation is the primary view


### PR DESCRIPTION
## Summary
- memory compression을 post-completion에서 제거 → 대화 전환 시 deferred 호출
  (sdk-url 세션과 claude -p CLI 동시 실행 시 exit 1 충돌 해결)
- Architect 프롬프트: 과거 작업 질문 시 tool-request 먼저 사용 강제

## Test plan
- [x] `cargo check` / `tsc --noEmit` 통과
- [ ] 에이전트 응답 후 `[memory] compression failed` 로그 사라지는지 확인
- [ ] 대화 전환 시 `[memory] deferred compression completed` 로그 확인
- [ ] Codex Architect에게 과거 플랜 질문 → 추측 대신 tool-request 마커 사용 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)