### PR TITLE
feat(rt): Voting + MoA Synthesizer — 다수 reviewer 투표 집계 + 자동 synthesizer

### DIFF
--- a/src-tauri/src/commands/roundtable.rs
+++ b/src-tauri/src/commands/roundtable.rs
@@ -30,6 +30,12 @@ pub struct RoundtableRunInput {
     #[allow(dead_code)]
     pub rounds: Option<u32>,
     pub mode: Option<String>,
+    /// When true AND there are ≥2 reviewer participants, an additional
+    /// synthesizer participant runs after the main round completes. Defaults to
+    /// false to preserve existing behavior; callers opt in explicitly.
+    /// See `docs/ideas/rtAlgorithmEnhancementIdeas.md` P1 for rationale.
+    #[serde(default)]
+    pub auto_synthesize: Option<bool>,
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -43,6 +49,120 @@ fn parse_strategy(mode: &str) -> (RoundStrategy, &'static str) {
 
 fn participant_names(participants: &[RoundtableParticipant]) -> String {
     participants.iter().map(|p| p.name.as_str()).collect::<Vec<_>>().join(", ")
+}
+
+/// Build a single-participant synthesizer "round" to summarize reviewers'
+/// verdicts. Returns (messages, responses) so callers can append them to the
+/// main round's output and persist them uniformly.
+///
+/// Gating:
+///  - Requires ≥2 participants with role == "reviewer" | "critic" in the
+///    prior round. Otherwise returns None (nothing to synthesize).
+///  - Picks synthesizer engine from the first reviewer's engine for cost
+///    parity. Model is left None so the engine picks its own default.
+#[allow(clippy::too_many_arguments)]
+async fn run_synthesizer_after_round(
+    original_participants: &[RoundtableParticipant],
+    round_responses: &[(String, String)],
+    prior_round_refs: &[String],
+    topic: &str,
+    rt_mode: &str,
+    round_num: u32,
+    conversation_id: &str,
+    state: &crate::db::DbState,
+    app: &tauri::AppHandle,
+    cancel: &crate::CancelRegistry,
+    trace_id: &str,
+    root_span_id: &str,
+    project_path: Option<&str>,
+    session_map: &mut SessionMap,
+) -> Option<(Vec<Message>, Vec<(String, String)>)> {
+    let reviewer_count = original_participants
+        .iter()
+        .filter(|p| matches!(p.role.as_deref(), Some("reviewer" | "critic")))
+        .count();
+    if reviewer_count < 2 {
+        eprintln!("[rt-synth] skipped: only {} reviewer(s)", reviewer_count);
+        return None;
+    }
+
+    // Inherit engine from first reviewer. Keep model=None so we don't accidentally
+    // pin a reviewer's fine-tuned model as the synthesizer.
+    let engine = original_participants
+        .iter()
+        .find(|p| matches!(p.role.as_deref(), Some("reviewer" | "critic")))
+        .and_then(|p| p.engine.clone())
+        .unwrap_or_else(|| "claude".into());
+
+    let synthesizer = RoundtableParticipant {
+        name: "Synthesizer".into(),
+        model: None,
+        engine: Some(engine),
+        blind: false,
+        role: Some("synthesizer".into()),
+        max_tokens: None,
+    };
+
+    // Emit a header message to delimit the synthesizer output in the transcript.
+    let header_content = format!("--- Synthesizer · {} reviewer verdicts ---", round_responses.len());
+    let _ = {
+        let conn = state.write.lock().ok()?;
+        super::roundtable_helpers::persist::persist_header(&conn, conversation_id, &header_content)
+            .ok()
+            .map(|h| {
+                let _ = app.emit("roundtable:progress", &h);
+                h
+            })
+    };
+
+    // Prepend a structured directive so the synthesizer knows *what* to produce.
+    // The existing role_guidance (types.rs `synthesizer`) already requests
+    // consensus / contested / dissent sections — we add the vote-tally instruction.
+    let directive = format!(
+        "## Synthesizer Task\n\
+         The {} reviewer verdicts above are the input. Do NOT overwrite them.\n\
+         Produce a summary with these required sections:\n\
+         1. **Vote tally** — count pass/fail/conditional verdicts.\n\
+         2. **Consensus** — points where all reviewers agreed.\n\
+         3. **Contested** — points where reviewers disagreed (cite which reviewer said what).\n\
+         4. **Dissent** — any minority position worth preserving.\n\
+         5. **Final recommendation** — one of: accept / revise / reject. Justify briefly.\n\n\
+         If the tally is split (e.g. 2 pass / 1 fail), do not rubber-stamp the majority —\n\
+         state the reasoning for your final recommendation.",
+        round_responses.len()
+    );
+    let synth_topic = format!("{}\n\n---\n\n{}", topic, directive);
+
+    // The synthesizer is in its own "round" (round_num + 1) but sees the prior
+    // round's responses as transcript. Use Sequential strategy (1 participant).
+    let result = super::roundtable_helpers::executor::execute_round(
+        std::slice::from_ref(&synthesizer),
+        round_responses,
+        round_num + 1,
+        round_num + 1,
+        &synth_topic,
+        crate::commands::roundtable_helpers::executor::RoundStrategy::Sequential,
+        rt_mode,
+        conversation_id,
+        state,
+        app,
+        cancel,
+        trace_id,
+        root_span_id,
+        project_path,
+        session_map,
+    )
+    .await;
+
+    let _ = prior_round_refs; // Reserved for future deliberative-mode integration.
+
+    match result {
+        Ok((msgs, responses)) => Some((msgs, responses)),
+        Err(e) => {
+            eprintln!("[rt-synth] synthesizer run failed: {e}");
+            None
+        }
+    }
 }
 
 /// Count existing round headers to determine the next round number.
@@ -323,12 +443,44 @@ pub async fn start_roundtable_run(
         let root_span_id = new_span_id();
         let t0 = std::time::Instant::now();
         let mut session_map = SessionMap::new();
+        let auto_synth = input.auto_synthesize.unwrap_or(false);
 
         let result = execute_round(
             &input.participants, &[], 1, 1, &enriched_prompt, strategy, &rt_mode,
             &cid, &bg_state, &app, &bg_cancel, &trace_id, &root_span_id, project_path.as_deref(),
             &mut session_map,
         ).await;
+
+        // Optionally run a synthesizer participant after the main round succeeds.
+        // Scope: only when caller opted in AND the main round ran to completion.
+        // Failures inside the synthesizer are logged but do not fail the whole RT.
+        let (result, synth_responses): (Result<_, AppError>, Vec<(String, String)>) = match result {
+            Ok((msgs, round_responses)) if auto_synth => {
+                let extra = run_synthesizer_after_round(
+                    &input.participants,
+                    &round_responses,
+                    &[],
+                    &prompt,
+                    &rt_mode,
+                    1,
+                    &cid,
+                    &bg_state,
+                    &app,
+                    &bg_cancel,
+                    &trace_id,
+                    &root_span_id,
+                    project_path.as_deref(),
+                    &mut session_map,
+                )
+                .await;
+                let mut all_responses = round_responses;
+                let extra_responses = extra.map(|(_, r)| r).unwrap_or_default();
+                all_responses.extend(extra_responses.iter().cloned());
+                (Ok((msgs, all_responses)), extra_responses)
+            }
+            other => (other, Vec::new()),
+        };
+        let _ = synth_responses;
 
         if let Ok(conn) = write_arc.lock() {
             let now = now_epoch_ms();
@@ -405,12 +557,40 @@ pub async fn start_roundtable_followup(
         let root_span_id = new_span_id();
         let t0 = std::time::Instant::now();
         let mut session_map = SessionMap::new();
+        let auto_synth = input.auto_synthesize.unwrap_or(false);
 
         let result = execute_round(
             &input.participants, &prior_transcript, round_num, round_num, &prompt, strategy, &rt_mode,
             &cid, &bg_state, &app, &bg_cancel, &trace_id, &root_span_id, project_path.as_deref(),
             &mut session_map,
         ).await;
+
+        // Optional synthesizer pass — see run_synthesizer_after_round for gating.
+        let result: Result<_, AppError> = match result {
+            Ok((msgs, responses)) if auto_synth => {
+                let extra = run_synthesizer_after_round(
+                    &input.participants,
+                    &responses,
+                    &[],
+                    &prompt,
+                    &rt_mode,
+                    round_num,
+                    &cid,
+                    &bg_state,
+                    &app,
+                    &bg_cancel,
+                    &trace_id,
+                    &root_span_id,
+                    project_path.as_deref(),
+                    &mut session_map,
+                )
+                .await;
+                let mut all_responses = responses;
+                if let Some((_, r)) = extra { all_responses.extend(r); }
+                Ok((msgs, all_responses))
+            }
+            other => other,
+        };
 
         if let Ok(conn) = write_arc.lock() {
             let now = now_epoch_ms();

--- a/src-tauri/src/http_api/agents.rs
+++ b/src-tauri/src/http_api/agents.rs
@@ -199,6 +199,7 @@ pub async fn start_rt_run(
         participants: input.participants,
         rounds: None,
         mode: input.mode,
+        auto_synthesize: None,
     };
 
     let db = state.db.clone();

--- a/src/components/tunaflow/context-panel/DevProgressView.tsx
+++ b/src/components/tunaflow/context-panel/DevProgressView.tsx
@@ -171,8 +171,8 @@ export function DevProgressView({ plan, onPlanUpdate }: DevProgressViewProps) {
       onPlanUpdate(plan.id, { phase: "review" as PlanPhase, reviewBranchId: branch.id });
       await loadBranches(plan.conversationId);
       await openThread(branch.id);
-      // Kick off the actual RT run — startReviewRT only scaffolds the branch/config.
-      await sendThreadRoundtable(prompt, participants, mode);
+      // Deep review = ≥2 reviewers → auto-synthesize MoA summary after the round.
+      await sendThreadRoundtable(prompt, participants, mode, { autoSynthesize: true });
     } catch (e) { console.warn("[tunaflow]", e); }
     setBusy(false);
     setReviewMode("idle");

--- a/src/components/tunaflow/context-panel/plans/PlanCard.tsx
+++ b/src/components/tunaflow/context-panel/plans/PlanCard.tsx
@@ -296,7 +296,7 @@ export function PlanCard({
                         handlePlanUpdate({ phase: "review", reviewBranchId: branch.id });
                         await loadBranches(plan.conversationId);
                         await openThread(branch.id);
-                        await sendThreadRoundtable(prompt, participants, mode);
+                        await sendThreadRoundtable(prompt, participants, mode, { autoSynthesize: true });
                       }}
                       className="ml-auto px-2 py-0.5 rounded text-[9px] font-medium bg-status-approved/20 hover:bg-status-approved/30 transition-colors"
                     >

--- a/src/lib/aggregateReviewVerdicts.ts
+++ b/src/lib/aggregateReviewVerdicts.ts
@@ -1,0 +1,188 @@
+/**
+ * aggregateReviewVerdicts — roll up multiple reviewers' verdicts into a single
+ * vote tally for the Plan → Review RT flow.
+ *
+ * Design notes (Harness roadmap item 12 / rtAlgorithmEnhancementIdeas.md P1):
+ *  - The individual verdicts are NOT overwritten — the synthesizer uses the
+ *    tally as input and produces a separate MoA-style summary message.
+ *  - Tally rule is **intentionally conservative**:
+ *     - unanimous pass → pass
+ *     - any fail → fail  (one reviewer saying "bug found" overrides agreement)
+ *     - otherwise        → conditional
+ *    Rationale: in a code review, a single credible failure claim should block
+ *    merge. The synthesizer can still flag dissent if the fail reason is weak.
+ *  - Per-dimension rubric stats (mean / min / max / stddev-ish) help the
+ *    synthesizer flag areas of disagreement explicitly.
+ */
+import type { ParsedReviewVerdict, ReviewRubric, ReviewVerdict } from "@/lib/planProposalParser";
+
+export interface RubricDimensionStats {
+  /** Arithmetic mean across reviewers that reported this rubric. */
+  mean: number;
+  min: number;
+  max: number;
+  /** Sample standard deviation (0 if only one reviewer). Used as disagreement signal. */
+  stddev: number;
+  /** How many reviewers actually provided a rubric score for this dimension. */
+  count: number;
+}
+
+export interface ReviewVerdictAggregate {
+  /** Total reviewer count (including those without rubric). */
+  reviewerCount: number;
+  /** Final consensus verdict — per the tally rule above. */
+  verdict: ReviewVerdict;
+  votes: {
+    pass: number;
+    fail: number;
+    conditional: number;
+  };
+  /** True when all reviewers agreed on verdict. */
+  unanimous: boolean;
+  /** True when the aggregate verdict was fail due to a single minority fail vote. */
+  minorityFail: boolean;
+  /** Per-dimension stats. `null` means no reviewer provided a rubric at all. */
+  rubric: null | {
+    planCoverage: RubricDimensionStats;
+    codeQuality: RubricDimensionStats;
+    testCoverage: RubricDimensionStats;
+    docQuality: RubricDimensionStats;
+    convention: RubricDimensionStats;
+    /** Max stddev across dimensions — useful as "overall disagreement" signal. */
+    maxStddev: number;
+  };
+  /** Union of findings across reviewers, deduplicated by lowercased prefix. */
+  findings: string[];
+  /** Union of recommendations, deduplicated. */
+  recommendations: string[];
+  /** Union of failed subtask ids. */
+  failedSubtaskIds: number[];
+}
+
+/** A verdict + the reviewer name who emitted it (for UI display). */
+export interface NamedVerdict extends ParsedReviewVerdict {
+  reviewerName?: string;
+}
+
+function rubricDimensionStats(values: number[]): RubricDimensionStats {
+  if (values.length === 0) {
+    return { mean: 0, min: 0, max: 0, stddev: 0, count: 0 };
+  }
+  const sum = values.reduce((a, b) => a + b, 0);
+  const mean = sum / values.length;
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  // Sample stddev — n=1 yields 0 (no disagreement signal possible with 1 sample).
+  const variance = values.length > 1
+    ? values.reduce((a, v) => a + (v - mean) ** 2, 0) / (values.length - 1)
+    : 0;
+  return { mean, min, max, stddev: Math.sqrt(variance), count: values.length };
+}
+
+/** Dedupe findings by lowercased 80-char prefix so "src/x.ts:1 ..." matches. */
+function dedupeByPrefix(items: string[], prefixLen = 80): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const item of items) {
+    const trimmed = item.trim();
+    if (!trimmed) continue;
+    const key = trimmed.slice(0, prefixLen).toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(trimmed);
+  }
+  return out;
+}
+
+export function aggregateReviewVerdicts(
+  verdicts: NamedVerdict[],
+): ReviewVerdictAggregate | null {
+  if (verdicts.length === 0) return null;
+
+  const votes = { pass: 0, fail: 0, conditional: 0 };
+  for (const v of verdicts) votes[v.verdict]++;
+
+  // Tally rule — see module header.
+  let consensus: ReviewVerdict;
+  if (votes.fail > 0) consensus = "fail";
+  else if (votes.pass === verdicts.length) consensus = "pass";
+  else consensus = "conditional";
+
+  const unanimous =
+    votes.pass === verdicts.length ||
+    votes.fail === verdicts.length ||
+    votes.conditional === verdicts.length;
+
+  const minorityFail = consensus === "fail" && votes.fail < verdicts.length;
+
+  // Rubric stats — only across reviewers who actually reported rubric.
+  const rubrics: ReviewRubric[] = verdicts
+    .map((v) => v.rubric)
+    .filter((r): r is ReviewRubric => !!r);
+
+  let rubric: ReviewVerdictAggregate["rubric"] = null;
+  if (rubrics.length > 0) {
+    const dim = (pick: (r: ReviewRubric) => number) => rubricDimensionStats(rubrics.map(pick));
+    const stats = {
+      planCoverage: dim((r) => r.planCoverage),
+      codeQuality: dim((r) => r.codeQuality),
+      testCoverage: dim((r) => r.testCoverage),
+      docQuality: dim((r) => r.docQuality),
+      convention: dim((r) => r.convention),
+    };
+    const maxStddev = Math.max(
+      stats.planCoverage.stddev,
+      stats.codeQuality.stddev,
+      stats.testCoverage.stddev,
+      stats.docQuality.stddev,
+      stats.convention.stddev,
+    );
+    rubric = { ...stats, maxStddev };
+  }
+
+  const findings = dedupeByPrefix(verdicts.flatMap((v) => v.findings));
+  const recommendations = dedupeByPrefix(verdicts.flatMap((v) => v.recommendations));
+  const failedSubtaskIds = Array.from(
+    new Set(verdicts.flatMap((v) => v.failedSubtaskIds)),
+  ).sort((a, b) => a - b);
+
+  return {
+    reviewerCount: verdicts.length,
+    verdict: consensus,
+    votes,
+    unanimous,
+    minorityFail,
+    rubric,
+    findings,
+    recommendations,
+    failedSubtaskIds,
+  };
+}
+
+/**
+ * Format a vote-tally summary suitable for injection into the synthesizer's
+ * prompt. Kept short — the synthesizer re-reads each reviewer's full verdict
+ * from the transcript, so this is only a structured snapshot.
+ */
+export function formatTallyForSynthesizer(agg: ReviewVerdictAggregate): string {
+  const lines: string[] = [
+    `## Vote Tally (from ${agg.reviewerCount} reviewer${agg.reviewerCount === 1 ? "" : "s"})`,
+    `- pass: ${agg.votes.pass} / fail: ${agg.votes.fail} / conditional: ${agg.votes.conditional}`,
+    `- aggregate verdict: **${agg.verdict}**${agg.unanimous ? " (unanimous)" : ""}${agg.minorityFail ? " (minority fail — investigate before overriding)" : ""}`,
+  ];
+  if (agg.rubric) {
+    const r = agg.rubric;
+    lines.push(
+      `- rubric mean: plan=${r.planCoverage.mean.toFixed(1)}, code=${r.codeQuality.mean.toFixed(1)}, test=${r.testCoverage.mean.toFixed(1)}, doc=${r.docQuality.mean.toFixed(1)}, conv=${r.convention.mean.toFixed(1)}`,
+      `- max disagreement (stddev): ${r.maxStddev.toFixed(2)} — flag dimensions >1.0 as contested`,
+    );
+  }
+  if (agg.findings.length > 0) {
+    lines.push("", "### Merged Findings (dedup)");
+    for (const f of agg.findings.slice(0, 20)) lines.push(`- ${f}`);
+  }
+  if (agg.failedSubtaskIds.length > 0) {
+    lines.push("", `### Failed subtask ids: ${agg.failedSubtaskIds.join(", ")}`);
+  }
+  return lines.join("\n");
+}

--- a/src/lib/planProposalParser.ts
+++ b/src/lib/planProposalParser.ts
@@ -516,6 +516,31 @@ export function extractReviewVerdict(content: string): ParsedReviewVerdict | nul
   return reviewResult;
 }
 
+/**
+ * Scan assistant messages in a RT review transcript and return every verdict
+ * that parses. Used by vote-aggregation path when `auto_synthesize` is on.
+ *
+ * - Only `assistant` messages are considered.
+ * - The Synthesizer message is skipped (per role_guidance it must not emit a
+ *   fresh verdict, but defensive guard in case it does). The synthesizer is
+ *   identified by persona === "Synthesizer" (see `run_synthesizer_after_round`
+ *   in roundtable.rs).
+ * - Each returned item includes the `reviewerName` for UI display.
+ */
+export function scanAllReviewerVerdicts(
+  messages: import("@/types").Message[],
+): Array<ParsedReviewVerdict & { reviewerName?: string }> {
+  const out: Array<ParsedReviewVerdict & { reviewerName?: string }> = [];
+  for (const m of messages) {
+    if (m.role !== "assistant") continue;
+    if (m.persona === "Synthesizer") continue;
+    if (!hasReviewVerdict(m.content)) continue;
+    const v = extractReviewVerdict(m.content);
+    if (v) out.push({ ...v, reviewerName: m.persona });
+  }
+  return out;
+}
+
 // ─── Tool request markers ──────────────────────────────────────────────────
 
 export interface ToolRequest {

--- a/src/lib/workflow/branchSync.ts
+++ b/src/lib/workflow/branchSync.ts
@@ -89,18 +89,57 @@ export async function autoDetectReviewVerdict(shadowConvId: string, messages: Me
     if (!plan || plan.reviewBranchId !== branchId) return;
     if (plan.phase !== "review") return;
 
+    const { scanAllReviewerVerdicts } = await import("@/lib/planProposalParser");
     const { scanMessagesForMarkers, processReviewVerdict } = await import("@/lib/workflowOrchestration");
-    const markers = scanMessagesForMarkers(messages);
-    if (!markers.reviewVerdict) return;
+    const { aggregateReviewVerdicts } = await import("@/lib/aggregateReviewVerdicts");
+
+    // Multi-reviewer path (RT): collect every reviewer verdict, aggregate, and
+    // feed the consensus to processReviewVerdict. Single-reviewer path falls
+    // back to the legacy last-verdict-wins behavior.
+    const all = scanAllReviewerVerdicts(messages);
+    let effectiveVerdict;
+    if (all.length >= 2) {
+      const agg = aggregateReviewVerdicts(all);
+      if (!agg) return;
+      // Flatten aggregate into ParsedReviewVerdict shape for processReviewVerdict.
+      effectiveVerdict = {
+        verdict: agg.verdict,
+        rubric: agg.rubric
+          ? {
+              planCoverage: agg.rubric.planCoverage.mean,
+              codeQuality: agg.rubric.codeQuality.mean,
+              testCoverage: agg.rubric.testCoverage.mean,
+              docQuality: agg.rubric.docQuality.mean,
+              convention: agg.rubric.convention.mean,
+            }
+          : undefined,
+        findings: agg.findings,
+        recommendations: agg.recommendations,
+        failedSubtaskIds: agg.failedSubtaskIds,
+        raw: `aggregated from ${agg.reviewerCount} reviewers (pass=${agg.votes.pass}, fail=${agg.votes.fail}, conditional=${agg.votes.conditional})`,
+      };
+    } else {
+      const markers = scanMessagesForMarkers(messages);
+      if (!markers.reviewVerdict) return;
+      effectiveVerdict = markers.reviewVerdict;
+    }
 
     const { toast } = await import("sonner");
-    const verdict = markers.reviewVerdict.verdict;
-    await processReviewVerdict(plan, markers.reviewVerdict);
+    const verdict = effectiveVerdict.verdict;
+    await processReviewVerdict(plan, effectiveVerdict);
 
     if (verdict === "pass") {
-      toast.success("Review 통과 — Plan 완료 처리됨");
+      toast.success(
+        all.length >= 2
+          ? `Review 통과 — 만장일치 (${all.length} reviewers)`
+          : "Review 통과 — Plan 완료 처리됨",
+      );
     } else if (verdict === "fail") {
-      toast.warning("Review 실패 — Rework 단계로 전환됨");
+      toast.warning(
+        all.length >= 2
+          ? `Review 실패 — ${all.length}명 중 fail 투표 있음 (Rework)`
+          : "Review 실패 — Rework 단계로 전환됨",
+      );
     } else {
       toast.info("Review 조건부 통과 — 사용자 판단 필요");
     }

--- a/src/stores/slices/threadRtRunner.ts
+++ b/src/stores/slices/threadRtRunner.ts
@@ -19,14 +19,15 @@ import type { RtParticipantStatus } from "./threadSlice";
 export async function runThreadRoundtable(
   set: SetState, get: GetState, command: string,
   prompt: string, participants: RoundtableParticipant[], mode?: RtMode,
+  opts?: { autoSynthesize?: boolean },
 ): Promise<void> {
   const { threadBranchConvId } = get();
   if (!threadBranchConvId) return;
   if (get().runningThreadIds.includes(threadBranchConvId)) {
     get()._enqueue(threadBranchConvId, prompt.slice(0, 30), () =>
       command === "start_roundtable_run"
-        ? get().sendThreadRoundtable(prompt, participants, mode)
-        : get().sendThreadRoundtableFollowup(prompt, participants, mode),
+        ? get().sendThreadRoundtable(prompt, participants, mode, opts)
+        : get().sendThreadRoundtableFollowup(prompt, participants, mode, opts),
     );
     return;
   }
@@ -139,7 +140,7 @@ export async function runThreadRoundtable(
   });
 
   try {
-    await invoke<{ messageId: string }>(command, { input: { conversationId: threadBranchConvId, prompt, participants, mode } });
+    await invoke<{ messageId: string }>(command, { input: { conversationId: threadBranchConvId, prompt, participants, mode, autoSynthesize: opts?.autoSynthesize } });
   } catch (e) {
     cleanup();
     set({ error: errorMessage(e), rtParticipantStatuses: new Map(), rtStatusConversationId: null });

--- a/src/stores/slices/threadSlice.ts
+++ b/src/stores/slices/threadSlice.ts
@@ -42,8 +42,8 @@ export interface ThreadSlice {
   closeThread: () => void;
   toggleDrawerPin: () => void;
   sendThreadMessage: (prompt: string, engine?: string, model?: string) => Promise<void>;
-  sendThreadRoundtable: (prompt: string, participants: RoundtableParticipant[], mode?: RtMode) => Promise<void>;
-  sendThreadRoundtableFollowup: (prompt: string, participants: RoundtableParticipant[], mode?: RtMode) => Promise<void>;
+  sendThreadRoundtable: (prompt: string, participants: RoundtableParticipant[], mode?: RtMode, opts?: { autoSynthesize?: boolean }) => Promise<void>;
+  sendThreadRoundtableFollowup: (prompt: string, participants: RoundtableParticipant[], mode?: RtMode, opts?: { autoSynthesize?: boolean }) => Promise<void>;
 }
 
 export const createThreadSlice = (set: SetState, get: GetState): ThreadSlice => ({
@@ -361,11 +361,11 @@ export const createThreadSlice = (set: SetState, get: GetState): ThreadSlice => 
     }
   },
 
-  sendThreadRoundtable: async (prompt: string, participants: RoundtableParticipant[], mode?: RtMode) => {
-    await runThreadRoundtable(set, get, "start_roundtable_run", prompt, participants, mode);
+  sendThreadRoundtable: async (prompt: string, participants: RoundtableParticipant[], mode?: RtMode, opts?: { autoSynthesize?: boolean }) => {
+    await runThreadRoundtable(set, get, "start_roundtable_run", prompt, participants, mode, opts);
   },
 
-  sendThreadRoundtableFollowup: async (prompt: string, participants: RoundtableParticipant[], mode?: RtMode) => {
-    await runThreadRoundtable(set, get, "start_roundtable_followup", prompt, participants, mode);
+  sendThreadRoundtableFollowup: async (prompt: string, participants: RoundtableParticipant[], mode?: RtMode, opts?: { autoSynthesize?: boolean }) => {
+    await runThreadRoundtable(set, get, "start_roundtable_followup", prompt, participants, mode, opts);
   },
 });

--- a/src/stores/slices/types.ts
+++ b/src/stores/slices/types.ts
@@ -149,8 +149,8 @@ export interface ChatState {
   openThread: (branchId: string) => Promise<void>;
   closeThread: () => void;
   sendThreadMessage: (prompt: string, engine?: string, model?: string) => Promise<void>;
-  sendThreadRoundtable: (prompt: string, participants: RoundtableParticipant[], mode?: RtMode) => Promise<void>;
-  sendThreadRoundtableFollowup: (prompt: string, participants: RoundtableParticipant[], mode?: RtMode) => Promise<void>;
+  sendThreadRoundtable: (prompt: string, participants: RoundtableParticipant[], mode?: RtMode, opts?: { autoSynthesize?: boolean }) => Promise<void>;
+  sendThreadRoundtableFollowup: (prompt: string, participants: RoundtableParticipant[], mode?: RtMode, opts?: { autoSynthesize?: boolean }) => Promise<void>;
   cancelOperation: (threadId?: string) => Promise<void>;
   toggleCrossSession: (conversationId: string) => void;
   loadSkills: () => Promise<void>;

--- a/src/tests/aggregateReviewVerdicts.test.ts
+++ b/src/tests/aggregateReviewVerdicts.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from "vitest";
+import {
+  aggregateReviewVerdicts,
+  formatTallyForSynthesizer,
+  type NamedVerdict,
+} from "@/lib/aggregateReviewVerdicts";
+import type { ParsedReviewVerdict, ReviewRubric, ReviewVerdict } from "@/lib/planProposalParser";
+
+function mkVerdict(
+  verdict: ReviewVerdict,
+  opts?: {
+    rubric?: Partial<ReviewRubric>;
+    findings?: string[];
+    recommendations?: string[];
+    failedSubtaskIds?: number[];
+    reviewerName?: string;
+  },
+): NamedVerdict {
+  const fullRubric: ReviewRubric | undefined = opts?.rubric
+    ? {
+        planCoverage: opts.rubric.planCoverage ?? 3,
+        codeQuality: opts.rubric.codeQuality ?? 3,
+        testCoverage: opts.rubric.testCoverage ?? 3,
+        docQuality: opts.rubric.docQuality ?? 3,
+        convention: opts.rubric.convention ?? 3,
+      }
+    : undefined;
+  const base: ParsedReviewVerdict = {
+    verdict,
+    rubric: fullRubric,
+    findings: opts?.findings ?? [],
+    recommendations: opts?.recommendations ?? [],
+    failedSubtaskIds: opts?.failedSubtaskIds ?? [],
+    raw: "",
+  };
+  return opts?.reviewerName ? { ...base, reviewerName: opts.reviewerName } : base;
+}
+
+describe("aggregateReviewVerdicts", () => {
+  it("returns null for empty input", () => {
+    expect(aggregateReviewVerdicts([])).toBeNull();
+  });
+
+  it("unanimous pass → pass, unanimous=true, minorityFail=false", () => {
+    const agg = aggregateReviewVerdicts([mkVerdict("pass"), mkVerdict("pass"), mkVerdict("pass")])!;
+    expect(agg.verdict).toBe("pass");
+    expect(agg.unanimous).toBe(true);
+    expect(agg.minorityFail).toBe(false);
+    expect(agg.votes.pass).toBe(3);
+  });
+
+  it("single fail among passes → fail (minorityFail=true)", () => {
+    const agg = aggregateReviewVerdicts([mkVerdict("pass"), mkVerdict("fail"), mkVerdict("pass")])!;
+    expect(agg.verdict).toBe("fail");
+    expect(agg.unanimous).toBe(false);
+    expect(agg.minorityFail).toBe(true);
+    expect(agg.votes.fail).toBe(1);
+  });
+
+  it("mix of pass/conditional (no fail) → conditional", () => {
+    const agg = aggregateReviewVerdicts([mkVerdict("pass"), mkVerdict("conditional")])!;
+    expect(agg.verdict).toBe("conditional");
+    expect(agg.unanimous).toBe(false);
+    expect(agg.minorityFail).toBe(false);
+  });
+
+  it("unanimous fail → fail, unanimous=true, minorityFail=false", () => {
+    const agg = aggregateReviewVerdicts([mkVerdict("fail"), mkVerdict("fail")])!;
+    expect(agg.verdict).toBe("fail");
+    expect(agg.unanimous).toBe(true);
+    expect(agg.minorityFail).toBe(false);
+  });
+
+  describe("rubric stats", () => {
+    it("is null when no reviewer provided a rubric", () => {
+      const agg = aggregateReviewVerdicts([mkVerdict("pass"), mkVerdict("conditional")])!;
+      expect(agg.rubric).toBeNull();
+    });
+
+    it("computes mean/min/max correctly", () => {
+      const agg = aggregateReviewVerdicts([
+        mkVerdict("pass", { rubric: { codeQuality: 5 } }),
+        mkVerdict("pass", { rubric: { codeQuality: 3 } }),
+        mkVerdict("pass", { rubric: { codeQuality: 4 } }),
+      ])!;
+      expect(agg.rubric).not.toBeNull();
+      expect(agg.rubric!.codeQuality.mean).toBeCloseTo(4, 5);
+      expect(agg.rubric!.codeQuality.min).toBe(3);
+      expect(agg.rubric!.codeQuality.max).toBe(5);
+      expect(agg.rubric!.codeQuality.count).toBe(3);
+      expect(agg.rubric!.codeQuality.stddev).toBeGreaterThan(0);
+    });
+
+    it("stddev is 0 when only one reviewer has rubric", () => {
+      const agg = aggregateReviewVerdicts([
+        mkVerdict("pass", { rubric: { codeQuality: 5 } }),
+        mkVerdict("pass"), // no rubric
+      ])!;
+      expect(agg.rubric!.codeQuality.count).toBe(1);
+      expect(agg.rubric!.codeQuality.stddev).toBe(0);
+    });
+
+    it("maxStddev picks the largest dimension spread", () => {
+      const agg = aggregateReviewVerdicts([
+        mkVerdict("pass", { rubric: { codeQuality: 1, testCoverage: 5 } }),
+        mkVerdict("pass", { rubric: { codeQuality: 5, testCoverage: 5 } }),
+      ])!;
+      // codeQuality spread 1↔5 >> testCoverage spread 5↔5
+      expect(agg.rubric!.codeQuality.stddev).toBeGreaterThan(agg.rubric!.testCoverage.stddev);
+      expect(agg.rubric!.maxStddev).toBe(agg.rubric!.codeQuality.stddev);
+    });
+  });
+
+  describe("findings / recommendations / failedSubtaskIds", () => {
+    it("dedupes findings by lowercased prefix", () => {
+      // Shared ≥80-char prefix (lowercased) → should dedupe.
+      const longFinding = "src/api.ts:10 missing parameter validation on user_id — enables SQL injection attack";
+      const agg = aggregateReviewVerdicts([
+        mkVerdict("fail", { findings: [longFinding, "new issue"] }),
+        mkVerdict("fail", { findings: [longFinding.toUpperCase() + " — confirmed by reviewer B"] }),
+      ])!;
+      // longFinding + upper variant share 80-char prefix → collapse to 1
+      expect(agg.findings).toHaveLength(2);
+    });
+
+    it("skips empty strings", () => {
+      const agg = aggregateReviewVerdicts([
+        mkVerdict("pass", { findings: ["", "   ", "real finding"] }),
+      ])!;
+      expect(agg.findings).toEqual(["real finding"]);
+    });
+
+    it("unions + sorts failedSubtaskIds", () => {
+      const agg = aggregateReviewVerdicts([
+        mkVerdict("fail", { failedSubtaskIds: [3, 1] }),
+        mkVerdict("fail", { failedSubtaskIds: [2, 1] }),
+      ])!;
+      expect(agg.failedSubtaskIds).toEqual([1, 2, 3]);
+    });
+  });
+});
+
+describe("formatTallyForSynthesizer", () => {
+  it("renders vote counts + consensus", () => {
+    const agg = aggregateReviewVerdicts([mkVerdict("pass"), mkVerdict("fail")])!;
+    const formatted = formatTallyForSynthesizer(agg);
+    expect(formatted).toContain("pass: 1");
+    expect(formatted).toContain("fail: 1");
+    expect(formatted).toContain("aggregate verdict: **fail**");
+    expect(formatted).toContain("minority fail");
+  });
+
+  it("includes rubric mean + max stddev when rubrics present", () => {
+    const agg = aggregateReviewVerdicts([
+      mkVerdict("pass", { rubric: { codeQuality: 5 } }),
+      mkVerdict("pass", { rubric: { codeQuality: 3 } }),
+    ])!;
+    const formatted = formatTallyForSynthesizer(agg);
+    expect(formatted).toContain("rubric mean");
+    expect(formatted).toContain("max disagreement");
+  });
+
+  it("omits findings section when empty", () => {
+    const agg = aggregateReviewVerdicts([mkVerdict("pass")])!;
+    const formatted = formatTallyForSynthesizer(agg);
+    expect(formatted).not.toContain("Merged Findings");
+  });
+
+  it("lists failed subtask ids when present", () => {
+    const agg = aggregateReviewVerdicts([mkVerdict("fail", { failedSubtaskIds: [4, 7] })])!;
+    const formatted = formatTallyForSynthesizer(agg);
+    expect(formatted).toContain("Failed subtask ids: 4, 7");
+  });
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -222,6 +222,9 @@ export interface RoundtableRunInput {
   rounds?: number;
   /** Execution mode (default "sequential") */
   mode?: RtMode;
+  /** When true, a synthesizer participant runs after the round to aggregate
+   *  reviewer verdicts. Requires ≥2 reviewer roles; silently skipped otherwise. */
+  autoSynthesize?: boolean;
 }
 
 export interface CreateBranchInput {


### PR DESCRIPTION
## Summary

Harness Maturity Audit §5.4 **항목 12** / `rtAlgorithmEnhancementIdeas.md` P1.

RT 리뷰에서 여러 reviewer verdict를 투표 집계하고, 선택적으로 **Synthesizer** participant가 한 번 더 실행되어 MoA 스타일 요약(Vote tally / Consensus / Contested / Dissent / Final recommendation)을 생성한다.

- Opt-in: `auto_synthesize` 플래그가 켜졌고 reviewer 참가자가 ≥2 명일 때만 동작
- Default **off**, Review RT 경로만 자동 켬
- 원 verdict는 유지 — synthesizer는 별도 메시지로 요약만 작성

## Details

### Rust — `roundtable.rs`
- `RoundtableRunInput.auto_synthesize: Option<bool>` 추가 (default false)
- 신규 `run_synthesizer_after_round()`:
  - ≥2 명의 `role="reviewer|critic"` 참가자가 있을 때만 동작
  - Synthesizer 참가자(role="synthesizer")를 동적으로 만들고 첫 reviewer의 engine 상속 (model=None → 기본)
  - `"--- Synthesizer · N reviewer verdicts ---"` 헤더 + 구조화 directive 주입
  - `execute_round(Sequential, 1 participant)`로 일반 RT 파이프라인 재사용
- `start_roundtable_run` / `start_roundtable_followup` 모두 플래그 소비
- Synthesizer 실패해도 메인 RT는 완료 처리 (fail-soft, eprintln 만 기록)

### Frontend
- 신규 `src/lib/aggregateReviewVerdicts.ts`
  - 투표 집계 규칙: unanimous pass → **pass** / 하나라도 fail → **fail** / 그 외 → **conditional**
  - 차원별 mean/min/max/sample-stddev + maxStddev (disagreement signal)
  - findings/recommendations 중복 제거(80-char prefix), failedSubtaskIds 합집합
  - `formatTallyForSynthesizer()` — 후속 동적 주입용 structured snapshot 제공
- `planProposalParser.scanAllReviewerVerdicts(messages)` 신규 — Synthesizer persona 제외
- `autoDetectReviewVerdict` 다중 verdict 분기:
  - ≥2 verdict → aggregate → `ParsedReviewVerdict`로 flatten → `processReviewVerdict`
  - 1개 → 기존 last-verdict 경로 유지
  - toast: "만장일치 (N reviewers)" / "N명 중 fail 투표 있음 (Rework)" 구분
- `sendThreadRoundtable / Followup` 시그니처에 `opts.autoSynthesize` 추가 → invoke payload로 전달
- `DevProgressView` + `PlanCard` Review RT 시작 경로가 `{ autoSynthesize: true }` 자동 전달

## 설계 결정 / 의도적 한계

- **Synthesizer 프롬프트에 Rust-side vote tally 미주입** — LLM이 transcript를 직접 읽어 tally. FE aggregate는 UI/DB 반영 용도. Rust verdict 파서 중복 회피.
- **전용 VoteTallyCard UI는 후속** — 현재 rubric 평균은 기존 `ReviewVerdictCard`가 표시. 토스트로 합의 정보 노출. 시각화 풍부화는 별도 PR로.
- **일반 대화 RT는 기본 off** — 자동 synthesizer는 review 전용. 일반 대화는 여전히 수동 Sequential/Deliberative.

## Test plan
- [x] `cargo check --lib` clean
- [x] `cargo test --lib` — 251/251 pass (회귀 없음)
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 220/220 pass (기존 192 + 12 onboarding + 16 aggregate)
- [ ] 수동 검증: Deep review(≥2 reviewer) 시작 → Round 1 완료 후 Synthesizer 메시지 추가 확인
- [ ] 수동 검증: 2 pass vs 1 fail 시 toast "fail 투표 있음", rework 전환 확인
- [ ] 수동 검증: 단일 reviewer 기존 경로 regression 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)