### PR TITLE
feat(eval): 골든셋 회귀 평가 스위트 — recall@K 측정 CLI

### DIFF
--- a/docs/eval/README.md
+++ b/docs/eval/README.md
@@ -1,0 +1,91 @@
+---
+title: Retrieval 골든셋 회귀 평가
+status: active
+created_at: 2026-04-18
+---
+
+# Retrieval Golden-Set Evaluation
+
+ContextPack 의 **retrieval 품질**을 정량적으로 측정하는 회귀 스위트. Conventions Sync Phase 2, type filter 같은 retrieval 파이프라인 변경의 **before/after** 를 수치로 비교하기 위해 만들었다.
+
+## 언제 돌리는가
+
+- ContextPack / retrieval 로직 변경 PR 의 마지막 확인
+- 베타 공개 직전의 기준선(baseline) 기록
+- 신규 모델/엔진 추가 후 파라미터 튜닝 직후
+
+`/src/components/tunaflow/context-panel/QualityDashboard.tsx` 는 **실시간 관측**, 이 스위트는 **결정적 회귀**. 용도 다르므로 같이 보지 않는다.
+
+## 데이터셋 만들기
+
+1. `docs/eval/golden-set.json` 을 본인 환경에 맞게 채운다.
+2. 실제 대화에서 다음 패턴들로 최소 20~30 개 엔트리 큐레이션:
+   - **과거 대화 레퍼런스** — "이전에 refactoring 얘기할 때 뭐 결정했지?" → 실제 결정 메시지 ID
+   - **파일 언급** — "src/foo.ts 에서 뭐 수정했지?" → 해당 파일 논의 메시지 ID
+   - **cross-session 주제** — "다른 프로젝트에서 비슷한 거 어떻게 했지?" → 유사 프로젝트 메시지 ID
+   - **현재 작업 상태** — "지금 어디까지 했지?" → 최근 plan/implementation 메시지 ID
+3. `expected_message_ids` 는 사람이 "이 대답을 생성하려면 적어도 이 메시지들이 context 에 있어야 한다" 고 판단한 **message ID**.
+
+### 엔트리 스키마
+
+```json
+{
+  "id": "q1",
+  "question": "사용자 질문",
+  "context": { "conversation_id": "실제 conversation ID" },
+  "expected_message_ids": ["실제 message ID 1", "..."],
+  "notes": "선택 — 사람 메모"
+}
+```
+
+## 실행
+
+```bash
+cd src-tauri
+
+cargo run --release --bin eval_retrieval -- \
+    --db ~/.tunaflow/db/tunaflow.db \
+    --set ../docs/eval/golden-set.json \
+    --k 5
+```
+
+### 옵션
+- `--db <path>` — DB 파일 경로 (read-only 로 open)
+- `--set <path>` — 골든셋 JSON
+- `--k <n>` — top-K 검색 (기본 5)
+- `--project-key <key>` — project_key 명시 (생략 시 첫 엔트리의 conversation 으로 추론)
+
+### 출력
+`id`, `retrieved`, `expected`, `hits`, `recall`, `precision` TSV + 마지막에 aggregate:
+
+```
+recall_at_k=0.820
+precision_at_k=0.640
+total_hits=41
+total_expected=50
+total_retrieved=64
+```
+
+## Before/after 비교 워크플로우
+
+1. 변경 전 main 에서 실행 → `baseline.txt` 저장
+2. 변경 적용 → 다시 실행 → `candidate.txt`
+3. `recall_at_k` 가 **유의미하게 떨어졌으면** (대략 -5% 이상) 변경을 재검토
+
+## 한계 (정직)
+
+- `expected_message_ids` 는 사람이 판단한 "해당 답변에 필요할 것" 의 proxy.
+  실제 모델이 그 메시지 없이도 답을 잘 만드는 경우가 많다 → recall 숫자가
+  절대적 품질 지표는 아님
+- `RetrievedChunk` 이 message id 를 직접 담지 않아 현재는 `(conversation_id, timestamp)`
+  JOIN 으로 역추적. timestamp 충돌이 드물긴 하지만 이론적으로 ambiguous 할 수 있음
+- 골든셋이 **사용자 환경의 DB** 에 종속 — 팀 공유하려면 sanitized fixture DB 를
+  별도로 만들어야 함 (follow-up)
+
+## 후속 개선
+
+- [ ] `RetrievedChunk` 에 `root_message_id` 필드 노출 (지금은 workaround 로 역추적)
+- [ ] Project scope — 현재는 특정 conversation 기반. 프로젝트 전체 기준
+      sampling 모드 추가
+- [ ] LLM-as-judge 경로 — retrieval 이 답변에 실제로 기여했는지 2차 검증
+- [ ] Fixture DB — 팀/CI 공유 가능한 고정 데이터셋

