### PR TITLE
refactor(send): extract shared send-pipeline primitives (Step 1/2)

### DIFF
--- a/src/lib/sendPipeline/buildSendInput.ts
+++ b/src/lib/sendPipeline/buildSendInput.ts
@@ -1,0 +1,67 @@
+/**
+ * Assembles `SendWithClaudeInput` for the `start_*_stream` backend commands.
+ * Shared between the main-chat and branch-drawer paths so that ContextPack
+ * inputs (budget override, user profile, workflow skills, persona, crossSession
+ * anchors) are evaluated identically.
+ *
+ * Caveat: `engine` is intentionally optional. The main-chat path forwards it
+ * so the backend can route across providers, whereas the branch path leaves
+ * it unset (backend picks the engine from the invoked command). Preserving
+ * that asymmetry is a behavior-preserving constraint of the refactor.
+ */
+import { invoke } from "@tauri-apps/api/core";
+import { getSetting } from "@/lib/appStore";
+import type { SendWithClaudeInput } from "@/types";
+
+export interface BuildSendInputParams {
+  projectKey: string;
+  conversationId: string;
+  prompt: string;
+  model?: string;
+  /** Main-chat only — branch path omits this field. */
+  engine?: string;
+  /** Main-chat only. */
+  systemPrompt?: string;
+  personaFragment?: string;
+  personaLabel?: string;
+  crossSessionIds?: string[];
+  /** ChatState.getEffectiveSkills — resolves phase-based workflow skill set. */
+  getEffectiveSkills: (phase: string | null, prompt: string) => string[];
+  opts?: { userMessageId?: string; imagePaths?: string[] };
+}
+
+interface BudgetConfig {
+  mode: string;
+  totalCap: number;
+}
+
+const BUDGET_DEFAULT: BudgetConfig = { mode: "auto", totalCap: 60000 };
+
+export async function buildSendInput(p: BuildSendInputParams): Promise<SendWithClaudeInput> {
+  const budgetCfg = await getSetting<BudgetConfig>("contextBudgetConfig", BUDGET_DEFAULT);
+  const userProfile = await getSetting<object | null>("userProfile", null).catch(() => null);
+  const planPhase = await invoke<string | null>("get_active_plan_phase", {
+    conversationId: p.conversationId,
+  }).catch(() => null);
+  const activeSkills = p.getEffectiveSkills(planPhase, p.prompt);
+
+  return {
+    projectKey: p.projectKey,
+    conversationId: p.conversationId,
+    prompt: p.prompt,
+    model: p.model,
+    ...(p.engine !== undefined ? { engine: p.engine } : {}),
+    ...(p.systemPrompt !== undefined ? { systemPrompt: p.systemPrompt } : {}),
+    activeSkills,
+    crossSessionIds: p.crossSessionIds,
+    personaFragment: p.personaFragment,
+    personaLabel: p.personaLabel,
+    contextModeOverride: budgetCfg.mode === "auto" ? undefined : budgetCfg.mode,
+    contextBudgetCap: budgetCfg.totalCap === 60000 ? undefined : budgetCfg.totalCap,
+    userProfileJson: userProfile ? JSON.stringify(userProfile) : undefined,
+    ...(p.opts?.userMessageId ? { userMessageId: p.opts.userMessageId } : {}),
+    ...(p.opts?.imagePaths && p.opts.imagePaths.length > 0
+      ? { imagePaths: p.opts.imagePaths }
+      : {}),
+  };
+}

