### PR TITLE
fix: LM Studio base URL + 인증 헤더 분리

### DIFF
--- a/src-tauri/src/agents/openai_compat.rs
+++ b/src-tauri/src/agents/openai_compat.rs
@@ -69,6 +69,25 @@ pub fn discover_models() -> Option<Vec<String>> {
 /// Function calling (tools) is included when supported.
 pub async fn stream_run<F, G>(
     input: RunInput,
+    on_progress: G,
+    on_chunk: F,
+) -> Result<RunOutput, AppError>
+where
+    F: FnMut(String) + Send,
+    G: FnMut(String) + Send,
+{
+    stream_run_with_base(input, ollama_base_url(), on_progress, on_chunk).await
+}
+
+/// LM Studio base URL (default: localhost:1234)
+pub fn lmstudio_base_url() -> String {
+    std::env::var("LMSTUDIO_ENDPOINT")
+        .unwrap_or_else(|_| "http://localhost:1234".into())
+}
+
+pub async fn stream_run_with_base<F, G>(
+    input: RunInput,
+    base: String,
     mut on_progress: G,
     mut on_chunk: F,
 ) -> Result<RunOutput, AppError>
@@ -76,7 +95,6 @@ where
     F: FnMut(String) + Send,
     G: FnMut(String) + Send,
 {
-    let base = ollama_base_url();
     let model = input.model.as_deref().unwrap_or("qwen3:8b");
     let url = format!("{}/v1/chat/completions", base);
 
@@ -108,23 +126,28 @@ where
         tools: Some(tools_json),
     };
 
-    on_progress(format!("Ollama ({}) initializing...", model));
+    let engine_name = if base.contains(":1234") || base.contains("lmstudio") { "LM Studio" } else { "Ollama" };
+    on_progress(format!("{} ({}) initializing...", engine_name, model));
 
     let client = Client::builder()
-        .timeout(std::time::Duration::from_secs(600)) // Local models can be slow
+        .timeout(std::time::Duration::from_secs(600))
         .build()
         .map_err(|e| AppError::Agent(format!("HTTP client build failed: {}", e)))?;
 
-    let response = client
-        .post(&url)
-        .json(&body)
+    let mut req = client.post(&url).json(&body);
+    if let Ok(token) = std::env::var("LMSTUDIO_API_KEY") {
+        if engine_name == "LM Studio" {
+            req = req.header("Authorization", format!("Bearer {}", token));
+        }
+    }
+    let response = req
         .send()
         .await
         .map_err(|e| {
             if e.is_connect() {
                 AppError::Agent(format!(
-                    "Ollama에 연결할 수 없습니다 ({}). Ollama가 실행 중인지 확인하세요: `ollama serve`",
-                    base
+                    "{}에 연결할 수 없습니다 ({}). {}가 실행 중인지 확인하세요.",
+                    engine_name, base, engine_name
                 ))
             } else {
                 AppError::Agent(format!("OpenAI-compatible API 요청 실패: {}", e))

--- a/src-tauri/src/commands/agents.rs
+++ b/src-tauri/src/commands/agents.rs
@@ -418,33 +418,42 @@ pub async fn start_openai_compat_stream(
 ) -> Result<StartRunResult, AppError> {
     let db = state.inner().clone();
     let db_post = state.inner().clone();
-    let id_frag = identity_fragment(&input, "ollama");
+    // Detect engine: lmstudio uses a different base URL (port 1234 vs 11434)
+    let is_lmstudio = input.model.as_deref()
+        .map(|m| !m.contains(':'))  // Ollama models have "name:tag", LM Studio models don't
+        .unwrap_or(false)
+        || input.persona_label.as_deref().map(|l| l.to_lowercase().contains("lmstudio") || l.to_lowercase().contains("lm studio")).unwrap_or(false);
+    let engine_label = if is_lmstudio { "lmstudio" } else { "ollama" };
+    let id_frag = identity_fragment(&input, engine_label);
     let write_arc = db_write_arc(&state);
     let cid = input.conversation_id.clone();
     let mo = input.model.clone();
 
     let prep = tokio::task::spawn_blocking(move || {
-        prepare_engine_run("ollama", &input, id_frag.as_deref(), &db)
+        prepare_engine_run(engine_label, &input, id_frag.as_deref(), &db)
     }).await.map_err(|_| AppError::Lock)??;
 
     let ret = prep.msg_id.clone();
     let PreparedRun { msg_id, job_id, enriched_prompt, project_path, ctx_meta, .. } = prep;
     let system_prompt = prep.system_context;
+    let base_url = if is_lmstudio { openai_compat::lmstudio_base_url() } else { std::env::var("OLLAMA_HOST").unwrap_or_else(|_| "http://localhost:11434".into()) };
 
     let cid2 = cid.clone();
+    let el = engine_label.to_string();
     tokio::spawn(async move {
         let pa = app.clone(); let pi = msg_id.clone(); let pc = cid2.clone();
         let c2 = app.clone(); let ci = msg_id.clone(); let cc = cid2.clone();
         let t0 = std::time::Instant::now();
-        let rr = openai_compat::stream_run(
+        let rr = openai_compat::stream_run_with_base(
             claude::RunInput { prompt: enriched_prompt, model: mo.clone(), system_prompt, resume_token: None, project_path },
+            base_url,
             move |t| { let _ = pa.emit("ollama:progress", ChunkPayload { message_id: pi.clone(), conversation_id: pc.clone(), text: t }); },
             move |t| { let _ = c2.emit("ollama:chunk", ChunkPayload { message_id: ci.clone(), conversation_id: cc.clone(), text: t }); },
         ).await;
         let dur = t0.elapsed().as_millis();
-        guardrail::log_run("ollama", mo.as_deref(), dur, 0, rr.is_ok());
+        guardrail::log_run(&el, mo.as_deref(), dur, 0, rr.is_ok());
         if let Ok(conn) = write_arc.lock() {
-            finalize_engine_run(&conn, "ollama", &msg_id, &cid, &job_id, &rr, dur, &ctx_meta, &app);
+            finalize_engine_run(&conn, &el, &msg_id, &cid, &job_id, &rr, dur, &ctx_meta, &app);
         }
         if rr.is_ok() { spawn_post_completion_tasks(db_post, cid); }
     });


### PR DESCRIPTION
## Summary
- Ollama(11434)와 LM Studio(1234) 포트 분리
- LMSTUDIO_API_KEY 인증 헤더 자동 추가
- stream_run_with_base 함수로 base URL 파라미터화

## Test plan
- [x] `cargo check` 통과
- [ ] LM Studio 엔진 선택 → 1234 포트로 요청 확인
- [ ] Ollama 엔진 선택 → 11434 포트로 요청 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)