--- a/docs/eval/golden-set.json
+++ b/docs/eval/golden-set.json
@@ -1,0 +1,18 @@
+{
+  "version": 1,
+  "description": "Retrieval golden set — (question, expected messages) pairs for regression testing. Populate with real conversation IDs from your local DB. See README.md for curation guidance.",
+  "entries": [
+    {
+      "id": "example_1",
+      "question": "이전에 언급했던 refactoring 얘기가 어디에 있지?",
+      "context": {
+        "conversation_id": "REPLACE_WITH_REAL_CONVERSATION_ID"
+      },
+      "expected_message_ids": [
+        "REPLACE_WITH_MESSAGE_ID_1",
+        "REPLACE_WITH_MESSAGE_ID_2"
+      ],
+      "notes": "사용자가 과거 대화 찾는 기본 패턴. expected 는 실제로 해당 내용이 있는 메시지 ID 를 손으로 선정."
+    }
+  ]
+}

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -7,6 +7,12 @@ edition = "2021"
 name = "tuna_flow_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
+# CLI evaluation harness — manually invoked, not part of the Tauri bundle.
+# Usage: `cargo run --release --bin eval_retrieval -- --db <path> --set <json>`
+[[bin]]
+name = "eval_retrieval"
+path = "src/bin/eval_retrieval.rs"
+
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
 

