### PR TITLE
fix(rt): save_rt_config invoke arg `config` → `configJson` — Review RT 진입 실패 해결

### DIFF
--- a/src/components/tunaflow/context-panel/DevProgressView.tsx
+++ b/src/components/tunaflow/context-panel/DevProgressView.tsx
@@ -167,24 +167,13 @@ export function DevProgressView({ plan, onPlanUpdate }: DevProgressViewProps) {
       } catch (e) { console.debug("[test-before-review-rt]", e); }
 
       const engines = chosenProfiles.map((p) => p.engine);
-      console.log("[rt-debug] startReviewRT begin", { planId: plan.id, engines });
       const { branch, participants, prompt, mode } = await startReviewRT(plan, msgs, testOutput, engines);
-      console.log("[rt-debug] startReviewRT done", { branchId: branch.id, participants, mode, promptLen: prompt.length });
       onPlanUpdate(plan.id, { phase: "review" as PlanPhase, reviewBranchId: branch.id });
       await loadBranches(plan.conversationId);
-      console.log("[rt-debug] openThread begin", { branchId: branch.id });
       await openThread(branch.id);
-      console.log("[rt-debug] openThread done", {
-        threadBranchId: useChatStore.getState().threadBranchId,
-        threadBranchConvId: useChatStore.getState().threadBranchConvId,
-      });
       // Deep review = ≥2 reviewers → auto-synthesize MoA summary after the round.
-      console.log("[rt-debug] sendThreadRoundtable begin");
       await sendThreadRoundtable(prompt, participants, mode, { autoSynthesize: true });
-      console.log("[rt-debug] sendThreadRoundtable done", {
-        runningThreadIds: useChatStore.getState().runningThreadIds,
-      });
-    } catch (e) { console.error("[rt-debug] startReviewRT/sendThreadRoundtable FAILED", e); }
+    } catch (e) { console.warn("[tunaflow]", e); }
     setBusy(false);
     setReviewMode("idle");
   };

--- a/src/lib/workflow/reviewWorkflow.ts
+++ b/src/lib/workflow/reviewWorkflow.ts
@@ -127,7 +127,10 @@ export async function startReviewRT(
 
   const mode = "sequential" as const;
   const rtConfig = JSON.stringify({ participants, mode });
-  await invoke("save_rt_config", { conversationId: shadowConvId, config: rtConfig });
+  // Tauri camelCase: Rust 의 `config_json: String` 은 FE 에서 `configJson` 으로 호출.
+  // 이전엔 `config` 로 잘못 보내 invoke 가 실패하며 save_rt_config 가 no-op 되고
+  // Review RT 진입 자체가 throw 되던 버그. s37 재현 로그로 특정.
+  await invoke("save_rt_config", { conversationId: shadowConvId, configJson: rtConfig });
 
   // NOTE: RT execution is the caller's responsibility.
   // After this returns, the caller should call openThread(branch.id) then

--- a/src/stores/slices/threadRtRunner.ts
+++ b/src/stores/slices/threadRtRunner.ts
@@ -22,17 +22,8 @@ export async function runThreadRoundtable(
   opts?: { autoSynthesize?: boolean },
 ): Promise<void> {
   const { threadBranchConvId } = get();
-  console.log("[rt-debug] runThreadRoundtable entry", {
-    command, threadBranchConvId,
-    participants: participants.length,
-    mode, autoSynthesize: opts?.autoSynthesize,
-  });
-  if (!threadBranchConvId) {
-    console.warn("[rt-debug] runThreadRoundtable EARLY RETURN — threadBranchConvId null");
-    return;
-  }
+  if (!threadBranchConvId) return;
   if (get().runningThreadIds.includes(threadBranchConvId)) {
-    console.log("[rt-debug] runThreadRoundtable ENQUEUED (already running)");
     get()._enqueue(threadBranchConvId, prompt.slice(0, 30), () =>
       command === "start_roundtable_run"
         ? get().sendThreadRoundtable(prompt, participants, mode, opts)
@@ -41,7 +32,6 @@ export async function runThreadRoundtable(
     return;
   }
   get()._startRun(threadBranchConvId);
-  console.log("[rt-debug] runThreadRoundtable _startRun called");
   const now = Date.now();
   set((state) => ({
     threadMessages: [
@@ -150,11 +140,8 @@ export async function runThreadRoundtable(
   });
 
   try {
-    console.log("[rt-debug] invoking Rust command", command);
-    const result = await invoke<{ messageId: string }>(command, { input: { conversationId: threadBranchConvId, prompt, participants, mode, autoSynthesize: opts?.autoSynthesize } });
-    console.log("[rt-debug] Rust command returned", result);
+    await invoke<{ messageId: string }>(command, { input: { conversationId: threadBranchConvId, prompt, participants, mode, autoSynthesize: opts?.autoSynthesize } });
   } catch (e) {
-    console.error("[rt-debug] Rust command FAILED", e);
     cleanup();
     set({ error: errorMessage(e), rtParticipantStatuses: new Map(), rtStatusConversationId: null });
     get()._endRun(threadBranchConvId);

--- a/src/tests/workflowOrchestration.test.ts
+++ b/src/tests/workflowOrchestration.test.ts
@@ -396,7 +396,7 @@ describe("startReviewRT", () => {
     // RT config should include both engines
     const saveCall = (invoke as any).mock.calls.find((c: string[]) => c[0] === "save_rt_config");
     expect(saveCall).toBeDefined();
-    const config = JSON.parse(saveCall[1].config);
+    const config = JSON.parse(saveCall[1].configJson);
     expect(config.participants.length).toBe(2);
     expect(config.participants[0].engine).toBe("gemini");
     expect(config.participants[1].engine).toBe("ollama");


### PR DESCRIPTION
사용자 콘솔 에러 직접 포착: `invalid args configJson for command save_rt_config: command save_rt_config missing required key configJson`.

## 원인
FE `reviewWorkflow.ts:130` 이 `config` 키로 보냄, Rust 는 camelCase rename 으로 `configJson` 요구. 다른 호출자는 정상.

## 수정
`configJson` 으로 교체. PR #70 진단 로그 rollback (원인 확정).

## 영향
Review RT 실제로 실행됨 → 드로어에 메시지 표시 + plan 이 정상 review 상태.
