### PR TITLE
refactor(workflow): Plan + Subtask stage 통합 → "Plan Check"

### DIFF
--- a/src/components/tunaflow/CenterPanel.tsx
+++ b/src/components/tunaflow/CenterPanel.tsx
@@ -24,9 +24,10 @@ const TABS: { id: CenterTab; label: string }[] = [
   { id: "notes", label: "Notes" },
 ];
 
-/** Map PlanPhase → WorkflowStageId for auto-switching the HarnessSummary sub-tab */
+/** Map PlanPhase → WorkflowStageId for auto-switching the HarnessSummary sub-tab.
+ *  drafting + subtask_review 는 모두 "Plan Check" 단계로 통합 (s37). */
 const PHASE_TO_STAGE: Record<string, WorkflowStageId> = {
-  drafting: "plan", subtask_review: "subtask",
+  drafting: "plan-check", subtask_review: "plan-check",
   approval: "dev",
   implementation: "dev", rework: "dev",
   review: "review", done: "done",
@@ -34,7 +35,7 @@ const PHASE_TO_STAGE: Record<string, WorkflowStageId> = {
 
 export function CenterPanel() {
   const [activeTab, setActiveTab] = useState<CenterTab>("chat");
-  const [activeStage, setActiveStage] = useState<WorkflowStageId>("plan");
+  const [activeStage, setActiveStage] = useState<WorkflowStageId>("plan-check");
   const [planRefreshKey, setPlanRefreshKey] = useState(0);
   const [terminalOpen, setTerminalOpen] = useState(false);
   const [terminalHeight, setTerminalHeight] = useState(320);
@@ -260,7 +261,7 @@ export function CenterPanel() {
                 }}
                 onStatusChanged={() => {
                   setPlanRefreshKey((k) => k + 1);
-                  setActiveStage("plan");
+                  setActiveStage("plan-check");
                 }}
                 onSwitchToChat={() => setActiveTab("chat")}
               />

--- a/src/components/tunaflow/chat/PlanProposalCard.tsx
+++ b/src/components/tunaflow/chat/PlanProposalCard.tsx
@@ -228,9 +228,9 @@ export function PlanProposalCard({ proposal, conversationId }: PlanProposalCardP
         );
       }
 
-      // Switch Workflow tab to subtask stage so newly promoted plan is visible
+      // Switch Workflow tab to plan-check stage so newly promoted plan is visible
       window.dispatchEvent(new CustomEvent("tunaflow:switch-tab", { detail: "workflow" }));
-      window.dispatchEvent(new CustomEvent("tunaflow:switch-stage", { detail: "subtask" }));
+      window.dispatchEvent(new CustomEvent("tunaflow:switch-stage", { detail: "plan-check" }));
 
       setStatus("promoted");
     } catch {

--- a/src/components/tunaflow/context-panel/HarnessSummary.tsx
+++ b/src/components/tunaflow/context-panel/HarnessSummary.tsx
@@ -28,9 +28,11 @@ function deriveStages(
   const hasReview = artifacts.some((a) => a.type === "review-findings");
   const hasDone = artifacts.some((a) => a.type === "architect-decision") || phase === "done";
 
+  // Plan + Subtask stages unified into "Plan Check" (s37) —
+  // drafting 은 승인 즉시 subtask_review 로 넘어가 거의 빈 탭이었고,
+  // 두 phase 모두 "사용자가 plan 을 검토·확정하는" 동일 맥락. UX 간소화.
   return [
-    { id: "plan", label: "Plan", active: !!plan },
-    { id: "subtask", label: "Subtask", active: phaseIdx >= 1 },
+    { id: "plan-check", label: "Plan Check", active: !!plan },
     { id: "dev", label: "Dev", active: phaseIdx >= 2 },
     { id: "review", label: "Review", active: phaseIdx >= 5 || hasReview },
     { id: "done", label: "Done", active: phaseIdx >= 6 || hasDone },
@@ -39,7 +41,7 @@ function deriveStages(
 
 // ─── Component ───────────────────────────────────────────────────────────────
 
-export type WorkflowStageId = "all" | "plan" | "subtask" | "dev" | "review" | "done";
+export type WorkflowStageId = "all" | "plan-check" | "dev" | "review" | "done";
 
 interface HarnessSummaryProps {
   conversationId: string;
@@ -95,11 +97,10 @@ export function HarnessSummary({ conversationId, activeStage, onStageClick, refr
 
   const stages = deriveStages(activePlan, subtasks, branches, artifacts);
 
-  // Per-stage plan counts
+  // Per-stage plan counts — "plan-check" 는 drafting + subtask_review 합산.
   const livePlans = allPlans.filter((p) => p.status !== "abandoned");
   const stageCounts: Record<string, number> = {
-    plan: livePlans.filter((p) => p.phase === "drafting").length,
-    subtask: livePlans.filter((p) => p.phase === "subtask_review").length,
+    "plan-check": livePlans.filter((p) => p.phase === "drafting" || p.phase === "subtask_review").length,
     dev: livePlans.filter((p) => p.phase === "approval" || p.phase === "implementation" || p.phase === "rework").length,
     review: livePlans.filter((p) => p.phase === "review").length,
     done: livePlans.filter((p) => p.phase === "done").length,

--- a/src/components/tunaflow/context-panel/PlansPanel.tsx
+++ b/src/components/tunaflow/context-panel/PlansPanel.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { useChatStore } from "@/stores/chatStore";
 import { ClipboardList } from "lucide-react";
+import { cn } from "@/lib/utils";
 import type { Plan, PlanPhase, PlanStatus } from "@/types";
 import * as planApi from "@/lib/api/plans";
 import { SubtaskReviewView } from "./SubtaskReviewView";
@@ -10,13 +11,14 @@ import { PlanCard } from "./plans/PlanCard";
 
 // ─── PlansPanel (main export) ────────────────────────────────────────────────
 
-/** Phase filter mapping for stage IDs */
+/** Phase filter mapping for stage IDs.
+ *  `plan-check` = drafting + subtask_review 통합 (s37) — "사용자가 plan 을
+ *  검토·확정하는" 동일 맥락의 두 phase 를 하나의 stage 로. */
 const STAGE_PHASE_MAP: Record<string, { phases: PlanPhase[]; includeAbandoned?: boolean; empty: string }> = {
-  plan:    { phases: ["drafting"],                              empty: "Chat 탭에서 Architect와 대화하여 Plan을 생성하세요." },
-  subtask: { phases: ["subtask_review"],                       empty: "Subtask 검토 중인 Plan이 없습니다." },
-  dev:     { phases: ["approval", "implementation", "rework"], empty: "구현 중인 Plan이 없습니다." },
-  review:  { phases: ["review"],                               empty: "리뷰 중인 Plan이 없습니다." },
-  done:    { phases: ["done"], includeAbandoned: true,         empty: "완료된 Plan이 없습니다." },
+  "plan-check": { phases: ["drafting", "subtask_review"],          empty: "검토 중인 Plan이 없습니다. Chat에서 Architect와 대화해 Plan을 제안받으세요." },
+  dev:          { phases: ["approval", "implementation", "rework"], empty: "구현 중인 Plan이 없습니다." },
+  review:       { phases: ["review"],                               empty: "리뷰 중인 Plan이 없습니다." },
+  done:         { phases: ["done"], includeAbandoned: true,         empty: "완료된 Plan이 없습니다." },
 };
 
 interface PlansPanelProps {
@@ -128,16 +130,35 @@ export function PlansPanel({ activeStage, onPhaseChanged, onStatusChanged, onSwi
         </div>
       )}
 
-      {activeStage === "subtask" ? (() => {
-        // Separate: new plans (never implemented) vs plans that went through Dev→Review cycle
-        // Plans with implementationBranchId have been through at least one implementation round
-        const normalPlans = filteredPlans.filter((p) => !p.implementationBranchId);
-        const escalatedPlans = filteredPlans.filter((p) => !!p.implementationBranchId);
+      {activeStage === "plan-check" ? (() => {
+        // plan-check = drafting + subtask_review 통합 (s37).
+        // - drafting: 아직 subtask 가 채워지지 않은 상태 → 일반 PlanCard 로 노출
+        // - subtask_review (normal): 새로 생성돼 검토 대기 중 → SubtaskReviewView
+        // - subtask_review (escalated, 이미 impl branch 존재): 설계 재검토 필요 → 별도 섹션
+        const draftingPlans = filteredPlans.filter((p) => p.phase === "drafting");
+        const normalPlans = filteredPlans.filter((p) => p.phase === "subtask_review" && !p.implementationBranchId);
+        const escalatedPlans = filteredPlans.filter((p) => p.phase === "subtask_review" && !!p.implementationBranchId);
         return (
           <>
-            {normalPlans.length > 0 && (
+            {draftingPlans.length > 0 && (
               <div className="space-y-2">
-                {normalPlans.length > 0 && escalatedPlans.length > 0 && (
+                {(normalPlans.length > 0 || escalatedPlans.length > 0) && (
+                  <p className="text-[9px] font-medium text-muted-foreground/40 uppercase tracking-wider px-1">작성 중</p>
+                )}
+                {draftingPlans.map((plan) => (
+                  <PlanCard
+                    key={plan.id}
+                    plan={plan}
+                    onStatusChange={handlePlanStatus}
+                    onPlanUpdated={handlePlanUpdated}
+                    onSwitchToChat={onSwitchToChat}
+                  />
+                ))}
+              </div>
+            )}
+            {normalPlans.length > 0 && (
+              <div className={cn("space-y-2", draftingPlans.length > 0 && "mt-4")}>
+                {(draftingPlans.length > 0 || escalatedPlans.length > 0) && (
                   <p className="text-[9px] font-medium text-muted-foreground/40 uppercase tracking-wider px-1">검토 대기</p>
                 )}
                 {normalPlans.map((plan) => (

--- a/src/stores/slices/threadSlice.ts
+++ b/src/stores/slices/threadSlice.ts
@@ -129,7 +129,8 @@ export const createThreadSlice = (set: SetState, get: GetState): ThreadSlice => 
           window.dispatchEvent(new CustomEvent("tunaflow:switch-tab", { detail: "workflow" }));
           // Also switch to the correct workflow stage based on plan phase
           const PHASE_TO_STAGE: Record<string, string> = {
-            drafting: "plan", subtask_review: "subtask", approval: "dev",
+            // drafting + subtask_review → "plan-check" 로 통합 (s37)
+            drafting: "plan-check", subtask_review: "plan-check", approval: "dev",
             implementation: "dev", rework: "dev", review: "review", done: "done",
           };
           const stage = PHASE_TO_STAGE[plan.phase];


### PR DESCRIPTION
Workflow 탭 stage chips 에서 Plan(거의 빈 탭) + Subtask(라벨 모호) 를 `Plan Check` 로 합병.

## 결과
Before: `Plan — Subtask — Dev — Review — Done — All`
After:  `Plan Check — Dev — Review — Done — All`

## Plan Check 내부 렌더
- 작성 중 (drafting) — PlanCard
- 검토 대기 (subtask_review, impl branch 없음) — SubtaskReviewView
- ⚠️ 설계 재검토 필요 (subtask_review, impl branch 있음) — SubtaskReviewView

## Test
- [x] tsc clean / vitest 222
- [ ] 수동: chip 4+All 인지 / 자동 전환 / drafting+subtask_review 렌더 섹션 분리
