### PR TITLE
fix: tool-request 결과 이중 전송 제거

### DIFF
--- a/src/stores/slices/runtimeSlice.ts
+++ b/src/stores/slices/runtimeSlice.ts
@@ -254,22 +254,10 @@ export const createRuntimeSlice = (set: SetState, get: GetState): RuntimeSlice =
             const { executeToolRequests } = await import("@/lib/toolRequestHandler");
             const followUp = await executeToolRequests(requests);
             if (followUp) {
-              // Persist as system message (not user) — avoids polluting user chat history
-              try {
-                const { invoke } = await import("@tauri-apps/api/core");
-                await invoke("persist_system_msg", {
-                  conversationId: selectedConversationId,
-                  content: followUp,
-                });
-                // Refresh messages to show the system message
-                const msgs = await invoke<import("@/types").Message[]>("list_messages", {
-                  conversationId: selectedConversationId,
-                });
-                set({ messages: msgs });
-              } catch (e) {
-                console.warn("[system-msg] persist failed, falling back to sendWithEngine:", e);
-              }
-              // Send follow-up to agent via normal path
+              // Send tool-request result to agent as a regular message.
+              // UI renders it as collapsible card (ToolResultCollapsible in MessageItem).
+              // System message separation requires a dedicated "send without persist" path
+              // which will be implemented when sdk-url session stabilizes.
               get()._endRun(selectedConversationId);
               get().sendWithEngine(engine, followUp, model);
               return;


### PR DESCRIPTION
## Summary
- persist_system_msg + sendWithEngine 동시 호출로 같은 내용 2번 저장 + 에이전트 2번 응답하는 버그 수정
- system msg 저장을 제거하고 sendWithEngine 단일 경로로 복원
- UI 접힘 렌더링(ToolResultCollapsible)은 유지

## Test plan
- [x] `tsc --noEmit` 통과
- [ ] tool-request 발동 시 에이전트 응답 1회만 확인
- [ ] 도구 결과가 접힘 카드 1개로 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)