### PR TITLE
fix(workflow): Architect 핸드오프 시 review 브랜치 auto-archive (3경로)

### DIFF
--- a/src/components/tunaflow/context-panel/SubtaskReviewView.tsx
+++ b/src/components/tunaflow/context-panel/SubtaskReviewView.tsx
@@ -374,6 +374,9 @@ export function SubtaskReviewView({ plan, onPlanUpdate, onSwitchToChat }: Subtas
                   await planApi.updatePlanPhase(plan.id, "drafting");
                   await planApi.createPlanEvent(plan.id, "architect_redesign_requested", "user",
                     `doom loop ${reviewHistory.length} failures`);
+                  // Baton moved to Architect — review branch is no longer active.
+                  const { archiveReviewBranchForHandoff } = await import("@/lib/workflowOrchestration");
+                  await archiveReviewBranchForHandoff(plan);
                   onPlanUpdate(plan.id, { phase: "drafting" as PlanPhase });
                   onSwitchToChat?.();
                 } catch (e) { console.warn("[tunaflow]", e); }

--- a/src/lib/workflow/implementWorkflow.ts
+++ b/src/lib/workflow/implementWorkflow.ts
@@ -114,6 +114,25 @@ export async function approveImplPlan(
  * Flow: Developer Branch → compress conversation → Architect reviews →
  *       produces revised plan-proposal → user merges via MergeBranchButton.
  */
+/**
+ * Archive the review branch (if any) when control has been handed off to the
+ * Architect. Shared by the three escalation paths:
+ *   1. `requestPlanRevision` (계획 수정 버튼) — direct user action
+ *   2. `doom_loop_escalated` (automatic, failCount ≥ 5)
+ *   3. `architect_redesign_requested` (SubtaskReviewView)
+ * Intentionally does NOT archive the implementation branch — that stays alive
+ * for the rework cycle. Errors are swallowed (archiving a stale/missing
+ * branch is not worth aborting the escalation).
+ */
+export async function archiveReviewBranchForHandoff(plan: Plan): Promise<void> {
+  if (!plan.reviewBranchId) return;
+  try {
+    await invoke("archive_branch", { id: plan.reviewBranchId });
+  } catch (e) {
+    console.debug("[archive-review-on-handoff]", e);
+  }
+}
+
 export async function requestPlanRevision(
   plan: Plan,
   branchMessages: Message[],
@@ -178,4 +197,6 @@ export async function requestPlanRevision(
   await sendToArchitect(architectEngine, prompt, systemPrompt);
 
   await planApi.createPlanEvent(plan.id, "revision_requested", "user", `from implementation branch, architect=${architectEngine}`);
+  // Baton has moved to Architect → review branch is no longer active.
+  await archiveReviewBranchForHandoff(plan);
 }

--- a/src/lib/workflow/reviewWorkflow.ts
+++ b/src/lib/workflow/reviewWorkflow.ts
@@ -242,6 +242,9 @@ export async function processReviewVerdict(
         "system",
         `Review 실패 ${failCount}회 — Architect 재설계로 강제 에스컬레이션`,
       );
+      // Baton has moved to Architect — review branch is no longer active.
+      const { archiveReviewBranchForHandoff } = await import("./implementWorkflow");
+      await archiveReviewBranchForHandoff(plan);
     } else if (failCount >= 3) {
       await planApi.createPlanEvent(
         plan.id,

--- a/src/tests/workflowOrchestration.test.ts
+++ b/src/tests/workflowOrchestration.test.ts
@@ -161,6 +161,20 @@ describe("requestPlanRevision", () => {
     // If it tried to import chatStore, it would fail or call sendWithEngine
     expect(sendFn).toHaveBeenCalledTimes(1);
   });
+
+  it("archives review branch when handing off to architect", async () => {
+    const sendFn = vi.fn(() => Promise.resolve());
+    const planWithReviewBranch = { ...mockPlan, reviewBranchId: "rev-br-42" };
+    await requestPlanRevision(planWithReviewBranch, [], "claude", sendFn);
+    // archive_branch should have been called with the review branch id
+    expect(invoke).toHaveBeenCalledWith("archive_branch", { id: "rev-br-42" });
+  });
+
+  it("skips archive when no review branch exists", async () => {
+    const sendFn = vi.fn(() => Promise.resolve());
+    await requestPlanRevision(mockPlan, [], "claude", sendFn);
+    expect(invoke).not.toHaveBeenCalledWith("archive_branch", expect.any(Object));
+  });
 });
 
 describe("scanMessagesForMarkers", () => {


### PR DESCRIPTION
리뷰 → 아키텍트로 baton 이 넘어간 뒤 review 브랜치가 살아있는 버그.

## 수정 경로 3곳
1. `requestPlanRevision` (계획 수정 버튼)
2. `doom_loop_escalated` (failCount ≥ 5)
3. `architect_redesign_requested` (SubtaskReviewView 버튼)

## 설계
- review 브랜치만 archive
- **impl 브랜치는 유지** (rework 사이클 연속성)
- pass 경로는 이미 양쪽 archive 중 → 건드리지 않음
- 공통 헬퍼 `archiveReviewBranchForHandoff` 로 추출

## Test
- [x] 단위 테스트 2건 추가 (archive when reviewBranchId / skip when absent)
- [x] vitest 222 pass / tsc clean
