### PR TITLE
feat(memory): semantic search on sliding-window chunks + dead_code removal

### DIFF
--- a/src-tauri/src/commands/vector_search/index.rs
+++ b/src-tauri/src/commands/vector_search/index.rs
@@ -1,6 +1,5 @@
 //! Conversation indexing — builds sliding-window chunks and stores embeddings.
 
-use rusqlite::Connection;
 use uuid::Uuid;
 
 use crate::agents::embedder;
@@ -92,97 +91,6 @@ pub(super) fn build_sliding_window_chunks(
 }
 
 // ─── Core indexing functions ──────────────────────────────────────────────────
-
-/// Build and store conversation chunks with embeddings.
-///
-/// Extracts user+assistant pairs from messages, embeds each pair,
-/// and stores in `conversation_chunks`. Replaces existing chunks for the conversation.
-#[allow(dead_code)]
-pub fn index_conversation(
-    conn: &Connection,
-    conversation_id: &str,
-    project_key: &str,
-) -> Result<usize, AppError> {
-    conn.execute(
-        "DELETE FROM conversation_chunks WHERE conversation_id = ?1",
-        [conversation_id],
-    )?;
-
-    let mut stmt = conn.prepare(
-        "SELECT id, role, content FROM messages
-         WHERE conversation_id = ?1
-         ORDER BY timestamp ASC",
-    )?;
-    let messages: Vec<(String, String, String)> = stmt
-        .query_map([conversation_id], |row| {
-            Ok((row.get(0)?, row.get(1)?, row.get(2)?))
-        })?
-        .filter_map(|r| r.ok())
-        .collect();
-
-    if messages.is_empty() {
-        return Ok(0);
-    }
-
-    // Build chunks: user+assistant pairs (skip workflow auto-generated prompts)
-    let mut chunks: Vec<(String, String, String)> = Vec::new();
-    let mut i = 0;
-    while i < messages.len() {
-        let (ref id, ref role, ref content) = messages[i];
-        if is_workflow_prompt(content) {
-            i += 1;
-            continue;
-        }
-        if role == "user" && i + 1 < messages.len() && messages[i + 1].1 == "assistant" {
-            let user_text = truncate_str(content, 200);
-            let asst_text = truncate_str(&messages[i + 1].2, 200);
-            let text = format!("Q: {}\nA: {}", user_text, asst_text);
-            chunks.push((id.clone(), "pair".to_string(), text));
-            i += 2;
-        } else {
-            let text = truncate_str(content, 300);
-            if text.len() >= 20 {
-                chunks.push((id.clone(), "anchor".to_string(), text));
-            }
-            i += 1;
-        }
-    }
-
-    if chunks.is_empty() {
-        return Ok(0);
-    }
-
-    let now = now_epoch_ms();
-    let mut indexed = 0;
-
-    for (root_id, kind, text) in &chunks {
-        let embedding = match embedder::embed_text(text, false) {
-            Ok(v) => v,
-            Err(e) => {
-                eprintln!("[vector] embed failed for chunk {}: {:?}", root_id, e);
-                continue;
-            }
-        };
-
-        let embedding_blob = embedding_to_blob(&embedding);
-        let id = Uuid::new_v4().to_string();
-
-        conn.execute(
-            "INSERT INTO conversation_chunks (id, project_key, conversation_id, kind, root_message_id, text_preview, embedding, created_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
-            rusqlite::params![id, project_key, conversation_id, kind, root_id, text, embedding_blob, now],
-        )?;
-        indexed += 1;
-    }
-
-    eprintln!(
-        "[vector] indexed {} chunks for {} (from {} messages)",
-        indexed,
-        conversation_id,
-        messages.len()
-    );
-    Ok(indexed)
-}
 
 /// Index a conversation's messages as vector chunks.
 /// Uses 3-phase lock strategy to prevent Mutex poison:

--- a/src-tauri/src/commands/vector_search/mod.rs
+++ b/src-tauri/src/commands/vector_search/mod.rs
@@ -7,7 +7,7 @@
 //! Sub-modules:
 //! - `helpers`: truncate_str, embedding_to_blob, blob_to_embedding, content classifiers
 //! - `index`: sliding-window chunking + index_conversation_chunks (Tauri command)
