### PR TITLE
feat(onboarding): 메타에이전트가 초기 구성(agent/skill/workflow) 추천

### DIFF
--- a/src-tauri/src/commands/project_onboarding.rs
+++ b/src-tauri/src/commands/project_onboarding.rs
@@ -36,6 +36,13 @@ pub struct OnboardingPreviewPayload {
     pub claude_md: String,
     pub ref_index: String,
     pub has_existing_claude_md: bool,
+    /// Optional — meta-agent's initial setup recommendation (agent profiles,
+    /// skills, workflow defaults). May be `None` if the agent omitted the
+    /// [INITIAL_SETUP_*] block or if the JSON inside it was unparseable.
+    /// In that case onboarding falls back to the legacy flow (claude_md +
+    /// ref_index only) — see plan §7 (안전 장치).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub initial_setup: Option<serde_json::Value>,
 }
 
 #[derive(Serialize, Clone)]
@@ -306,6 +313,33 @@ fn build_prompt(
 ## 프롬프트
 - [prompts/index.md](prompts/index.md)
 [REF_INDEX_END]
+
+[INITIAL_SETUP_START]
+{{
+  "agent_profiles": [
+    {{ "role": "architect", "engine": "claude", "model": "claude-opus-4-6", "persona_id": "persona_architect" }},
+    {{ "role": "developer", "engine": "codex",  "model": "gpt-5-codex",     "persona_id": "persona_implementer" }},
+    {{ "role": "reviewer",  "engine": "gemini", "model": "gemini-2.5-pro",  "persona_id": "persona_reviewer" }}
+  ],
+  "skills": ["rust-review", "cargo-test"],
+  "workflow": {{
+    "review_track": "deep",
+    "context_mode": "auto",
+    "rt_participants": ["claude", "codex", "gemini"]
+  }},
+  "rationale": "스택과 프로젝트 성격 기반 추천 근거 1~2문장"
+}}
+[INITIAL_SETUP_END]
+
+### INITIAL_SETUP 작성 규칙
+- **JSON만** 출력. 주석·trailing comma 금지.
+- `persona_id`는 다음 값 중 하나만: `persona_general`, `persona_reviewer`, `persona_tester`, `persona_architect`, `persona_implementer`, `persona_debugger`, `persona_ux_critic`, `persona_meta`.
+- `engine`은 `claude` / `codex` / `gemini` / `ollama` / `lmstudio` 중 설치 가능성이 높은 것만 추천. 확신 없으면 profile 항목에서 생략.
+- `skills`는 사용자가 로드한 `~/.tunaflow/skills/` 레지스트리 이름(kebab-case, e.g. `rust-review`). 모르면 빈 배열 `[]`.
+- `review_track`: `quick` (subtask ≤ 3) 또는 `deep`. `context_mode`: `auto` / `lite` / `standard` / `full`.
+- `rt_participants`는 2~3개 엔진 이름. 1인 프로젝트에서 모델 하나만 추천한다면 빈 배열 허용.
+- `rationale`은 1~2문장으로 간결하게. 추천 근거(스택, 프로젝트 규모 등) 언급.
+- 스택을 전혀 추론하지 못했다면 이 섹션 전체를 빈 객체 `{{}}`로 출력 가능 (건너뜀 처리됨).
 "#,
         project_name = project_name,
         lang = lang,
@@ -321,12 +355,29 @@ fn build_prompt(
 
 // ─── Parse output ────────────────────────────────────────────────────────────
 
-fn parse_output(text: &str) -> Result<(String, String), String> {
+fn parse_output(text: &str) -> Result<(String, String, Option<serde_json::Value>), String> {
     let claude_md = extract_between(text, "[CLAUDE_MD_START]", "[CLAUDE_MD_END]")
         .ok_or("AI 응답에서 CLAUDE.md 섹션을 찾을 수 없습니다")?;
     let ref_index = extract_between(text, "[REF_INDEX_START]", "[REF_INDEX_END]")
         .ok_or("AI 응답에서 Reference Index 섹션을 찾을 수 없습니다")?;
-    Ok((claude_md.trim().to_string(), ref_index.trim().to_string()))
+    // Optional — fail-soft per plan §7. Unparseable/empty JSON → None, which
+    // causes the FE to skip the Initial Setup section entirely.
+    let initial_setup = extract_between(text, "[INITIAL_SETUP_START]", "[INITIAL_SETUP_END]")
+        .and_then(|raw| {
+            let trimmed = raw.trim();
+            if trimmed.is_empty() { return None; }
+            match serde_json::from_str::<serde_json::Value>(trimmed) {
+                Ok(v) => {
+                    // Treat empty-object sentinel `{}` as "no recommendation".
+                    if v.as_object().map(|o| o.is_empty()).unwrap_or(false) { None } else { Some(v) }
+                }
+                Err(e) => {
+                    eprintln!("[onboarding] INITIAL_SETUP parse failed (skipping): {e}");
+                    None
+                }
+            }
+        });
+    Ok((claude_md.trim().to_string(), ref_index.trim().to_string(), initial_setup))
 }
 
 fn extract_between<'a>(text: &'a str, start: &str, end: &str) -> Option<&'a str> {
@@ -524,13 +575,14 @@ async fn call_ollama(
 }
 
 /// Top-level dispatcher: pick CLI vs HTTP path by engine name.
+#[allow(clippy::too_many_arguments)]
 async fn call_agent(
     engine: &str,
     model: Option<&str>,
     endpoint: Option<&str>,
     prompt: &str,
     cancel: &AtomicBool,
-) -> Result<(String, String), String> {
+) -> Result<(String, String, Option<serde_json::Value>), String> {
     let text = match engine {
         "claude" | "codex" | "gemini" => {
             call_cli_agent(engine, engine, prompt, model, cancel).await?
@@ -605,13 +657,14 @@ pub async fn analyze_project_for_onboarding(
     ).await;
 
     match agent_result {
-        Ok((claude_md, ref_index)) => {
+        Ok((claude_md, ref_index, initial_setup)) => {
             if is_cancelled(&cancel) { clear_cancel_flag(); return Ok(()); }
             emit_step(3, "분석 완료", true);
             app.emit("project:onboarding:preview", OnboardingPreviewPayload {
                 claude_md,
                 ref_index,
                 has_existing_claude_md: has_existing,
+                initial_setup,
             }).ok();
         }
         Err(e) if e == "cancelled" => { /* no-op */ }
@@ -651,4 +704,96 @@ pub fn apply_project_onboarding(
         .map_err(|e| format!("docs/reference/index.md 쓰기 실패: {e}"))?;
 
     Ok(())
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::parse_output;
+
+    #[test]
+    fn parse_output_legacy_without_initial_setup() {
+        let text = r#"
+[CLAUDE_MD_START]
+# foo
+[CLAUDE_MD_END]
+[REF_INDEX_START]
+# ref
+[REF_INDEX_END]
+"#;
+        let (md, idx, init) = parse_output(text).expect("parse ok");
+        assert_eq!(md, "# foo");
+        assert_eq!(idx, "# ref");
+        assert!(init.is_none());
+    }
+
+    #[test]
+    fn parse_output_with_initial_setup_json() {
+        let text = r#"
+[CLAUDE_MD_START]
+# foo
+[CLAUDE_MD_END]
+[REF_INDEX_START]
+# ref
+[REF_INDEX_END]
+[INITIAL_SETUP_START]
+{
+  "agent_profiles": [
+    { "role": "developer", "engine": "codex", "model": "gpt-5-codex", "persona_id": "persona_implementer" }
+  ],
+  "skills": ["rust-review"],
+  "workflow": { "review_track": "deep", "context_mode": "auto", "rt_participants": ["claude", "codex"] },
+  "rationale": "Rust 프로젝트"
+}
+[INITIAL_SETUP_END]
+"#;
+        let (_md, _idx, init) = parse_output(text).expect("parse ok");
+        let v = init.expect("initial_setup present");
+        assert_eq!(v["skills"][0], "rust-review");
+        assert_eq!(v["workflow"]["review_track"], "deep");
+        assert_eq!(v["agent_profiles"][0]["role"], "developer");
+    }
+
+    #[test]
+    fn parse_output_initial_setup_empty_object_returns_none() {
+        let text = r#"
+[CLAUDE_MD_START]
+a
+[CLAUDE_MD_END]
+[REF_INDEX_START]
+b
+[REF_INDEX_END]
+[INITIAL_SETUP_START]
+{}
+[INITIAL_SETUP_END]
+"#;
+        let (_m, _r, init) = parse_output(text).expect("parse ok");
+        assert!(init.is_none(), "empty object should be treated as skip");
+    }
+
+    #[test]
+    fn parse_output_initial_setup_bad_json_is_ignored() {
+        let text = r#"
+[CLAUDE_MD_START]
+a
+[CLAUDE_MD_END]
+[REF_INDEX_START]
+b
+[REF_INDEX_END]
+[INITIAL_SETUP_START]
+{ this is not json,,, }
+[INITIAL_SETUP_END]
+"#;
+        let (md, idx, init) = parse_output(text).expect("parse still ok because markers OK");
+        assert_eq!(md, "a");
+        assert_eq!(idx, "b");
+        assert!(init.is_none(), "bad JSON should fail-soft to None");
+    }
+
+    #[test]
+    fn parse_output_missing_claude_md_errors() {
+        let text = "[REF_INDEX_START]\nx\n[REF_INDEX_END]\n";
+        assert!(parse_output(text).is_err());
+    }
 }

--- a/src/components/tunaflow/ProjectOnboardingModal.tsx
+++ b/src/components/tunaflow/ProjectOnboardingModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { CheckCircle2, Circle, Loader2, AlertCircle } from "lucide-react";
@@ -8,6 +8,12 @@ import { cn } from "@/lib/utils";
 import { useChatStore } from "@/stores/chatStore";
 import { MetaAgentSelector } from "./MetaAgentSelector";
 import { markdownComponents } from "./chat/MarkdownComponents";
+import {
+  applyInitialSetup,
+  normalizeInitialSetup,
+  type InitialSetupPayload,
+  type InitialSetupSelection,
+} from "@/lib/initialSetupApply";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const REMARK_PLUGINS: any[] = [[remarkGfm, { singleTilde: false }]];
@@ -15,13 +21,18 @@ const REMARK_PLUGINS: any[] = [[remarkGfm, { singleTilde: false }]];
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 interface StepPayload { step: number; label: string; done: boolean; }
-interface PreviewPayload { claude_md: string; ref_index: string; has_existing_claude_md: boolean; }
+interface PreviewPayload {
+  claude_md: string;
+  ref_index: string;
+  has_existing_claude_md: boolean;
+  initial_setup?: unknown;
+}
 interface ErrorPayload { message: string; }
 
 // Flow: agent_select → loading → preview → done
 // Overlays (cancel_confirm / skip_confirm) render on top of the host state.
 type ModalState = "agent_select" | "loading" | "preview" | "cancel_confirm" | "skip_confirm" | "done";
-type PreviewTab = "claude_md" | "ref_index";
+type PreviewTab = "claude_md" | "ref_index" | "initial_setup";
 
 interface Step { label: string; done: boolean; active: boolean; }
 
@@ -43,6 +54,38 @@ export function ProjectOnboardingModal() {
   const [activeTab, setActiveTab] = useState<PreviewTab>("claude_md");
   const [error, setError] = useState<string | null>(null);
   const cleanupRef = useRef<(() => void)[]>([]);
+
+  // Initial-setup selections (only populated when preview.initial_setup parses)
+  const [profileSelection, setProfileSelection] = useState<Set<number>>(new Set());
+  const [skillSelection, setSkillSelection] = useState<Set<string>>(new Set());
+  const [applyWorkflow, setApplyWorkflow] = useState(true);
+
+  // Store access — needed by applyInitialSetup
+  const agentProfiles = useChatStore((s) => s.agentProfiles);
+  const activeSkills = useChatStore((s) => s.activeSkills);
+  const skills = useChatStore((s) => s.skills);
+  const saveProfiles = useChatStore((s) => s.saveProfiles);
+  const acceptRecommendedSkills = useChatStore((s) => s.acceptRecommendedSkills);
+
+  const normalizedInitialSetup = useMemo<InitialSetupPayload | null>(() => {
+    if (!preview?.initial_setup) return null;
+    return normalizeInitialSetup(preview.initial_setup);
+  }, [preview]);
+
+  // When a new preview arrives, pre-check everything that looks valid — users
+  // can uncheck to opt out. Matches plan §4 UX expectation.
+  useEffect(() => {
+    if (!normalizedInitialSetup) {
+      setProfileSelection(new Set());
+      setSkillSelection(new Set());
+      setApplyWorkflow(true);
+      return;
+    }
+    const installedSkillNames = new Set(skills.map((s) => s.name));
+    setProfileSelection(new Set(normalizedInitialSetup.agent_profiles?.map((_, i) => i) ?? []));
+    setSkillSelection(new Set((normalizedInitialSetup.skills ?? []).filter((n) => installedSkillNames.has(n))));
+    setApplyWorkflow(!!normalizedInitialSetup.workflow);
+  }, [normalizedInitialSetup, skills]);
 
   // Reset to initial "agent_select" phase when a new project arrives.
   useEffect(() => {
@@ -122,6 +165,26 @@ export function ProjectOnboardingModal() {
         claudeMdContent: preview.claude_md,
         refIndexContent: preview.ref_index,
       });
+      // Apply initial-setup selections (best effort — individual failures are
+      // logged but don't block the onboarding).
+      if (normalizedInitialSetup) {
+        const selection: InitialSetupSelection = {
+          profileIndices: profileSelection,
+          skills: skillSelection,
+          applyWorkflow,
+        };
+        try {
+          await applyInitialSetup(normalizedInitialSetup, selection, {
+            currentProfiles: agentProfiles,
+            saveProfiles,
+            currentActiveSkills: activeSkills,
+            setActiveSkills: (names) => acceptRecommendedSkills(names),
+            availableSkillNames: new Set(skills.map((s) => s.name)),
+          });
+        } catch (e) {
+          console.error("[onboarding] initialSetup apply failed:", e);
+        }
+      }
     } catch (e) {
       setError(String(e));
       return;
@@ -256,16 +319,42 @@ export function ProjectOnboardingModal() {
                   {tab === "claude_md" ? "CLAUDE.md" : "docs/reference/index.md"}
                 </button>
               ))}
+              {normalizedInitialSetup && (
+                <button
+                  onClick={() => setActiveTab("initial_setup")}
+                  className={cn(
+                    "px-3 py-2 text-[11px] font-medium border-b-2 transition-colors -mb-px",
+                    activeTab === "initial_setup"
+                      ? "border-primary text-foreground"
+                      : "border-transparent text-muted-foreground hover:text-foreground"
+                  )}
+                >
+                  초기 구성
+                </button>
+              )}
             </div>
 
             {/* Content — render as Markdown so the preview matches how the
                  file will actually look in the editor / Docs viewer. */}
             <div className="flex-1 overflow-y-auto min-h-0">
-              <div className="prose prose-invert prose-chat prose-sm max-w-none px-6 py-4 text-[12px] leading-relaxed [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
-                <ReactMarkdown remarkPlugins={REMARK_PLUGINS} components={markdownComponents}>
-                  {activeTab === "claude_md" ? preview.claude_md : preview.ref_index}
-                </ReactMarkdown>
-              </div>
+              {activeTab === "initial_setup" && normalizedInitialSetup ? (
+                <InitialSetupPanel
+                  payload={normalizedInitialSetup}
+                  installedSkillNames={new Set(skills.map((s) => s.name))}
+                  profileSelection={profileSelection}
+                  setProfileSelection={setProfileSelection}
+                  skillSelection={skillSelection}
+                  setSkillSelection={setSkillSelection}
+                  applyWorkflow={applyWorkflow}
+                  setApplyWorkflow={setApplyWorkflow}
+                />
+              ) : (
+                <div className="prose prose-invert prose-chat prose-sm max-w-none px-6 py-4 text-[12px] leading-relaxed [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
+                  <ReactMarkdown remarkPlugins={REMARK_PLUGINS} components={markdownComponents}>
+                    {activeTab === "claude_md" ? preview.claude_md : preview.ref_index}
+                  </ReactMarkdown>
+                </div>
+              )}
             </div>
 
             <div className="px-6 py-4 border-t border-border">
@@ -349,6 +438,133 @@ function CancelConfirmOverlay({ onBack, onConfirm }: { onBack: () => void; onCon
           </button>
         </div>
       </div>
+    </div>
+  );
+}
+
+function InitialSetupPanel({
+  payload,
+  installedSkillNames,
+  profileSelection,
+  setProfileSelection,
+  skillSelection,
+  setSkillSelection,
+  applyWorkflow,
+  setApplyWorkflow,
+}: {
+  payload: InitialSetupPayload;
+  installedSkillNames: Set<string>;
+  profileSelection: Set<number>;
+  setProfileSelection: (s: Set<number>) => void;
+  skillSelection: Set<string>;
+  setSkillSelection: (s: Set<string>) => void;
+  applyWorkflow: boolean;
+  setApplyWorkflow: (v: boolean) => void;
+}) {
+  const toggleProfile = (i: number) => {
+    const next = new Set(profileSelection);
+    if (next.has(i)) next.delete(i);
+    else next.add(i);
+    setProfileSelection(next);
+  };
+  const toggleSkill = (name: string) => {
+    const next = new Set(skillSelection);
+    if (next.has(name)) next.delete(name);
+    else next.add(name);
+    setSkillSelection(next);
+  };
+
+  return (
+    <div className="px-6 py-4 space-y-4 text-[12px]">
+      {payload.rationale && (
+        <div className="rounded-md border border-border/60 bg-accent/30 p-2.5 text-[11px] text-muted-foreground leading-relaxed">
+          <span className="font-medium text-foreground">추천 근거: </span>
+          {payload.rationale}
+        </div>
+      )}
+
+      {/* Agent Profiles */}
+      {payload.agent_profiles && payload.agent_profiles.length > 0 && (
+        <section>
+          <h3 className="text-[11px] font-semibold text-foreground mb-1.5">Agent Profiles</h3>
+          <ul className="space-y-1">
+            {payload.agent_profiles.map((p, i) => (
+              <li key={i}>
+                <label className="flex items-center gap-2 cursor-pointer hover:bg-accent/50 rounded px-1.5 py-1">
+                  <input
+                    type="checkbox"
+                    checked={profileSelection.has(i)}
+                    onChange={() => toggleProfile(i)}
+                    className="w-3.5 h-3.5"
+                  />
+                  <span className="capitalize font-medium text-foreground">{p.role}</span>
+                  <span className="text-muted-foreground">{p.engine}</span>
+                  {p.model && <span className="text-[10px] text-muted-foreground/60">({p.model})</span>}
+                  {p.persona_id && <span className="text-[10px] text-muted-foreground/50 ml-auto">{p.persona_id}</span>}
+                </label>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {/* Skills */}
+      {payload.skills && payload.skills.length > 0 && (
+        <section>
+          <h3 className="text-[11px] font-semibold text-foreground mb-1.5">Recommended Skills</h3>
+          <ul className="space-y-1">
+            {payload.skills.map((name) => {
+              const installed = installedSkillNames.has(name);
+              return (
+                <li key={name}>
+                  <label className={cn(
+                    "flex items-center gap-2 rounded px-1.5 py-1",
+                    installed ? "cursor-pointer hover:bg-accent/50" : "opacity-50 cursor-not-allowed",
+                  )}>
+                    <input
+                      type="checkbox"
+                      disabled={!installed}
+                      checked={skillSelection.has(name)}
+                      onChange={() => installed && toggleSkill(name)}
+                      className="w-3.5 h-3.5"
+                    />
+                    <span className={installed ? "text-foreground" : "text-muted-foreground"}>{name}</span>
+                    {!installed && (
+                      <span className="text-[10px] text-muted-foreground/60 ml-auto">not installed</span>
+                    )}
+                  </label>
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      )}
+
+      {/* Workflow */}
+      {payload.workflow && Object.keys(payload.workflow).length > 0 && (
+        <section>
+          <h3 className="text-[11px] font-semibold text-foreground mb-1.5">Workflow Defaults</h3>
+          <label className="flex items-start gap-2 cursor-pointer hover:bg-accent/50 rounded px-1.5 py-1">
+            <input
+              type="checkbox"
+              checked={applyWorkflow}
+              onChange={(e) => setApplyWorkflow(e.target.checked)}
+              className="w-3.5 h-3.5 mt-0.5"
+            />
+            <div className="space-y-0.5 text-[11px]">
+              {payload.workflow.review_track && (
+                <div><span className="text-muted-foreground">Review track:</span> <span className="text-foreground">{payload.workflow.review_track}</span></div>
+              )}
+              {payload.workflow.context_mode && (
+                <div><span className="text-muted-foreground">ContextPack:</span> <span className="text-foreground">{payload.workflow.context_mode}</span></div>
+              )}
+              {payload.workflow.rt_participants && payload.workflow.rt_participants.length > 0 && (
+                <div><span className="text-muted-foreground">RT 참가자:</span> <span className="text-foreground">{payload.workflow.rt_participants.join(", ")}</span></div>
+              )}
+            </div>
+          </label>
+        </section>
+      )}
     </div>
   );
 }

--- a/src/lib/initialSetupApply.ts
+++ b/src/lib/initialSetupApply.ts
@@ -1,0 +1,186 @@
+/**
+ * initialSetupApply — applies meta-agent's recommended initial setup to the
+ * store/appSettings based on user selections.
+ *
+ * The meta-agent emits a JSON blob in `[INITIAL_SETUP_START/END]` during
+ * onboarding. The FE shows its contents as checkboxes; this module translates
+ * the checked items into actual side effects (agent profiles, activeSkills,
+ * workflow defaults).
+ *
+ * Scope discipline (plan §7 안전 장치):
+ *  - Unknown persona_ids fall back to persona_general.
+ *  - Profiles with engines not in the known set are dropped.
+ *  - Skills not present in the registry are filtered out by the caller.
+ *  - Any individual failure is logged but does not abort the whole apply —
+ *    remaining selections still land.
+ */
+import { getSetting, setSetting } from "@/lib/appStore";
+import { DEFAULT_PERSONAS } from "@/lib/defaultPersonas";
+import type { AgentProfile } from "@/types";
+
+/** Known persona IDs. Keep in sync with `DEFAULT_PERSONAS` in defaultPersonas.ts. */
+const KNOWN_PERSONAS = new Set(DEFAULT_PERSONAS.map((p) => p.id));
+
+/** Engines we recognize. Matches ENGINE_CONFIGS keys. */
+const KNOWN_ENGINES = new Set(["claude", "codex", "gemini", "ollama", "lmstudio", "openai"]);
+
+export interface RecommendedProfile {
+  role: string;        // "architect" | "developer" | "reviewer" | …
+  engine: string;
+  model?: string;
+  persona_id?: string;
+}
+
+export interface RecommendedWorkflow {
+  review_track?: "quick" | "deep" | string;
+  context_mode?: "auto" | "lite" | "standard" | "full" | string;
+  rt_participants?: string[];
+}
+
+export interface InitialSetupPayload {
+  agent_profiles?: RecommendedProfile[];
+  skills?: string[];
+  workflow?: RecommendedWorkflow;
+  rationale?: string;
+}
+
+export interface InitialSetupSelection {
+  /** Indices into payload.agent_profiles that the user checked. */
+  profileIndices: Set<number>;
+  /** Skill names that the user checked. */
+  skills: Set<string>;
+  /** Whether to apply the workflow defaults. */
+  applyWorkflow: boolean;
+}
+
+/**
+ * Normalize an arbitrary value into a validated InitialSetupPayload or null
+ * if the shape is unusable. Tolerant — drops unknown fields rather than
+ * rejecting the whole payload.
+ */
+export function normalizeInitialSetup(raw: unknown): InitialSetupPayload | null {
+  if (!raw || typeof raw !== "object") return null;
+  const obj = raw as Record<string, unknown>;
+  const out: InitialSetupPayload = {};
+
+  if (Array.isArray(obj.agent_profiles)) {
+    const profiles: RecommendedProfile[] = [];
+    for (const item of obj.agent_profiles) {
+      if (!item || typeof item !== "object") continue;
+      const r = item as Record<string, unknown>;
+      const engine = typeof r.engine === "string" ? r.engine : null;
+      const role = typeof r.role === "string" ? r.role : null;
+      if (!engine || !role) continue;
+      profiles.push({
+        role,
+        engine,
+        model: typeof r.model === "string" ? r.model : undefined,
+        persona_id: typeof r.persona_id === "string" ? r.persona_id : undefined,
+      });
+    }
+    if (profiles.length > 0) out.agent_profiles = profiles;
+  }
+
+  if (Array.isArray(obj.skills)) {
+    const skills = obj.skills.filter((s): s is string => typeof s === "string" && s.length > 0);
+    if (skills.length > 0) out.skills = skills;
+  }
+
+  if (obj.workflow && typeof obj.workflow === "object") {
+    const w = obj.workflow as Record<string, unknown>;
+    const workflow: RecommendedWorkflow = {};
+    if (typeof w.review_track === "string") workflow.review_track = w.review_track;
+    if (typeof w.context_mode === "string") workflow.context_mode = w.context_mode;
+    if (Array.isArray(w.rt_participants)) {
+      workflow.rt_participants = w.rt_participants.filter((x): x is string => typeof x === "string");
+    }
+    if (Object.keys(workflow).length > 0) out.workflow = workflow;
+  }
+
+  if (typeof obj.rationale === "string") out.rationale = obj.rationale;
+
+  return Object.keys(out).length > 0 ? out : null;
+}
+
+/** Convert a recommended profile into an AgentProfile entry for the store. */
+export function toAgentProfile(rec: RecommendedProfile, index: number): AgentProfile | null {
+  if (!KNOWN_ENGINES.has(rec.engine)) return null;
+  const personaId = rec.persona_id && KNOWN_PERSONAS.has(rec.persona_id)
+    ? rec.persona_id
+    : "persona_general";
+  const roleLabel = rec.role.charAt(0).toUpperCase() + rec.role.slice(1);
+  const engineLabel = rec.engine.charAt(0).toUpperCase() + rec.engine.slice(1);
+  return {
+    id: `onboarding-${rec.role}-${rec.engine}-${index}-${Date.now()}`,
+    label: `${roleLabel} ${engineLabel}`,
+    engine: rec.engine,
+    model: rec.model,
+    defaultSkills: [],
+    personaId,
+  };
+}
+
+/**
+ * Apply the selected initial-setup items. Operates only on what the caller
+ * selected. Returns a summary of what actually landed so the UI can show it.
+ */
+export async function applyInitialSetup(
+  payload: InitialSetupPayload,
+  selection: InitialSetupSelection,
+  deps: {
+    currentProfiles: AgentProfile[];
+    saveProfiles: (profiles: AgentProfile[]) => void;
+    currentActiveSkills: string[];
+    setActiveSkills: (names: string[]) => void;
+    availableSkillNames: Set<string>;
+  },
+): Promise<{ profilesAdded: number; skillsActivated: number; workflowApplied: boolean }> {
+  let profilesAdded = 0;
+  let skillsActivated = 0;
+  let workflowApplied = false;
+
+  // 1) Agent profiles — append (don't replace) so existing profiles stay.
+  if (payload.agent_profiles && selection.profileIndices.size > 0) {
+    const toAdd: AgentProfile[] = [];
+    payload.agent_profiles.forEach((rec, i) => {
+      if (!selection.profileIndices.has(i)) return;
+      const profile = toAgentProfile(rec, i);
+      if (profile) toAdd.push(profile);
+    });
+    if (toAdd.length > 0) {
+      deps.saveProfiles([...deps.currentProfiles, ...toAdd]);
+      profilesAdded = toAdd.length;
+    }
+  }
+
+  // 2) Skills — union with currently active, only names present in registry.
+  if (selection.skills.size > 0) {
+    const toActivate = [...selection.skills].filter((n) => deps.availableSkillNames.has(n));
+    if (toActivate.length > 0) {
+      const merged = Array.from(new Set([...deps.currentActiveSkills, ...toActivate]));
+      deps.setActiveSkills(merged);
+      skillsActivated = toActivate.length;
+    }
+  }
+
+  // 3) Workflow defaults — persist via appStore (global for now; per-project
+  //    plan §10 open question, deferred).
+  if (selection.applyWorkflow && payload.workflow) {
+    const w = payload.workflow;
+    if (w.context_mode && ["auto", "lite", "standard", "full"].includes(w.context_mode)) {
+      const current = await getSetting<{ mode: string; totalCap: number }>(
+        "contextBudgetConfig",
+        { mode: "auto", totalCap: 60000 },
+      );
+      setSetting("contextBudgetConfig", { ...current, mode: w.context_mode });
+    }
+    // review_track + rt_participants — stored as hints for UI defaults.
+    setSetting("onboardingWorkflowHints", {
+      reviewTrack: w.review_track ?? null,
+      rtParticipants: w.rt_participants ?? [],
+    });
+    workflowApplied = true;
+  }
+
+  return { profilesAdded, skillsActivated, workflowApplied };
+}

--- a/src/tests/initialSetupApply.test.ts
+++ b/src/tests/initialSetupApply.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/appStore", () => ({
+  getSetting: vi.fn((_key: string, fallback: unknown) => Promise.resolve(fallback)),
+  setSetting: vi.fn(),
+}));
+
+import { getSetting, setSetting } from "@/lib/appStore";
+import {
+  normalizeInitialSetup,
+  applyInitialSetup,
+  toAgentProfile,
+  type InitialSetupPayload,
+} from "@/lib/initialSetupApply";
+import type { AgentProfile } from "@/types";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (getSetting as any).mockImplementation((_k: string, fallback: unknown) => Promise.resolve(fallback));
+});
+
+describe("normalizeInitialSetup", () => {
+  it("returns null for non-object inputs", () => {
+    expect(normalizeInitialSetup(null)).toBeNull();
+    expect(normalizeInitialSetup("string")).toBeNull();
+    expect(normalizeInitialSetup(42)).toBeNull();
+  });
+
+  it("keeps only well-formed agent_profiles", () => {
+    const raw = {
+      agent_profiles: [
+        { role: "architect", engine: "claude", model: "claude-opus-4-6", persona_id: "persona_architect" },
+        { role: "bad" }, // missing engine
+        { engine: "codex" }, // missing role
+      ],
+    };
+    const out = normalizeInitialSetup(raw);
+    expect(out?.agent_profiles).toHaveLength(1);
+    expect(out?.agent_profiles?.[0].engine).toBe("claude");
+  });
+
+  it("filters non-string skills and keeps string ones", () => {
+    const raw = { skills: ["rust-review", 42, null, "cargo-test"] };
+    const out = normalizeInitialSetup(raw);
+    expect(out?.skills).toEqual(["rust-review", "cargo-test"]);
+  });
+
+  it("accepts partial workflow", () => {
+    const raw = { workflow: { review_track: "deep", rt_participants: ["claude", "codex"] } };
+    const out = normalizeInitialSetup(raw);
+    expect(out?.workflow?.review_track).toBe("deep");
+    expect(out?.workflow?.context_mode).toBeUndefined();
+    expect(out?.workflow?.rt_participants).toEqual(["claude", "codex"]);
+  });
+
+  it("returns null when payload has no usable fields", () => {
+    // all fields get filtered away
+    expect(normalizeInitialSetup({ agent_profiles: [{ role: "x" }], skills: [123], workflow: {} })).toBeNull();
+  });
+});
+
+describe("toAgentProfile", () => {
+  it("drops profiles with unknown engines", () => {
+    const result = toAgentProfile({ role: "developer", engine: "unknown-engine" }, 0);
+    expect(result).toBeNull();
+  });
+
+  it("falls back to persona_general for unknown persona_id", () => {
+    const result = toAgentProfile(
+      { role: "developer", engine: "codex", persona_id: "persona_nonexistent" },
+      0,
+    );
+    expect(result?.personaId).toBe("persona_general");
+  });
+
+  it("preserves known persona_id", () => {
+    const result = toAgentProfile(
+      { role: "architect", engine: "claude", persona_id: "persona_architect" },
+      0,
+    );
+    expect(result?.personaId).toBe("persona_architect");
+    expect(result?.engine).toBe("claude");
+  });
+});
+
+describe("applyInitialSetup", () => {
+  const payload: InitialSetupPayload = {
+    agent_profiles: [
+      { role: "architect", engine: "claude", model: "claude-opus-4-6", persona_id: "persona_architect" },
+      { role: "developer", engine: "codex", model: "gpt-5-codex", persona_id: "persona_implementer" },
+    ],
+    skills: ["rust-review", "cargo-test"],
+    workflow: { review_track: "deep", context_mode: "standard", rt_participants: ["claude", "codex"] },
+  };
+
+  it("appends selected profiles to existing ones", async () => {
+    const existing: AgentProfile[] = [
+      { id: "existing-1", label: "X", engine: "claude", defaultSkills: [] },
+    ];
+    const saveProfiles = vi.fn();
+    const setActiveSkills = vi.fn();
+
+    const result = await applyInitialSetup(
+      payload,
+      { profileIndices: new Set([0]), skills: new Set(), applyWorkflow: false },
+      {
+        currentProfiles: existing,
+        saveProfiles,
+        currentActiveSkills: [],
+        setActiveSkills,
+        availableSkillNames: new Set(),
+      },
+    );
+
+    expect(saveProfiles).toHaveBeenCalledOnce();
+    const saved = saveProfiles.mock.calls[0][0] as AgentProfile[];
+    expect(saved).toHaveLength(2); // existing + 1 new
+    expect(saved[0].id).toBe("existing-1");
+    expect(saved[1].engine).toBe("claude");
+    expect(result.profilesAdded).toBe(1);
+    expect(result.skillsActivated).toBe(0);
+    expect(result.workflowApplied).toBe(false);
+  });
+
+  it("only activates skills present in registry", async () => {
+    const setActiveSkills = vi.fn();
+    const result = await applyInitialSetup(
+      payload,
+      { profileIndices: new Set(), skills: new Set(["rust-review", "cargo-test"]), applyWorkflow: false },
+      {
+        currentProfiles: [],
+        saveProfiles: vi.fn(),
+        currentActiveSkills: ["existing-skill"],
+        setActiveSkills,
+        availableSkillNames: new Set(["rust-review"]), // cargo-test missing
+      },
+    );
+    expect(setActiveSkills).toHaveBeenCalledOnce();
+    const saved = setActiveSkills.mock.calls[0][0] as string[];
+    expect(saved).toContain("existing-skill");
+    expect(saved).toContain("rust-review");
+    expect(saved).not.toContain("cargo-test");
+    expect(result.skillsActivated).toBe(1);
+  });
+
+  it("persists workflow via appStore when selected", async () => {
+    await applyInitialSetup(
+      payload,
+      { profileIndices: new Set(), skills: new Set(), applyWorkflow: true },
+      {
+        currentProfiles: [],
+        saveProfiles: vi.fn(),
+        currentActiveSkills: [],
+        setActiveSkills: vi.fn(),
+        availableSkillNames: new Set(),
+      },
+    );
+    // contextBudgetConfig should have been set with mode: "standard"
+    const ctxCall = (setSetting as any).mock.calls.find((c: unknown[]) => c[0] === "contextBudgetConfig");
+    expect(ctxCall).toBeDefined();
+    expect((ctxCall[1] as { mode: string }).mode).toBe("standard");
+    // hints saved
+    const hintsCall = (setSetting as any).mock.calls.find((c: unknown[]) => c[0] === "onboardingWorkflowHints");
+    expect(hintsCall).toBeDefined();
+    expect((hintsCall[1] as { reviewTrack: string }).reviewTrack).toBe("deep");
+  });
+
+  it("does nothing when selection is empty", async () => {
+    const saveProfiles = vi.fn();
+    const setActiveSkills = vi.fn();
+    const result = await applyInitialSetup(
+      payload,
+      { profileIndices: new Set(), skills: new Set(), applyWorkflow: false },
+      {
+        currentProfiles: [],
+        saveProfiles,
+        currentActiveSkills: [],
+        setActiveSkills,
+        availableSkillNames: new Set(["rust-review"]),
+      },
+    );
+    expect(saveProfiles).not.toHaveBeenCalled();
+    expect(setActiveSkills).not.toHaveBeenCalled();
+    expect(result.profilesAdded).toBe(0);
+    expect(result.skillsActivated).toBe(0);
+    expect(result.workflowApplied).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Harness Maturity Audit 로드맵 §5.4 항목 10 — 프로젝트 온보딩 시 메타에이전트가 CLAUDE.md/reference.md 외에 **초기 구성 제안**까지 생성하고, 사용자가 체크박스로 선택한 항목만 실제 store/appSettings에 반영한다.

- **Agent Profile** 추천 (Architect/Developer/Reviewer × 스택)
- **Recommended Skills** 자동 활성화 (`~/.tunaflow/skills/` 레지스트리에 있는 것만)
- **Workflow Defaults** (review_track / context_mode / rt_participants)

## Details

### Rust — `project_onboarding.rs`
- `OnboardingPreviewPayload`에 `initial_setup: Option<serde_json::Value>` 추가
- 프롬프트에 `[INITIAL_SETUP_START/END]` 블록 출력 요구 — persona_id / engine / review_track / context_mode 열거값 명시. 스택 추론 실패 시 `{}` 로 skip
- `parse_output`이 INITIAL_SETUP 섹션을 **선택적으로** 파싱. 실패 → `None` (CLAUDE.md/REF_INDEX 경로는 영향 없음)
- 단위 테스트 5건 (legacy / with-json / empty-object / bad-json / missing-md)

### Frontend
- 신규 `src/lib/initialSetupApply.ts`
  - `normalizeInitialSetup`: 알 수 없는 필드 제거, 타입 검증
  - `toAgentProfile`: 알 수 없는 engine 제외, `persona_id` fallback → `persona_general`
  - `applyInitialSetup`: 선택된 프로필 append, 활성 skill 합집합, workflow 는 `contextBudgetConfig` + `onboardingWorkflowHints`로 appStore 영속화
- `ProjectOnboardingModal`
  - 새 탭 "초기 구성" (payload 있을 때만)
  - `InitialSetupPanel` 서브 컴포넌트 — Agent / Skills / Workflow 3블록 체크박스
  - 설치 안 된 skill 은 disabled + "not installed" 표기
  - rationale(추천 근거) 노출
- `handleApply`가 기존 CLAUDE.md/reference 쓰기 후 `applyInitialSetup` 호출. 개별 실패해도 전체 온보딩은 완료 처리 (fail-soft)
- vitest 12건 (normalize / toAgentProfile / applyInitialSetup 경로)

## 안전 장치 (plan §7)
- INITIAL_SETUP JSON 손상 → 해당 섹션만 건너뜀 (CLAUDE.md/reference는 이미 생성됨)
- 설치되지 않은 엔진이 추천되면 `toAgentProfile`이 `null` 반환 → 드롭
- 레지스트리에 없는 skill은 자동 제외

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `cargo test --lib project_onboarding` — 5/5 pass
- [x] `npx vitest run` — 204/204 pass
- [ ] 수동 검증: 신규 프로젝트 생성 → 메타에이전트 분석 → "초기 구성" 탭 표시 → 체크박스 선택 → 적용 후 Settings에서 profile/skill 반영 확인
- [ ] 수동 검증: 메타에이전트가 `[INITIAL_SETUP]` 블록을 생략하거나 손상된 JSON 반환 시 기존 온보딩 흐름 그대로 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)