### PR TITLE
feat(meta): Meta 배지 트리거 3종 추가

### DIFF
--- a/src/components/tunaflow/context-panel/SubtaskReviewView.tsx
+++ b/src/components/tunaflow/context-panel/SubtaskReviewView.tsx
@@ -377,6 +377,8 @@ export function SubtaskReviewView({ plan, onPlanUpdate, onSwitchToChat }: Subtas
                   // Baton moved to Architect — review branch is no longer active.
                   const { archiveReviewBranchForHandoff } = await import("@/lib/workflowOrchestration");
                   await archiveReviewBranchForHandoff(plan);
+                  // Meta notification — Architect-led redesign cycle started.
+                  window.dispatchEvent(new CustomEvent("tunaflow:meta-task"));
                   onPlanUpdate(plan.id, { phase: "drafting" as PlanPhase });
                   onSwitchToChat?.();
                 } catch (e) { console.warn("[tunaflow]", e); }

--- a/src/lib/workflow/reviewWorkflow.ts
+++ b/src/lib/workflow/reviewWorkflow.ts
@@ -168,6 +168,8 @@ export async function processReviewVerdict(
     await planApi.updatePlanPhase(plan.id, "done");
     await planApi.updatePlanStatus(plan.id, "done");
     await planApi.createPlanEvent(plan.id, "review_passed", "reviewer", detail);
+    // Notify Meta — plan cycle finished, user may want next-priority suggestion.
+    window.dispatchEvent(new CustomEvent("tunaflow:meta-task"));
     try {
       await failureLessonsApi.resolveFailureLessonsByPlan(
         plan.id,
@@ -245,6 +247,8 @@ export async function processReviewVerdict(
       // Baton has moved to Architect — review branch is no longer active.
       const { archiveReviewBranchForHandoff } = await import("./implementWorkflow");
       await archiveReviewBranchForHandoff(plan);
+      // Meta notification — escalation requires user attention.
+      window.dispatchEvent(new CustomEvent("tunaflow:meta-task"));
     } else if (failCount >= 3) {
       await planApi.createPlanEvent(
         plan.id,
@@ -252,6 +256,8 @@ export async function processReviewVerdict(
         "system",
         `Review 실패 ${failCount}회 — 설계 재검토를 권장합니다. Architect 재설계 또는 Developer 계속 rework 중 선택하세요.`,
       );
+      // Meta notification — user should review whether to keep iterating or redesign.
+      window.dispatchEvent(new CustomEvent("tunaflow:meta-task"));
     }
   } else {
     await planApi.createPlanEvent(plan.id, "review_conditional", "reviewer", detail);


### PR DESCRIPTION
현재 `tunaflow:meta-task` 는 insight-update 1경로뿐이라 Meta 배지가 의미있는 알림 역할을 못 함. 4개 워크플로우 전환점 추가.

## 추가 지점
- `review_passed` — plan 사이클 완료
- `doom_loop_warning` (3회 실패)
- `doom_loop_escalated` (5회 실패)
- `architect_redesign_requested` (SubtaskReviewView)

## 미추가 (의도적)
- `review_failed` 매 건 — 소음 방지
- `revision_requested` — 사용자 직접 트리거

## Test
- [x] tsc clean / vitest 222
