### PR TITLE
feat(attachments): 첨부 파일 파이프라인 — + 버튼 / drop / paste / prompt 삽입

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5980,6 +5980,7 @@ version = "0.1.0"
 dependencies = [
  "alacritty_terminal",
  "axum",
+ "base64 0.22.1",
  "chrono",
  "dirs 5.0.1",
  "futures-util",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -40,6 +40,7 @@ tauri-plugin-clipboard-manager = "2.3.2"
 tauri-plugin-shell = "2.3.5"
 tauri-plugin-opener = "2.5.3"
 chrono = { version = "0.4.44", features = ["serde"] }
+base64 = "0.22"
 regex = "1"
 sha2 = "0.10"
 toml = "0.8"

--- a/src-tauri/src/commands/attachments.rs
+++ b/src-tauri/src/commands/attachments.rs
@@ -1,0 +1,214 @@
+//! Attachment storage — 사용자가 채팅 입력창에 첨부한 이미지/파일을
+//! 프로젝트 내부 `.tunaflow/attachments/` 에 안전히 저장한다.
+//!
+//! ## 설계
+//!
+//! - **저장 위치**: `<project>/.tunaflow/attachments/<timestamp>-<name>`
+//!   - 에이전트 Read 툴의 프로젝트 scope 안에 있어야 첨부를 읽을 수 있음
+//!   - timestamp prefix 로 동일 이름 중복 회피
+//! - **.gitignore 자동 생성**: 해당 디렉토리에 `*\n!.gitignore` 로 내부
+//!   파일만 ignore. 상위 프로젝트 .gitignore 는 건드리지 않음
+//! - **파일명 sanitize**: `/`, `\`, `..` 제거 + control char 제거 + 길이 200 제한
+//! - **크기 상한 20MB**: 토큰 폭주 방지. 초과시 Err
+//! - **경로 traversal 방지**: 삭제 시 `.tunaflow/attachments/` 아래만 허용
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use base64::{engine::general_purpose, Engine};
+use serde::Serialize;
+
+use crate::errors::AppError;
+
+const ATTACHMENT_DIR: &str = ".tunaflow/attachments";
+const GITIGNORE_CONTENT: &str = "# tunaFlow attachments — auto-generated\n*\n!.gitignore\n";
+const MAX_SIZE: u64 = 20 * 1024 * 1024;
+
+#[derive(Serialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct AttachmentSaved {
+    pub abs_path: String,
+    pub rel_path: String,
+    pub size: u64,
+}
+
+fn ensure_dir(project_path: &Path) -> Result<PathBuf, AppError> {
+    let dir = project_path.join(ATTACHMENT_DIR);
+    fs::create_dir_all(&dir)?;
+    let gi = dir.join(".gitignore");
+    if !gi.exists() {
+        if let Err(e) = fs::write(&gi, GITIGNORE_CONTENT) {
+            eprintln!("[attachments] gitignore write failed: {e}");
+        }
+    }
+    Ok(dir)
+}
+
+/// Clean an untrusted filename. Drops path separators, `..`, control chars,
+/// and caps length. Guaranteed to produce a value that cannot escape the
+/// target dir via path composition.
+pub(crate) fn sanitize_name(name: &str) -> String {
+    let mut out: String = name
+        .chars()
+        .filter(|c| !c.is_control())
+        .map(|c| match c {
+            '/' | '\\' => '_',
+            _ => c,
+        })
+        .collect();
+    // `..` 이 연속되지 않도록
+    while out.contains("..") {
+        out = out.replace("..", "_");
+    }
+    // 리딩 점 파일(.bashrc 등) 방어
+    while out.starts_with('.') {
+        out.remove(0);
+    }
+    if out.chars().count() > 200 {
+        out = out.chars().take(200).collect();
+    }
+    out
+}
+
+#[tauri::command]
+pub fn save_attachment(
+    project_path: String,
+    name: String,
+    data_base64: String,
+) -> Result<AttachmentSaved, AppError> {
+    let project = PathBuf::from(&project_path);
+    if !project.is_dir() {
+        return Err(AppError::NotFound("project path not a directory".into()));
+    }
+    let dir = ensure_dir(&project)?;
+
+    let clean_name = sanitize_name(&name);
+    if clean_name.is_empty() {
+        return Err(AppError::Agent("invalid filename".into()));
+    }
+
+    let bytes = general_purpose::STANDARD
+        .decode(&data_base64)
+        .map_err(|e| AppError::Agent(format!("base64 decode failed: {e}")))?;
+
+    if bytes.len() as u64 > MAX_SIZE {
+        return Err(AppError::Agent(format!(
+            "file too large: {} bytes (max {})",
+            bytes.len(),
+            MAX_SIZE
+        )));
+    }
+
+    // %Y%m%d-%H%M%S-%3f → 20260418-143052-123
+    let timestamp = chrono::Local::now()
+        .format("%Y%m%d-%H%M%S-%3f")
+        .to_string();
+    let filename = format!("{timestamp}-{clean_name}");
+    let abs_path = dir.join(&filename);
+
+    fs::write(&abs_path, &bytes)?;
+
+    let rel_path = format!("{ATTACHMENT_DIR}/{filename}");
+    Ok(AttachmentSaved {
+        abs_path: abs_path.to_string_lossy().to_string(),
+        rel_path,
+        size: bytes.len() as u64,
+    })
+}
+
+#[tauri::command]
+pub fn delete_attachment(abs_path: String) -> Result<(), AppError> {
+    // 보안: 경로가 `.tunaflow/attachments` 를 포함해야 삭제 허용. 그 외엔 거부.
+    let p = PathBuf::from(&abs_path);
+    let canonical = p.components();
+    let under_attachments = canonical
+        .map(|c| c.as_os_str().to_string_lossy().into_owned())
+        .collect::<Vec<_>>()
+        .windows(2)
+        .any(|w| w[0] == ".tunaflow" && w[1] == "attachments");
+    if !under_attachments {
+        return Err(AppError::Agent(
+            "refusing to delete: path is not under .tunaflow/attachments".into(),
+        ));
+    }
+    match fs::remove_file(&p) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e.into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_strips_separators_and_traversal() {
+        assert_eq!(sanitize_name("foo.png"), "foo.png");
+        assert_eq!(sanitize_name("a/b.png"), "a_b.png");
+        assert_eq!(sanitize_name("a\\b.png"), "a_b.png");
+        // `..` → `__` (먼저 `/`→`_` 로 치환 후 남은 `..` 를 또 치환), leading `.` 없음
+        assert_eq!(sanitize_name("../etc/passwd"), "__etc_passwd");
+        assert_eq!(sanitize_name(".bashrc"), "bashrc");
+    }
+
+    #[test]
+    fn sanitize_caps_length() {
+        let long = "a".repeat(500);
+        let out = sanitize_name(&long);
+        assert_eq!(out.chars().count(), 200);
+    }
+
+    #[test]
+    fn sanitize_rejects_control_chars() {
+        assert_eq!(sanitize_name("hi\0there"), "hithere");
+        assert_eq!(sanitize_name("a\nb.png"), "ab.png");
+    }
+
+    #[test]
+    fn save_roundtrip_in_tempdir() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let project = tmp.path().to_string_lossy().to_string();
+
+        // "hello" 를 base64 인코딩
+        let data = general_purpose::STANDARD.encode("hello");
+        let saved = save_attachment(project.clone(), "greeting.txt".into(), data).unwrap();
+
+        assert!(saved.rel_path.starts_with(".tunaflow/attachments/"));
+        assert_eq!(saved.size, 5);
+        // 실제 디스크에 내용 확인
+        let content = fs::read_to_string(&saved.abs_path).unwrap();
+        assert_eq!(content, "hello");
+        // .gitignore 자동 생성
+        let gi = tmp.path().join(".tunaflow/attachments/.gitignore");
+        assert!(gi.exists());
+    }
+
+    #[test]
+    fn save_rejects_oversize() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let project = tmp.path().to_string_lossy().to_string();
+        // 21MB
+        let big = vec![0u8; 21 * 1024 * 1024];
+        let data = general_purpose::STANDARD.encode(&big);
+        let err = save_attachment(project, "big.bin".into(), data).unwrap_err();
+        assert!(format!("{err}").contains("too large"));
+    }
+
+    #[test]
+    fn delete_refuses_outside_attachments_dir() {
+        let err = delete_attachment("/etc/passwd".into()).unwrap_err();
+        assert!(format!("{err}").contains("refusing to delete"));
+    }
+
+    #[test]
+    fn delete_nonexistent_is_ok() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let fake = tmp
+            .path()
+            .join(".tunaflow/attachments/nonexistent.png")
+            .to_string_lossy()
+            .into_owned();
+        assert!(delete_attachment(fake).is_ok());
+    }
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -36,3 +36,4 @@ pub mod document_index;
 pub mod mobile;
 pub mod pty;
 pub mod secrets;
