### PR TITLE
feat: Trace 정비 + 고도화 Phase 1-4

### DIFF
--- a/src-tauri/src/commands/agents_helpers/send_common/persistence.rs
+++ b/src-tauri/src/commands/agents_helpers/send_common/persistence.rs
@@ -218,12 +218,12 @@ pub fn finalize_engine_run(
             );
             // Record error span too — without this, trace history is blind to
             // every failed run (observed: trace_log status=err = 0 across 1058 rows).
-            insert_trace_log(conn, conversation_id, 0, 0, 0.0, now,
+            insert_trace_log_with_context(conn, conversation_id, 0, 0, 0.0, now,
                 &SpanInfo {
                     trace_id: &new_trace_id(), span_id: new_span_id(), parent_span_id: None,
                     operation: "agent.stream", engine: engine_key,
                     duration_ms: duration_ms as i64, status: "error",
-                });
+                }, ctx_meta, Some(msg_id));
             let _ = super::super::super::jobs::complete_job(conn, job_id, "error", Some(&em));
             let _ = app.emit("agent:error", serde_json::json!({
                 "messageId": msg_id, "conversationId": conversation_id, "engine": engine_key, "error": em

--- a/src-tauri/src/commands/agents_helpers/send_common/prompt_assembly.rs
+++ b/src-tauri/src/commands/agents_helpers/send_common/prompt_assembly.rs
@@ -522,6 +522,8 @@ pub fn assemble_prompt(
         length: total_len,
         hash: sizes_json,
         truncated,
+        cache_read_tokens: 0,
+        cache_creation_tokens: 0,
     };
 
     (assembled, system_context, meta)

--- a/src-tauri/src/commands/agents_helpers/trace_log.rs
+++ b/src-tauri/src/commands/agents_helpers/trace_log.rs
@@ -21,6 +21,10 @@ pub struct ContextPackMeta {
     pub length: usize,
     pub hash: String,
     pub truncated: bool,
+    /// Cache read tokens (prompt cache hits — discounted rate)
+    pub cache_read_tokens: i64,
+    /// Cache creation tokens (new cache entries — premium rate)
+    pub cache_creation_tokens: i64,
 }
 
 impl ContextPackMeta {
@@ -44,7 +48,7 @@ impl ContextPackMeta {
             s.hash(&mut h);
             format!("{:016x}", h.finish())
         });
-        Self { mode: mode.to_string(), sections, length, hash, truncated: was_truncated }
+        Self { mode: mode.to_string(), sections, length, hash, truncated: was_truncated, cache_read_tokens: 0, cache_creation_tokens: 0 }
     }
 
     /// JSON-encoded sections list for DB storage.
@@ -125,8 +129,9 @@ pub fn insert_trace_log_with_context(
         "INSERT INTO trace_log
          (conversation_id, input_tokens, output_tokens, cost_usd, recorded_at,
           trace_id, span_id, parent_span_id, operation, engine, duration_ms, status,
-          context_mode, context_sections, context_length, context_hash, context_truncated, usage_status, message_id)
-         VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19)",
+          context_mode, context_sections, context_length, context_hash, context_truncated,
+          usage_status, message_id, cache_read_tokens, cache_creation_tokens)
+         VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20,?21)",
         params![
             conversation_id, input_tokens, output_tokens, cost_usd, recorded_at,
             span.trace_id, span.span_id, span.parent_span_id,
@@ -134,6 +139,7 @@ pub fn insert_trace_log_with_context(
             ctx.mode, ctx.sections_json(), ctx.length as i64, ctx.hash,
             if ctx.truncated { 1 } else { 0 },
             usage_status, message_id,
+            ctx.cache_read_tokens, ctx.cache_creation_tokens,
         ],
     );
 }