--- a/src/lib/sendPipeline/createPlaceholders.ts
+++ b/src/lib/sendPipeline/createPlaceholders.ts
@@ -1,0 +1,66 @@
+/**
+ * Optimistic message pair appended to the UI while the agent is still
+ * running. One entry represents the user prompt (or the system-followup
+ * marker for auto tool-request replies), the other is the assistant
+ * thinking placeholder that later gets swapped with the real messageId
+ * on the first `*:progress` event.
+ *
+ * Shared between the main-chat and branch-drawer send paths. The branch
+ * variant passes `progressLabel` (engine display name) so the spinner UI
+ * renders it while the main path leaves progress blank.
+ */
+import type { Message } from "@/types";
+
+export interface PlaceholderParams {
+  convId: string;
+  prompt: string;
+  engineKey: string;
+  model?: string;
+  /** Shown under the assistant bubble; only the main path stores persona here. */
+  persona?: string;
+  /** Optional spinner label (branch drawer uses the engine display name). */
+  progressLabel?: string;
+  /**
+   * When present, this send is a system-followup (tool-request auto-reply).
+   * Backend has already persisted the system message with this id, so we
+   * render it with `role: "system"` and the real id instead of a temp id.
+   */
+  userMessageId?: string;
+  /** Injected for deterministic testing. */
+  now?: number;
+}
+
+export function createPlaceholders(p: PlaceholderParams): [Message, Message] {
+  const now = p.now ?? Date.now();
+  const isSystemFollowup = !!p.userMessageId;
+  const first: Message = isSystemFollowup
+    ? {
+        id: p.userMessageId!,
+        conversationId: p.convId,
+        role: "system",
+        content: p.prompt,
+        timestamp: now,
+        status: "done",
+      }
+    : {
+        id: `temp-user-${now}`,
+        conversationId: p.convId,
+        role: "user",
+        content: p.prompt,
+        timestamp: now,
+        status: "done",
+      };
+  const thinking: Message = {
+    id: `temp-thinking-${now}`,
+    conversationId: p.convId,
+    role: "assistant",
+    content: "",
+    ...(p.progressLabel ? { progressContent: p.progressLabel } : {}),
+    timestamp: now,
+    status: "streaming",
+    engine: p.engineKey,
+    model: p.model,
+    ...(p.persona ? { persona: p.persona } : {}),
+  };
+  return [first, thinking];
+}

--- a/src/lib/sendPipeline/index.ts
+++ b/src/lib/sendPipeline/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Shared send-pipeline primitives — Step 1 of the runtime/thread send-path
+ * consolidation described in `docs/plans/refactorRoadmap_2026-04-20.md` §1-3.
+ *
+ * Current scope: pure helpers + input builder. The streaming lifecycle
+ * (event listeners, DB reload, tool-request follow-up) is still handled
+ * in each slice; Step 2 will pull that out too.
+ */
+export { resolveModel } from "./resolveModel";
+export type { ResolveModelState } from "./resolveModel";
+export { createPlaceholders } from "./createPlaceholders";
+export type { PlaceholderParams } from "./createPlaceholders";
+export { buildSendInput } from "./buildSendInput";
+export type { BuildSendInputParams } from "./buildSendInput";

--- a/src/lib/sendPipeline/resolveModel.ts
+++ b/src/lib/sendPipeline/resolveModel.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared model-fallback logic. When a caller invokes `sendWithEngine` /
+ * `sendThreadMessage` without passing `model`, we resolve one to avoid
+ * reaching the backend with `model=None` (which breaks codex app-server
+ * with a 400 and silently falls back to a stale default on other engines).
+ *
+ * Resolution order:
+ *   1. `_convEngineMap[convId]` — last-used engine/model remembered for this
+ *      conversation (only used when the saved engine matches the requested
+ *      `engine`; otherwise the pair is meaningless).
+ *   2. First entry in `agentProfiles` that matches `engine` and has a model.
+ *
+ * Returns `undefined` when nothing resolves — the caller should log a warning
+ * and still forward the original (undefined) model.
+ */
+import type { AgentProfile } from "@/types";
+
+export interface ResolveModelState {
+  _convEngineMap: Record<string, { engine: string; model?: string } | undefined>;
+  agentProfiles: AgentProfile[];
+}
+
+export function resolveModel(
+  state: ResolveModelState,
+  convId: string,
+  engine: string,
+): string | undefined {
+  const saved = state._convEngineMap[convId];
+  if (saved?.engine === engine && saved?.model) {
+    return saved.model;
+  }
+  const prof = state.agentProfiles.find((p) => p.engine === engine && p.model);
+  return prof?.model;
+}

--- a/src/stores/slices/runtimeSlice.ts
+++ b/src/stores/slices/runtimeSlice.ts
@@ -3,29 +3,19 @@ import { listen } from "@tauri-apps/api/event";
 import { errorMessage } from "@/lib/utils";
 import { usePtyStore, isPtyEngine } from "@/stores/ptyStore";
 import { sendMessageViaPty } from "./ptyMessageSender";
