### PR TITLE
chore(settings): PTY Interactive Mode 토글 숨김

### DIFF
--- a/src/components/tunaflow/settings/RuntimeSection.tsx
+++ b/src/components/tunaflow/settings/RuntimeSection.tsx
@@ -627,7 +627,9 @@ export function RuntimeSection() {
         </div>
       </div>
 
-      <PtyModeToggle />
+      {/* PtyModeToggle 숨김 (s37): PTY 는 현재 메인/브랜치 send 경로에서
+          기본 off 이고 내부 터미널(VTE) 패널 전용. 설정 토글은 혼선만 줌.
+          메인 send 가 PTY 로 복귀하면 다시 노출. */}
       <ContextBudgetControl />
       <WorkflowSkillsConfig />
       <InsightAgentConfig />


### PR DESCRIPTION
PTY 는 현재 메인/브랜치 send 에서 기본 off, 실제 사용은 내부 터미널뿐. 설정 UI 기본값(`true`)과 런타임 동작(`false`)이 불일치해 사용자 혼선.

컴포넌트는 유지, 렌더만 주석 처리.
