### PR TITLE
sec(A): DB/디렉토리 권한 조이기 + retrieval 로그 프라이버시 강화

### DIFF
--- a/src-tauri/src/commands/agents_helpers/send_common/context_loading.rs
+++ b/src-tauri/src/commands/agents_helpers/send_common/context_loading.rs
@@ -293,17 +293,23 @@ pub fn load_context_data(
                 .unwrap_or_default()
         }).unwrap_or_default();
         let mut fts_chunks = retrieve_relevant_chunks_with_overlap(conn, pk, conversation_id, prompt, &recent_ids, 10, None);
-        // Safe truncation helper for logging (respects char boundaries)
+        // Safe truncation helper for logging (respects char boundaries). In release
+        // builds we only log lengths, not content previews — user prompts/messages
+        // may contain API keys or other secrets pasted inline, and eprintln output
+        // can land in systemd journals, shell scrollback, or screen-recorded demos.
+        #[cfg(debug_assertions)]
         let safe_trunc = |s: &str, max: usize| -> String {
             if s.len() <= max { return s.to_string(); }
             let mut end = max;
             while end > 0 && !s.is_char_boundary(end) { end -= 1; }
             format!("{}…", &s[..end])
         };
+        #[cfg(not(debug_assertions))]
+        let safe_trunc = |_s: &str, _max: usize| -> String { format!("<{}ch>", _s.len()) };
 
-        eprintln!("[retrieval] FTS5: {} chunks for query=\"{}\"", fts_chunks.len(), safe_trunc(prompt, 60));
+        eprintln!("[retrieval] FTS5: {} chunks for query=\"{}\"", fts_chunks.len(), safe_trunc(prompt, 30));
         for (i, c) in fts_chunks.iter().enumerate() {
-            let preview = c.messages.first().map(|(_, t, _, _)| safe_trunc(t, 80)).unwrap_or_default();
+            let preview = c.messages.first().map(|(_, t, _, _)| safe_trunc(t, 40)).unwrap_or_default();
             eprintln!("[retrieval]   fts[{}] kind={} score={:.3} conv={} text=\"{}\"", i, c.kind, c.score, safe_trunc(&c.conversation_id, 8), preview);
         }
 
@@ -316,7 +322,7 @@ pub fn load_context_data(
             let vec_results = crate::commands::vector_search::search_similar(conn, &query_emb, pk, conversation_id, 5);
             eprintln!("[retrieval] Vector: {} chunks (threshold 0.3)", vec_results.len());
             for (i, vc) in vec_results.iter().enumerate() {
-                eprintln!("[retrieval]   vec[{}] score={:.3} conv={} text=\"{}\"", i, vc.score, safe_trunc(&vc.conversation_id, 8), safe_trunc(&vc.text_preview, 80));
+                eprintln!("[retrieval]   vec[{}] score={:.3} conv={} text=\"{}\"", i, vc.score, safe_trunc(&vc.conversation_id, 8), safe_trunc(&vc.text_preview, 40));
             }
             // RRF merge: add vector-only results that aren't already in FTS results
             let fts_conv_ids: std::collections::HashSet<String> = fts_chunks.iter().map(|c| c.conversation_id.clone()).collect();

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -2,10 +2,69 @@ pub mod migrations;
 pub mod models;
 pub mod schema;
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use rusqlite::Connection;
 use crate::errors::AppError;
+
+/// Tighten file permissions to owner-only (0600) on Unix. No-op on other OSes.
+/// Missing files are silently skipped. Logs but does not fail on permission
+/// errors — we'd rather run with loose perms than refuse to start.
+#[cfg(unix)]
+fn chmod_owner_only(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    if !path.exists() { return; }
+    let perms = std::fs::Permissions::from_mode(0o600);
+    if let Err(e) = std::fs::set_permissions(path, perms) {
+        eprintln!("[db-sec] chmod 600 failed for {:?}: {}", path, e);
+    }
+}
+
+#[cfg(not(unix))]
+fn chmod_owner_only(_path: &Path) {
+    // Windows: file ACLs are user-scoped by default under the user profile;
+    // we don't attempt to further restrict here. Document in threat model.
+}
+
+/// Apply 0600 perms to the primary DB file + its WAL/SHM/bak siblings. Called
+/// on app init (catches legacy 644 files) and after backup copy (catches new
+/// `.bak` which otherwise inherits umask default).
+pub(crate) fn secure_db_files(db_path: &Path) {
+    chmod_owner_only(db_path);
+    for ext in ["db-wal", "db-shm", "db.bak"] {
+        chmod_owner_only(&db_path.with_extension(ext));
+    }
+    // Also tighten the parent directory to 0700 so other OS users cannot list
+    // contents. Only in dev (we control `~/.tunaflow/`); release uses
+    // OS-managed `Application Support/<bundle-id>/` which is already user-scoped.
+    #[cfg(unix)]
+    if let Some(parent) = db_path.parent() {
+        use std::os::unix::fs::PermissionsExt;
+        if parent.exists() {
+            if let Ok(meta) = std::fs::metadata(parent) {
+                let mut perms = meta.permissions();
+                perms.set_mode(0o700);
+                if let Err(e) = std::fs::set_permissions(parent, perms) {
+                    eprintln!("[db-sec] chmod 700 failed for dir {:?}: {}", parent, e);
+                }
+            }
+        }
+        // Also the grandparent (~/.tunaflow/) which holds `db/`, `skills/`, etc.
+        if let Some(root) = parent.parent() {
+            let is_tunaflow_root = root.file_name()
+                .and_then(|n| n.to_str())
+                .map(|n| n == ".tunaflow")
+                .unwrap_or(false);
+            if is_tunaflow_root && root.exists() {
+                if let Ok(meta) = std::fs::metadata(root) {
+                    let mut perms = meta.permissions();
+                    perms.set_mode(0o700);
+                    let _ = std::fs::set_permissions(root, perms);
+                }
+            }
+        }
+    }
+}
 
 /// Tauri managed state: dual connections for read/write separation.
 ///
@@ -53,6 +112,9 @@ pub fn init(db_path: PathBuf) -> Result<(Connection, Connection), AppError> {
         }
     }
 
