### PR TITLE
fix: sdk-url 고아 프로세스 방지 (rate limit 보호)

### DIFF
--- a/src-tauri/src/agents/claude_sdk_session.rs
+++ b/src-tauri/src/agents/claude_sdk_session.rs
@@ -760,6 +760,43 @@ fn build_user_message(content: &str) -> String {
 /// 모든 활성 SDK 세션을 종료한다 (앱 종료 시 호출).
 #[allow(dead_code)]
 pub fn shutdown_all_sessions() {
-    SESSIONS.lock().clear();
+    let sessions: Vec<_> = SESSIONS.lock().drain().collect();
+    for (conv_id, _session) in &sessions {
+        eprintln!("[sdk-session] shutting down session for conv: {}", conv_id);
+    }
+    drop(sessions); // Drop triggers _monitor_abort → kill_on_drop
     RESUME_IDS.lock().clear();
+}
+
+/// Kill any orphaned `claude --sdk-url` processes from previous app runs.
+/// Called on app startup to prevent zombie processes that consume rate limit quota.
+pub fn kill_orphan_sdk_processes() {
+    use std::process::Command;
+    let output = match Command::new("pgrep").args(["-f", "claude.*--sdk-url"]).output() {
+        Ok(o) => o,
+        Err(_) => return,
+    };
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let current_pid = std::process::id();
+    let mut killed = 0;
+    for line in stdout.lines() {
+        if let Ok(pid) = line.trim().parse::<u32>() {
+            if pid == current_pid { continue; }
+            // Check if this process is orphaned (PPID=1) or belongs to a dead parent
+            if let Ok(ppid_out) = Command::new("ps").args(["-o", "ppid=", "-p", &pid.to_string()]).output() {
+                let ppid_str = String::from_utf8_lossy(&ppid_out.stdout).trim().to_string();
+                if let Ok(ppid) = ppid_str.parse::<u32>() {
+                    // PPID=1 means orphaned (parent died)
+                    if ppid == 1 {
+                        eprintln!("[sdk-session] killing orphan claude --sdk-url process PID={}", pid);
+                        let _ = Command::new("kill").arg(pid.to_string()).output();
+                        killed += 1;
+                    }
+                }
+            }
+        }
+    }
+    if killed > 0 {
+        eprintln!("[sdk-session] cleaned up {} orphan sdk-url process(es)", killed);
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -243,6 +243,10 @@ pub fn run() {
             // Backfill NULL-embedding chunks left over from v32 (bge-m3 migration).
             // Sleeps 15s before starting to let embedder/rawq settle, then processes
             // one conversation/project at a time with throttling.
+            // Kill orphaned sdk-url/app-server processes from previous runs.
+            // These can silently consume rate limit quota if left alive.
+            crate::agents::claude_sdk_session::kill_orphan_sdk_processes();
+
             crate::commands::vector_search::spawn_startup_backfill(
                 app.state::<DbState>().inner().clone(),
             );
@@ -460,6 +464,10 @@ pub fn run() {
                 use tauri::Manager;
                 use tauri_plugin_window_state::{AppHandleExt, StateFlags};
                 let _ = window.app_handle().save_window_state(StateFlags::all());
+                // Kill all sdk-url/app-server sessions to prevent orphan processes
+                crate::agents::claude_sdk_session::shutdown_all_sessions();
+                crate::agents::claude_sdk_session::kill_orphan_sdk_processes();
+                eprintln!("[shutdown] all agent sessions terminated");
             }
         })
         .run(tauri::generate_context!())


### PR DESCRIPTION
## Summary
실제 사고: 앱 종료 후 sdk-url 프로세스가 12시간 생존 → weekly 5% 소비.

- 앱 시작: PPID=1인 고아 프로세스 자동 kill
- 앱 종료: CloseRequested에서 세션 정리 + orphan kill
- shutdown_all_sessions() 개선

## Test plan
- [x] `cargo check` 통과
- [ ] 앱 시작 시 `[sdk-session] cleaned up N orphan` 로그 확인
- [ ] 앱 X 버튼 종료 후 `ps aux | grep sdk-url` 프로세스 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)