### PR TITLE
feat(memory): eager compression trigger in post-completion (P1 #3, option B)

### DIFF
--- a/src-tauri/src/commands/agents_helpers/send_common/persistence.rs
+++ b/src-tauri/src/commands/agents_helpers/send_common/persistence.rs
@@ -21,6 +21,15 @@ fn embed_semaphore() -> std::sync::Arc<tokio::sync::Semaphore> {
         .clone()
 }
 
+static COMPRESS_SEMAPHORE: std::sync::OnceLock<std::sync::Arc<tokio::sync::Semaphore>> =
+    std::sync::OnceLock::new();
+
+fn compress_semaphore() -> std::sync::Arc<tokio::sync::Semaphore> {
+    COMPRESS_SEMAPHORE
+        .get_or_init(|| std::sync::Arc::new(tokio::sync::Semaphore::new(1)))
+        .clone()
+}
+
 use super::super::trace_log::{insert_trace_log, insert_trace_log_with_context, new_span_id, new_trace_id, SpanInfo, ContextPackMeta};
 use super::context_loading::{load_context_data, load_project_path};
 use super::prompt_assembly::assemble_prompt;
@@ -313,9 +322,29 @@ pub fn spawn_post_completion_tasks(db: crate::db::DbState, conversation_id: Stri
     std::thread::spawn(move || {
         let cid_short = if conversation_id.len() >= 8 { &conversation_id[..8] } else { &conversation_id };
 
-        // 1. Memory compression — DEFERRED to conversation switch / idle.
-        // Running claude -p here while sdk-url session is active causes exit 1 (CLI lock conflict).
-        // Compression is triggered by `compress_conversation_memory` Tauri command instead.
+        // 1. Memory compression — eager trigger (P1 #3 option B, two-turn window).
+        //    Runs Haiku summarization in background after every completion.
+        //    `compress_memory_blocking` prefers Anthropic SDK (no CLI conflict with
+        //    an active sdk-url session) and falls back to CLI -p. Internal
+        //    `needs_compression` threshold check keeps this cheap when not needed.
+        //    Semaphore ensures only one compression runs at a time — concurrent
+        //    completions (RT, rapid sends) queue or skip; the next completion will
+        //    reattempt if threshold is still met.
+        //    If compression completes before the next user turn, that turn's
+        //    ContextPack sees fresh topics and `memory:TOPIC` tool-requests can
+        //    hit them immediately. If not, the batch/idle path still catches up.
+        {
+            let sem = compress_semaphore();
+            if sem.try_acquire().is_ok() {
+                match crate::commands::memory_compression::compress_memory_blocking(&db, &conversation_id) {
+                    Ok(true) => eprintln!("[post-completion] memory compressed for {}", cid_short),
+                    Ok(false) => {} // threshold not met or empty transcript — silent
+                    Err(e) => eprintln!("[post-completion] compression error: {}", e),
+                }
+            } else {
+                eprintln!("[post-completion] compression semaphore busy, skipping for {}", cid_short);
+            }
+        }
 
         // 2. Session link discovery — read lock for discovery, write lock only for save
         let project_key: Option<String> = {


### PR DESCRIPTION
## Summary

**P1 #3 option B** — compression 을 사용자 턴 직후 백그라운드에서 즉시 실행. 다음 턴까지 완료되면 ContextPack 이 fresh topics 를 봄. 안 끝나면 기존 경로로 폴백.

## Before

\`spawn_post_completion_tasks\` 의 compression 단계는 **비활성** 상태였음:

> Running claude -p here while sdk-url session is active causes exit 1 (CLI lock conflict).  
> Compression is triggered by \`compress_conversation_memory\` Tauri command instead.

결과: 사용자 턴 직후 topics 가 추가되지 않음 → 다음 turn 에서 \`memory:TOPIC\` 도구 요청이 **방금 요약된 내용을 못 찾음**.

## After

\`compress_memory_blocking(db, conversation_id)\` 를 post-completion 스레드에서 호출. 이 함수는:
- **Anthropic SDK 우선** → sdk-url CLI 세션과 충돌 없음 (s36 에서 추가된 경로)
- Fallback CLI \`-p\` — SDK 없을 때만
- 내부 \`needs_compression\` 임계값 체크 → 필요 없을 때 즉시 Ok(false) 반환해 비용 없음

### 제어

- **Semaphore(1)** (\`compress_semaphore\`): 여러 completion 이 동시 발생할 때(RT 라운드, 연속 전송) 직렬화. try_acquire 로 **바쁘면 skip** — 다음 completion 이 재시도
- 에러는 \`eprintln!\` 로 로깅 + 삼킴 → 현재 응답에 영향 없음
- 기존 \`embed_semaphore\` 패턴과 동일

## Two-turn window semantics

| 케이스 | 동작 |
|---|---|
| 사용자가 다음 턴을 **느리게** 보냄 (compression 완료 이후) | ContextPack 이 fresh topics 사용, \`memory:TOPIC\` 즉시 매칭 |
| 사용자가 **빨리** 보냄 (compression 진행 중) | 기존 경로처럼 압축 전 상태 사용 — regressionnot. Semaphore 바쁘면 이번엔 skip |
| 여러 RT 라운드가 빠르게 완료 | semaphore 로 직렬화, 첫 라운드만 실제 실행 |

## Test plan

- [x] \`cargo check --lib\` → 0 errors
- [x] \`cargo test --lib\` → 295 passed / 2 ignored
- [ ] 머지 후 앱에서 검증:
  - [ ] 긴 대화(threshold 초과) 응답 완료 직후 로그에 \`[post-completion] memory compressed for <conv>\` 출력 확인
  - [ ] 다음 turn 에서 \`tool-request:memory:<topic>\` 시 새로 요약된 topic 이 결과에 포함되는지
  - [ ] RT 다중 라운드 동시 완료 시 semaphore busy 로그 확인 (중복 compression 안 도는지)

## 사이드이펙트

- **Haiku API 호출량 증가**: 압축 가능 상태(threshold 초과)의 모든 completion 마다 1회. 기존엔 수동 트리거만 → 이제 자동. Anthropic 쿼터 주의
- **Post-completion 지연 체감 가능성**: compression 이 동기적으로 실행되는데 이건 별도 스레드라 UI 는 막지 않음. 다만 세마포어를 Drop 할 때까지 다음 completion 의 compression 은 대기
- **SDK 없을 때 CLI fallback**: sdk-url 세션 충돌로 실패할 수 있음. 로깅만 하고 넘어감 — silent degrade

## 롤백

완전 비파괴. revert 로 post-completion 블록 원상 복구 가능. DB 영향 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)