+    // Tighten perms on legacy-mode (0644) files before opening. Covers DB + WAL + SHM + bak.
+    secure_db_files(&db_path);
+
     // Write connection — runs migrations, enables WAL + foreign keys
     let write_conn = Connection::open(&db_path)?;
     write_conn.execute_batch("PRAGMA journal_mode = WAL;")?;
@@ -68,6 +130,10 @@ pub fn init(db_path: PathBuf) -> Result<(Connection, Connection), AppError> {
     )?;
     read_conn.execute_batch("PRAGMA busy_timeout = 5000;")?;
     read_conn.execute_batch("PRAGMA foreign_keys = ON;")?;
+
+    // Re-tighten perms after WAL file creation (opening in WAL mode creates the
+    // `-wal` and `-shm` siblings with umask default, usually 0644).
+    secure_db_files(&db_path);
 
     Ok((write_conn, read_conn))
 }


### PR DESCRIPTION
## 목적
베타 전 기본 위생 수준의 파일 시스템 보안.

## 변경
### 파일 권한
- `db/mod.rs` 에 `secure_db_files()` 추가
- DB + WAL + SHM + bak → `0600` (owner r/w only)
- dev 경로의 `db/`, `~/.tunaflow/` 디렉토리 → `0700`
- Unix 전용, Windows no-op (OS 기본 user-scoped)
- `db::init` 에서 backup 직후 + WAL 생성 직후 두 번 호출 (WAL 파일이 umask 기본 0644로 새로 만들어지는 구간 커버)

### retrieval 로그 preview 축소
- `safe_trunc` 을 `#[cfg(debug_assertions)]` 로 분기
- Release: 길이만 (`<N ch>` 형태) 출력
- Dev: preview 유지하되 60/80 → 30/40자 수준으로 축소
- 근거: 사용자가 prompt 앞부분에 API key/password/token 붙여넣으면 eprintln 출력이 systemd journal, shell scrollback, 데모 영상으로 유출 위험

## Test plan
- [x] `cargo test --lib` 269 pass
- [x] `cargo check --lib` clean
- [ ] 수동: 앱 재기동 후 `ls -la ~/.tunaflow/db/` 에서 `rw-------` 확인
- [ ] 수동: `~/.tunaflow/` 자체도 `drwx------` 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)