### PR TITLE
fix(plan-proposal): stop showing false-success on branch-only proposals

### DIFF
--- a/src/components/tunaflow/chat/PlanProposalCard.tsx
+++ b/src/components/tunaflow/chat/PlanProposalCard.tsx
@@ -61,13 +61,21 @@ export function PlanProposalCard({ proposal, conversationId }: PlanProposalCardP
       );
 
       if (!matchingPlan) {
-        // Truly new proposal — no plan with this title exists at all
-        if (isBranchContext) { setStatus("promoted"); return; }
+        // Truly new proposal. Branch context used to jump to `promoted`
+        // here on the assumption that a twin card in main chat would call
+        // createPlan — but Insight Review branches (and any other path
+        // where the marker lives only in the branch) never surface in the
+        // parent conversation, so `createPlan` was never invoked and the
+        // card rendered "등록됨" while the Plans tab stayed empty.
+        // Drop into `idle` so the user sees the promote button.
         setStatus("idle");
         return;
       }
 
-      // Branch context 에서는 main chat 의 card 가 promote/overwrite 를 전담.
+      // Matching plan already exists in the parent conversation — a main
+      // chat card has already persisted it, so the branch card only needs
+      // to acknowledge. This is a real "promoted" state (DB row exists),
+      // unlike the removed no-match branch above.
       if (isBranchContext) {
         setStatus("promoted");
         return;
@@ -271,6 +279,17 @@ export function PlanProposalCard({ proposal, conversationId }: PlanProposalCardP
   const handlePromote = async (force = false) => {
     if (!force && proposal.subtasks.length === 0) {
       setStatus("warn-empty");
+      return;
+    }
+    // `plans.conversation_id` has an FK into `conversations`; a branch
+    // shadow id (`branch:…`) would violate it. Guard here in case the
+    // parent resolution at line 32 fell through to the shadow id because
+    // no main conversation was selected when the card mounted.
+    if (planConvId.startsWith("branch:")) {
+      import("sonner")
+        .then(({ toast }) => toast.error("Plan 등록 실패: 부모 대화를 선택한 뒤 다시 시도해주세요."))
+        .catch(() => {});
+      setStatus("idle");
       return;
     }
     setStatus("promoting");


### PR DESCRIPTION
## Summary
\`PlanProposalCard\` was rendering "Plan 탭에 등록됨" inside any branch conversation without ever invoking \`createPlan\`. The assumption was that a twin card in the main chat would persist the plan — but Insight Review branches (and any other branch where the plan-proposal marker lives only in the branch message) never produce a twin, so the Plans tab stayed empty while the UI reported success.

## Root cause
\`src/components/tunaflow/chat/PlanProposalCard.tsx:65\` — when no plan with the proposal's title exists yet and \`isBranchContext\` is true, the card short-circuited to \`status="promoted"\`. That path rendered "Plan 탭에 등록됨" (line 372) but never called \`planApi.createPlan\` — the \`handlePromote\` function is only reachable from the idle UI button, which the branch path skipped.

## Fix
1. **Drop the no-match branch-context fast-path** — let \`status\` fall through to \`idle\` so the user sees the promote button. Triggering \`handlePromote\` is now the only way to reach \`createPlan\`, closing the gap.
2. **Guard \`handlePromote\`** against \`planConvId\` that stays as a branch shadow id (\`branch:…\`). \`plans.conversation_id\` has an FK into \`conversations\`; a shadow id would trip a constraint error silently. The guard surfaces a toast and resets to idle instead.

Preserved (unchanged):
- Matching-plan branch-context path — still acknowledges with \`promoted\` because the main chat already persisted the plan (real DB row exists)
- Main-chat auto-merge on revision requests
- \`overwriteCandidate\` flow for done/abandoned plans
- Branch auto-adopt after promote

## Test plan
- [x] \`npx tsc --noEmit\` — 0 errors
- [x] \`npx vitest run\` — 241 passed (baseline; parser tests unchanged)
- [ ] CI green
- [ ] Manual: Insight 탭 분석 → 아키텍트(인사이트 브랜치) → plan 요청 → 제안 카드에서 "Plan으로 승격" 버튼 눌러야 실제 Plan 탭에 생성됨을 확인

## Out of scope
- Automatic promote on branch adopt (separate design)
- Insight orchestration flow redesign (next PR covers the state-persistence bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)