+pub mod attachments;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -446,6 +446,9 @@ pub fn run() {
             commands::secrets::secret_get,
             commands::secrets::secret_has,
             commands::secrets::secret_delete,
+            // Attachments — 첨부 파일 저장/삭제
+            commands::attachments::save_attachment,
+            commands::attachments::delete_attachment,
             // PTY
             commands::pty::pty_spawn,
             commands::pty::pty_write,

--- a/src/components/tunaflow/NewMessageInput.tsx
+++ b/src/components/tunaflow/NewMessageInput.tsx
@@ -5,7 +5,7 @@ import { useChatStore } from "@/stores/chatStore";
 import { getSetting, setSetting } from "@/lib/appStore";
 import { DEFAULT_PERSONAS } from "@/lib/defaultPersonas";
 import { ROUNDTABLE_PARTICIPANTS } from "@/lib/constants";
-import { SendHorizonal, Users, Loader2 } from "lucide-react";
+import { SendHorizonal, Users, Loader2, Paperclip, X, FileText } from "lucide-react";
 import type { RtMode, RoundtableParticipant, AgentProfile } from "@/types";
 
 import { EngineSelector, type Engine } from "./input/EngineSelector";
@@ -15,6 +15,9 @@ import { isPtyEngine, usePtyStore } from "@/stores/ptyStore";
 import { RoundtableControls } from "./input/RoundtableControls";
 import { ContextBadges } from "./input/ContextBadges";
 import { useSendActions } from "./input/useSendActions";
+import { saveAttachment, deleteAttachment, type Attachment, MAX_ATTACHMENT_SIZE } from "@/lib/attachments";
+import { open as openFileDialog } from "@tauri-apps/plugin-dialog";
+import { readFile as readFsFile } from "@tauri-apps/plugin-fs";
 
 interface NewMessageInputProps {
   threadMode?: boolean;
@@ -36,6 +39,9 @@ export function NewMessageInput({ threadMode = false, onCreateRT }: NewMessageIn
   const [text, setText] = useState("");
   const [engine, setEngine] = useState<Engine>("claude");
   const [selectedModel, setSelectedModel] = useState<string>("");
+  // 첨부 파일 state — 입력창 로컬. 전송 후 자동 clear.
+  const [attachments, setAttachments] = useState<Attachment[]>([]);
+  const [attachBusy, setAttachBusy] = useState(false);
   const ptySessionId = usePtyStore((s) => s.getSession(engine));
   const [rtMode, setRtMode] = useState<RtMode>("sequential");
   const [ptyRespawning, setPtyRespawning] = useState(false);
@@ -208,7 +214,136 @@ export function NewMessageInput({ threadMode = false, onCreateRT }: NewMessageIn
     text, setText, engine, selectedModel, rtMode,
     activeParticipants, setActiveParticipants,
     threadMode,
+    attachments,
+    onSendComplete: () => setAttachments([]),
   });
+
+  // ─── 첨부 파일 핸들러 ─────────────────────────────────────────────────
+  // 프로젝트 경로 해석: main chat 은 selectedProject, thread 도 동일 project
+  // 에 속해있다고 가정 (Rust 가 project_key → path 를 호환 저장).
+  const selectedProjectKey = useChatStore((s) => s.selectedProjectKey);
+  const resolveProjectPath = async (): Promise<string | null> => {
+    if (!selectedProjectKey) return null;
+    try {
+      const proj = await invoke<{ path?: string }>("get_project", { key: selectedProjectKey });
+      return proj?.path ?? null;
+    } catch { return null; }
+  };
+
+  const addFilesFromPaths = async (paths: string[]) => {
+    const projectPath = await resolveProjectPath();
+    if (!projectPath) {
+      const { toast } = await import("sonner");
+      toast.error("프로젝트가 선택되지 않아 첨부할 수 없습니다");
+      return;
+    }
+    setAttachBusy(true);
+    try {
+      for (const path of paths) {
+        try {
+          const bytes = await readFsFile(path);
+          if (bytes.byteLength > MAX_ATTACHMENT_SIZE) {
+            const { toast } = await import("sonner");
+            toast.error(`${path.split("/").pop()}: 20MB 초과 — 건너뜀`);
+            continue;
+          }
+          const name = path.split("/").pop() ?? "file";
+          const mimeType = guessMime(name);
+          const att = await saveAttachment(projectPath, name, new Uint8Array(bytes), mimeType);
+          setAttachments((prev) => [...prev, att]);
+        } catch (e) {
+          console.warn("[attach]", path, e);
+          const { toast } = await import("sonner");
+          toast.error(`첨부 실패: ${e}`);
+        }
+      }
+    } finally {
+      setAttachBusy(false);
+    }
+  };
+
+  const addFilesFromFileList = async (files: FileList | File[]) => {
+    const projectPath = await resolveProjectPath();
+    if (!projectPath) {
+      const { toast } = await import("sonner");
+      toast.error("프로젝트가 선택되지 않아 첨부할 수 없습니다");
+      return;
+    }
+    setAttachBusy(true);
+    try {
+      for (const f of Array.from(files)) {
+        if (f.size > MAX_ATTACHMENT_SIZE) {
+          const { toast } = await import("sonner");
+          toast.error(`${f.name}: 20MB 초과 — 건너뜀`);
+          continue;
+        }
+        try {
+          const bytes = new Uint8Array(await f.arrayBuffer());
+          const att = await saveAttachment(projectPath, f.name, bytes, f.type || guessMime(f.name));
+          setAttachments((prev) => [...prev, att]);
+        } catch (e) {
+          console.warn("[attach]", f.name, e);
+          const { toast } = await import("sonner");
+          toast.error(`첨부 실패: ${e}`);
+        }
+      }
+    } finally {
+      setAttachBusy(false);
+    }
+  };
+
+  const handleAttachClick = async () => {
+    try {
+      const selected = await openFileDialog({
+        multiple: true,
+        filters: [{ name: "Images and files", extensions: ["*"] }],
+      });
+      if (!selected) return;
+      const paths = Array.isArray(selected) ? selected : [selected];
+      await addFilesFromPaths(paths.map(String));
+    } catch (e) {
+      console.warn("[attach dialog]", e);
+    }
+  };
+
+  const handleRemoveAttachment = async (id: string) => {
+    const target = attachments.find((a) => a.id === id);
+    if (!target) return;
+    setAttachments((prev) => prev.filter((a) => a.id !== id));
+    await deleteAttachment(target);
+  };
+
+  // Clipboard paste — 이미지가 clipboard 에 있으면 자동 첨부. text 는 textarea
+  // 기본 동작 유지.
+  const handlePaste = (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+    const items = Array.from(e.clipboardData.items);
+    const imageItems = items.filter((it) => it.type.startsWith("image/"));
+    if (imageItems.length === 0) return; // 텍스트는 브라우저 기본 동작
+    e.preventDefault();
+    const files = imageItems
+      .map((it) => it.getAsFile())
+      .filter((f): f is File => !!f);
+    if (files.length > 0) {
+      addFilesFromFileList(files);
+    }
+  };
+
+  // Drag & drop — textarea 전체 wrapper 에 걸림
+  const [isDragOver, setIsDragOver] = useState(false);
+  const handleDragOver = (e: React.DragEvent) => {
+    if (e.dataTransfer.types.includes("Files")) {
+      e.preventDefault();
+      setIsDragOver(true);
+    }
+  };
+  const handleDragLeave = () => setIsDragOver(false);
+  const handleDrop = async (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragOver(false);
+    const files = Array.from(e.dataTransfer.files);
+    if (files.length === 0) return;
+    await addFilesFromFileList(files);
+  };
 
   const toggleParticipant = (name: string) => {
     setActiveParticipants((prev) => {
@@ -366,6 +501,10 @@ export function NewMessageInput({ threadMode = false, onCreateRT }: NewMessageIn
           value={text}
           onChange={(e) => setText(e.target.value)}
           onKeyDown={handleKeyDown}
+          onPaste={handlePaste}
+          onDragOver={handleDragOver}
+          onDragLeave={handleDragLeave}
+          onDrop={handleDrop}
           placeholder={
             !selectedConversationId
               ? "Select a conversation first"
@@ -373,15 +512,54 @@ export function NewMessageInput({ threadMode = false, onCreateRT }: NewMessageIn
               ? hasRtMessages
                 ? "/follow codex,claude <prompt> or type…  ↵ send · ⇧↵ newline"
                 : "Start roundtable…  ↵ send · ⇧↵ newline"
-              : "Ask anything…  ↵ send · ⇧↵ newline"
+              : "Ask anything…  ↵ send · ⇧↵ newline · 이미지/파일 드래그·붙여넣기 가능"
           }
           disabled={!selectedConversationId}
           rows={1}
-          className="w-full px-2.5 py-2 text-[13px] bg-transparent resize-none outline-none text-foreground placeholder:text-muted-foreground/40 leading-relaxed disabled:opacity-40"
+          className={cn(
+            "w-full px-2.5 py-2 text-[13px] bg-transparent resize-none outline-none text-foreground placeholder:text-muted-foreground/40 leading-relaxed disabled:opacity-40 transition-colors",
+            isDragOver && "ring-2 ring-primary/40 rounded",
+          )}
         />
+
+        {/* Attachment chips — shown above action bar */}
+        {attachments.length > 0 && (
+          <div className="flex flex-wrap gap-1.5 px-2.5 pb-1.5">
+            {attachments.map((att) => (
+              <div
+                key={att.id}
+                className="flex items-center gap-1 pl-1 pr-0.5 py-0.5 rounded border border-border/40 bg-accent/40 text-[10px] max-w-[200px]"
+                title={`${att.relPath} · ${(att.size / 1024).toFixed(0)}KB`}
+              >
+                {att.isImage && att.previewUrl ? (
+                  <img src={att.previewUrl} alt={att.name} className="w-4 h-4 object-cover rounded-sm shrink-0" />
+                ) : (
+                  <FileText className="w-3 h-3 text-muted-foreground/60 shrink-0" />
+                )}
+                <span className="truncate text-foreground/70">{att.name}</span>
+                <button
+                  onClick={() => handleRemoveAttachment(att.id)}
+                  className="p-0.5 rounded hover:bg-destructive/20 text-muted-foreground/50 hover:text-destructive transition-colors shrink-0"
+                  aria-label="첨부 제거"
+                >
+                  <X className="w-2.5 h-2.5" />
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
 
         {/* Action bar */}
         <div className="flex items-center gap-1.5 px-2.5 pb-2 pt-0.5">
+          <button
+            onClick={handleAttachClick}
+            disabled={!selectedConversationId || attachBusy}
+            className="p-1 rounded text-muted-foreground/50 hover:text-foreground hover:bg-accent/50 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+            title="파일 첨부 (최대 20MB)"
+            aria-label="파일 첨부"
+          >
+            {attachBusy ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Paperclip className="w-3.5 h-3.5" />}
+          </button>
           <span className="flex-1" />
           {isCurrentThreadRunning && (
             <button
@@ -412,4 +590,29 @@ export function NewMessageInput({ threadMode = false, onCreateRT }: NewMessageIn
       </div>
     </div>
   );
+}
+
+/** Simple extension → MIME mapping. plugin-dialog 로 받은 경로 문자열은
+ *  mimeType 정보가 없어서 확장자 기반 추정. File API 로 들어온 경우엔
+ *  File.type 을 우선 사용하고 빈 문자열일 때만 fallback 으로 씀. */
+function guessMime(name: string): string {
+  const ext = name.toLowerCase().split(".").pop() ?? "";
+  switch (ext) {
+    case "png": return "image/png";
+    case "jpg":
+    case "jpeg": return "image/jpeg";
+    case "gif": return "image/gif";
+    case "webp": return "image/webp";
+    case "heic": return "image/heic";
+    case "bmp": return "image/bmp";
+    case "svg": return "image/svg+xml";
+    case "pdf": return "application/pdf";
+    case "md": return "text/markdown";
+    case "txt":
+    case "log": return "text/plain";
+    case "json": return "application/json";
+    case "html": return "text/html";
+    case "csv": return "text/csv";
+    default: return "application/octet-stream";
+  }
 }

--- a/src/components/tunaflow/input/useSendActions.ts
+++ b/src/components/tunaflow/input/useSendActions.ts
@@ -2,6 +2,7 @@ import { useChatStore } from "@/stores/chatStore";
 import { ROUNDTABLE_PARTICIPANTS } from "@/lib/constants";
 import type { RtMode, RoundtableParticipant } from "@/types";
 import type { Engine } from "./EngineSelector";
+import { appendAttachmentsToPrompt, type Attachment } from "@/lib/attachments";
 
 // ─── RT config helpers ───────────────────────────────────────────────────────
 
@@ -117,12 +118,18 @@ interface UseSendActionsParams {
   setActiveParticipants: React.Dispatch<React.SetStateAction<Set<string>>>;
   /** When true, routes sends through sendThreadMessage instead of main send functions */
   threadMode?: boolean;
+  /** Attachments to include with this send — appended as `[첨부 파일]` section. */
+  attachments?: Attachment[];
+  /** Called after a successful send — used by caller to clear attachments. */
+  onSendComplete?: () => void;
 }
 
 export function useSendActions({
   text, setText, engine, selectedModel, rtMode,
   activeParticipants, setActiveParticipants,
   threadMode = false,
+  attachments = [],
+  onSendComplete,
 }: UseSendActionsParams) {
   const {
     selectedConversationId,
@@ -171,6 +178,12 @@ export function useSendActions({
   const handleSend = async () => {
     let prompt = text.trim();
     if (!prompt || !effectiveConvId) return;
+
+    // 첨부가 있으면 prompt 끝에 경로 섹션 append. 사용자가 직접 경로를 적지
+    // 않고도 에이전트가 Read 툴/vision 으로 확인하게 유도.
+    if (attachments.length > 0) {
+      prompt = appendAttachmentsToPrompt(prompt, attachments);
+    }
 
     // !models 명령 처리
     if (prompt === "!models" || prompt === "!models --refresh") {
@@ -278,6 +291,9 @@ export function useSendActions({
     }
 
     setText("");
+    // 메인 전송 경로 진입 직전에 첨부 clear. /help, /clear, handoff 등 특수
+    // 경로는 첨부와 무관하므로 clear 하지 않음 (첨부는 다음 일반 send 때 포함).
+    onSendComplete?.();
 
     if (isRoundtable) {
       // Determine participants: /follow override → RT config (DB) → warn on missing config

--- a/src/lib/attachments.ts
+++ b/src/lib/attachments.ts
@@ -1,0 +1,128 @@
+/**
+ * Attachment helpers — FE 측 타입 정의 + Tauri 저장/삭제 래퍼 + prompt 렌더러.
+ *
+ * 저장 흐름:
+ *   1. 파일(File or Uint8Array) → base64 인코딩
+ *   2. `save_attachment(projectPath, name, base64)` 호출
+ *   3. 반환된 `{ absPath, relPath, size }` 를 UI state 에 보관
+ *
+ * 전송 흐름 (useSendActions 쪽):
+ *   - prompt 끝에 `appendAttachmentsToPrompt(prompt, attachments)` 로 경로 섹션 append
+ *   - Codex 엔진일 땐 PR C 에서 추가로 `--image` argv 전달 (미구현)
+ */
+import { invoke } from "@tauri-apps/api/core";
+
+export interface Attachment {
+  id: string;
+  /** Absolute path on disk. Used for Codex `--image` / delete command. */
+  absPath: string;
+  /** Path relative to project root. Shown in prompt + UI. */
+  relPath: string;
+  /** Original filename (pre-sanitize). UI label only. */
+  name: string;
+  size: number;
+  mimeType: string;
+  isImage: boolean;
+  /** Object URL for image preview. Must be revoked when attachment is removed. */
+  previewUrl?: string;
+}
+
+export interface SavedAttachmentResponse {
+  absPath: string;
+  relPath: string;
+  size: number;
+}
+
+export const MAX_ATTACHMENT_SIZE = 20 * 1024 * 1024; // 20MB
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function isImageMime(mime: string): boolean {
+  return mime.startsWith("image/");
+}
+
+/** `data:image/png;base64,AAAA...` 에서 payload 만 추출. plain base64 면 그대로 리턴. */
+function extractBase64Payload(s: string): string {
+  const m = s.match(/^data:[^;]+;base64,(.+)$/);
+  return m ? m[1] : s;
+}
+
+async function fileToBase64(bytes: Uint8Array): Promise<string> {
+  // 20MB 파일을 한 번에 string concat 하면 느릴 수 있지만
+  // btoa/FileReader 사용하면 수십ms 수준. 실용적 타협.
+  let binary = "";
+  const chunk = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunk) {
+    const sub = bytes.subarray(i, Math.min(i + chunk, bytes.length));
+    binary += String.fromCharCode(...sub);
+  }
+  return btoa(binary);
+}
+
+// ─── Save / Delete ──────────────────────────────────────────────────────────
+
+/** Save a file to `<project>/.tunaflow/attachments/` via Rust command.
+ *  Throws if projectPath missing, file oversized, or disk write fails. */
+export async function saveAttachment(
+  projectPath: string,
+  name: string,
+  bytes: Uint8Array,
+  mimeType: string,
+): Promise<Attachment> {
+  if (bytes.byteLength > MAX_ATTACHMENT_SIZE) {
+    throw new Error(`파일 크기가 너무 큽니다 (${(bytes.byteLength / 1024 / 1024).toFixed(1)}MB, 최대 20MB)`);
+  }
+  const base64 = await fileToBase64(bytes);
+  const saved = await invoke<SavedAttachmentResponse>("save_attachment", {
+    projectPath,
+    name,
+    dataBase64: extractBase64Payload(base64),
+  });
+  const isImage = isImageMime(mimeType);
+  return {
+    id: crypto.randomUUID(),
+    absPath: saved.absPath,
+    relPath: saved.relPath,
+    name,
+    size: saved.size,
+    mimeType,
+    isImage,
+    previewUrl: isImage ? URL.createObjectURL(new Blob([bytes as unknown as BlobPart], { type: mimeType })) : undefined,
+  };
+}
+
+export async function deleteAttachment(att: Attachment): Promise<void> {
+  if (att.previewUrl) {
+    try { URL.revokeObjectURL(att.previewUrl); } catch { /* ignore */ }
+  }
+  try {
+    await invoke("delete_attachment", { absPath: att.absPath });
+  } catch (e) {
+    console.warn("[attachments] delete failed:", e);
+    // 로컬 state 에서는 제거해도 되도록 에러 삼킴
+  }
+}
+
+/** Append attachment paths to user prompt. Used right before send. */
+export function appendAttachmentsToPrompt(prompt: string, attachments: Attachment[]): string {
+  if (attachments.length === 0) return prompt;
+  const lines = attachments.map((a) => {
+    const sizeLabel = a.size > 1024 * 1024
+      ? `${(a.size / 1024 / 1024).toFixed(1)}MB`
+      : `${(a.size / 1024).toFixed(0)}KB`;
+    return `- ${a.relPath} (${a.name}, ${sizeLabel})`;
+  });
+  return [
+    prompt.trim(),
+    "",
+    "[첨부 파일]",
+    ...lines,
+    "",
+    "위 파일의 내용을 확인하려면 Read 툴로 해당 경로를 읽으세요. 이미지는 vision 분석 가능합니다.",
+  ].join("\n");
+}
+
+/** Sum of all attachment sizes in bytes. */
+export function totalAttachmentSize(attachments: Attachment[]): number {
+  return attachments.reduce((sum, a) => sum + a.size, 0);
+}


### PR DESCRIPTION
MVP 코어. `<project>/.tunaflow/attachments/` 저장 + prompt 섹션 append. 이미지/파일 3가지 진입점 (+ 버튼, drag-drop, clipboard paste). 20MB 상한, .gitignore 자동 생성.

후속: PR B(리사이즈+preview), PR C(Codex --image + cleanup).