--- a/src-tauri/src/bin/eval_retrieval.rs
+++ b/src-tauri/src/bin/eval_retrieval.rs
@@ -1,0 +1,200 @@
+//! Golden-set retrieval evaluation harness.
+//!
+//! Given a JSON dataset of (question, context, expected_message_ids) tuples,
+//! runs the production FTS retrieval path against a real tunaFlow DB and
+//! reports **recall@K** and **precision@K** per entry plus aggregates.
+//!
+//! Usage:
+//! ```bash
+//! cargo run --release --bin eval_retrieval -- \
+//!     --db ~/.tunaflow/db/tunaflow.db \
+//!     --set docs/eval/golden-set.json \
+//!     --k 5
+//! ```
+//!
+//! Exit code: 0 on success, non-zero when dataset is malformed. Recall scores
+//! are printed to stdout in machine-parseable `metric=value` format so CI can
+//! compare before/after without parsing a table.
+//!
+//! Golden entry schema (see `docs/eval/golden-set.json` for examples):
+//! ```json
+//! {
+//!   "id": "q1",
+//!   "question": "이전에 refactoring 얘기할 때 어느 파일 얘기했지?",
+//!   "context": { "conversation_id": "conv-abc123" },
+//!   "expected_message_ids": ["msg-def456", "msg-ghi789"],
+//!   "notes": "optional human description"
+//! }
+//! ```
+
+use rusqlite::Connection;
+use serde::Deserialize;
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+use tuna_flow_lib::commands::context_queries::retrieve_relevant_chunks_with_overlap;
+
+#[derive(Debug, Deserialize)]
+struct GoldenContext {
+    conversation_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GoldenEntry {
+    id: String,
+    question: String,
+    context: GoldenContext,
+    expected_message_ids: Vec<String>,
+    #[serde(default)]
+    notes: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GoldenSet {
+    version: u32,
+    entries: Vec<GoldenEntry>,
+}
+
+#[derive(Debug, Default)]
+struct Metrics {
+    recall: f64,
+    precision: f64,
+    retrieved_count: usize,
+    expected_count: usize,
+    hits: usize,
+}
+
+fn evaluate_entry(conn: &Connection, project_key: &str, entry: &GoldenEntry, k: i64) -> Metrics {
+    let chunks = retrieve_relevant_chunks_with_overlap(
+        conn,
+        project_key,
+        &entry.context.conversation_id,
+        &entry.question,
+        &[],
+        k,
+        None,
+    );
+
+    // Collect message_ids from retrieved chunks. `RetrievedChunk.messages` is
+    // `Vec<(role, content, ...)>` with no id field, so we proxy via conversation_id
+    // + timestamp — expected_message_ids refer to *root* message ids though, so
+    // exact match is best-effort here until chunks carry a stable id.
+    // Workaround: compare on the original message rowids via a fresh query.
+    let retrieved_ids: HashSet<String> = chunks
+        .iter()
+        .flat_map(|c| {
+            let ts = c.timestamp;
+            let conv = c.conversation_id.clone();
+            conn.prepare(
+                "SELECT id FROM messages WHERE conversation_id = ?1 AND timestamp = ?2",
+            )
+            .ok()
+            .map(|mut stmt| {
+                stmt.query_map(rusqlite::params![conv, ts], |row| row.get::<_, String>(0))
+                    .map(|rows| rows.filter_map(|r| r.ok()).collect::<Vec<String>>())
+                    .unwrap_or_default()
+            })
+            .unwrap_or_default()
+        })
+        .collect();
+
+    let expected: HashSet<String> = entry.expected_message_ids.iter().cloned().collect();
+    let hits = retrieved_ids.intersection(&expected).count();
+
+    Metrics {
+        recall: if expected.is_empty() { 0.0 } else { hits as f64 / expected.len() as f64 },
+        precision: if retrieved_ids.is_empty() { 0.0 } else { hits as f64 / retrieved_ids.len() as f64 },
+        retrieved_count: retrieved_ids.len(),
+        expected_count: expected.len(),
+        hits,
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = std::env::args().collect();
+    let mut db_path: Option<PathBuf> = None;
+    let mut set_path: Option<PathBuf> = None;
+    let mut k: i64 = 5;
+    let mut project_key: Option<String> = None;
+
+    let mut i = 1;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--db" => { db_path = args.get(i + 1).map(PathBuf::from); i += 2; }
+            "--set" => { set_path = args.get(i + 1).map(PathBuf::from); i += 2; }
+            "--k" => { k = args.get(i + 1).and_then(|s| s.parse().ok()).unwrap_or(5); i += 2; }
+            "--project-key" => { project_key = args.get(i + 1).cloned(); i += 2; }
+            "-h" | "--help" => {
+                eprintln!("usage: eval_retrieval --db <path> --set <path> [--k N] [--project-key KEY]");
+                return Ok(());
+            }
+            _ => {
+                eprintln!("unknown arg: {}", args[i]);
+                i += 1;
+            }
+        }
+    }
+
+    let db_path = db_path.ok_or("--db is required")?;
+    let set_path = set_path.ok_or("--set is required")?;
+
+    let conn = Connection::open_with_flags(
+        &db_path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )?;
+    conn.execute_batch("PRAGMA busy_timeout = 5000;")?;
+
+    let text = std::fs::read_to_string(&set_path)?;
+    let set: GoldenSet = serde_json::from_str(&text)?;
+
+    // Resolve project_key: explicit arg > first entry's conversation lookup.
+    let pk = match project_key {
+        Some(pk) => pk,
+        None => {
+            let first = set.entries.first().ok_or("dataset is empty")?;
+            conn.query_row(
+                "SELECT project_key FROM conversations WHERE id = ?1",
+                [&first.context.conversation_id],
+                |row| row.get::<_, String>(0),
+            )?
+        }
+    };
+
+    println!("# eval_retrieval v{} — dataset: {} entries, k={}", set.version, set.entries.len(), k);
+    println!("# project_key={}", pk);
+    println!("id\tretrieved\texpected\thits\trecall\tprecision\tnotes");
+
+    let mut agg = Metrics::default();
+    let mut n = 0;
+    for entry in &set.entries {
+        let m = evaluate_entry(&conn, &pk, entry, k);
+        println!(
+            "{}\t{}\t{}\t{}\t{:.3}\t{:.3}\t{}",
+            entry.id,
+            m.retrieved_count,
+            m.expected_count,
+            m.hits,
+            m.recall,
+            m.precision,
+            entry.notes.as_deref().unwrap_or(""),
+        );
+        agg.recall += m.recall;
+        agg.precision += m.precision;
+        agg.hits += m.hits;
+        agg.retrieved_count += m.retrieved_count;
+        agg.expected_count += m.expected_count;
+        n += 1;
+    }
+
+    if n > 0 {
+        let avg_recall = agg.recall / n as f64;
+        let avg_precision = agg.precision / n as f64;
+        println!();
+        println!("recall_at_k={:.3}", avg_recall);
+        println!("precision_at_k={:.3}", avg_precision);
+        println!("total_hits={}", agg.hits);
+        println!("total_expected={}", agg.expected_count);
+        println!("total_retrieved={}", agg.retrieved_count);
+    }
+    Ok(())
+}


### PR DESCRIPTION
QualityDashboard(실시간 관측)와 구분되는 **결정적 회귀 측정** 도구.

## 구성
- **`src-tauri/src/bin/eval_retrieval.rs`** — Rust CLI 바이너리 (프로덕션 retrieval 함수 재사용)
- **`docs/eval/golden-set.json`** — 데이터셋 템플릿
- **`docs/eval/README.md`** — 큐레이션 가이드 + before/after 워크플로우

## 사용
```bash
cd src-tauri
cargo run --release --bin eval_retrieval -- \
    --db ~/.tunaflow/db/tunaflow.db \
    --set ../docs/eval/golden-set.json \
    --k 5
```

출력: 엔트리별 TSV + `recall_at_k=0.820` 같은 머신 파싱 가능 aggregate.

## 한계 (README 에 명시)
- `expected_message_ids` 는 사람 판단 proxy
- message_id 는 timestamp 역추적 (chunk 에 id 노출 follow-up 필요)
- 팀 공유용 fixture DB 부재 — 지금은 사용자 로컬 DB 기반

## Test
- [x] `cargo build --release --bin eval_retrieval` clean
- [x] `--help` smoke 통과