-import { getSetting } from "@/lib/appStore";
 import { useToolStepsStore } from "@/stores/toolStepsStore";
 import { serializeSteps } from "@/lib/toolSteps";
 import { createRtChunkBatcher, createSingleChunkThrottler } from "./streamingUtils";
+import { resolveModel, createPlaceholders, buildSendInput } from "@/lib/sendPipeline";
 import type {
   SetState,
   GetState,
   QueuedAction,
   Message,
-  SendWithClaudeInput,
   RoundtableRunInput,
   RoundtableParticipant,
   RtMode,
 } from "./types";
-
-/** Load context budget config from appStore and return fields for SendWithClaudeInput */
-async function loadBudgetOverrides(): Promise<{ contextModeOverride?: string; contextBudgetCap?: number }> {
-  const cfg = await getSetting<{ mode: string; totalCap: number }>("contextBudgetConfig", { mode: "auto", totalCap: 60000 });
-  return {
-    contextModeOverride: cfg.mode === "auto" ? undefined : cfg.mode,
-    contextBudgetCap: cfg.totalCap === 60000 ? undefined : cfg.totalCap,
-  };
-}
 
 // ─── Engine configuration — canonical source: lib/engineConfig ──────────────
 import { ENGINE_CONFIGS } from "@/lib/engineConfig";
@@ -117,20 +107,8 @@ export const createRuntimeSlice = (set: SetState, get: GetState): RuntimeSlice =
     const { selectedProjectKey, selectedConversationId, runningThreadIds } = get();
     if (!selectedProjectKey || !selectedConversationId) return;
 
