### PR TITLE
refactor(send): unify streaming lifecycle via setupStreamLifecycle (Step 2/2)

### DIFF
--- a/src/stores/slices/agentStreamHelper.ts
+++ b/src/stores/slices/agentStreamHelper.ts
@@ -1,6 +1,17 @@
 /**
  * Shared agent streaming helpers — extracted from runtimeSlice + threadSlice
- * to eliminate event-listener duplication.
+ * to eliminate event-listener duplication (Finding 1-3 Step 2).
+ *
+ * Responsibilities:
+ *   - `setupStreamLifecycle` — progress/chunk/completed/error listener wiring
+ *     with conversation filtering + tool-steps logging. Main/branch
+ *     differences live in the injected callbacks, not inside this module.
+ *   - `extractAndPersistFollowup` — detect tool-request markers in the
+ *     completed message, execute them, and persist the resulting system
+ *     message. The caller decides when to call `_endRun` and whether to
+ *     re-enter the send path (those signatures differ across slices).
+ *   - `handleToolRequests` / `saveToolSteps` — low-level helpers retained
+ *     from the previous revision, still used directly by the branch path.
  */
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
@@ -8,83 +19,114 @@ import { useToolStepsStore } from "@/stores/toolStepsStore";
 import { serializeSteps } from "@/lib/toolSteps";
 import type { Message } from "@/types";
 
-// ─── Placeholder messages ──────────────────────────────────────────────
+// ─── Event payload types ───────────────────────────────────────────────
 
