### PR TITLE
fix: engine 키 직접 전달 — LM Studio 라우팅 수정

### DIFF
--- a/src-tauri/src/commands/agents.rs
+++ b/src-tauri/src/commands/agents.rs
@@ -45,6 +45,9 @@ pub struct SendWithClaudeInput {
     /// Serialized user profile JSON (from frontend settings store).
     #[serde(default)]
     pub user_profile_json: Option<String>,
+    /// Engine key from frontend (e.g. "ollama", "lmstudio") for backend routing.
+    #[serde(default)]
+    pub engine: Option<String>,
 }
 
 /// Wrap persona_fragment with identity framing block for a given engine.
@@ -418,11 +421,7 @@ pub async fn start_openai_compat_stream(
 ) -> Result<StartRunResult, AppError> {
     let db = state.inner().clone();
     let db_post = state.inner().clone();
-    // Detect engine: lmstudio uses a different base URL (port 1234 vs 11434)
-    let is_lmstudio = input.model.as_deref()
-        .map(|m| !m.contains(':'))  // Ollama models have "name:tag", LM Studio models don't
-        .unwrap_or(false)
-        || input.persona_label.as_deref().map(|l| l.to_lowercase().contains("lmstudio") || l.to_lowercase().contains("lm studio")).unwrap_or(false);
+    let is_lmstudio = input.engine.as_deref() == Some("lmstudio");
     let engine_label = if is_lmstudio { "lmstudio" } else { "ollama" };
     let id_frag = identity_fragment(&input, engine_label);
     let write_arc = db_write_arc(&state);

--- a/src/stores/slices/runtimeSlice.ts
+++ b/src/stores/slices/runtimeSlice.ts
@@ -311,6 +311,7 @@ export const createRuntimeSlice = (set: SetState, get: GetState): RuntimeSlice =
         projectKey: selectedProjectKey,
         conversationId: selectedConversationId,
         prompt, model, systemPrompt,
+        engine,
         activeSkills: effectiveSkills,
         crossSessionIds: get().crossSessionIds,
         personaFragment: get().personaFragment ?? undefined,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -173,6 +173,8 @@ export interface SendWithClaudeInput {
   userMessageId?: string;
   prompt: string;
   model?: string;
+  /** Engine key for backend routing (e.g. "ollama" vs "lmstudio") */
+  engine?: string;
   /** Passed directly when no agent is selected */
   systemPrompt?: string;
   /** Agent name → loads docs/agents/{name}.md as system prompt (ContextPack step 1) */


### PR DESCRIPTION
## Summary
- SendWithClaudeInput에 engine 필드 추가
- 프론트에서 engine 키 전달 → 모델명 패턴 판별 제거
- LM Studio: localhost:1234 + LMSTUDIO_API_KEY
- Ollama: localhost:11434

🤖 Generated with [Claude Code](https://claude.com/claude-code)