### PR TITLE
feat(contextpack): Conventions Sync Phase 2 — 정적 레이어 분기 + 토글

### DIFF
--- a/src-tauri/src/commands/agents_helpers/send_common/context_loading.rs
+++ b/src-tauri/src/commands/agents_helpers/send_common/context_loading.rs
@@ -83,6 +83,12 @@ pub struct ContextData {
     /// Serialized user profile JSON (from frontend settings store).
     /// Contains name, title, bio, preferredLanguages, gitName, gitEmail, githubOrg.
     pub user_profile: Option<String>,
+
+    /// Conventions Sync Phase 2 — when true, the ContextPack skips the static
+    /// layers (platform / agent-role / persona / user-profile) because they've
+    /// been synced into CLAUDE.md/AGENTS.md/GEMINI.md. Default false.
+    /// Toggled per-project via `set_project_conventions_sync` Tauri command.
+    pub conventions_synced: bool,
 }
 
 /// Phase A: Load all data needed for ContextPack assembly from DB.
@@ -439,6 +445,13 @@ pub fn load_context_data(
         None
     };
 
+    // Phase 2 — conventions sync per-project toggle. We already fetched
+    // `project_key` above for retrieval; reuse it here instead of re-querying.
+    let conventions_synced = project_key
+        .as_deref()
+        .map(|pk| crate::commands::conventions_sync::is_conventions_sync_enabled(conn, pk))
+        .unwrap_or(false);
+
     ContextData {
         conversation_id: conversation_id.to_string(),
         project_path: project_path.map(|s| s.to_string()),
@@ -463,6 +476,7 @@ pub fn load_context_data(
         context_mode_override: context_mode_override.map(|s| s.to_string()),
         context_budget_cap,
         user_profile: user_profile_json.map(|s| s.to_string()),
+        conventions_synced,
     }
 }
 

--- a/src-tauri/src/commands/agents_helpers/send_common/mod.rs
+++ b/src-tauri/src/commands/agents_helpers/send_common/mod.rs
@@ -46,6 +46,7 @@ mod tests {
             context_mode_override: None,
             context_budget_cap: None,
             user_profile: None,
+            conventions_synced: false,
         }
     }
 
