### PR TITLE
fix(insight): 배지는 open findings 수로 + 아키텍트 전송 즉시 resolved

### DIFF
--- a/src-tauri/src/commands/insight.rs
+++ b/src-tauri/src/commands/insight.rs
@@ -148,6 +148,26 @@ pub fn list_insight_sessions(
     Ok(rows.filter_map(|r| r.ok()).collect())
 }
 
+/// Count "open" findings across all sessions in a project. Used by the
+/// Center tab badge — replaces the prior "completed session count" metric
+/// which didn't decrease as users processed findings (every analysis added
+/// to the count regardless of follow-through). Open = needs user action.
+#[tauri::command]
+pub fn count_open_insight_findings(
+    project_key: String,
+    state: State<DbState>,
+) -> Result<i64, AppError> {
+    let conn = state.read.lock().map_err(|_| AppError::Lock)?;
+    let count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM insight_findings f
+         JOIN insight_sessions s ON s.id = f.session_id
+         WHERE s.project_key = ?1 AND f.status = 'open'",
+        [&project_key],
+        |row| row.get(0),
+    ).unwrap_or(0);
+    Ok(count)
+}
+
 #[tauri::command]
 pub fn update_insight_session_status(
     session_id: String,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -423,6 +423,7 @@ pub fn run() {
             commands::insight::delete_insight_session,
             commands::insight::create_insight_findings_batch,
             commands::insight::list_insight_findings,
+            commands::insight::count_open_insight_findings,
             commands::insight::update_insight_finding_status,
             commands::insight::update_insight_findings_batch_status,
             commands::insight::resolve_insight_findings_by_plan,

--- a/src/components/tunaflow/CenterPanel.tsx
+++ b/src/components/tunaflow/CenterPanel.tsx
@@ -123,11 +123,14 @@ export function CenterPanel() {
       .catch(() => setPlanCount(0));
   }, [canonicalConvId, planRefreshKey]);
 
-  // Fetch insight session count badge
+  // Fetch open finding count for Insight tab badge.
+  // Previously surfaced "completed session count" which only grew (every
+  // analysis added +1, processing findings never reduced it). Now surfaces
+  // "how many findings still need user action" = open findings only.
   useEffect(() => {
     if (!selectedProjectKey) { setInsightCount(0); return; }
-    invoke<{ status: string }[]>("list_insight_sessions", { projectKey: selectedProjectKey })
-      .then((sessions) => setInsightCount(sessions.filter((s) => s.status === "completed").length))
+    invoke<number>("count_open_insight_findings", { projectKey: selectedProjectKey })
+      .then(setInsightCount)
       .catch(() => setInsightCount(0));
   }, [selectedProjectKey]);
 

--- a/src/components/tunaflow/context-panel/InsightPanel.tsx
+++ b/src/components/tunaflow/context-panel/InsightPanel.tsx
@@ -196,12 +196,20 @@ ${lines.join("\n\n")}`;
 
       if (!newBranch) { toast.error("브랜치 생성 실패"); return; }
 
-      // Mark findings as in_progress and link to branch for auto-cleanup
+      // Handoff to Architect = findings done from Insight's perspective. Mark
+      // them resolved immediately so the user's "needs action" queue stays
+      // clean. The linked branch preserves the trail — user can revisit what
+      // happened via that branch. Previously these went to `in_progress` with
+      // no actionable UI, polluting the list indefinitely until the linked
+      // branch happened to archive.
       const ids = targetFindings.map((f) => f.id);
-      await insightApi.updateInsightFindingsBatchStatus(ids, "in_progress");
+      const resolution = `Sent to Architect via branch ${newBranch.id.slice(0, 8)}`;
+      await Promise.all(
+        ids.map((id) => insightApi.updateInsightFindingStatus(id, "resolved", resolution)),
+      );
       insightApi.linkInsightFindingsToBranch(ids, newBranch.id)
         .catch((e) => console.debug("[insight] link branch failed:", e));
-      setFindings((prev) => prev.map((f) => ids.includes(f.id) ? { ...f, status: "in_progress" as const } : f));
+      setFindings((prev) => prev.map((f) => ids.includes(f.id) ? { ...f, status: "resolved" as const } : f));
       setSelectedIds(new Set());
 
       // Open branch drawer and send message


### PR DESCRIPTION
사용자 피드백 기반. 배지 (N) 은 completed 세션 수 → open findings 수로. `in_progress` 상태는 신규 발생 막음(즉시 resolved).

## 원인
- 배지 의미 불명 — 세션 수만 올라가고 처리해도 안 줄어듦
- handleSendToArchitect 가 findings 를 `in_progress`로 둬 정리 부담 발생

## 변경
- **Backend**: `count_open_insight_findings(project_key)` 신규 커맨드
- **CenterPanel**: 배지 로직 교체 (session count → open finding count)
- **InsightPanel**: 아키텍트 전송 시 즉시 `resolved` + resolution 에 linked branch id 기록

## Test
- [x] cargo test --lib 274 / vitest 222 / tsc clean
- [ ] 수동: 배지 숫자가 findings 처리할 때마다 감소하는지
- [ ] 수동: 아키텍트 전송한 findings 가 active list 에서 사라지는지
