### PR TITLE
fix(plans): make plans.slug the single source of truth for doc filenames

### DIFF
--- a/docs/agents/architect.md
+++ b/docs/agents/architect.md
@@ -47,6 +47,13 @@ After the plan is promoted, write documents directly in `docs/plans/`:
 - `{slug}-task-02.md` — Subtask 2 work instruction
 - Continue for each subtask
 
+**`{slug}` is not something you invent.** The ContextPack `## Active Plan` section
+includes `> **Plan slug (canonical):** `<value>`` — use that value verbatim.
+Do not abbreviate, truncate, or re-slugify the plan title yourself. tunaFlow
+(Reviewer context loader, result/review report writers) reads file names back
+using this exact slug; any deviation — including a stray trailing `-` — means
+your task files will be invisible to downstream agents.
+
 Each task file MUST contain:
 1. **Changed files** — exact paths verified against the codebase (new files: state explicitly)
 2. **Change description** — what to add/modify/remove and why

--- a/src-tauri/src/commands/agents_helpers/context_pack/db_queries.rs
+++ b/src-tauri/src/commands/agents_helpers/context_pack/db_queries.rs
@@ -25,17 +25,17 @@ pub fn build_plan_section(
     conn: &rusqlite::Connection,
     conversation_id: &str,
 ) -> Option<String> {
-    let plan: (String, String, Option<String>, String) = conn
+    let plan: (String, String, Option<String>, String, Option<String>) = conn
         .query_row(
-            "SELECT id, title, description, phase FROM plans
+            "SELECT id, title, description, phase, slug FROM plans
              WHERE conversation_id = ?1 AND status = 'active'
              ORDER BY updated_at DESC LIMIT 1",
             [conversation_id],
-            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?)),
         )
         .ok()?;
 