@@ -401,5 +402,65 @@ mod tests {
         let (_, _, meta) = assemble_prompt(&data, None);
         // At minimum: project + platform
         assert!(meta.sections.len() >= 2, "sections should have at least project + platform: {:?}", meta.sections);
+    }
+
+    // ─── Conventions Sync Phase 2 — static layer skip ────────────────────
+
+    #[test]
+    fn conventions_synced_skips_platform_section() {
+        let mut data = empty_context_data();
+        data.conventions_synced = true;
+        let (assembled, _, meta) = assemble_prompt(&data, None);
+        // Skipped — marker present, content absent
+        assert!(meta.sections.contains(&"platform:skipped".to_string()), "should mark platform skipped: {:?}", meta.sections);
+        assert!(!meta.sections.contains(&"platform".to_string()));
+        // PLATFORM_TIER0 content should NOT appear in assembled output
+        assert!(!assembled.contains("tunaFlow platform"), "platform text leaked");
+    }
+
+    #[test]
+    fn conventions_synced_skips_agent_role_section() {
+        let mut data = empty_context_data();
+        data.conventions_synced = true;
+        data.agent_role_doc = Some("Do the thing".into());
+        let (assembled, _, meta) = assemble_prompt(&data, None);
+        assert!(meta.sections.contains(&"agent-role:skipped".to_string()));
+        assert!(!assembled.contains("Do the thing"));
+    }
+
+    #[test]
+    fn conventions_synced_skips_user_profile() {
+        let mut data = empty_context_data();
+        data.conventions_synced = true;
+        data.user_profile = Some(r#"{"name":"Alice","title":"Engineer"}"#.into());
+        let (assembled, _, meta) = assemble_prompt(&data, None);
+        assert!(meta.sections.contains(&"user-profile:skipped".to_string()));
+        assert!(!assembled.contains("Name: Alice"));
+    }
+
+    #[test]
+    fn conventions_not_synced_keeps_static_sections() {
+        let mut data = empty_context_data();
+        data.conventions_synced = false;
+        data.agent_role_doc = Some("Do the thing".into());
+        data.user_profile = Some(r#"{"name":"Alice"}"#.into());
+        let (assembled, _, meta) = assemble_prompt(&data, None);
+        // Default path — all layers present
+        assert!(meta.sections.contains(&"platform".to_string()));
+        assert!(meta.sections.contains(&"agent-role".to_string()));
+        assert!(meta.sections.contains(&"user-profile".to_string()));
+        assert!(assembled.contains("Do the thing"));
+        assert!(assembled.contains("Name: Alice"));
+    }
+
+    #[test]
+    fn conventions_synced_preserves_dynamic_layers() {
+        let mut data = empty_context_data();
+        data.conventions_synced = true;
+        data.plan_section = Some("## Active Plan\n\n### Migration".into());
+        data.context_mode_override = Some("standard".into());
+        let (_, _, meta) = assemble_prompt(&data, None);
+        // Dynamic layer stays even when static layers are skipped
+        assert!(meta.sections.contains(&"plan".to_string()), "plan should stay: {:?}", meta.sections);
     }
 }

--- a/src-tauri/src/commands/agents_helpers/send_common/prompt_assembly.rs
+++ b/src-tauri/src/commands/agents_helpers/send_common/prompt_assembly.rs
@@ -127,32 +127,54 @@ pub fn assemble_prompt(
         included_sections.push("project".into());
     }
 
+    // Phase 2 — when conventions are synced into the project's CLAUDE.md /
+    // AGENTS.md / GEMINI.md, the static layers are prepended automatically by
+    // the CLI and live in the prompt-cache window. Skip them here to avoid
+    // sending the same text twice (and invalidating the cache).
+    // Identity stays in-line because it's RT-specific and not persisted.
+    let skip_static = data.conventions_synced;
+
     // Tier 0: tunaFlow platform instructions (always injected, minimal footprint)
-    sections.push(PLATFORM_TIER0.to_string());
-    included_sections.push("platform".into());
+    if !skip_static {
+        sections.push(PLATFORM_TIER0.to_string());
+        included_sections.push("platform".into());
+    } else {
+        included_sections.push("platform:skipped".into());
+    }
 
     // Agent role document (docs/agents/{role}.md) — injected right after platform
     if let Some(role_doc) = &data.agent_role_doc {
-        sections.push(format!("## Agent Role Instructions\n\n{}", role_doc));
-        included_sections.push("agent-role".into());
+        if !skip_static {
+            sections.push(format!("## Agent Role Instructions\n\n{}", role_doc));
+            included_sections.push("agent-role".into());
+        } else {
+            included_sections.push("agent-role:skipped".into());
+        }
     }
 
     // Identity + Persona section
     {
         let (identity_block, persona_block) = parse_identity_and_persona(identity_fragment);
         if let Some(id) = &identity_block {
+            // Identity is RT-specific and always needed (not synced to file).
             sections.push(id.clone());
             included_sections.push("identity".into());
         }
         if let Some(p) = &persona_block {
-            sections.push(p.clone());
-            included_sections.push("persona".into());
+            if !skip_static {
+                sections.push(p.clone());
+                included_sections.push("persona".into());
+            } else {
+                included_sections.push("persona:skipped".into());
+            }
         }
     }
 
     // User profile section — injected right after identity/persona
     if let Some(profile_json) = &data.user_profile {
-        if let Ok(p) = serde_json::from_str::<serde_json::Value>(profile_json) {
+        if skip_static {
+            included_sections.push("user-profile:skipped".into());
+        } else if let Ok(p) = serde_json::from_str::<serde_json::Value>(profile_json) {
             let mut lines: Vec<String> = Vec::new();
             if let Some(v) = p.get("name").and_then(|v| v.as_str()).filter(|s| !s.is_empty()) {
                 lines.push(format!("Name: {}", v));

--- a/src-tauri/src/commands/conventions_sync.rs
+++ b/src-tauri/src/commands/conventions_sync.rs
@@ -388,6 +388,42 @@ pub fn list_project_conventions(
     list_conventions(&conn, &project_key, persona_label.as_deref())
 }
 
+/// Read the per-project `conventions_sync_enabled` flag. Defaults to false
+/// when the column is NULL or the row is missing — safe for legacy projects
+/// created before migration v37.
+pub fn is_conventions_sync_enabled(conn: &Connection, project_key: &str) -> bool {
+    conn.query_row(
+        "SELECT COALESCE(conventions_sync_enabled, 0) FROM projects WHERE key = ?1",
+        params![project_key],
+        |row| row.get::<_, i64>(0),
+    )
+    .map(|v| v != 0)
+    .unwrap_or(false)
+}
+
+#[tauri::command]
+pub fn get_project_conventions_sync(
+    state: State<DbState>,
+    project_key: String,
+) -> Result<bool, AppError> {
+    let conn = state.read.lock().map_err(|_| AppError::Lock)?;
+    Ok(is_conventions_sync_enabled(&conn, &project_key))
+}
+
+#[tauri::command]
+pub fn set_project_conventions_sync(
+    state: State<DbState>,
+    project_key: String,
+    enabled: bool,
+) -> Result<(), AppError> {
+    let conn = state.write.lock().map_err(|_| AppError::Lock)?;
+    conn.execute(
+        "UPDATE projects SET conventions_sync_enabled = ?1 WHERE key = ?2",
+        params![if enabled { 1i64 } else { 0i64 }, project_key],
+    )?;
+    Ok(())
+}
+
 #[tauri::command]
 pub fn set_project_convention(
     state: State<DbState>,

--- a/src-tauri/src/db/migrations.rs
+++ b/src-tauri/src/db/migrations.rs
@@ -133,6 +133,9 @@ pub fn run(conn: &Connection) -> Result<(), AppError> {
     if current < 36 {
         apply_v36(conn)?;
     }
+    if current < 37 {
+        apply_v37(conn)?;
+    }
     Ok(())
 }
 
@@ -845,6 +848,17 @@ fn apply_v36(conn: &Connection) -> Result<(), AppError> {
     add_column_if_missing(conn, "trace_log", "cache_read_tokens", "INTEGER DEFAULT 0")?;
     add_column_if_missing(conn, "trace_log", "cache_creation_tokens", "INTEGER DEFAULT 0")?;
     conn.execute("INSERT INTO schema_version (version, applied_at) VALUES (36, ?1)", [now_epoch()])?;
+    Ok(())
+}
+
+/// v37 — per-project conventions sync toggle. When on, ContextPack skips the
+/// static layers (platform / agent-role / persona / user-profile) because
+/// they've been synced into CLAUDE.md/AGENTS.md/GEMINI.md — they get prepended
+/// automatically by the CLI and (for Anthropic API) benefit from prompt cache.
+/// Default 0 (off) — experimental opt-in. See `conventionsContextSyncPlan.md`.
+fn apply_v37(conn: &Connection) -> Result<(), AppError> {
+    add_column_if_missing(conn, "projects", "conventions_sync_enabled", "INTEGER DEFAULT 0")?;
+    conn.execute("INSERT INTO schema_version (version, applied_at) VALUES (37, ?1)", [now_epoch()])?;
     Ok(())
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -433,6 +433,13 @@ pub fn run() {
             commands::insight::export_insight_to_files,
             commands::insight_extract::run_insight_extraction,
             commands::insight_extract::run_insight_analysis,
+            // Conventions sync (Phase 2 — ContextPack 정적 레이어 외부화 토글)
+            commands::conventions_sync::list_project_conventions,
+            commands::conventions_sync::set_project_convention,
+            commands::conventions_sync::delete_project_convention,
+            commands::conventions_sync::sync_project_conventions,
+            commands::conventions_sync::get_project_conventions_sync,
+            commands::conventions_sync::set_project_conventions_sync,
             // PTY
             commands::pty::pty_spawn,
             commands::pty::pty_write,

--- a/src/components/tunaflow/settings/ConventionsSection.tsx
+++ b/src/components/tunaflow/settings/ConventionsSection.tsx
@@ -50,6 +50,8 @@ export function ConventionsSection() {
   const [syncing, setSyncing] = useState(false);
   const [report, setReport] = useState<SyncReport | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [syncEnabled, setSyncEnabled] = useState<boolean>(false);
+  const [togglingSync, setTogglingSync] = useState(false);
 
   // 새 행 폼
   const [newLayer, setNewLayer] = useState<string>("platform");
@@ -76,6 +78,27 @@ export function ConventionsSection() {
   };
 
   useEffect(() => { reload(); /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, [projectKey, personaFilter]);
+
+  // Load per-project toggle state (Phase 2 — in-app switch replaces env flag)
+  useEffect(() => {
+    if (!projectKey) { setSyncEnabled(false); return; }
+    invoke<boolean>("get_project_conventions_sync", { projectKey })
+      .then(setSyncEnabled)
+      .catch(() => setSyncEnabled(false));
+  }, [projectKey]);
+
+  const handleToggleSync = async (next: boolean) => {
+    if (!projectKey) return;
+    setTogglingSync(true);
+    try {
+      await invoke("set_project_conventions_sync", { projectKey, enabled: next });
+      setSyncEnabled(next);
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setTogglingSync(false);
+    }
+  };
 
   const handleAdd = async () => {
     if (!projectKey || !newContent.trim()) return;
@@ -139,13 +162,31 @@ export function ConventionsSection() {
       <div>
         <h2 className="text-[14px] font-[550] text-foreground mb-1">Conventions Context Sync</h2>
         <p className="text-[12px] text-muted-foreground mb-2">
-          정적 ContextPack layer를 CLAUDE.md / AGENTS.md / GEMINI.md로 sync합니다.
-          편집 후 "Sync Now" 버튼으로 파일 갱신.
+          정적 ContextPack layer(platform / agent role / persona / user profile)를
+          CLAUDE.md / AGENTS.md / GEMINI.md로 sync 합니다. 편집 후 "Sync Now" 로 파일 갱신.
         </p>
-        <p className="text-[11px] text-amber-600/80">
-          ⚠️ Phase 1 실험. ContextPack에서 정적 layer가 실제로 생략되려면
-          앱을 <code className="px-1 bg-card rounded">TUNAFLOW_CONVENTIONS_SYNC=1</code> 환경변수로 실행하세요.
-        </p>
+        {projectKey && (
+          <label className="flex items-start gap-2 mt-2 p-2 rounded border border-border/50 bg-card/50 cursor-pointer hover:bg-card transition-colors">
+            <input
+              type="checkbox"
+              checked={syncEnabled}
+              onChange={(e) => handleToggleSync(e.target.checked)}
+              disabled={togglingSync}
+              className="mt-0.5"
+            />
+            <div className="flex-1">
+              <div className="text-[12px] font-medium text-foreground">
+                ContextPack 에서 정적 레이어 생략
+                {togglingSync && <Loader2 className="inline-block w-3 h-3 ml-1.5 animate-spin text-muted-foreground" />}
+              </div>
+              <p className="text-[10.5px] text-muted-foreground/80 mt-0.5 leading-relaxed">
+                켜면 매 turn 정적 레이어를 재송신하지 않습니다. CLI 가 CLAUDE.md/AGENTS.md 를
+                자동 prepending 하며 Anthropic API 경로에서는 prompt cache 적중으로 비용 절감.
+                먼저 아래에서 해당 프로젝트의 conventions 를 추가하고 "Sync Now" 로 파일을 만들어야 실제 효과.
+              </p>
+            </div>
+          </label>
+        )}
       </div>
 
       {/* Project + persona filter */}


### PR DESCRIPTION
## Summary

Harness Maturity Audit §5.3 **항목 8** / `conventionsContextSyncPlan.md` Phase 2.

ContextPack 의 정적 레이어(platform / agent-role / persona / user-profile)를 CLAUDE.md / AGENTS.md / GEMINI.md 로 sync 한 뒤 본문에서 **생략**. CLI 가 이들 파일을 자동 prepending 하므로 동일 내용을 두 번 송신하는 것을 피하고, Anthropic API 경로에서는 **prompt cache 적중**으로 비용 절감.

## Details

### Rust
- **v37 migration**: `projects.conventions_sync_enabled INTEGER DEFAULT 0`
- **`ContextData.conventions_synced`** 필드 + `load_context_data` 에서 project_key 로 flag 조회 (기존 project_key 쿼리 재사용, 신규 DB 호출 없음)
- **`assemble_prompt`** 4개 지점 skip:
  - platform / agent-role / persona-block / user-profile
  - identity 는 유지 (RT-specific, sync 대상 아님)
  - skip 시 `included_sections` 에 `xxx:skipped` 마커 → trace 에서 사후 분석 가능
- **`conventions_sync`** 에 `is_conventions_sync_enabled` pub fn + Tauri command `get_project_conventions_sync` / `set_project_conventions_sync`
- **`lib.rs invoke_handler`** 에 conventions_sync 6개 command 등록. **Phase 1 에서 정의됐지만 handler 에 누락돼 FE 가 부를 수 없던 상태 복구** (이번에 수정)
- 단위 테스트 5건 추가 — synced 시 platform/agent-role/user-profile skip, not synced 기본 동작, synced 상태에서도 동적 레이어(plan) 유지

### FE
- `ConventionsSection.tsx` 에 **프로젝트별 토글** 체크박스 추가
- 이전 `TUNAFLOW_CONVENTIONS_SYNC=1` env flag 안내 → 인앱 토글 + 실제 효과 발휘 조건 설명으로 교체
- 기존 convention 편집/sync UI 는 그대로

## 의도적 한계 / 후속 미해결

- **identity_block 은 skip 대상 아님** — RT 참가자별로 매 턴 생성되는 dynamic
- **토큰 절감량 trace 측정** — 현재는 `sections` 의 `:skipped` 마커로 사후 계산 가능. 별도 `static_tokens_saved` 필드 도입은 후속 PR 에서 ROI 보고 판단
- **persona / user_profile 의 sync 파일 쓰기 UX** — Phase 1 편집 UI 그대로. ContextPack 정적 본문 → DB 자동 추출 migration 은 별도 작업 (`conventionsContextSyncPlan.md` §169 Phase 2 원안)
- **cache 효과 실측** — Anthropic API 사용 시 trace 의 `cache_read_tokens` 값으로 검증 필요 (PR #50 에 의해 컬럼 존재 복구됨)

## Test plan
- [x] `cargo check --lib` clean
- [x] `cargo test --lib` 256/256 pass (기존 251 + 신규 5)
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` 220/220 pass (FE 쪽 기능 변경 없음)
- [ ] 수동 검증: Settings → Conventions 섹션에서 토글 on → Sync Now → 이후 일반 chat 전송 시 ContextPack 본문에서 platform/persona/user-profile 관련 섹션 제거 확인 (trace 의 context_sections 에 `:skipped` 마커 확인)
- [ ] 수동 검증: 토글 off 로 되돌리면 기존 동작 복귀

🤖 Generated with [Claude Code](https://claude.com/claude-code)