--- a/src-tauri/src/commands/diagnostics.rs
+++ b/src-tauri/src/commands/diagnostics.rs
@@ -1,0 +1,162 @@
+//! Runtime diagnostics — rate limit, process health.
+//!
+//! Rate limit data: 3-source fallback (duckbar → OMC plugin → abtop).
+//! All sources are file-based caches written by external tools.
+
+use serde::Serialize;
+use crate::errors::AppError;
+
+#[derive(Debug, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct RateLimitInfo {
+    pub five_hour_pct: Option<f64>,
+    pub five_hour_resets_at: Option<String>,
+    pub weekly_pct: Option<f64>,
+    pub weekly_resets_at: Option<String>,
+    pub extra_usage_enabled: Option<bool>,
+    pub extra_usage_pct: Option<f64>,
+    pub source: String,
+    pub stale: bool,
+}
+
+/// Read rate limit info from available cache files.
+/// 3-source fallback: duckbar → OMC plugin → abtop.
+#[tauri::command]
+pub fn get_rate_limit_info() -> Result<Option<RateLimitInfo>, AppError> {
+    let claude_dir = match dirs::home_dir() {
+        Some(h) => h.join(".claude"),
+        None => return Ok(None),
+    };
+
+    // Source 1: duckbar cache
+    let duckbar_path = claude_dir.join(".duckbar-ratelimits-cache.json");
+    if let Some(info) = read_duckbar_cache(&duckbar_path) {
+        return Ok(Some(info));
+    }
+
+    // Source 2: oh-my-claudecode plugin cache
+    let omc_path = claude_dir.join("plugins/oh-my-claudecode/.usage-cache.json");
+    if let Some(info) = read_omc_cache(&omc_path) {
+        return Ok(Some(info));
+    }
+
+    // Source 3: abtop StatusLine hook
+    let abtop_path = claude_dir.join("abtop-rate-limits.json");
+    if let Some(info) = read_abtop_cache(&abtop_path) {
+        return Ok(Some(info));
+    }
+
+    Ok(None)
+}
+
+fn is_stale(cached_at: &str, max_age_secs: u64) -> bool {
+    // Parse ISO 8601 timestamp and check age
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    // Try parsing as ISO 8601
+    if let Ok(dt) = chrono_parse_approx(cached_at) {
+        return now.saturating_sub(dt) > max_age_secs;
+    }
+    true // Can't parse = treat as stale
+}
+
+fn chrono_parse_approx(s: &str) -> Result<u64, ()> {
+    // Simple ISO 8601 parser: "2026-04-16T07:52:37Z"
+    use std::time::{SystemTime, UNIX_EPOCH};
+    // Try dateutil-style parse via string matching
+    if s.len() >= 19 {
+        let parts: Vec<&str> = s.split(&['T', '-', ':', 'Z', '+'][..]).collect();
+        if parts.len() >= 6 {
+            // Rough epoch calculation (not accounting for leap seconds etc)
+            let y: u64 = parts[0].parse().map_err(|_| ())?;
+            let m: u64 = parts[1].parse().map_err(|_| ())?;
+            let d: u64 = parts[2].parse().map_err(|_| ())?;
+            let h: u64 = parts[3].parse().map_err(|_| ())?;
+            let min: u64 = parts[4].parse().map_err(|_| ())?;
+            let sec: u64 = parts[5].parse().map_err(|_| ())?;
+            // Days from epoch (approximate)
+            let days = (y - 1970) * 365 + (y - 1969) / 4 + month_days(m) + d - 1;
+            return Ok(days * 86400 + h * 3600 + min * 60 + sec);
+        }
+    }
+    // Try parsing as unix timestamp
+    s.parse::<u64>().map_err(|_| ())
+}
+
+fn month_days(m: u64) -> u64 {
+    match m {
+        1 => 0, 2 => 31, 3 => 59, 4 => 90, 5 => 120, 6 => 151,
+        7 => 181, 8 => 212, 9 => 243, 10 => 273, 11 => 304, 12 => 334,
+        _ => 0,
+    }
+}
+
+fn read_duckbar_cache(path: &std::path::Path) -> Option<RateLimitInfo> {
+    let text = std::fs::read_to_string(path).ok()?;
+    let v: serde_json::Value = serde_json::from_str(&text).ok()?;
+
+    let cached_at = v.get("_cachedAt").and_then(|v| v.as_str()).unwrap_or("");
+    let stale = is_stale(cached_at, 600); // 10 min
+
+    Some(RateLimitInfo {
+        five_hour_pct: v.get("fiveHourPercent").and_then(|v| v.as_f64()),
+        five_hour_resets_at: v.get("fiveHourResetsAt").and_then(|v| v.as_str()).map(String::from),
+        weekly_pct: v.get("weeklyPercent").and_then(|v| v.as_f64()),
+        weekly_resets_at: v.get("weeklyResetsAt").and_then(|v| v.as_str()).map(String::from),
+        extra_usage_enabled: v.get("extraUsageEnabled").and_then(|v| v.as_bool()),
+        extra_usage_pct: {
+            let used = v.get("extraUsageUsed").and_then(|v| v.as_f64());
+            let limit = v.get("extraUsageLimit").and_then(|v| v.as_f64());
+            match (used, limit) {
+                (Some(u), Some(l)) if l > 0.0 => Some((u / l) * 100.0),
+                _ => None,
+            }
+        },
+        source: "duckbar".into(),
+        stale,
+    })
+}
+
+fn read_omc_cache(path: &std::path::Path) -> Option<RateLimitInfo> {
+    let text = std::fs::read_to_string(path).ok()?;
+    let v: serde_json::Value = serde_json::from_str(&text).ok()?;
+
+    Some(RateLimitInfo {
+        five_hour_pct: v.get("fiveHourPct").and_then(|v| v.as_f64()),
+        five_hour_resets_at: v.get("fiveHourResetsAt").and_then(|v| v.as_str()).map(String::from),
+        weekly_pct: v.get("weeklyPct").and_then(|v| v.as_f64()),
+        weekly_resets_at: v.get("weeklyResetsAt").and_then(|v| v.as_str()).map(String::from),
+        extra_usage_enabled: None,
+        extra_usage_pct: None,
+        source: "omc".into(),
+        stale: false, // OMC has its own freshness management
+    })
+}
+
+fn read_abtop_cache(path: &std::path::Path) -> Option<RateLimitInfo> {
+    let text = std::fs::read_to_string(path).ok()?;
+    let v: serde_json::Value = serde_json::from_str(&text).ok()?;
+
+    let updated = v.get("updated_at").and_then(|v| v.as_u64()).unwrap_or(0);
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let stale = now.saturating_sub(updated) > 600;
+
+    let five_hour = v.get("five_hour");
+    let seven_day = v.get("seven_day");
+
+    Some(RateLimitInfo {
+        five_hour_pct: five_hour.and_then(|w| w.get("used_percentage")).and_then(|v| v.as_f64()),
+        five_hour_resets_at: five_hour.and_then(|w| w.get("resets_at")).and_then(|v| v.as_str()).map(String::from),
+        weekly_pct: seven_day.and_then(|w| w.get("used_percentage")).and_then(|v| v.as_f64()),
+        weekly_resets_at: seven_day.and_then(|w| w.get("resets_at")).and_then(|v| v.as_str()).map(String::from),
+        extra_usage_enabled: None,
+        extra_usage_pct: None,
+        source: "abtop".into(),
+        stale,
+    })
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -8,6 +8,7 @@ pub mod context_hub;
 pub mod context_queries;
 pub mod conventions_sync;
 pub mod conversation_memory;
+pub mod diagnostics;
 pub mod memory_topics;
 pub mod memory_compression;
 pub mod conversations;

--- a/src-tauri/src/commands/tracing.rs
+++ b/src-tauri/src/commands/tracing.rs
@@ -39,6 +39,9 @@ pub struct TraceSpan {
     pub context_truncated: Option<i64>,
     // Message linkage (v23)
     pub message_id: Option<String>,
+    // Cache token classification (v35)
+    pub cache_read_tokens: Option<i64>,
+    pub cache_creation_tokens: Option<i64>,
 }
 
 /// List trace spans for a conversation, ordered by recorded_at descending.
@@ -56,7 +59,7 @@ pub fn list_traces(
             "SELECT id, conversation_id, trace_id, span_id, parent_span_id, operation, engine,
                     input_tokens, output_tokens, cost_usd, duration_ms, status, recorded_at,
                     context_mode, context_sections, context_length, context_hash, context_truncated,
-                    message_id
+                    message_id, cache_read_tokens, cache_creation_tokens
              FROM trace_log
              WHERE conversation_id = ?1 AND trace_id = ?2
              ORDER BY recorded_at DESC",
@@ -67,7 +70,7 @@ pub fn list_traces(
             "SELECT id, conversation_id, trace_id, span_id, parent_span_id, operation, engine,
                     input_tokens, output_tokens, cost_usd, duration_ms, status, recorded_at,
                     context_mode, context_sections, context_length, context_hash, context_truncated,
-                    message_id
+                    message_id, cache_read_tokens, cache_creation_tokens
              FROM trace_log
              WHERE conversation_id = ?1
              ORDER BY recorded_at DESC",
@@ -123,5 +126,7 @@ fn map_span(row: &rusqlite::Row) -> rusqlite::Result<TraceSpan> {
         context_hash: row.get(16)?,
         context_truncated: row.get(17)?,
         message_id: row.get(18)?,
+        cache_read_tokens: row.get(19).ok(),
+        cache_creation_tokens: row.get(20).ok(),
     })
 }

--- a/src-tauri/src/db/migrations.rs
+++ b/src-tauri/src/db/migrations.rs
@@ -127,6 +127,9 @@ pub fn run(conn: &Connection) -> Result<(), AppError> {
     if current < 34 {
         apply_v34(conn)?;
     }
+    if current < 35 {
+        apply_v35(conn)?;
+    }
     Ok(())
 }
 
@@ -817,6 +820,15 @@ fn apply_v34(conn: &Connection) -> Result<(), AppError> {
     // Enables auto-resolve when the branch is adopted/archived.
     add_column_if_missing(conn, "insight_findings", "review_branch_id", "TEXT")?;
     conn.execute("INSERT INTO schema_version (version, applied_at) VALUES (34, ?1)", [now_epoch()])?;
+    Ok(())
+}
+
+fn apply_v35(conn: &Connection) -> Result<(), AppError> {
+    // Cache token classification for accurate cost calculation.
+    // Claude API returns cache_read_input_tokens and cache_creation_input_tokens.
+    add_column_if_missing(conn, "trace_log", "cache_read_tokens", "INTEGER DEFAULT 0")?;
+    add_column_if_missing(conn, "trace_log", "cache_creation_tokens", "INTEGER DEFAULT 0")?;
+    conn.execute("INSERT INTO schema_version (version, applied_at) VALUES (35, ?1)", [now_epoch()])?;
     Ok(())
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -310,6 +310,7 @@ pub fn run() {
             commands::agents::prewarm_sdk_session,
             commands::agents::has_active_sdk_session,
             commands::agents::persist_system_msg,
+            commands::diagnostics::get_rate_limit_info,
             // Jobs
             commands::jobs::list_active_jobs,
             commands::jobs::cleanup_stale_jobs,

--- a/src/components/tunaflow/RuntimeStatusBar.tsx
+++ b/src/components/tunaflow/RuntimeStatusBar.tsx
@@ -88,6 +88,7 @@ export function RuntimeStatusBar() {
   const [lastSkippedLayers, setLastSkippedLayers] = useState(0);
   const [lastContextPct, setLastContextPct] = useState<number | null>(null);
   const [gitStatus, setGitStatus] = useState<{ branch: string | null; dirty: boolean; added: number; modified: number; untracked: number } | null>(null);
+  const [rateLimit, setRateLimit] = useState<{ fiveHourPct: number | null; weeklyPct: number | null; source: string; stale: boolean } | null>(null);
   const [traceOpen, setTraceOpen] = useState(false);
   const terminalOpen = usePtyStore((s) => s.terminalOpen);
   const toggleTerminal = usePtyStore((s) => s.toggleTerminal);
@@ -188,6 +189,20 @@ export function RuntimeStatusBar() {
     const timer = setInterval(poll, 10000);
     return () => { cancelled = true; clearInterval(timer); };
   }, [selectedProjectKey]);
+
+  // Rate limit — slow poll (60s), reads cached files only (no API calls)
+  useEffect(() => {
+    let cancelled = false;
+    const poll = async () => {
+      try {
+        const info = await invoke<{ fiveHourPct: number | null; weeklyPct: number | null; source: string; stale: boolean } | null>("get_rate_limit_info");
+        if (!cancelled) setRateLimit(info && !info.stale ? info : null);
+      } catch { if (!cancelled) setRateLimit(null); }
+    };
+    poll();
+    const timer = setInterval(poll, 60000);
+    return () => { cancelled = true; clearInterval(timer); };
+  }, []);
 
   // Aggregate cost + last context mode from conversation
   useEffect(() => {
@@ -308,6 +323,33 @@ export function RuntimeStatusBar() {
               {(gitStatus.added > 0 || gitStatus.modified > 0 || gitStatus.untracked > 0) && (
                 <span className="text-tf-micro text-prose-disabled">
                   {gitStatus.added > 0 && `+${gitStatus.added}`}{gitStatus.added > 0 && gitStatus.modified > 0 && " "}{gitStatus.modified > 0 && `~${gitStatus.modified}`}{(gitStatus.added > 0 || gitStatus.modified > 0) && gitStatus.untracked > 0 && " "}{gitStatus.untracked > 0 && `?${gitStatus.untracked}`}
+                </span>
+              )}
+            </span>
+          </>
+        )}
+
+        {/* Rate limit */}
+        {rateLimit && (
+          <>
+            <span className="w-px h-3 bg-border/30" />
+            <span className="flex items-center gap-1.5 px-2 text-muted-foreground/40 text-tf-micro">
+              {rateLimit.fiveHourPct != null && (
+                <span className={cn(
+                  "font-mono",
+                  rateLimit.fiveHourPct >= 90 ? "text-red-400/70" :
+                  rateLimit.fiveHourPct >= 70 ? "text-amber-400/70" : ""
+                )}>
+                  5h:{rateLimit.fiveHourPct.toFixed(0)}%
+                </span>
+              )}
+              {rateLimit.weeklyPct != null && (
+                <span className={cn(
+                  "font-mono",
+                  rateLimit.weeklyPct >= 90 ? "text-red-400/70" :
+                  rateLimit.weeklyPct >= 70 ? "text-amber-400/70" : ""
+                )}>
+                  7d:{rateLimit.weeklyPct.toFixed(0)}%
                 </span>
               )}
             </span>

--- a/src/components/tunaflow/context-panel/useTraceData.ts
+++ b/src/components/tunaflow/context-panel/useTraceData.ts
@@ -72,8 +72,22 @@ export function useTraceData(convId: string | null) {
   const threadRunning = convId ? runningThreadIds.includes(convId) : false;
   useEffect(() => {
     if (!threadRunning) return;
-    const interval = setInterval(() => { loadJobs(); setTick((t) => t + 1); }, 1000);
+    let traceTickCount = 0;
+    const interval = setInterval(() => {
+      loadJobs();
+      setTick((t) => t + 1);
+      // Traces: refresh every 5 ticks (5s) during active run
+      traceTickCount++;
+      if (traceTickCount >= 5) { traceTickCount = 0; loadTraces(); }
+    }, 1000);
     return () => clearInterval(interval);
+  }, [threadRunning]);
+
+  // Auto-refresh traces when a run completes (threadRunning goes false)
+  const prevRunning = useState(false);
+  useEffect(() => {
+    if (prevRunning[0] && !threadRunning) { loadTraces(); loadMemoryStatus(); }
+    prevRunning[1](threadRunning);
   }, [threadRunning]);
 
   return {


### PR DESCRIPTION
## Summary
Trace 시스템 전체 정비: 버그 수정 3건 + rate limit 읽기 + DB v35 캐시 토큰.

Phase 1: error trace context 보존, realtime 갱신, completion auto-refresh
Phase 2: 이미 구현 확인 (tok/s, context %, sparkline)
Phase 3: duckbar/OMC/abtop 3단계 rate limit + RuntimeStatusBar 게이지
Phase 4: DB v35 cache_read_tokens/cache_creation_tokens

## Test plan
- [x] `cargo check` 통과
- [x] `tsc --noEmit` 통과
- [ ] TracePanel에서 에이전트 실행 중 5초마다 자동 갱신 확인
- [ ] 에이전트 에러 시 trace에 context 메타 기록 확인
- [ ] duckbar 설치 시 RuntimeStatusBar에 rate limit % 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)