### PR TITLE
fix(db): v36 repair migration — trace cache 컬럼 누락 복구

### DIFF
--- a/src-tauri/src/db/migrations.rs
+++ b/src-tauri/src/db/migrations.rs
@@ -130,6 +130,9 @@ pub fn run(conn: &Connection) -> Result<(), AppError> {
     if current < 35 {
         apply_v35(conn)?;
     }
+    if current < 36 {
+        apply_v36(conn)?;
+    }
     Ok(())
 }
 
@@ -829,6 +832,19 @@ fn apply_v35(conn: &Connection) -> Result<(), AppError> {
     add_column_if_missing(conn, "trace_log", "cache_read_tokens", "INTEGER DEFAULT 0")?;
     add_column_if_missing(conn, "trace_log", "cache_creation_tokens", "INTEGER DEFAULT 0")?;
     conn.execute("INSERT INTO schema_version (version, applied_at) VALUES (35, ?1)", [now_epoch()])?;
+    Ok(())
+}
+
+/// v36 — defensive repair for users whose DB ended up at schema_version=35
+/// but with missing `cache_read_tokens` / `cache_creation_tokens` columns
+/// (seen in the wild after DB backup/restore mishap). `add_column_if_missing`
+/// is idempotent, so running this is a no-op on correctly-migrated DBs.
+/// Without this, `list_traces` SELECT fails with "no such column" and the
+/// FE silently shows "No trace data yet" — see session 2026-04-18 s37.
+fn apply_v36(conn: &Connection) -> Result<(), AppError> {
+    add_column_if_missing(conn, "trace_log", "cache_read_tokens", "INTEGER DEFAULT 0")?;
+    add_column_if_missing(conn, "trace_log", "cache_creation_tokens", "INTEGER DEFAULT 0")?;
+    conn.execute("INSERT INTO schema_version (version, applied_at) VALUES (36, ?1)", [now_epoch()])?;
     Ok(())
 }
 


### PR DESCRIPTION
## 증상
Trace 패널이 "No trace data yet" 로만 표시되는 사용자 DB 확인.

## 원인 분석
사용자 로컬 DB 에서 다음 상태 확인:
- `schema_version.MAX(version) = 35`
- `PRAGMA table_info(trace_log)` 에 `cache_read_tokens` / `cache_creation_tokens` 컬럼 **부재**
- trace_log 행 1139개 존재

DB 백업/복원 과정 등에서 `schema_version` 은 마이그레이션됐지만 ALTER TABLE 실제 적용은 유실된 상태로 추정.

`list_traces` 의 SQL (`src-tauri/src/commands/tracing.rs:59-62`) 이 해당 컬럼을 SELECT 하므로 `conn.prepare()` 자체가 "no such column" 으로 실패. FE `useTraceData.loadTraces` (`src/components/tunaflow/context-panel/useTraceData.ts:45`) 의 `catch` 가 에러를 삼키고 `setSpans([])` → UI "No trace data yet" 으로 표시됨.

## 수정
v36 repair migration 추가. `add_column_if_missing` 은 idempotent 하므로 정상 마이그레이션된 DB 에서는 no-op, 컬럼이 없으면 재적용.

개발 중 한번 로컬 DB 에 수동 ALTER 로 재현 확인 — migration 적용 후 1139 개 trace 행이 정상 SELECT 가능.

## Test plan
- [x] `cargo check --lib` clean
- [x] `cargo test --lib` 251/251 pass
- [x] 로컬 DB 수동 복구 검증: `ALTER TABLE trace_log ADD COLUMN ...` 성공 → list_traces 동작 확인
- [ ] 수동 검증: 앱 재실행하여 Trace 패널에 기존 1139 개 spans 가 표시되는지

## 후속 TODO (미해결, 별도 PR)
`prompt_assembly.rs:525-526` 의 `cache_read_tokens: 0, cache_creation_tokens: 0` 하드코딩. LLM 응답의 실제 캐시 토큰을 파싱해 주입하는 로직 별도 필요. 현재 PR 은 "컬럼 존재 → SELECT 성공" 만 복구. UI 렌더링은 0값으로 표시됨 (데이터 품질 이슈, UI 기능 이슈는 아님).

🤖 Generated with [Claude Code](https://claude.com/claude-code)