### PR TITLE
fix(plan): gate 'Subtask 검토' button until architect docs are written

### DIFF
--- a/src/components/tunaflow/context-panel/plans/DraftingActions.tsx
+++ b/src/components/tunaflow/context-panel/plans/DraftingActions.tsx
@@ -20,10 +20,14 @@ export function DraftingActions({
   onSwitchToChat?: () => void;
 }) {
   const { sendWithEngine, selectedConversationId, getConversationEngine, projects, selectedProjectKey } = useChatStore();
+  const runningThreadIds = useChatStore((s) => s.runningThreadIds);
   const [busy, setBusy] = useState(false);
   const [syncing, setSyncing] = useState(false);
   const hasEmptyDetails = subtasks.some((s) => !s.details?.trim());
   const hasSubtasks = subtasks.length > 0;
+  // Architect 가 해당 plan 의 대화에서 여전히 실행 중인가. Drafting 단계에서 agent
+  // running 은 대부분 "plan 문서 작성 중" — 확정 시그널 아니지만 가장 실용적인 proxy.
+  const isArchitectWriting = runningThreadIds.includes(plan.conversationId) && hasEmptyDetails;
   const mainEngine = (() => {
     if (!selectedConversationId) return "claude";
     const saved = getConversationEngine(selectedConversationId);
@@ -116,22 +120,24 @@ export function DraftingActions({
 
   return (
     <div className="mt-2 pt-2 border-t border-border/20 space-y-1.5">
-      {hasEmptyDetails && hasSubtasks && (
+      {hasEmptyDetails && hasSubtasks && !isArchitectWriting && (
         <p className="text-[9px] text-amber-600/60">일부 subtask에 상세 설계가 없습니다.</p>
       )}
       <div className="flex items-center gap-2 flex-wrap">
         {hasEmptyDetails && hasSubtasks && (
           <>
-            <button onClick={handleDetailDesign} disabled={busy || syncing} className="flex items-center gap-1 px-2.5 py-1 rounded-md text-[10px] font-medium bg-amber-500/10 text-amber-600 hover:bg-amber-500/20 disabled:opacity-50 transition-colors">
+            <button onClick={handleDetailDesign} disabled={busy || syncing || isArchitectWriting} className="flex items-center gap-1 px-2.5 py-1 rounded-md text-[10px] font-medium bg-amber-500/10 text-amber-600 hover:bg-amber-500/20 disabled:opacity-50 transition-colors">
               <FileText className="w-3 h-3" />{busy ? "요청 중..." : "상세 설계 요청"}
             </button>
-            <button onClick={handleSyncFromDocs} disabled={busy || syncing} className="flex items-center gap-1 px-2.5 py-1 rounded-md text-[10px] font-medium bg-primary/10 text-primary hover:bg-primary/20 disabled:opacity-50 transition-colors">
+            <button onClick={handleSyncFromDocs} disabled={busy || syncing || isArchitectWriting} className="flex items-center gap-1 px-2.5 py-1 rounded-md text-[10px] font-medium bg-primary/10 text-primary hover:bg-primary/20 disabled:opacity-50 transition-colors">
               {syncing ? <Loader2 className="w-3 h-3 animate-spin" /> : <RefreshCw className="w-3 h-3" />}
               {syncing ? "동기화 중..." : "docs에서 동기화"}
             </button>
           </>
         )}
-        {hasSubtasks && (
+        {/* Subtask 검토 버튼: 상세 설계가 모두 채워졌을 때만 노출. 문서 작성 완료 전에는
+            Dev 로 올라가는 관문이 아예 보이지 않음 — 사용자가 미완성 문서로 진행하는 사고 방지. */}
+        {hasSubtasks && !hasEmptyDetails && (
           <button onClick={handleStartReview} disabled={busy || syncing} className="flex items-center gap-1 px-2.5 py-1 rounded-md text-[10px] font-medium bg-primary/10 text-primary hover:bg-primary/20 disabled:opacity-50 transition-colors">
             <Search className="w-3 h-3" />{busy ? "이동 중..." : "Subtask 검토"}
           </button>
@@ -140,6 +146,13 @@ export function DraftingActions({
           <p className="text-[9px] text-muted-foreground/50">Subtask가 없습니다. Chat에서 Architect에게 Plan 수정을 요청하세요.</p>
         )}
       </div>
+      {/* 아키텍트 문서 작성 중 표시 — agent 가 해당 conv 에서 실행 중이고 아직 details 비어있을 때 */}
+      {isArchitectWriting && (
+        <div className="flex items-center gap-1.5 pt-1 text-[10px] text-muted-foreground">
+          <Loader2 className="w-3 h-3 animate-spin text-primary" />
+          <span>아키텍트 문서 작성 중...</span>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Problem

Plan Proposal 승인 시점에 plan 이 생성되면서 곧바로 Plan Check(Workflow 탭) 에 "Subtask 검토" 버튼이 노출됐습니다. Architect 가 아직 \`docs/plans/<slug>.md\` + \`<slug>-task-N.md\` 문서를 다 쓰기 전에도 사용자가 버튼을 눌러 subtask_review → approval → Dev 까지 진행할 수 있는 상태였습니다. 사용자 관찰:

> 플랜승인 → 워크플로우 표시(승인 버튼 잠김표시) → 아키텍트 문서 작성 → 플랜체크 승인버튼 클릭 → DEV 의 경로인데 플랜체크에 플랜들이 올라가는게 문서 작성이 완료된 이후 여야하는거 아냐?

## Fix

`DraftingActions.tsx` 한 파일만 수정:

1. **"Subtask 검토" 버튼 조건부 숨김** — `!hasEmptyDetails` (모든 subtask 에 details 존재) 일 때만 노출. 이전엔 `hasSubtasks` 만 체크해서 details 유무와 무관하게 떴음
2. **"아키텍트 문서 작성 중..." 스피너 추가** — 해당 plan 의 parent conversation 에서 agent 가 실행 중이고 `hasEmptyDetails` 인 경우 표시. 사용자가 대기 상태를 시각적으로 인지 가능
3. **보조 버튼 비활성화 동기화** — `상세 설계 요청` / `docs에서 동기화` 버튼도 `isArchitectWriting` 일 때 disabled 처리 (중복 요청 방지)
4. **배너 노이즈 축소** — `"일부 subtask 에 상세 설계가 없습니다"` 경고는 스피너가 보일 때 숨김 (같은 정보 두 번 안 띄움)

### 완료 감지 시그널 선택

"Architect 문서 작성 완료" 를 직접 감지하는 이벤트는 현재 없음. 아래 옵션 중 **가장 실용적인 proxy** 를 선택:

| 옵션 | 신호 | 장단 |
|---|---|---|
| plan_events | `doc_written` event | 명시적이지만 Architect 출력에 의존 — 아직 해당 이벤트 미발행 |
| file existence | `docs/plans/<slug>.md` 존재 여부 | 확정적이나 Tauri invoke 필요 (비용) |
| subtask.details | 모든 details 채워짐 | **채택** — 현재 \`hasSyncFromDocs\` 가 이 경로로 채움. details 있음 = 문서 + 동기화 둘 다 완료 |
| agent running | parent conv 에서 agent 실행 중 | "작성 중" proxy 로만 사용 — 완료 판정 아님 |

즉 "Dev 관문 열림" = `!hasEmptyDetails`, "작성 중 표시" = `runningThreadIds.includes(conv) && hasEmptyDetails`.

## Side effects

- 사용자가 **details 를 비워둔 채 빠르게 Dev 로 가고 싶은 케이스가 막힘**. 현재 그런 use case 가 의도적으로 없다고 판단. 필요 시 추후 "상세 없이 진행" 오버라이드 추가 가능
- 아키텍트가 응답 중인데 사용자가 다른 주제로 말을 건 경우에도 스피너가 뜰 수 있음 (agent running 이 doc 작성과 무관할 때). 실무상 드물고 무해

## Test plan

- [x] \`npx tsc --noEmit\` → 0 errors
- [x] \`npx vitest run\` → 222 passed / 18 files
- [ ] 수동 검증:
  - [ ] Plan Proposal 승인 직후: "Subtask 검토" 버튼 **안 보여야** 함 + "상세 설계 요청" / "docs에서 동기화" 버튼만 노출
  - [ ] "상세 설계 요청" 클릭 → 아키텍트 응답 시작 → 카드 하단 "아키텍트 문서 작성 중..." 스피너 나타남
  - [ ] 아키텍트 응답 완료 후 "docs에서 동기화" 클릭 → subtask details 채워짐 → 스피너 사라지고 "Subtask 검토" 버튼 노출
  - [ ] "Subtask 검토" 클릭 → phase='subtask_review' 전환, 기존 플로우 그대로 진행

## Rollback

단일 파일 변경이라 1 커밋 revert 로 복구 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)