-    // model 방어선 — 호출부에서 인자를 잊어도 backend 가 model=None 으로 빠져
-    // codex app-server 400 등이 나지 않도록 store 레벨에서 폴백. 우선순위:
-    //   1) 같은 engine 으로 이 대화에 저장된 _convEngineMap[conv].model
-    //   2) agentProfiles 에서 engine 매칭되는 첫 프로필의 model
-    // 둘 다 없으면 그대로 undefined 전달(경고 로그 1회).
     if (!model) {
-      const state = get();
-      const saved = state._convEngineMap[selectedConversationId];
-      if (saved?.engine === engine && saved?.model) {
-        model = saved.model;
-      } else {
-        const prof = state.agentProfiles.find((p) => p.engine === engine && p.model);
-        if (prof?.model) model = prof.model;
-      }
+      model = resolveModel(get(), selectedConversationId, engine);
       if (!model) {
         console.warn(`[sendWithEngine] model unresolved for engine=${engine} conv=${selectedConversationId.slice(0, 12)}…`);
       }
@@ -174,16 +152,18 @@ export const createRuntimeSlice = (set: SetState, get: GetState): RuntimeSlice =
     get()._startRun(selectedConversationId);
     const now = Date.now();
     const persona = get().personaLabel ?? undefined;
-    const isSystemFollowup = !!opts?.userMessageId;
+    const [firstMsg, thinkingMsg] = createPlaceholders({
+      convId: selectedConversationId,
+      prompt,
+      engineKey: config.engineKey,
+      model,
+      persona,
+      userMessageId: opts?.userMessageId,
+      now,
+    });
     set((state) => ({
       error: null,
-      messages: [
-        ...state.messages,
-        ...(isSystemFollowup
-          ? [{ id: opts!.userMessageId!, conversationId: selectedConversationId, role: "system" as const, content: prompt, timestamp: now, status: "done" as const }]
-          : [{ id: `temp-user-${now}`, conversationId: selectedConversationId, role: "user" as const, content: prompt, timestamp: now, status: "done" as const }]),
-        { id: `temp-thinking-${now}`, conversationId: selectedConversationId, role: "assistant" as const, content: "", timestamp: now, status: "streaming" as const, engine: config.engineKey, model, persona },
-      ],
+      messages: [...state.messages, firstMsg, thinkingMsg],
     }));
 
     // Helper: replace placeholder with real message on first event, update content on subsequent
@@ -322,25 +302,19 @@ export const createRuntimeSlice = (set: SetState, get: GetState): RuntimeSlice =
     });
 
     try {
-      const bo = await loadBudgetOverrides();
-      // Resolve phase-based workflow skills
-      const planPhase = await invoke<string | null>("get_active_plan_phase", { conversationId: selectedConversationId }).catch(() => null);
-      const effectiveSkills = get().getEffectiveSkills(planPhase, prompt);
-      const userProfile = await getSetting("userProfile", null as unknown as object).catch(() => null);
-      const input: SendWithClaudeInput = {
+      const input = await buildSendInput({
         projectKey: selectedProjectKey,
         conversationId: selectedConversationId,
-        prompt, model, systemPrompt,
+        prompt,
         engine,
-        activeSkills: effectiveSkills,
-        crossSessionIds: get().crossSessionIds,
+        model,
+        systemPrompt,
         personaFragment: get().personaFragment ?? undefined,
         personaLabel: get().personaLabel ?? undefined,
-        userProfileJson: userProfile ? JSON.stringify(userProfile) : undefined,
-        ...(opts?.userMessageId ? { userMessageId: opts.userMessageId } : {}),
-        ...(opts?.imagePaths && opts.imagePaths.length > 0 ? { imagePaths: opts.imagePaths } : {}),
-        ...bo,
-      };
+        crossSessionIds: get().crossSessionIds,
+        getEffectiveSkills: get().getEffectiveSkills,
+        opts,
+      });
       await invoke<{ messageId: string }>(config.command, { input });
     } catch (e) {
       cleanup();

--- a/src/stores/slices/threadSlice.ts
+++ b/src/stores/slices/threadSlice.ts
@@ -7,6 +7,7 @@ import { useToolStepsStore } from "@/stores/toolStepsStore";
 import { handleToolRequests, saveToolSteps } from "./agentStreamHelper";
 import { autoSyncImplCompletion, autoDetectReviewVerdict } from "@/lib/workflow/branchSync";
 import { runThreadRoundtable } from "./threadRtRunner";
+import { resolveModel, createPlaceholders, buildSendInput } from "@/lib/sendPipeline";
 import type {
   SetState,
   GetState,
@@ -15,7 +16,6 @@ import type {
   Message,
   Memo,
   Artifact,
-  SendWithClaudeInput,
   RoundtableParticipant,
   RtMode,
 } from "./types";
@@ -175,20 +175,9 @@ export const createThreadSlice = (set: SetState, get: GetState): ThreadSlice => 
     if (!threadBranchConvId || !selectedProjectKey || !threadBranchId) return;
     const convId = threadBranchConvId; // narrowed: string (guaranteed by guard above)
     const engineKey = engine ?? "claude";
-    const isSystemFollowup = !!opts?.userMessageId;
 
-    // runtimeSlice.sendWithEngine 와 동일한 model 폴백 규칙 (engine 일치 시 conv 저장값,
-    // 아니면 agentProfiles 의 engine 매칭 프로필 model). 자동 전송 경로에서 model 인자
-    // 누락 시 codex app-server 400 방지.
     if (!model) {
-      const state = get();
-      const saved = state._convEngineMap[convId];
-      if (saved?.engine === engineKey && saved?.model) {
-        model = saved.model;
-      } else {
-        const prof = state.agentProfiles.find((p) => p.engine === engineKey && p.model);
-        if (prof?.model) model = prof.model;
-      }
+      model = resolveModel(get(), convId, engineKey);
       if (!model) {
         console.warn(`[sendThreadMessage] model unresolved for engine=${engineKey} conv=${convId.slice(0, 12)}…`);
       }
@@ -270,43 +259,31 @@ export const createThreadSlice = (set: SetState, get: GetState): ThreadSlice => 
     get()._startRun(convId);
 
     const now = Date.now();
+    const threadEngineConfig = ENGINE_CONFIGS[engine ?? "claude"] ?? ENGINE_CONFIGS.claude;
+    const [firstMsg, thinkingMsg] = createPlaceholders({
+      convId,
+      prompt,
+      engineKey: threadEngineConfig.engineKey,
+      model,
+      progressLabel: threadEngineConfig.label,
+      userMessageId: opts?.userMessageId,
+      now,
+    });
     set((state) => ({
-      threadMessages: [
-        ...state.threadMessages,
-        // Tool-request auto follow-up 은 사용자가 직접 입력한 게 아니므로
-        // role="system" 으로 구분. `userMessageId` 가 주어지면 백엔드가
-        // persist_system_msg 로 이미 저장한 system 메시지 ID 를 그대로 씀.
-        isSystemFollowup
-          ? { id: opts!.userMessageId!, conversationId: convId, role: "system" as const, content: prompt, timestamp: now, status: "done" as const }
-          : { id: `temp-user-${now}`, conversationId: convId, role: "user" as const, content: prompt, timestamp: now, status: "done" as const },
-        { id: `temp-thinking-${now}`, conversationId: convId, role: "assistant", content: "", progressContent: (ENGINE_CONFIGS[engine ?? "claude"] ?? ENGINE_CONFIGS.claude).label, timestamp: now, status: "streaming", engine: (ENGINE_CONFIGS[engine ?? "claude"] ?? ENGINE_CONFIGS.claude).engineKey, model },
-      ],
+      threadMessages: [...state.threadMessages, firstMsg, thinkingMsg],
     }));
 
-    const { getSetting } = await import("@/lib/appStore");
-    const budgetCfg = await getSetting<{ mode: string; totalCap: number }>("contextBudgetConfig", { mode: "auto", totalCap: 60000 });
-    const userProfile = await getSetting("userProfile", null as unknown as object).catch(() => null);
-    // Resolve phase-based workflow skills
-    const planPhase = await invoke<string | null>("get_active_plan_phase", { conversationId: convId }).catch(() => null);
-    const effectiveSkills = get().getEffectiveSkills(planPhase, prompt);
-    const input: SendWithClaudeInput = {
+    const input = await buildSendInput({
       projectKey: selectedProjectKey,
       conversationId: convId,
       prompt,
       model,
-      activeSkills: effectiveSkills,
-      crossSessionIds: get().crossSessionIds,
       personaFragment: get().personaFragment ?? undefined,
       personaLabel: get().personaLabel ?? undefined,
-      contextModeOverride: budgetCfg.mode === "auto" ? undefined : budgetCfg.mode,
-      contextBudgetCap: budgetCfg.totalCap === 60000 ? undefined : budgetCfg.totalCap,
-      userProfileJson: userProfile ? JSON.stringify(userProfile) : undefined,
-      // When this send is a system-followup (tool-request result), the system
-      // message has already been persisted via persist_system_msg → pass the
-      // pre-existing id so Rust skips user-message creation.
-      ...(opts?.userMessageId ? { userMessageId: opts.userMessageId } : {}),
-      ...(opts?.imagePaths && opts.imagePaths.length > 0 ? { imagePaths: opts.imagePaths } : {}),
-    };
+      crossSessionIds: get().crossSessionIds,
+      getEffectiveSkills: get().getEffectiveSkills,
+      opts,
+    });
 
     // Event listeners for streaming updates
     const { listen } = await import("@tauri-apps/api/event");

--- a/src/tests/sendPipeline-buildSendInput.test.ts
+++ b/src/tests/sendPipeline-buildSendInput.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { invoke } from "@tauri-apps/api/core";
+import { getSetting } from "@/lib/appStore";
+import { buildSendInput } from "@/lib/sendPipeline/buildSendInput";
+
+vi.mock("@/lib/appStore", () => ({
+  getSetting: vi.fn(),
+}));
+
+const mockedInvoke = vi.mocked(invoke);
+const mockedGetSetting = vi.mocked(getSetting);
+
+beforeEach(() => {
+  mockedInvoke.mockReset();
+  mockedGetSetting.mockReset();
+  // Default: no plan phase, auto budget, no user profile.
+  mockedInvoke.mockImplementation(async () => null);
+  mockedGetSetting.mockImplementation(async <T,>(key: string, fallback: T): Promise<T> => {
+    if (key === "contextBudgetConfig") return { mode: "auto", totalCap: 60000 } as T;
+    return fallback;
+  });
+});
+
+describe("buildSendInput", () => {
+  it("includes engine and systemPrompt only when caller passes them (main variant)", async () => {
+    const input = await buildSendInput({
+      projectKey: "proj",
+      conversationId: "c1",
+      prompt: "q",
+      engine: "claude",
+      model: "sonnet-4-6",
+      systemPrompt: "be terse",
+      getEffectiveSkills: () => ["s1", "s2"],
+    });
+    expect(input.engine).toBe("claude");
+    expect(input.systemPrompt).toBe("be terse");
+    expect(input.activeSkills).toEqual(["s1", "s2"]);
+    // auto + default cap → both overrides unset
+    expect(input.contextModeOverride).toBeUndefined();
+    expect(input.contextBudgetCap).toBeUndefined();
+  });
+
+  it("omits engine/systemPrompt for the branch variant", async () => {
+    const input = await buildSendInput({
+      projectKey: "proj",
+      conversationId: "branch:x",
+      prompt: "q",
+      model: "sonnet-4-6",
+      getEffectiveSkills: () => [],
+    });
+    expect("engine" in input).toBe(false);
+    expect("systemPrompt" in input).toBe(false);
+  });
+
+  it("passes plan phase into getEffectiveSkills", async () => {
+    mockedInvoke.mockImplementation(async (cmd: string) =>
+      cmd === "get_active_plan_phase" ? "review" : null,
+    );
+    const spy = vi.fn(() => ["dev-skill"]);
+    const input = await buildSendInput({
+      projectKey: "proj",
+      conversationId: "c1",
+      prompt: "ship it",
+      model: "sonnet-4-6",
+      getEffectiveSkills: spy,
+    });
+    expect(spy).toHaveBeenCalledWith("review", "ship it");
+    expect(input.activeSkills).toEqual(["dev-skill"]);
+  });
+});

--- a/src/tests/sendPipeline-createPlaceholders.test.ts
+++ b/src/tests/sendPipeline-createPlaceholders.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { createPlaceholders } from "@/lib/sendPipeline/createPlaceholders";
+
+const NOW = 1_700_000_000_000;
+
+describe("createPlaceholders", () => {
+  it("main variant — user prompt + plain thinking placeholder (no progressContent)", () => {
+    const [first, thinking] = createPlaceholders({
+      convId: "conv-1",
+      prompt: "hello",
+      engineKey: "claude",
+      model: "sonnet-4-6",
+      persona: "Reviewer",
+      now: NOW,
+    });
+    expect(first).toMatchObject({
+      id: `temp-user-${NOW}`,
+      conversationId: "conv-1",
+      role: "user",
+      content: "hello",
+      status: "done",
+    });
+    expect(thinking).toMatchObject({
+      id: `temp-thinking-${NOW}`,
+      conversationId: "conv-1",
+      role: "assistant",
+      content: "",
+      status: "streaming",
+      engine: "claude",
+      model: "sonnet-4-6",
+      persona: "Reviewer",
+    });
+    expect(thinking.progressContent).toBeUndefined();
+  });
+
+  it("branch variant — progressContent carries the engine display label", () => {
+    const [, thinking] = createPlaceholders({
+      convId: "branch:abc",
+      prompt: "review this",
+      engineKey: "codex",
+      progressLabel: "Codex (GPT-5)",
+      now: NOW,
+    });
+    expect(thinking.progressContent).toBe("Codex (GPT-5)");
+    expect(thinking.engine).toBe("codex");
+  });
+
+  it("system-followup — uses the pre-persisted id and role=system", () => {
+    const [first] = createPlaceholders({
+      convId: "conv-1",
+      prompt: "[tool-request:...]",
+      engineKey: "claude",
+      userMessageId: "msg-sys-001",
+      now: NOW,
+    });
+    expect(first.id).toBe("msg-sys-001");
+    expect(first.role).toBe("system");
+    expect(first.content).toBe("[tool-request:...]");
+  });
+
+  it("omits persona and progressContent when not provided", () => {
+    const [, thinking] = createPlaceholders({
+      convId: "conv-1",
+      prompt: "q",
+      engineKey: "claude",
+      now: NOW,
+    });
+    expect(thinking.persona).toBeUndefined();
+    expect(thinking.progressContent).toBeUndefined();
+  });
+});

--- a/src/tests/sendPipeline-resolveModel.test.ts
+++ b/src/tests/sendPipeline-resolveModel.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { resolveModel, type ResolveModelState } from "@/lib/sendPipeline/resolveModel";
+import type { AgentProfile } from "@/types";
+
+const profile = (engine: string, model?: string): AgentProfile => ({
+  id: `p-${engine}`,
+  label: engine,
+  engine,
+  model,
+  defaultSkills: [],
+});
+
+describe("resolveModel", () => {
+  it("uses _convEngineMap when the saved engine matches the request", () => {
+    const state: ResolveModelState = {
+      _convEngineMap: { c1: { engine: "claude", model: "sonnet-4-6" } },
+      agentProfiles: [profile("claude", "sonnet-4-5")],
+    };
+    expect(resolveModel(state, "c1", "claude")).toBe("sonnet-4-6");
+  });
+
+  it("ignores _convEngineMap when the saved engine differs", () => {
+    const state: ResolveModelState = {
+      _convEngineMap: { c1: { engine: "codex", model: "gpt-5-codex" } },
+      agentProfiles: [profile("claude", "sonnet-4-6")],
+    };
+    expect(resolveModel(state, "c1", "claude")).toBe("sonnet-4-6");
+  });
+
+  it("falls back to the first matching agent profile with a model", () => {
+    const state: ResolveModelState = {
+      _convEngineMap: {},
+      agentProfiles: [profile("claude"), profile("claude", "sonnet-4-6"), profile("claude", "sonnet-4-5")],
+    };
+    expect(resolveModel(state, "c1", "claude")).toBe("sonnet-4-6");
+  });
+
+  it("returns undefined when no state resolves", () => {
+    const state: ResolveModelState = {
+      _convEngineMap: {},
+      agentProfiles: [profile("codex", "gpt-5-codex")],
+    };
+    expect(resolveModel(state, "c1", "claude")).toBeUndefined();
+  });
+
+  it("returns undefined when _convEngineMap has the engine but no model", () => {
+    const state: ResolveModelState = {
+      _convEngineMap: { c1: { engine: "claude" } },
+      agentProfiles: [profile("claude")],
+    };
+    expect(resolveModel(state, "c1", "claude")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Phase 1 Finding 1-3 from `docs/plans/refactorRoadmap_2026-04-20.md` — **Step 1 of 2**. Pulls the three duplicated concerns from \`runtimeSlice.sendWithEngine\` and \`threadSlice.sendThreadMessage\` into pure helpers under \`src/lib/sendPipeline/\`.
- **Step 2 (separate PR)** will unify the streaming lifecycle (event listeners, DB reload, tool-request follow-up). Roundtable and PTY are intentionally untouched.

## Helpers
| Helper | Responsibility |
|---|---|
| \`resolveModel()\` | \`_convEngineMap\` + \`agentProfiles\` fallback — preserved verbatim from both slices |
| \`createPlaceholders()\` | User/system + thinking placeholder factory; main vs branch variant via \`progressLabel\` / \`persona\` |
| \`buildSendInput()\` | \`SendWithClaudeInput\` assembly — budget override, workflow skills, user profile, persona, opts |

## Slice changes
- \`runtimeSlice.sendWithEngine\`: 22 lines → helpers
- \`threadSlice.sendThreadMessage\`: 29 lines → helpers
- Behavior preserved:
  - Main-chat path still forwards \`engine\` / \`systemPrompt\` into the input
  - Branch path still omits them (backend picks the engine from the invoked command)

## Test plan
- [x] \`npx tsc --noEmit\` — 0 errors
- [x] \`npx vitest run\` — **234 passed** (baseline 222 + 12 new)
  - resolveModel: 5 cases (saved match / engine mismatch / profile fallback / no resolution / model-less profile)
  - createPlaceholders: 4 cases (main / branch / system-followup / minimal)
  - buildSendInput: 3 cases (main variant / branch variant / plan phase passed into skills)
- [ ] CI green
- [ ] Manual smoke: main chat send, branch drawer send (HMR)

## Out of scope (Step 2 / later Findings)
- Streaming lifecycle unification (event listeners, chunk throttle, DB reload)
- Tool-request follow-up helper
- Roundtable (\`runRoundtable\` / \`runThreadRoundtable\`)
- PTY lifecycle
- Workflow auto-sync hooks (\`autoSyncImplCompletion\`, \`autoDetectReviewVerdict\`) — Finding 1-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)