-export function createPlaceholders(
-  conversationId: string,
-  prompt: string,
-  engineKey: string,
-  model?: string,
-): [user: Message, thinking: Message] {
-  const now = Date.now();
-  return [
-    { id: `temp-user-${now}`, conversationId, role: "user", content: prompt, timestamp: now, status: "done" },
-    { id: `temp-thinking-${now}`, conversationId, role: "assistant", content: "", timestamp: now, status: "streaming", engine: engineKey, model: model ?? undefined },
-  ];
+export interface ProgressPayload {
+  messageId: string;
+  conversationId: string;
+  text: string;
 }
 
-// ─── Event listener setup ──────────────────────────────────────────────
-
-export interface StreamListenerConfig {
+export interface ChunkPayload {
+  messageId: string;
   conversationId: string;
+  text: string;
+}
+
+export interface CompletedPayload {
+  messageId: string;
+  conversationId: string;
+  durationMs?: number;
+  inputTokens?: number;
+  outputTokens?: number;
+  costUsd?: number;
+}
+
+export interface ErrorPayload {
+  /** Present on the main-chat path; omitted on branch thread errors. */
+  messageId?: string;
+  conversationId: string;
+  error: string;
+}
+
+// ─── setupStreamLifecycle ──────────────────────────────────────────────
+
+export interface StreamLifecycleConfig {
+  convId: string;
   engineKey: string;
   hasChunkEvent: boolean;
-  /** Check whether this conversation is still active in UI */
-  isActive: () => boolean;
-  /** Apply a message update to the store */
-  updateMessage: (messageId: string, field: "content" | "progressContent", text: string) => void;
-  /** Replace placeholder with real message */
-  swapPlaceholder: (messageId: string, engineKey: string, model?: string) => void;
+  onProgress: (payload: ProgressPayload) => void;
+  onChunk: (payload: ChunkPayload) => void;
+  onCompleted: (payload: CompletedPayload) => Promise<void>;
+  onError: (payload: ErrorPayload) => Promise<void>;
 }
 
-export interface StreamListenerHandle {
+export interface StreamLifecycleHandle {
+  /** Detach all listeners. Safe to call multiple times. */
   cleanup: () => void;
-  /** Call before cleanup to discard pending throttled chunk */
-  discardPending: () => void;
 }
 
-export async function setupStreamListeners(config: StreamListenerConfig): Promise<StreamListenerHandle> {
-  const { conversationId, engineKey, hasChunkEvent, isActive, updateMessage, swapPlaceholder } = config;
+/**
+ * Wire the four-listener pattern (progress / chunk / completed / error) used
+ * by both runtimeSlice.sendWithEngine and threadSlice.sendThreadMessage.
+ *
+ * The caller supplies UI/state mutations via callbacks — this function
+ * handles conversation filtering (each listener fires for every active
+ * conversation; we filter to `convId`), tool-steps logging on progress,
+ * tool-steps persistence on completed, and listener cleanup.
+ *
+ * Chunk throttling is NOT applied here; the caller should wrap `onChunk`
+ * with `createSingleChunkThrottler` when desired (main-chat path) or pass
+ * a direct handler (branch drawer path).
+ */
+export async function setupStreamLifecycle(
+  config: StreamLifecycleConfig,
+): Promise<StreamLifecycleHandle> {
+  const { convId, engineKey, hasChunkEvent, onProgress, onChunk, onCompleted, onError } = config;
+
   const progressEvent = `${engineKey}:progress`;
   const chunkEvent = `${engineKey}:chunk`;
 
-  // Throttled chunk state
-  let pendingChunk: { messageId: string; text: string } | null = null;
-  let chunkTimer: ReturnType<typeof setTimeout> | null = null;
-  const flushChunk = () => {
-    if (pendingChunk && isActive()) {
-      updateMessage(pendingChunk.messageId, "content", pendingChunk.text);
-    }
-    pendingChunk = null;
-    chunkTimer = null;
-  };
-
-  const ulP = await listen<{ messageId: string; conversationId: string; text: string }>(progressEvent, (e) => {
-    if (e.payload.conversationId !== conversationId) return;
+  const ulProgress = await listen<ProgressPayload>(progressEvent, (e) => {
+    if (e.payload.conversationId !== convId) return;
+    // Parse tool steps from the __STEP__ prefix even after the user has
+    // navigated away — the step log is persisted to DB on completion and
+    // must reflect the full run, not only the segment where UI was visible.
     useToolStepsStore.getState().handleProgress(e.payload.messageId, e.payload.text);
-    if (!isActive()) return;
-    swapPlaceholder(e.payload.messageId, engineKey);
+    onProgress(e.payload);
   });
 
-  const ulC = hasChunkEvent
-    ? await listen<{ messageId: string; conversationId: string; text: string }>(chunkEvent, (e) => {
-        if (e.payload.conversationId !== conversationId) return;
-        pendingChunk = e.payload;
-        if (!chunkTimer) chunkTimer = setTimeout(flushChunk, 200);
+  const ulChunk = hasChunkEvent
+    ? await listen<ChunkPayload>(chunkEvent, (e) => {
+        if (e.payload.conversationId !== convId) return;
+        onChunk(e.payload);
       })
     : () => {};
 
+  const ulCompleted = await listen<CompletedPayload>("agent:completed", async (e) => {
+    if (e.payload.conversationId !== convId) return;
+    // Persist accumulated tool-steps before the completion callback triggers
+    // its DB reload — otherwise the reload would overwrite in-memory steps.
+    await saveToolSteps(e.payload.messageId);
+    await onCompleted(e.payload);
+  });
+
+  const ulError = await listen<ErrorPayload>("agent:error", async (e) => {
+    if (e.payload.conversationId !== convId) return;
+    await onError(e.payload);
+  });
+
   return {
     cleanup: () => {
-      if (chunkTimer) { clearTimeout(chunkTimer); chunkTimer = null; }
-      flushChunk();
-      ulP(); ulC();
+      ulProgress();
+      ulChunk();
+      ulCompleted();
+      ulError();
     },
-    discardPending: () => { pendingChunk = null; },
   };
 }
 
-// ─── Completion handler ────────────────────────────────────────────────
+// ─── Tool-steps persistence ────────────────────────────────────────────
 
 export async function saveToolSteps(messageId: string): Promise<void> {
   const tsStore = useToolStepsStore.getState();
@@ -94,6 +136,48 @@ export async function saveToolSteps(messageId: string): Promise<void> {
       .catch((e) => console.debug("[save-steps]", e));
     tsStore.clear(messageId);
   }
+}
+
+// ─── Tool-request follow-up ────────────────────────────────────────────
+
+export interface FollowupResult {
+  followUp: string;
+  /**
+   * Persisted system-message id. `null` when persistence failed; the caller
+   * may still send the follow-up but Rust will create a fresh user-message
+   * instead of reusing this id.
+   */
+  sysMsgId: string | null;
+}
+
+/**
+ * Detect tool-request markers in the completed assistant message, execute
+ * them, and persist the resulting follow-up text as a system message.
+ *
+ * The caller is responsible for `_endRun(...)` bookkeeping and the recursive
+ * re-send — both of those differ meaningfully between runtimeSlice (main
+ * chat: `_endRun(convId)`, recurses via `sendWithEngine`) and threadSlice
+ * (branch drawer: `_endRun(convId, { silent: true })` before recursing via
+ * `sendThreadMessage`), so consolidating them here would either blur the
+ * idle↔running flicker contract or force an ugly variant flag.
+ *
+ * Returns `null` when there are no markers, letting callers use a plain
+ * `if (!followup) { _endRun(); return; }` pattern.
+ */
+export async function extractAndPersistFollowup(
+  msg: Message | undefined,
+  convId: string,
+): Promise<FollowupResult | null> {
+  const followUp = await handleToolRequests(msg);
+  if (!followUp) return null;
+  const sysMsgId = await invoke<string>("persist_system_msg", {
+    conversationId: convId,
+    content: followUp,
+  }).catch((e) => {
+    console.warn("[tool-request] persist_system_msg failed:", e);
+    return null;
+  });
+  return { followUp, sysMsgId };
 }
 
 export async function handleToolRequests(
@@ -111,8 +195,4 @@ export async function handleToolRequests(
     console.warn("[tool-request]", err);
   }
   return null;
-}
-
-export async function reloadMessages(conversationId: string): Promise<Message[]> {
-  return invoke<Message[]>("list_messages", { conversationId });
 }

--- a/src/stores/slices/runtimeSlice.ts
+++ b/src/stores/slices/runtimeSlice.ts
@@ -3,10 +3,13 @@ import { listen } from "@tauri-apps/api/event";
 import { errorMessage } from "@/lib/utils";
 import { usePtyStore, isPtyEngine } from "@/stores/ptyStore";
 import { sendMessageViaPty } from "./ptyMessageSender";
-import { useToolStepsStore } from "@/stores/toolStepsStore";
-import { serializeSteps } from "@/lib/toolSteps";
 import { createRtChunkBatcher, createSingleChunkThrottler } from "./streamingUtils";
 import { resolveModel, createPlaceholders, buildSendInput } from "@/lib/sendPipeline";
+import {
+  setupStreamLifecycle,
+  extractAndPersistFollowup,
+  type StreamLifecycleHandle,
+} from "./agentStreamHelper";
 import type {
   SetState,
   GetState,
@@ -167,138 +170,111 @@ export const createRuntimeSlice = (set: SetState, get: GetState): RuntimeSlice =
     }));
 
     // Helper: replace placeholder with real message on first event, update content on subsequent
+    const isStillActive = () => get().selectedConversationId === selectedConversationId;
+
+    // Replace-or-update used by both placeholder swap and chunk flush. Once
+    // the real messageId arrives, subsequent calls update its content; the
+    // first call drops the temp-thinking placeholder and inserts the real
+    // streaming row in its place.
     const replaceOrUpdate = (messageId: string, text: string) => {
       set((state) => {
         const existing = state.messages.find((m) => m.id === messageId);
         if (existing) {
           return { messages: state.messages.map((m) => m.id === messageId ? { ...m, content: text } : m) };
         }
-        // First event with real messageId — replace placeholder
         const withoutPlaceholder = state.messages.filter((m) => !m.id.startsWith("temp-thinking-"));
         return { messages: [...withoutPlaceholder, { id: messageId, conversationId: selectedConversationId, role: "assistant" as const, content: text, timestamp: Date.now(), status: "streaming" as const, engine: config.engineKey, model, persona }] };
       });
     };
 
-    // Event listeners — progress swaps placeholder, chunk updates content
-    // Guard: skip UI updates if user navigated away (backend still persists to DB)
-    const isStillActive = () => get().selectedConversationId === selectedConversationId;
-    const eventPrefix = engine === "claude" ? "claude" : engine;
-    const unlistenProgress = await listen<{ messageId: string; conversationId: string; text: string }>(
-      `${eventPrefix}:progress`, (e) => {
-        if (e.payload.conversationId !== selectedConversationId) return;
-        // Parse tool steps from __STEP__ prefix (always, even if navigated away)
-        useToolStepsStore.getState().handleProgress(e.payload.messageId, e.payload.text);
-        if (!isStillActive()) return;
-        // Swap the placeholder to real messageId (content stays empty → typing indicator)
-        set((state) => {
-          const hasReal = state.messages.some((m) => m.id === e.payload.messageId);
-          if (hasReal) return state; // already swapped
-          const withoutPlaceholder = state.messages.filter((m) => !m.id.startsWith("temp-thinking-"));
-          return { messages: [...withoutPlaceholder, { id: e.payload.messageId, conversationId: selectedConversationId, role: "assistant" as const, content: "", timestamp: Date.now(), status: "streaming" as const, engine: config.engineKey, model, persona }] };
-        });
-      },
-    );
-    // Throttle chunk updates to ~5 per second (200ms) to reduce re-renders during streaming
+    // Main-chat throttles chunk updates to ~5 per second to reduce re-renders.
+    // Branch drawer does not throttle (see threadSlice).
     const chunkThrottle = createSingleChunkThrottler(
       isStillActive,
       (messageId, text) => replaceOrUpdate(messageId, text),
     );
-    const unlistenChunk = config.hasChunkEvent
-      ? await listen<{ messageId: string; conversationId: string; text: string }>(
-          `${eventPrefix}:chunk`, (e) => {
-            if (e.payload.conversationId !== selectedConversationId) return;
-            chunkThrottle.handleChunk(e.payload);
-          },
-        )
-      : () => {};
 
-    const cleanup = () => {
-      // Flush any pending throttled chunk before cleanup
+    const eventPrefix = engine === "claude" ? "claude" : engine;
+    let lifecycle: StreamLifecycleHandle | undefined;
+    const cleanupAll = () => {
+      // Discard pending throttled chunk BEFORE listener cleanup — DB reload
+      // below has the final content, and a late flush would race the
+      // set(status:'done') applied via the completed DB reload.
       chunkThrottle.cleanup();
-      unlistenProgress(); unlistenChunk(); unlistenDone(); unlistenErr();
+      lifecycle?.cleanup();
     };
 
-    const unlistenDone = await listen<{ messageId: string; conversationId: string; durationMs?: number; inputTokens?: number; outputTokens?: number; costUsd?: number }>("agent:completed", async (e) => {
-      if (e.payload.conversationId !== selectedConversationId) return;
-      // Discard pending chunk BEFORE cleanup — DB reload has final content.
-      // Without this, the throttle flush races with the DB reload set(status:'done').
-      chunkThrottle.cleanup();
-      cleanup();
-      // Save tool steps to progressContent for lazy-load display
-      const tsStore = useToolStepsStore.getState();
-      const steps = tsStore.getSteps(e.payload.messageId);
-      if (steps.length > 0) {
-        invoke("save_progress_content", { messageId: e.payload.messageId, progressContent: serializeSteps(steps) }).catch((e) => console.debug("[save-steps]", e));
-        tsStore.clear(e.payload.messageId);
-      }
-      // Always reload from DB, apply atomically inside set to avoid race conditions
-      const freshMessages = await invoke<Message[]>("list_messages", { conversationId: selectedConversationId });
-      // Merge runtime metadata (duration, tokens) into the completed message
-      const { messageId, durationMs, inputTokens, outputTokens, costUsd } = e.payload;
-      const enriched = freshMessages.map((m) =>
-        m.id === messageId ? { ...m, durationMs, inputTokens, outputTokens, costUsd } : m
-      );
-      set((state) => {
-        if (state.selectedConversationId === selectedConversationId) {
-          return { messages: enriched };
-        }
-        const stale = new Set(state._staleConversations);
-        stale.add(selectedConversationId);
-        return { _staleConversations: stale };
-      });
-      // Check for tool-request markers in the completed message → auto follow-up.
-      // _endRun is deferred until after tool-request handling to prevent idle↔running flicker.
-      const lastMsg = enriched.find((m) => m.id === messageId);
-      if (lastMsg?.role === "assistant") {
-        try {
-          const { extractToolRequests } = await import("@/lib/planProposalParser");
-          const requests = extractToolRequests(lastMsg.content);
-          if (requests.length > 0) {
-            const { executeToolRequests } = await import("@/lib/toolRequestHandler");
-            const followUp = await executeToolRequests(requests);
-            if (followUp) {
-              // Persist as system message, then send to agent with that ID
-              // → Rust skips user message creation (userMessageId already exists)
-              // → UI shows system message as collapsible card
-              const sysMsgId = await invoke<string>("persist_system_msg", {
-                conversationId: selectedConversationId,
-                content: followUp,
-              });
-              get()._endRun(selectedConversationId);
-              get().sendWithEngine(engine, followUp, model, undefined, { userMessageId: sysMsgId });
-              return;
-            }
-          }
-        } catch (err) {
-          console.warn("[tool-request]", err);
-        }
-      }
-
-      get()._endRun(selectedConversationId);
-    });
-
-    const unlistenErr = await listen<{ messageId: string; conversationId: string; error: string }>("agent:error", async (e) => {
-      if (e.payload.conversationId !== selectedConversationId) return;
-      chunkThrottle.cleanup();
-      cleanup();
-      import("@/stores/notificationStore").then(({ notify }) => {
-        const state = get();
-        const conv = state.conversations.find((c) => c.id === selectedConversationId);
-        notify("error", state.personaLabel ?? "에이전트", `오류: ${e.payload.error.slice(0, 80)}`, selectedConversationId, {
-          engine: state.getConversationEngine(selectedConversationId)?.engine,
-          conversationTitle: conv?.customLabel ?? conv?.label,
+    lifecycle = await setupStreamLifecycle({
+      convId: selectedConversationId,
+      engineKey: eventPrefix,
+      hasChunkEvent: config.hasChunkEvent,
+      onProgress: (p) => {
+        if (!isStillActive()) return;
+        // Swap the placeholder to the real messageId (content stays empty →
+        // typing indicator). First progress event is the swap trigger.
+        set((state) => {
+          const hasReal = state.messages.some((m) => m.id === p.messageId);
+          if (hasReal) return state;
+          const withoutPlaceholder = state.messages.filter((m) => !m.id.startsWith("temp-thinking-"));
+          return { messages: [...withoutPlaceholder, { id: p.messageId, conversationId: selectedConversationId, role: "assistant" as const, content: "", timestamp: Date.now(), status: "streaming" as const, engine: config.engineKey, model, persona }] };
         });
-      }).catch((e) => console.debug("[notify:error]", e));
-      const freshMessages = await invoke<Message[]>("list_messages", { conversationId: selectedConversationId });
-      set((state) => {
-        if (state.selectedConversationId === selectedConversationId) {
-          return { error: e.payload.error, messages: freshMessages };
+      },
+      onChunk: (p) => chunkThrottle.handleChunk(p),
+      onCompleted: async (p) => {
+        cleanupAll();
+        const freshMessages = await invoke<Message[]>("list_messages", { conversationId: selectedConversationId });
+        const { messageId, durationMs, inputTokens, outputTokens, costUsd } = p;
+        const enriched = freshMessages.map((m) =>
+          m.id === messageId ? { ...m, durationMs, inputTokens, outputTokens, costUsd } : m
+        );
+        set((state) => {
+          if (state.selectedConversationId === selectedConversationId) {
+            return { messages: enriched };
+          }
+          // User navigated away — leave their current view untouched and
+          // mark this conversation stale so the next open triggers a reload.
+          const stale = new Set(state._staleConversations);
+          stale.add(selectedConversationId);
+          return { _staleConversations: stale };
+        });
+        // Tool-request follow-up — _endRun deferred until after handling to
+        // prevent idle↔running flicker. Main chat recurses via sendWithEngine.
+        const lastMsg = enriched.find((m) => m.id === messageId);
+        const followup = await extractAndPersistFollowup(lastMsg, selectedConversationId);
+        if (followup) {
+          get()._endRun(selectedConversationId);
+          get().sendWithEngine(
+            engine,
+            followup.followUp,
+            model,
+            undefined,
+            followup.sysMsgId ? { userMessageId: followup.sysMsgId } : undefined,
+          );
+          return;
         }
-        const stale = new Set(state._staleConversations);
-        stale.add(selectedConversationId);
-        return { _staleConversations: stale };
-      });
-      get()._endRun(selectedConversationId);
+        get()._endRun(selectedConversationId);
+      },
+      onError: async (p) => {
+        cleanupAll();
+        import("@/stores/notificationStore").then(({ notify }) => {
+          const state = get();
+          const conv = state.conversations.find((c) => c.id === selectedConversationId);
+          notify("error", state.personaLabel ?? "에이전트", `오류: ${p.error.slice(0, 80)}`, selectedConversationId, {
+            engine: state.getConversationEngine(selectedConversationId)?.engine,
+            conversationTitle: conv?.customLabel ?? conv?.label,
+          });
+        }).catch((e) => console.debug("[notify:error]", e));
+        const freshMessages = await invoke<Message[]>("list_messages", { conversationId: selectedConversationId });
+        set((state) => {
+          if (state.selectedConversationId === selectedConversationId) {
+            return { error: p.error, messages: freshMessages };
+          }
+          const stale = new Set(state._staleConversations);
+          stale.add(selectedConversationId);
+          return { _staleConversations: stale };
+        });
+        get()._endRun(selectedConversationId);
+      },
     });
 
     try {
@@ -317,7 +293,7 @@ export const createRuntimeSlice = (set: SetState, get: GetState): RuntimeSlice =
       });
       await invoke<{ messageId: string }>(config.command, { input });
     } catch (e) {
-      cleanup();
+      cleanupAll();
       set((state) => ({
         error: errorMessage(e),
         messages: state.messages

--- a/src/stores/slices/threadSlice.ts
+++ b/src/stores/slices/threadSlice.ts
@@ -3,8 +3,12 @@ import { errorMessage } from "@/lib/utils";
 import { ENGINE_CONFIGS } from "@/lib/engineConfig";
 import { usePtyStore, isPtyEngine } from "@/stores/ptyStore";
 import { sendMessageViaPty } from "./ptyMessageSender";
-import { useToolStepsStore } from "@/stores/toolStepsStore";
-import { handleToolRequests, saveToolSteps } from "./agentStreamHelper";
+import {
+  handleToolRequests,
+  setupStreamLifecycle,
+  extractAndPersistFollowup,
+  type StreamLifecycleHandle,
+} from "./agentStreamHelper";
 import { autoSyncImplCompletion, autoDetectReviewVerdict } from "@/lib/workflow/branchSync";
 import { runThreadRoundtable } from "./threadRtRunner";
 import { resolveModel, createPlaceholders, buildSendInput } from "@/lib/sendPipeline";
@@ -285,11 +289,9 @@ export const createThreadSlice = (set: SetState, get: GetState): ThreadSlice => 
       opts,
     });
 
-    // Event listeners for streaming updates
-    const { listen } = await import("@tauri-apps/api/event");
-    const progressEvent = `${engineKey}:progress`;
-    const chunkEvent = `${engineKey}:chunk`;
-
+    // Branch drawer writes progress to `progressContent` and chunks to
+    // `content` — two fields of the same row — so the spinner text stays
+    // visible while streamed content appears beneath it.
     const replaceOrAdd = (messageId: string, field: "content" | "progressContent", text: string) => {
       set((state) => {
         const existing = state.threadMessages.find((m) => m.id === messageId);
@@ -301,89 +303,89 @@ export const createThreadSlice = (set: SetState, get: GetState): ThreadSlice => 
       });
     };
 
-    // Guard: only update UI if this branch is still the active thread (prevents cross-project contamination)
+    // Guard: only update UI if this branch is still the active thread
+    // (prevents cross-project contamination when user switches projects
+    // mid-stream).
     const isActiveThread = () => get().threadBranchConvId === convId;
 
-    const ulP = await listen<{ messageId: string; conversationId: string; text: string }>(progressEvent, (e) => {
-      if (e.payload.conversationId !== convId) return;
-      useToolStepsStore.getState().handleProgress(e.payload.messageId, e.payload.text);
-      if (!isActiveThread()) return;
-      replaceOrAdd(e.payload.messageId, "progressContent", e.payload.text);
-    });
-    const ulC = chunkEvent ? await listen<{ messageId: string; conversationId: string; text: string }>(chunkEvent, (e) => {
-      if (e.payload.conversationId !== convId) return;
-      if (!isActiveThread()) return;
-      replaceOrAdd(e.payload.messageId, "content", e.payload.text);
-    }) : () => {};
-    const cleanup = () => { ulP(); ulC(); ulD(); ulE(); };
+    let lifecycle: StreamLifecycleHandle | undefined;
 
-    const ulD = await listen<{ messageId: string; conversationId: string }>("agent:completed", async (e) => {
-      if (e.payload.conversationId !== convId) return;
-      cleanup();
-      await saveToolSteps(e.payload.messageId);
-      const threadMessages = await invoke<Message[]>("list_messages", { conversationId: convId });
-      set({ threadMessages });
-      // Check for tool-request markers → auto follow-up in thread.
-      // _endRun is deferred until after tool-request handling to prevent idle↔running flicker.
-      const lastMsg = threadMessages.find((m) => m.id === e.payload.messageId);
-      let toolRequestHandled = false;
-      const followUp = await handleToolRequests(lastMsg);
-      if (followUp) {
-        const saved = get().getConversationEngine(convId);
-        get()._endRun(convId, { silent: true });
-        // Persist follow-up as a system message so UI renders it as
-        // auto-generated (not user-typed) and Rust skips user-message creation.
-        // Matches runtimeSlice.ts:253-270 for the main-chat path.
-        const sysMsgId = await invoke<string>("persist_system_msg", {
-          conversationId: convId,
-          content: followUp,
-        }).catch((e) => { console.warn("[thread] persist_system_msg failed:", e); return null; });
-        get().sendThreadMessage(
-          followUp,
-          saved?.engine ?? "claude",
-          saved?.model ?? undefined,
-          sysMsgId ? { userMessageId: sysMsgId } : undefined,
-        );
-        toolRequestHandled = true;
-      }
-      // Auto-sync implementation subtasks + detect completion
-      autoSyncImplCompletion(convId, threadMessages);
-      // Auto-detect review verdict after tool-request handling
-      autoDetectReviewVerdict(convId, threadMessages);
-      // Notify thread completion
-      import("@/stores/notificationStore").then(({ notify }) => {
-        const state = get();
-        const branch = state.branches.find((b) => `branch:${b.id}` === convId);
-        const engine = state.getConversationEngine(convId)?.engine;
-        const lastAsst = threadMessages.filter((m) => m.role === "assistant").slice(-1)[0];
-        notify("completed", state.personaLabel ?? "에이전트", "응답 완료", convId, {
-          engine,
-          conversationTitle: branch?.customLabel ?? branch?.label,
-          preview: lastAsst?.content?.replace(/\n+/g, " ").slice(0, 80),
-        });
-      }).catch((e) => console.debug("[notify:completed]", e));
-      if (!toolRequestHandled) get()._endRun(convId, { silent: true });
-    });
-    const ulE = await listen<{ conversationId: string; error: string }>("agent:error", async (e) => {
-      if (e.payload.conversationId !== convId) return;
-      cleanup(); set({ error: e.payload.error });
-      import("@/stores/notificationStore").then(({ notify }) => {
-        const state = get();
-        const branch = state.branches.find((b) => `branch:${b.id}` === convId);
-        notify("error", state.personaLabel ?? "에이전트", `오류: ${e.payload.error.slice(0, 80)}`, convId, {
-          engine: state.getConversationEngine(convId)?.engine,
-          conversationTitle: branch?.customLabel ?? branch?.label,
-        });
-      }).catch((e) => console.debug("[notify:error]", e));
-      const threadMessages = await invoke<Message[]>("list_messages", { conversationId: convId });
-      set({ threadMessages }); get()._endRun(convId);
+    lifecycle = await setupStreamLifecycle({
+      convId,
+      engineKey,
+      hasChunkEvent: threadEngineConfig.hasChunkEvent,
+      onProgress: (p) => {
+        if (!isActiveThread()) return;
+        replaceOrAdd(p.messageId, "progressContent", p.text);
+      },
+      onChunk: (p) => {
+        if (!isActiveThread()) return;
+        replaceOrAdd(p.messageId, "content", p.text);
+      },
+      onCompleted: async (p) => {
+        lifecycle?.cleanup();
+        const threadMessages = await invoke<Message[]>("list_messages", { conversationId: convId });
+        set({ threadMessages });
+
+        // Tool-request follow-up — _endRun runs with { silent: true } before
+        // the recursive send so the UI does not flash idle between turns.
+        const lastMsg = threadMessages.find((m) => m.id === p.messageId);
+        const followup = await extractAndPersistFollowup(lastMsg, convId);
+        let toolRequestHandled = false;
+        if (followup) {
+          const saved = get().getConversationEngine(convId);
+          get()._endRun(convId, { silent: true });
+          get().sendThreadMessage(
+            followup.followUp,
+            saved?.engine ?? "claude",
+            saved?.model ?? undefined,
+            followup.sysMsgId ? { userMessageId: followup.sysMsgId } : undefined,
+          );
+          toolRequestHandled = true;
+        }
+
+        // Workflow auto-sync — scoped to branch path only (main chat never
+        // drives subtask status transitions). Keep as direct calls here so
+        // that their future extraction (Finding 1-5) is visible.
+        autoSyncImplCompletion(convId, threadMessages);
+        autoDetectReviewVerdict(convId, threadMessages);
+
+        import("@/stores/notificationStore").then(({ notify }) => {
+          const state = get();
+          const branch = state.branches.find((b) => `branch:${b.id}` === convId);
+          const engine = state.getConversationEngine(convId)?.engine;
+          const lastAsst = threadMessages.filter((m) => m.role === "assistant").slice(-1)[0];
+          notify("completed", state.personaLabel ?? "에이전트", "응답 완료", convId, {
+            engine,
+            conversationTitle: branch?.customLabel ?? branch?.label,
+            preview: lastAsst?.content?.replace(/\n+/g, " ").slice(0, 80),
+          });
+        }).catch((e) => console.debug("[notify:completed]", e));
+
+        if (!toolRequestHandled) get()._endRun(convId, { silent: true });
+      },
+      onError: async (p) => {
+        lifecycle?.cleanup();
+        set({ error: p.error });
+        import("@/stores/notificationStore").then(({ notify }) => {
+          const state = get();
+          const branch = state.branches.find((b) => `branch:${b.id}` === convId);
+          notify("error", state.personaLabel ?? "에이전트", `오류: ${p.error.slice(0, 80)}`, convId, {
+            engine: state.getConversationEngine(convId)?.engine,
+            conversationTitle: branch?.customLabel ?? branch?.label,
+          });
+        }).catch((e) => console.debug("[notify:error]", e));
+        const threadMessages = await invoke<Message[]>("list_messages", { conversationId: convId });
+        set({ threadMessages });
+        get()._endRun(convId);
+      },
     });
 
     try {
       const config = ENGINE_CONFIGS[engineKey] ?? ENGINE_CONFIGS.claude;
       await invoke<{ messageId: string }>(config.command, { input });
     } catch (e) {
-      cleanup();
+      lifecycle?.cleanup();
       set((state) => ({ error: errorMessage(e), threadMessages: state.threadMessages.filter((m) => !m.id.startsWith("temp-thinking-")) }));
       get()._endRun(convId);
     }

--- a/src/tests/agentStreamHelper.test.ts
+++ b/src/tests/agentStreamHelper.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { listen } from "@tauri-apps/api/event";
+import {
+  setupStreamLifecycle,
+  extractAndPersistFollowup,
+} from "@/stores/slices/agentStreamHelper";
+import type { Message } from "@/types";
+
+const mockedListen = vi.mocked(listen);
+
+type ListenHandler = (e: { payload: Record<string, unknown> }) => void | Promise<void>;
+
+beforeEach(() => {
+  mockedListen.mockReset();
+});
+
+describe("setupStreamLifecycle", () => {
+  it("filters events by conversationId", async () => {
+    const handlers = new Map<string, ListenHandler>();
+    mockedListen.mockImplementation(async (event: string, handler: unknown) => {
+      handlers.set(event, handler as ListenHandler);
+      return () => {};
+    });
+    const onProgress = vi.fn();
+
+    await setupStreamLifecycle({
+      convId: "c1",
+      engineKey: "claude",
+      hasChunkEvent: true,
+      onProgress,
+      onChunk: vi.fn(),
+      onCompleted: vi.fn().mockResolvedValue(undefined),
+      onError: vi.fn().mockResolvedValue(undefined),
+    });
+
+    const progress = handlers.get("claude:progress");
+    expect(progress).toBeDefined();
+    await progress!({ payload: { messageId: "m1", conversationId: "c2", text: "other" } });
+    expect(onProgress).not.toHaveBeenCalled();
+
+    await progress!({ payload: { messageId: "m1", conversationId: "c1", text: "hi" } });
+    expect(onProgress).toHaveBeenCalledWith({ messageId: "m1", conversationId: "c1", text: "hi" });
+  });
+
+  it("skips chunk listener when hasChunkEvent=false", async () => {
+    const registered = new Set<string>();
+    mockedListen.mockImplementation(async (event: string) => {
+      registered.add(event);
+      return () => {};
+    });
+    await setupStreamLifecycle({
+      convId: "c1",
+      engineKey: "codex",
+      hasChunkEvent: false,
+      onProgress: vi.fn(),
+      onChunk: vi.fn(),
+      onCompleted: vi.fn().mockResolvedValue(undefined),
+      onError: vi.fn().mockResolvedValue(undefined),
+    });
+    expect(registered.has("codex:progress")).toBe(true);
+    expect(registered.has("codex:chunk")).toBe(false);
+    expect(registered.has("agent:completed")).toBe(true);
+    expect(registered.has("agent:error")).toBe(true);
+  });
+
+  it("forwards error payload without messageId (branch variant)", async () => {
+    const handlers = new Map<string, ListenHandler>();
+    mockedListen.mockImplementation(async (event: string, handler: unknown) => {
+      handlers.set(event, handler as ListenHandler);
+      return () => {};
+    });
+    const onError = vi.fn().mockResolvedValue(undefined);
+    await setupStreamLifecycle({
+      convId: "c1",
+      engineKey: "claude",
+      hasChunkEvent: true,
+      onProgress: vi.fn(),
+      onChunk: vi.fn(),
+      onCompleted: vi.fn().mockResolvedValue(undefined),
+      onError,
+    });
+    const errHandler = handlers.get("agent:error")!;
+    await errHandler({ payload: { conversationId: "c1", error: "boom" } });
+    expect(onError).toHaveBeenCalledWith({ conversationId: "c1", error: "boom" });
+  });
+
+  it("cleanup detaches every listener that was registered", async () => {
+    const unlisten = vi.fn();
+    mockedListen.mockImplementation(async () => unlisten);
+    const handle = await setupStreamLifecycle({
+      convId: "c1",
+      engineKey: "claude",
+      hasChunkEvent: true,
+      onProgress: vi.fn(),
+      onChunk: vi.fn(),
+      onCompleted: vi.fn().mockResolvedValue(undefined),
+      onError: vi.fn().mockResolvedValue(undefined),
+    });
+    handle.cleanup();
+    // progress + chunk + completed + error = 4 listeners
+    expect(unlisten).toHaveBeenCalledTimes(4);
+  });
+});
+
+describe("extractAndPersistFollowup", () => {
+  it("returns null for undefined message", async () => {
+    expect(await extractAndPersistFollowup(undefined, "c1")).toBeNull();
+  });
+
+  it("returns null for user messages (no tool-request path)", async () => {
+    const msg: Message = {
+      id: "u1", conversationId: "c1", role: "user",
+      content: "hello", timestamp: 0, status: "done",
+    };
+    expect(await extractAndPersistFollowup(msg, "c1")).toBeNull();
+  });
+
+  it("returns null for assistant messages without markers", async () => {
+    const msg: Message = {
+      id: "a1", conversationId: "c1", role: "assistant",
+      content: "a plain response with no markers",
+      timestamp: 0, status: "done",
+    };
+    expect(await extractAndPersistFollowup(msg, "c1")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Phase 1 Finding 1-3 from \`docs/plans/refactorRoadmap_2026-04-20.md\` — **Step 2 of 2**. Extracts the progress/chunk/completed/error listener wiring into \`agentStreamHelper.setupStreamLifecycle\`, and collapses the tool-request follow-up boilerplate into \`extractAndPersistFollowup\`.

Follows Step 1 (PR #85 — pure helpers) which consolidated \`resolveModel\`, \`createPlaceholders\`, \`buildSendInput\`.

## Design (codex review incorporated)

- **Callback injection over variant flags** — each slice keeps full control over two divergent behaviors that variant flags would blur:
  - **Inactive-state reload**: main marks \`_staleConversations\` when user navigates away; branch updates \`threadMessages\` directly.
  - **Error payload shape**: main carries \`messageId\`, branch does not.
  \`setupStreamLifecycle\` only owns listener wiring, convId filter, and tool-steps persist on completed.
- **\`extractAndPersistFollowup\` returns \`{ followUp, sysMsgId }\`** — callers still own \`_endRun\` timing and the recursive send. Main uses \`_endRun(convId)\`; branch uses \`_endRun(convId, { silent: true })\` before recursing (the idle↔running flicker contract that a unified helper would have to re-introduce as a flag).
- **Extends \`agentStreamHelper.ts\` instead of adding a new folder** — dead code (\`createPlaceholders\`, \`setupStreamListeners\`, \`reloadMessages\`, none in use) removed; live exports (\`handleToolRequests\`, \`saveToolSteps\`) retained since \`ptyMessageSender\` still calls them.

## Slice line deltas

| File | Listener block |
|---|---|
| \`runtimeSlice.sendWithEngine\` | 140 → 80 lines |
| \`threadSlice.sendThreadMessage\` | 110 → 60 lines |

No user-visible behavior change. Preserved: chunk throttle (main only), progress-field semantics (main swaps placeholder; branch writes \`progressContent\`), \`autoSyncImplCompletion\` + \`autoDetectReviewVerdict\` hooks (branch only).

## Test plan
- [x] \`npx tsc --noEmit\` — 0 errors
- [x] \`npx vitest run\` — **241 passed** (baseline 234 + 7 new)
  - setupStreamLifecycle — convId filter, chunk-event gating, error payload w/o messageId, cleanup detaches 4 listeners
  - extractAndPersistFollowup — undefined / user / assistant-without-markers null-returns
- [ ] CI green
- [ ] Manual smoke (HMR): main send, branch drawer send, main tool-request recurse, branch tool-request recurse

## Out of scope
- Roundtable lifecycle (\`runRoundtable\` / \`runThreadRoundtable\`)
- PTY \`sendMessageViaPty\` lifecycle
- Workflow hooks (\`autoSyncImplCompletion\`, \`autoDetectReviewVerdict\`) — Finding 1-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)