-//! - `query`: search_similar, vec0 KNN, brute-force, search_conversation_vectors (Tauri command)
+//! - `query`: search_similar, vec0 KNN, brute-force, search_conversation_vectors, search_memory_semantic (Tauri commands)
 
 mod backfill;
 mod helpers;

--- a/src-tauri/src/commands/vector_search/query.rs
+++ b/src-tauri/src/commands/vector_search/query.rs
@@ -191,6 +191,138 @@ pub fn search_conversation_vectors(
     ))
 }
 
+// ─── Memory semantic search (within a single conversation) ────────────────────
+
+/// A hit returned by `search_memory_semantic` — the semantic replacement for
+/// substring-matching `list_memory_topics`. Unlike `VectorChunk`, this is
+/// conversation-scoped and always kind='window' (v39 cleaned up legacy kinds).
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MemorySearchHit {
+    pub chunk_id: String,
+    pub text: String,
+    pub score: f32,
+    /// Timestamp of the root message that anchors this chunk (epoch ms).
+    pub timestamp: Option<i64>,
+}
+
+/// Search for semantically similar chunks **within a single conversation**.
+/// Restricted to kind='window' (sliding-window summaries of 3-turn context).
+/// Tries vec0 KNN first; falls back to brute-force cosine on the conv's chunks.
+pub fn search_within_conversation(
+    conn: &Connection,
+    query_embedding: &[f32],
+    conversation_id: &str,
+    limit: usize,
+) -> Vec<MemorySearchHit> {
+    let query_blob = embedding_to_blob(query_embedding);
+
+    // Try sqlite-vec KNN first
+    let vec0_sql = "
+        SELECT cc.id, cc.text_preview, cc.root_message_id, vc.distance
+        FROM vec_chunks vc
+        JOIN conversation_chunks cc ON cc.rowid = vc.rowid
+        WHERE vc.embedding MATCH ?1
+          AND cc.conversation_id = ?2
+          AND cc.kind = 'window'
+          AND vc.k = ?3
+        ORDER BY vc.distance
+    ";
+    let fetch_limit = limit.saturating_mul(2).max(limit);
+    if let Ok(mut stmt) = conn.prepare(vec0_sql) {
+        let rows: Vec<(String, String, String, f64)> = stmt
+            .query_map(
+                rusqlite::params![query_blob, conversation_id, fetch_limit as i64],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .map(|rows| rows.filter_map(|r| r.ok()).collect())
+            .unwrap_or_default();
+
+        if !rows.is_empty() {
+            let mut hits: Vec<MemorySearchHit> = Vec::with_capacity(limit);
+            for (chunk_id, text, root_msg_id, distance) in rows.into_iter().take(limit) {
+                let score = 1.0 - (distance as f32 / 2.0);
+                let timestamp = conn
+                    .query_row(
+                        "SELECT timestamp FROM messages WHERE id = ?1",
+                        [&root_msg_id],
+                        |r| r.get::<_, i64>(0),
+                    )
+                    .ok();
+                hits.push(MemorySearchHit { chunk_id, text, score, timestamp });
+            }
+            return hits;
+        }
+    }
+
+    // Fallback: brute-force cosine on chunks of this conversation only
+    let Ok(mut stmt) = conn.prepare(
+        "SELECT cc.id, cc.text_preview, cc.embedding, cc.root_message_id
+         FROM conversation_chunks cc
+         WHERE cc.conversation_id = ?1
+           AND cc.kind = 'window'
+           AND cc.embedding IS NOT NULL",
+    ) else { return Vec::new(); };
+
+    let mut scored: Vec<(MemorySearchHit, String)> = stmt
+        .query_map([conversation_id], |row| {
+            let id: String = row.get(0)?;
+            let text: String = row.get(1)?;
+            let blob: Vec<u8> = row.get(2)?;
+            let root_msg_id: String = row.get(3)?;
+            Ok((id, text, blob, root_msg_id))
+        })
+        .map(|rows| {
+            rows.filter_map(|r| r.ok())
+                .filter_map(|(id, text, blob, root_msg_id)| {
+                    let embedding = blob_to_embedding(&blob)?;
+                    let score = crate::agents::rawq::cosine_similarity(query_embedding, &embedding);
+                    Some((MemorySearchHit { chunk_id: id, text, score, timestamp: None }, root_msg_id))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    scored.sort_by(|a, b| b.0.score.partial_cmp(&a.0.score).unwrap_or(std::cmp::Ordering::Equal));
+    scored.truncate(limit);
+
+    // Resolve timestamps for truncated results
+    scored
+        .into_iter()
+        .map(|(mut hit, root_msg_id)| {
+            hit.timestamp = conn
+                .query_row(
+                    "SELECT timestamp FROM messages WHERE id = ?1",
+                    [&root_msg_id],
+                    |r| r.get::<_, i64>(0),
+                )
+                .ok();
+            hit
+        })
+        .collect()
+}
+
+/// Semantic memory search **within the current conversation**.
+///
+/// Supersedes the substring-matching path in `toolRequestHandler.memory:` which
+/// filtered on `conversation_memory.topic.toLowerCase().includes(query)`. That
+/// missed topically-related hits with different wording. This searches
+/// `conversation_chunks` (kind='window') by embedding similarity via vec0 KNN.
+///
+/// Returns up to `limit` (default 3, clamp 1..=10) hits ordered by relevance.
+#[tauri::command]
+pub fn search_memory_semantic(
+    conversation_id: String,
+    query: String,
+    limit: Option<i64>,
+    state: tauri::State<crate::db::DbState>,
+) -> Result<Vec<MemorySearchHit>, AppError> {
+    let lim = limit.unwrap_or(3).clamp(1, 10) as usize;
+    let query_embedding = embedder::embed_text(&query, true)?;
+    let conn = state.read.lock().map_err(|_| AppError::Lock)?;
+    Ok(search_within_conversation(&conn, &query_embedding, &conversation_id, lim))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -368,6 +500,72 @@ mod tests {
         let scratch_results = search_brute_force(&conn, &emb, "P", "scratch-D", "scratchpad", 10);
         assert_eq!(scratch_results.len(), 1);
         assert_eq!(scratch_results[0].conversation_id, "scratch-B");
+    }
+
+    #[test]
+    fn search_within_conversation_scopes_to_target_conv_only() {
+        use rusqlite::Connection;
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("
+            CREATE TABLE conversation_chunks (
+                id TEXT PRIMARY KEY,
+                project_key TEXT NOT NULL,
+                conversation_id TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                root_message_id TEXT NOT NULL,
+                text_preview TEXT NOT NULL,
+                embedding BLOB,
+                created_at INTEGER NOT NULL
+            );
+            CREATE TABLE messages (
+                id TEXT PRIMARY KEY, conversation_id TEXT, role TEXT, content TEXT, timestamp INTEGER
+            );
+        ").unwrap();
+
+        let emb_a = fake_embedding(10);
+        let emb_b = fake_embedding(20);
+        let emb_noise = fake_embedding(999);
+        let blob_a = embedding_to_blob(&emb_a);
+        let blob_b = embedding_to_blob(&emb_b);
+        let blob_n = embedding_to_blob(&emb_noise);
+
+        // target conv (A): 1 window chunk matching query, 1 noise window chunk
+        conn.execute("INSERT INTO messages(id,conversation_id,role,content,timestamp) VALUES('mA1','A','assistant','a1',100)", []).unwrap();
+        conn.execute("INSERT INTO messages(id,conversation_id,role,content,timestamp) VALUES('mA2','A','assistant','a2',200)", []).unwrap();
+        conn.execute(
+            "INSERT INTO conversation_chunks(id,project_key,conversation_id,kind,root_message_id,text_preview,embedding,created_at)
+             VALUES('cA1','P','A','window','mA1','A1 matching text',?1,0)",
+            [&blob_a],
+        ).unwrap();
+        conn.execute(
+            "INSERT INTO conversation_chunks(id,project_key,conversation_id,kind,root_message_id,text_preview,embedding,created_at)
+             VALUES('cA2','P','A','window','mA2','A2 noise text',?1,0)",
+            [&blob_n],
+        ).unwrap();
+
+        // stale anchor/pair in target conv — must be filtered out by kind='window' clause
+        conn.execute(
+            "INSERT INTO conversation_chunks(id,project_key,conversation_id,kind,root_message_id,text_preview,embedding,created_at)
+             VALUES('cA3','P','A','pair','mA1','A3 legacy pair',?1,0)",
+            [&blob_a],
+        ).unwrap();
+
+        // other conv (B): matching embedding, must NOT be returned
+        conn.execute("INSERT INTO messages(id,conversation_id,role,content,timestamp) VALUES('mB1','B','assistant','b1',300)", []).unwrap();
+        conn.execute(
+            "INSERT INTO conversation_chunks(id,project_key,conversation_id,kind,root_message_id,text_preview,embedding,created_at)
+             VALUES('cB1','P','B','window','mB1','B1 matching text',?1,0)",
+            [&blob_b],
+        ).unwrap();
+
+        // Query close to emb_a (in target conv A). Expect A1 first, A2 second, no B, no pair.
+        let hits = search_within_conversation(&conn, &emb_a, "A", 5);
+        assert!(!hits.is_empty(), "should find at least one hit in conv A");
+        assert_eq!(hits[0].chunk_id, "cA1", "highest similarity chunk is cA1");
+        assert!(!hits.iter().any(|h| h.chunk_id == "cB1"), "must not cross conversation boundary");
+        assert!(!hits.iter().any(|h| h.chunk_id == "cA3"), "must not return kind='pair' legacy rows");
+        // Timestamp resolved from root message
+        assert_eq!(hits[0].timestamp, Some(100));
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -378,6 +378,7 @@ pub fn run() {
             // Vector Search
             commands::vector_search::index_conversation_chunks,
             commands::vector_search::search_conversation_vectors,
+            commands::vector_search::search_memory_semantic,
             commands::vector_search::get_vector_index_status,
             // Context Hub
             commands::context_hub::context_hub_health,

--- a/src/lib/toolRequestHandler.ts
+++ b/src/lib/toolRequestHandler.ts
@@ -76,22 +76,27 @@ export async function executeToolRequests(requests: ToolRequest[]): Promise<stri
           }
         }
       } else if (req.type === "memory") {
-        // Tier 2 Pull: compressed conversation memory by topic
+        // Tier 2 Pull: semantic search over sliding-window chunks of current conv.
+        // Replaces prior substring match on conversation_memory (topic/summary) —
+        // that missed topically-related hits with different wording.
         const { useChatStore } = await import("@/stores/chatStore");
         const convId = useChatStore.getState().selectedConversationId;
         if (convId) {
-          const topics = await invoke<{ topic: string; summary: string }[]>(
-            "list_memory_topics", { conversationId: convId }
-          ).catch(() => []);
-          const matched = topics.filter((t) =>
-            t.topic.toLowerCase().includes(req.query.toLowerCase()) ||
-            t.summary.toLowerCase().includes(req.query.toLowerCase())
-          ).slice(0, 3);
-          if (matched.length > 0) {
-            const lines = matched.map((t) => `### ${t.topic}\n${t.summary.slice(0, 800)}`);
+          type Hit = { chunkId: string; text: string; score: number; timestamp: number | null };
+          const hits = await invoke<Hit[]>("search_memory_semantic", {
+            conversationId: convId, query: req.query, limit: 3,
+          }).catch(() => [] as Hit[]);
+          if (hits.length > 0) {
+            const lines = hits.map((h) => {
+              const when = h.timestamp
+                ? new Date(h.timestamp).toLocaleString("ko-KR", { month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit" })
+                : "";
+              const header = when ? `### ${when} (유사도 ${h.score.toFixed(2)})` : `### 유사도 ${h.score.toFixed(2)}`;
+              return `${header}\n${h.text.slice(0, 800)}`;
+            });
             results.push(`## 🧠 대화 기억: "${req.query}"\n\n${lines.join("\n\n")}`);
           } else {
-            results.push(`> "${req.query}" 관련 대화 기억을 찾지 못했습니다.`);
+            results.push(`> "${req.query}" 관련 대화 기억을 찾지 못했습니다. (아직 인덱싱 안 됐거나 의미적으로 매칭되지 않음)`);
           }
         }
       } else if (req.type === "recent_turns") {


### PR DESCRIPTION
## Summary

P1 장기 기억 품질 업그레이드 1·2 (dead_code 정리 + semantic 검색). #3 compression 즉시 실행은 별도 PR.

## 커밋

| 커밋 | 내용 |
|---|---|
| 710383a | `chore(vector): remove dead index_conversation fn` — 과거 anchor/pair 방식 인덱서 삭제. 프로덕션 경로(sliding-window) 와 중복 + s38 v39 migration 으로 관련 stale row 이미 정리됨 |
| 4230edb | `feat(memory): semantic search via vec0 on conversation_chunks` — `tool-request:memory:<query>` 를 substring → vec0 KNN 기반 의미 검색으로 교체 |

## 변경 세부

### Dead code 정리
- `vector_search::index::index_conversation` 제거 (`#[allow(dead_code)]` 마크된 상태였음)
- 프로덕션 경로 `index_conversation_chunks` / `index_chunks_blocking` 는 그대로 — `build_sliding_window_chunks` (kind='window') 사용
- `vector_search/mod.rs` 모듈 주석에 `search_memory_semantic` 추가
- `rusqlite::Connection` unused import 제거 (다른 심볼은 유지)

### Semantic memory search
- 새 함수: `query::search_within_conversation(conn, query_embedding, conversation_id, limit)` — vec0 KNN + brute-force fallback. 둘 다 `cc.conversation_id = ?` + `cc.kind = 'window'` 필터
- 새 Tauri 커맨드: `search_memory_semantic(conversationId, query, limit?)` — embed query (query=true) + limit clamp 1..=10
- 새 struct: `MemorySearchHit { chunkId, text, score, timestamp }`
- FE `toolRequestHandler.ts memory:` 핸들러 교체 — 이제 타임스탬프 + 유사도 점수 함께 렌더

### 왜 필요한가
- **이전**: `list_memory_topics` 결과에 `topic.toLowerCase().includes(query)` / `summary.includes(query)` — substring. `memory:auth` 쿼리는 제목에 "auth" 들어간 것만 찾음
- **이후**: 쿼리 임베딩 → 대화 내 window chunks 에 대해 cosine 유사도 top-K. "auth" 로 물어도 "로그인 오류" 같은 의미적 이웃 발견

## Test plan

- [x] `cargo test --lib` → **295 passed** (기존 294 + 신규 1), 2 ignored
- [x] `npx vitest run` → 226 passed
- [x] `npx tsc --noEmit` → 0 errors
- [ ] 머지 후 실제 프로젝트에서 `tool-request:memory:<query>` 로 의미 검색 동작 확인 (vec0 인덱스가 이미 있는 대화에서)

## 사이드이펙트 경고

- **빈 인덱스 대화**: `conversation_chunks` 가 비어있으면 hit 0개 → "관련 대화 기억 찾지 못했습니다" 메시지 표시. 기존 동작과 동일
- **vec0 시도 실패 시 자동 fallback**: brute-force cosine 으로 전환. 대화 내 chunks 수가 적으면(보통 1k 미만) 성능 차이 미미
- **`list_memory_topics` 는 그대로**: HTTP API 및 향후 UI 에서 raw topic 리스트가 필요할 수 있어 보존. 프런트 `tool-request:memory:` 만 새 경로 사용
- **timestamp 는 root 메시지 기준**: sliding window chunk 의 첫 메시지 timestamp. 유저가 시간 순으로 정렬·필터하려면 이 값을 씀

## 다음

P1-#3 compression trigger 즉시 실행 — UX 결정 필요 (사용자 턴 제출 직후 blocking vs 다음 턴 완료본만 사용). 별도 PR 로 열겠음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)