### PR TITLE
fix(build): Cargo default-run 지정 — `cargo run` 모호성 해소

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,6 +2,9 @@
 name = "tuna-flow"
 version = "0.1.0"
 edition = "2021"
+# Multiple bins exist (tuna-flow desktop app, eval_retrieval CLI). Pin the
+# default so `cargo run` (Tauri dev server) resolves unambiguously.
+default-run = "tuna-flow"
 
 [lib]
 name = "tuna_flow_lib"


### PR DESCRIPTION
PR #60 에서 eval_retrieval 바이너리 추가 뒤 `tauri dev` 실패 수정.

`[package] default-run = "tuna-flow"` 지정. eval CLI 는 `cargo run --bin eval_retrieval` 로 명시 호출.