-    let (plan_id, title, description, phase) = plan;
+    let (plan_id, title, description, phase, slug) = plan;
 
     let mut stmt = conn
         .prepare(
@@ -55,6 +55,19 @@ pub fn build_plan_section(
     if let Some(desc) = &description {
         if !desc.is_empty() {
             out.push_str(&format!("{}\n", desc));
+        }
+    }
+    // Canonical slug — the only correct filename prefix for this plan's
+    // documents. Architect must write `docs/plans/{slug}-task-NN.md` using
+    // this exact value (not a slugify of the title, not a manual
+    // abbreviation). Reviewer and result/review writers all read the same
+    // source, so any other prefix will not be discovered downstream.
+    if let Some(s) = &slug {
+        if !s.is_empty() {
+            out.push_str(&format!(
+                "\n> **Plan slug (canonical):** `{}`\n> Task file prefix MUST be `{}-task-NN.md` — use this slug verbatim.\n",
+                s, s
+            ));
         }
     }
     out.push_str(&format!("\n> **Current phase: {}** — Do NOT create a new plan. Propose revisions to this plan if needed.\n", phase));

--- a/src-tauri/src/commands/agents_helpers/send_common/context_loading.rs
+++ b/src-tauri/src/commands/agents_helpers/send_common/context_loading.rs
@@ -215,12 +215,20 @@ pub fn load_context_data(
     let plan_document: Option<String> = if has_active_plan {
         if let Some(pp) = project_path {
             let plan_row = conn.query_row(
-                "SELECT title, phase FROM plans WHERE conversation_id = ?1 AND status = 'active' LIMIT 1",
+                "SELECT title, phase, slug FROM plans WHERE conversation_id = ?1 AND status = 'active' LIMIT 1",
                 [plan_lookup_conv.as_deref().unwrap_or(conversation_id)],
-                |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+                |row| Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, Option<String>>(2)?,
+                )),
             ).ok();
-            plan_row.and_then(|(title, phase)| {
-                let slug = crate::commands::plans::slugify_pub(&title);
+            plan_row.and_then(|(title, phase, slug_opt)| {
+                // Prefer the canonical slug persisted in `plans.slug` (v26). Fall
+                // back to title-based slugify only for pre-v26 rows. All writers
+                // (generate_plan_document/review/result) use the same source, so
+                // the Reviewer must match their filenames exactly.
+                let slug = slug_opt.unwrap_or_else(|| crate::commands::plans::slugify_pub(&title));
                 let plans_dir = std::path::Path::new(pp).join("docs").join("plans");
                 let mut combined = String::new();
 

--- a/src-tauri/src/commands/plans.rs
+++ b/src-tauri/src/commands/plans.rs
@@ -593,8 +593,11 @@ pub fn generate_plan_document(
     // Generate markdown
     let md = build_plan_markdown(&plan, &subtasks, &events);
 
-    // Write to file
-    let slug = slugify(&plan.title);
+    // Write to file. Canonical slug lives in plans.slug (v26); title-based
+    // slugify is kept as a fallback for pre-v26 rows that somehow missed
+    // backfill — all other paths (review, result, Reviewer context loader)
+    // must stay in sync with this source.
+    let slug = plan.slug.clone().unwrap_or_else(|| slugify(&plan.title));
     let dir = Path::new(&project_path).join("docs").join("plans");
     std::fs::create_dir_all(&dir)
         .map_err(|e| AppError::Agent(format!("Failed to create dir: {}", e)))?;
@@ -657,7 +660,7 @@ pub fn generate_review_report(
     };
 
     // Determine round number from existing files
-    let slug = slugify(&plan.title);
+    let slug = plan.slug.clone().unwrap_or_else(|| slugify(&plan.title));
     let dir = Path::new(&project_path).join("docs").join("plans");
     std::fs::create_dir_all(&dir).map_err(|e| AppError::Agent(format!("mkdir: {}", e)))?;
     let mut round = 1;
@@ -734,7 +737,7 @@ pub fn generate_result_report(
             .map_err(|_| AppError::NotFound(format!("plan {} not found", plan_id)))?
     };
 
-    let slug = slugify(&plan.title);
+    let slug = plan.slug.clone().unwrap_or_else(|| slugify(&plan.title));
     let dir = Path::new(&project_path).join("docs").join("plans");
     std::fs::create_dir_all(&dir).map_err(|e| AppError::Agent(format!("mkdir: {}", e)))?;
 


### PR DESCRIPTION
## Summary
Architect-written task files and Rust-written plan/review/result files were drifting onto different slug computations for the same plan. Observed in \`tunaflow-mobile/docs/plans/\` where one plan produced both \`...mock-.md\` + \`...mock--task-NN.md\` (Architect) and \`...mock.md\` + \`...mock-result.md\` (Rust). The Reviewer context loader (\`context_loading.rs:235\`) breaks out of its task-glob loop on the first miss, so every drifted plan silently loses **all** task context for review.

## Root cause
Every writer and reader re-ran \`slugify(&plan.title)\` instead of reading \`plans.slug\`:
- \`plans.rs:597 / 660 / 737\` — generate_plan_document, generate_review_report, generate_result_report
- \`context_loading.rs:223\` — Reviewer task-file loader
- Architect has no signal of what canonical slug tunaFlow expects, so any cosmetic title edit or abbreviation produces an invisible file tree.

## Fix
\`plans.slug\` (v26 column, already backfilled via \`find_unique_slug\`) is now the single source of truth:
- 4 Rust read paths use \`plan.slug.clone().unwrap_or_else(|| slugify(&plan.title))\` — fallback is only for pre-v26 rows that missed backfill
- \`build_plan_section\` (ContextPack Plans section) exposes \`> **Plan slug (canonical):** \\\`<value>\\\`\` verbatim
- \`docs/agents/architect.md\` instructs the Architect to paste the slug exactly, never to self-slugify

## Scope / non-goals
- No DB schema change (column already exists)
- No user-visible behavior change for plans created after this lands
- Pre-existing divergent files in \`tunaflow-mobile\` are **not** renamed here — that is a data cleanup task separate from this PR

## Test plan
- [x] \`cargo check --lib\` — 0 errors (3 pre-existing warnings unchanged)
- [x] \`cargo test --lib\` — 295 passed (baseline)
- [x] \`cargo test --tests\` — 25 passed (baseline)
- [ ] CI green
- [ ] Manual: create a fresh plan with a long title containing parentheses; confirm Architect-written task files match \`plan.slug\` exactly and Reviewer loads them

🤖 Generated with [Claude Code](https://claude.com/claude-code)