### PR TITLE
fix: 알림 중복 + RT Review 진입 실패 2건

### DIFF
--- a/src/components/tunaflow/BranchThreadPanel.tsx
+++ b/src/components/tunaflow/BranchThreadPanel.tsx
@@ -383,7 +383,7 @@ function StuckRecoveryButton({ convId }: { convId: string | null }) {
     try {
       const msgs = await invoke<Message[]>("list_messages", { conversationId: convId });
       useChatStore.setState({ threadMessages: msgs });
-      useChatStore.getState()._endRun(convId);
+      useChatStore.getState()._endRun(convId, { silent: true });
     } catch (e) {
       console.error("[recovery]", e);
     } finally {

--- a/src/components/tunaflow/RuntimeStatusBar.tsx
+++ b/src/components/tunaflow/RuntimeStatusBar.tsx
@@ -143,7 +143,7 @@ export function RuntimeStatusBar() {
         if (orphans.length > 0) {
           console.warn("[orphan-recovery] Clearing stale runningThreadIds:", orphans);
           for (const id of orphans) {
-            useChatStore.getState()._endRun(id);
+            useChatStore.getState()._endRun(id, { silent: true });
           }
           // Reload current conversation messages to clear "streaming" status
           const convId = useChatStore.getState().selectedConversationId;

--- a/src/components/tunaflow/context-panel/DevProgressView.tsx
+++ b/src/components/tunaflow/context-panel/DevProgressView.tsx
@@ -18,7 +18,7 @@ interface DevProgressViewProps {
 }
 
 export function DevProgressView({ plan, onPlanUpdate }: DevProgressViewProps) {
-  const { openThread, sendThreadMessage, loadBranches, saveConversationEngine } = useChatStore();
+  const { openThread, sendThreadMessage, sendThreadRoundtable, loadBranches, saveConversationEngine } = useChatStore();
   const profiles = useChatStore((s) => s.agentProfiles);
   const runningThreadIds = useChatStore((s) => s.runningThreadIds);
 
@@ -167,10 +167,12 @@ export function DevProgressView({ plan, onPlanUpdate }: DevProgressViewProps) {
       } catch (e) { console.debug("[test-before-review-rt]", e); }
 
       const engines = chosenProfiles.map((p) => p.engine);
-      const { branch } = await startReviewRT(plan, msgs, testOutput, engines);
+      const { branch, participants, prompt, mode } = await startReviewRT(plan, msgs, testOutput, engines);
       onPlanUpdate(plan.id, { phase: "review" as PlanPhase, reviewBranchId: branch.id });
       await loadBranches(plan.conversationId);
       await openThread(branch.id);
+      // Kick off the actual RT run — startReviewRT only scaffolds the branch/config.
+      await sendThreadRoundtable(prompt, participants, mode);
     } catch (e) { console.warn("[tunaflow]", e); }
     setBusy(false);
     setReviewMode("idle");

--- a/src/components/tunaflow/context-panel/plans/PlanCard.tsx
+++ b/src/components/tunaflow/context-panel/plans/PlanCard.tsx
@@ -37,7 +37,7 @@ export function PlanCard({
   onSwitchToChat?: () => void;
   defaultExpanded?: boolean;
 }) {
-  const { sendFollowup, setHandoffSource, branches, openThread, loadBranches, runningThreadIds } = useChatStore();
+  const { sendFollowup, setHandoffSource, branches, openThread, sendThreadRoundtable, loadBranches, runningThreadIds } = useChatStore();
   const [plan, setPlan] = useState(initialPlan);
   // Sync local plan state when parent re-renders with updated plan (e.g., auto-detect verdict)
   useEffect(() => {
@@ -292,10 +292,11 @@ export function PlanCard({
                             }
                           }
                         } catch (e) { console.debug("[test-before-review]", e); }
-                        const { branch } = await startReviewRT(plan, msgs, testOutput);
+                        const { branch, participants, prompt, mode } = await startReviewRT(plan, msgs, testOutput);
                         handlePlanUpdate({ phase: "review", reviewBranchId: branch.id });
                         await loadBranches(plan.conversationId);
                         await openThread(branch.id);
+                        await sendThreadRoundtable(prompt, participants, mode);
                       }}
                       className="ml-auto px-2 py-0.5 rounded text-[9px] font-medium bg-status-approved/20 hover:bg-status-approved/30 transition-colors"
                     >

--- a/src/lib/workflow/reviewWorkflow.ts
+++ b/src/lib/workflow/reviewWorkflow.ts
@@ -26,12 +26,18 @@ export type { CreateBranchResult };
 
 // ─── Phase D→E: impl-complete → Start Review RT ───────────────────────────
 
+export interface StartReviewRTResult extends CreateBranchResult {
+  participants: RoundtableParticipant[];
+  prompt: string;
+  mode: "sequential";
+}
+
 export async function startReviewRT(
   plan: Plan,
   implMessages: Message[],
   testOutput?: string,
   reviewerEngines?: string[],
-): Promise<CreateBranchResult> {
+): Promise<StartReviewRTResult> {
   await planApi.updatePlanPhase(plan.id, "review");
   await planApi.createPlanEvent(plan.id, "impl_completed", "developer");
 
@@ -119,12 +125,17 @@ export async function startReviewRT(
     role: "reviewer" as const,
   }));
 
-  const rtConfig = JSON.stringify({ participants, mode: "sequential" });
+  const mode = "sequential" as const;
+  const rtConfig = JSON.stringify({ participants, mode });
   await invoke("save_rt_config", { conversationId: shadowConvId, config: rtConfig });
 
-  await invoke("create_user_message", { input: { conversationId: shadowConvId, content: prompt } });
-
-  return { branch, shadowConvId };
+  // NOTE: RT execution is the caller's responsibility.
+  // After this returns, the caller should call openThread(branch.id) then
+  // sendThreadRoundtable(prompt, participants, mode) to actually run the review.
+  // We intentionally do NOT create a user_message here — sendThreadRoundtable
+  // persists the prompt as the user message itself, and pre-seeding it would
+  // cause a duplicate prompt in the branch.
+  return { branch, shadowConvId, participants, prompt, mode };
 }
 
 // ─── Phase E: Process review verdict ──────────────────────────────────────

--- a/src/stores/slices/ptyMessageSender.ts
+++ b/src/stores/slices/ptyMessageSender.ts
@@ -373,8 +373,10 @@ export async function sendMessageViaPty(
 
               // Post-completion handling
               if (opts.onCompleted) {
+                // onCompleted callbacks (e.g. threadSlice) issue their own notify;
+                // pass silent:true to prevent _endRun from double-notifying.
                 const handled = await opts.onCompleted(savedMsg, result.text);
-                if (!handled) get()._endRun(conversationId);
+                if (!handled) get()._endRun(conversationId, { silent: true });
               } else {
                 // Default: scan markers + notify
                 if (result.text) {

--- a/src/stores/slices/runtimeSlice.ts
+++ b/src/stores/slices/runtimeSlice.ts
@@ -39,7 +39,7 @@ export interface RuntimeSlice {
   messageQueue: QueuedAction[];
   error: string | null;
   _startRun: (threadId: string) => void;
-  _endRun: (threadId: string) => void;
+  _endRun: (threadId: string, opts?: { silent?: boolean }) => void;
   _enqueue: (threadId: string, label: string, execute: () => Promise<void>) => void;
   cancelOperation: (threadId?: string) => Promise<void>;
   sendMessage: (prompt: string, model?: string, systemPrompt?: string) => Promise<void>;
@@ -64,13 +64,14 @@ export const createRuntimeSlice = (set: SetState, get: GetState): RuntimeSlice =
     }));
   },
 
-  _endRun: (threadId: string) => {
+  _endRun: (threadId: string, opts?: { silent?: boolean }) => {
     set((state) => {
       const next = state.runningThreadIds.filter((id) => id !== threadId);
       return { runningThreadIds: next };
     });
-    // Notify completion — skip if error was set (error handler sends its own notification)
-    if (!get().error) {
+    // Notify completion — skip if error was set (error handler sends its own notification),
+    // or if caller already notified (silent: true) to prevent double-notification.
+    if (!get().error && !opts?.silent) {
       import("@/stores/notificationStore").then(({ notify }) => {
         const state = get();
         const conv = state.conversations.find((c) => c.id === threadId);

--- a/src/stores/slices/threadRtRunner.ts
+++ b/src/stores/slices/threadRtRunner.ts
@@ -118,7 +118,7 @@ export async function runThreadRoundtable(
       });
     }).catch((e) => console.debug("[notify:rt-completed]", e));
     setTimeout(() => set({ rtParticipantStatuses: new Map(), rtStatusConversationId: null }), 2000);
-    get()._endRun(threadBranchConvId);
+    get()._endRun(threadBranchConvId, { silent: true });
   });
   const ulE = await listen<{ conversationId: string; error: string }>("agent:error", async (e) => {
     if (e.payload.conversationId !== threadBranchConvId) return;

--- a/src/stores/slices/threadSlice.ts
+++ b/src/stores/slices/threadSlice.ts
@@ -204,7 +204,7 @@ export const createThreadSlice = (set: SetState, get: GetState): ThreadSlice => 
                 const followUp = await handleToolRequests(savedMsg.role === "assistant" ? { ...savedMsg, content: text } : savedMsg);
                 if (followUp) {
                   const saved = get().getConversationEngine(convId);
-                  get()._endRun(convId);
+                  get()._endRun(convId, { silent: true });
                   get().sendThreadMessage(followUp, saved?.engine ?? "claude", saved?.model ?? undefined);
                   toolRequestHandled = true;
                 }
@@ -314,7 +314,7 @@ export const createThreadSlice = (set: SetState, get: GetState): ThreadSlice => 
       const followUp = await handleToolRequests(lastMsg);
       if (followUp) {
         const saved = get().getConversationEngine(convId);
-        get()._endRun(convId);
+        get()._endRun(convId, { silent: true });
         get().sendThreadMessage(followUp, saved?.engine ?? "claude", saved?.model ?? undefined);
         toolRequestHandled = true;
       }
@@ -334,7 +334,7 @@ export const createThreadSlice = (set: SetState, get: GetState): ThreadSlice => 
           preview: lastAsst?.content?.replace(/\n+/g, " ").slice(0, 80),
         });
       }).catch((e) => console.debug("[notify:completed]", e));
-      if (!toolRequestHandled) get()._endRun(convId);
+      if (!toolRequestHandled) get()._endRun(convId, { silent: true });
     });
     const ulE = await listen<{ conversationId: string; error: string }>("agent:error", async (e) => {
       if (e.payload.conversationId !== convId) return;

--- a/src/stores/slices/types.ts
+++ b/src/stores/slices/types.ts
@@ -120,7 +120,7 @@ export interface ChatState {
 
   setHandoffSource: (source: { type: string; content: string } | null) => void;
   _startRun: (threadId: string) => void;
-  _endRun: (threadId: string) => void;
+  _endRun: (threadId: string, opts?: { silent?: boolean }) => void;
   _enqueue: (threadId: string, label: string, execute: () => Promise<void>) => void;
   loadProjects: () => Promise<void>;
   loadEngineModels: (refresh?: boolean) => Promise<void>;

--- a/src/tests/workflowOrchestration.test.ts
+++ b/src/tests/workflowOrchestration.test.ts
@@ -351,7 +351,7 @@ describe("startReviewBranch", () => {
 // ─── startReviewRT ──────────────────────────────────────────────────────
 
 describe("startReviewRT", () => {
-  it("creates RT branch with reviewer participants", async () => {
+  it("creates RT branch with reviewer participants and returns runnable config", async () => {
     const implMsgs: Message[] = [
       { id: "m1", conversationId: "c1", role: "assistant", content: "implemented X", timestamp: 0, status: "done" },
     ];
@@ -367,11 +367,17 @@ describe("startReviewRT", () => {
       }),
     }));
     expect(invoke).toHaveBeenCalledWith("save_rt_config", expect.any(Object));
+    // Caller is responsible for running RT — startReviewRT must NOT pre-create
+    // a user message (sendThreadRoundtable persists the prompt itself).
+    expect(invoke).not.toHaveBeenCalledWith("create_user_message", expect.any(Object));
     expect(result.branch.id).toBe("br-1");
+    expect(result.participants.length).toBeGreaterThanOrEqual(2);
+    expect(result.prompt).toContain("코드 리뷰어");
+    expect(result.mode).toBe("sequential");
   });
 
   it("uses custom reviewer engines", async () => {
-    await startReviewRT(mockPlan, [], undefined, ["gemini", "ollama"]);
+    const result = await startReviewRT(mockPlan, [], undefined, ["gemini", "ollama"]);
 
     // RT config should include both engines
     const saveCall = (invoke as any).mock.calls.find((c: string[]) => c[0] === "save_rt_config");
@@ -380,5 +386,7 @@ describe("startReviewRT", () => {
     expect(config.participants.length).toBe(2);
     expect(config.participants[0].engine).toBe("gemini");
     expect(config.participants[1].engine).toBe("ollama");
+    // Returned participants should match
+    expect(result.participants.map((p) => p.engine)).toEqual(["gemini", "ollama"]);
   });
 });


### PR DESCRIPTION
## Summary

- **알림 중복**: 완료 시 알림이 2회 울리던 버그 수정
- **RT Review 진입 실패**: "Review RT 시작" 버튼이 눌려도 드로어만 열리고 실제 RT는 돌지 않던 버그 수정

## Details

### 1) 알림 중복
`runtimeSlice._endRun`이 기본적으로 `notify("completed")`를 호출하는데, 여러 호출처(threadSlice / threadRtRunner / ptyMessageSender / RuntimeStatusBar / BranchThreadPanel)가 이미 직접 notify 한 뒤 `_endRun`을 호출해 중복 발생.

**Fix**: `_endRun` 시그니처에 `{ silent?: boolean }` 옵션 추가. 직접 notify 하는 경로 7곳에 `silent:true` 전달. 수동 복구 / orphan 정리 경로도 silent 처리.

### 2) RT Review 진입 실패
`startReviewRT`이 branch + RT config + user-message를 만들고 끝났다. 실제 `sendThreadRoundtable`을 호출하지 않아 드로어만 열렸다.

**Fix**:
- `startReviewRT` 반환 타입을 `{ branch, shadowConvId, participants, prompt, mode }`로 확장
- 내부의 `create_user_message` 제거 (`sendThreadRoundtable`이 prompt를 user 메시지로 persist 하므로 중복 방지)
- `DevProgressView` / `PlanCard` 두 호출자가 `openThread` → `sendThreadRoundtable(prompt, participants, mode)`로 실제 RT 실행

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 192/192 pass (기존 테스트 + `create_user_message` 미호출 검증 추가)
- [ ] 수동 검증: Plan에서 "Review RT 시작" 클릭 → 드로어 열림 + RT 실제 실행 확인
- [ ] 수동 검증: 메시지 완료 시 알림이 1회만 울리는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)