### PR TITLE
fix(insight): preserve analysis state across Insight tab unmounts

### DIFF
--- a/src/components/tunaflow/context-panel/InsightPanel.tsx
+++ b/src/components/tunaflow/context-panel/InsightPanel.tsx
@@ -18,13 +18,18 @@ import { QuadrantSection } from "./insight/InsightQuadrant";
 export function InsightPanel() {
   const selectedProjectKey = useChatStore((s) => s.selectedProjectKey);
   const projects = useChatStore((s) => s.projects);
+  // Running-analysis state lives in the store so a tab switch (which
+  // unmounts this component — see CenterPanel conditional render) does
+  // not discard the live progress log while the background Tauri
+  // command is still executing.
+  const running = useChatStore((s) => s.insightRunning);
+  const progressLines = useChatStore((s) => s.insightProgressLines);
+  const persistedActiveSessionId = useChatStore((s) => s.insightActiveSessionId);
 
   const [sessions, setSessions] = useState<InsightSession[]>([]);
   const [activeSession, setActiveSession] = useState<InsightSession | null>(null);
   const [findings, setFindings] = useState<InsightFinding[]>([]);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
-  const [running, setRunning] = useState(false);
-  const [progressLines, setProgressLines] = useState<string[]>([]);
   const [categoryFilter, setCategoryFilter] = useState<InsightCategory | "all">("all");
   const [activeFinding, setActiveFinding] = useState<InsightFinding | null>(null);
   // Previous session accordion
@@ -32,14 +37,21 @@ export function InsightPanel() {
   const [sessionFindings, setSessionFindings] = useState<Record<string, InsightFinding[]>>({});
   const progressEndRef = useRef<HTMLDivElement>(null);
 
-  // Load sessions
+  // Load sessions. When the panel remounts (user returns to the tab
+  // mid-run), prefer the session id the store is tracking so the
+  // findings list stays anchored to the latest run instead of snapping
+  // back to list[0].
   useEffect(() => {
     if (!selectedProjectKey) return;
     insightApi.listInsightSessions(selectedProjectKey).then((list) => {
       setSessions(list);
-      if (list.length > 0) setActiveSession(list[0]);
+      const preferred = persistedActiveSessionId
+        ? list.find((s) => s.id === persistedActiveSessionId)
+        : null;
+      if (preferred) setActiveSession(preferred);
+      else if (list.length > 0) setActiveSession(list[0]);
     }).catch(console.error);
-  }, [selectedProjectKey]);
+  }, [selectedProjectKey, persistedActiveSessionId]);
 
   // Load findings when session changes
   useEffect(() => {
@@ -52,7 +64,9 @@ export function InsightPanel() {
     progressEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [progressLines]);
 
-  // Run analysis
+  // Run analysis. Progress / running state routes through the store so
+  // that the background Tauri command keeps pushing updates even after
+  // the user switches tabs and the panel unmounts.
   const handleRunAnalysis = useCallback(async () => {
     if (!selectedProjectKey || running) return;
     const project = projects.find((p) => p.key === selectedProjectKey);
@@ -61,8 +75,8 @@ export function InsightPanel() {
       return;
     }
 
-    setRunning(true);
-    setProgressLines(["시작..."]);
+    const store = useChatStore.getState();
+    store.insightStartRun();
     setActiveFinding(null);
     try {
       const cats = categoryFilter !== "all" ? [categoryFilter] : undefined;
@@ -70,18 +84,17 @@ export function InsightPanel() {
         projectKey: selectedProjectKey,
         projectPath: project.path,
         categories: cats,
-        onProgress: (msg) => setProgressLines((prev) => [...prev, msg]),
+        onProgress: (msg) => useChatStore.getState().insightAppendProgress(msg),
       });
       setActiveSession(session);
       setFindings(newFindings);
       setSessions((prev) => [session, ...prev.filter((s) => s.id !== session.id)]);
-      setProgressLines((prev) => [...prev, `✓ 완료: ${newFindings.length}건 발견`]);
+      useChatStore.getState().insightAppendProgress(`✓ 완료: ${newFindings.length}건 발견`);
+      useChatStore.getState().insightFinishRun(session.id);
       toast.success(`분석 완료: ${newFindings.length}건 발견`);
     } catch (err) {
-      setProgressLines((prev) => [...prev, `✗ 실패: ${err}`]);
+      useChatStore.getState().insightFailRun(String(err));
       toast.error(`분석 실패: ${err}`);
-    } finally {
-      setRunning(false);
     }
   }, [selectedProjectKey, projects, categoryFilter, running]);
 
@@ -224,16 +237,23 @@ ${lines.join("\n\n")}`;
     }
   }, []);
 
-  // Revalidate open findings against current codebase
+  // Revalidate open findings against current codebase. Routes the same
+  // store-backed progress path as handleRunAnalysis so revalidation
+  // logs also survive tab unmounts.
   const handleRevalidate = useCallback(async () => {
     if (running || !selectedProjectKey) return;
     const openCount = findings.filter((f) => f.status === "open").length;
     if (openCount === 0) { toast.info("재검토할 open findings가 없습니다"); return; }
 
-    setRunning(true);
-    setProgressLines([`${openCount}건 재검토 중...`]);
+    const store = useChatStore.getState();
+    store.insightStartRun();
+    store.insightAppendProgress(`${openCount}건 재검토 중...`);
     try {
-      const results = await revalidateFindings(findings, selectedProjectKey, (msg) => setProgressLines((p) => [...p, msg]));
+      const results = await revalidateFindings(
+        findings,
+        selectedProjectKey,
+        (msg) => useChatStore.getState().insightAppendProgress(msg),
+      );
       const resolved = results.filter((r) => r.status === "resolved");
       const uncertain = results.filter((r) => r.status === "uncertain");
 
@@ -251,11 +271,11 @@ ${lines.join("\n\n")}`;
       const msg = resolved.length > 0
         ? `재검토 완료: ${resolved.length}건 해결됨으로 업데이트${uncertain.length > 0 ? `, ${uncertain.length}건 불확실` : ""}`
         : `재검토 완료: 모든 findings가 여전히 유효합니다`;
+      useChatStore.getState().insightFinishRun();
       toast.success(msg);
     } catch (err) {
+      useChatStore.getState().insightFailRun(String(err));
       toast.error(`재검토 실패: ${err}`);
-    } finally {
-      setRunning(false);
     }
   }, [running, findings, selectedProjectKey]);
 

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -7,6 +7,7 @@ import { createThreadSlice } from "./slices/threadSlice";
 import { createRuntimeSlice } from "./slices/runtimeSlice";
 import { createAssetSlice } from "./slices/assetSlice";
 import { createEngineModelSlice } from "./slices/engineModelSlice";
+import { createInsightSlice } from "./slices/insightSlice";
 
 export type { ChatState };
 
@@ -19,4 +20,5 @@ export const useChatStore = create<ChatState>((set, get) => ({
   ...createRuntimeSlice(set, get),
   ...createAssetSlice(set, get),
   ...createEngineModelSlice(set, get),
+  ...createInsightSlice(set, get),
 }));

--- a/src/stores/slices/insightSlice.ts
+++ b/src/stores/slices/insightSlice.ts
@@ -1,0 +1,57 @@
+/**
+ * Insight-panel runtime state that must survive tab unmount.
+ *
+ * `InsightPanel` lives inside `CenterPanel` which conditionally renders
+ * tabs (`{tab === "insight" && <InsightPanel />}`), so switching to Chat
+ * or Workflow tears the component down. Before this slice existed, the
+ * `running` / `progressLines` flags were `useState` and therefore reset
+ * to their initial values whenever the user revisited the tab — even
+ * though the Tauri background command (`run_insight_analysis`) kept
+ * executing. This slice parks the live analysis state at module scope
+ * so the mounted panel can read the current value and keep rendering.
+ */
+import type { SetState, GetState } from "./types";
+
+export interface InsightSlice {
+  /** True while an analysis run is in flight. Set by `insightStartRun`,
+   *  cleared by `insightFinishRun` / `insightFailRun`. */
+  insightRunning: boolean;
+  /** Append-only log shown in the progress panel. Retained after
+   *  completion so users see what the last run did. */
+  insightProgressLines: string[];
+  /** Most recent session id — used to re-select the active session on
+   *  remount so the findings list stays anchored to the latest run. */
+  insightActiveSessionId: string | null;
+
+  insightStartRun: () => void;
+  insightAppendProgress: (line: string) => void;
+  insightFinishRun: (sessionId?: string | null) => void;
+  insightFailRun: (reason: string) => void;
+  insightSetActiveSessionId: (id: string | null) => void;
+}
+
+export const createInsightSlice = (set: SetState, _get: GetState): InsightSlice => ({
+  insightRunning: false,
+  insightProgressLines: [],
+  insightActiveSessionId: null,
+
+  insightStartRun: () => set({ insightRunning: true, insightProgressLines: ["시작..."] }),
+
+  insightAppendProgress: (line: string) =>
+    set((state) => ({ insightProgressLines: [...state.insightProgressLines, line] })),
+
+  insightFinishRun: (sessionId?: string | null) =>
+    set((state) => ({
+      insightRunning: false,
+      insightActiveSessionId: sessionId ?? state.insightActiveSessionId,
+    })),
+
+  insightFailRun: (reason: string) =>
+    set((state) => ({
+      insightRunning: false,
+      insightProgressLines: [...state.insightProgressLines, `✗ 실패: ${reason}`],
+    })),
+
+  insightSetActiveSessionId: (id: string | null) =>
+    set({ insightActiveSessionId: id }),
+});

--- a/src/stores/slices/types.ts
+++ b/src/stores/slices/types.ts
@@ -168,6 +168,16 @@ export interface ChatState {
   createArtifact: (input: CreateArtifactInput) => Promise<void>;
   updateArtifactStatus: (id: string, status: "draft" | "approved" | "rejected") => Promise<void>;
   deleteArtifact: (id: string) => Promise<void>;
+
+  // ─── Insight panel runtime state (survives tab unmount) ─────────────
+  insightRunning: boolean;
+  insightProgressLines: string[];
+  insightActiveSessionId: string | null;
+  insightStartRun: () => void;
+  insightAppendProgress: (line: string) => void;
+  insightFinishRun: (sessionId?: string | null) => void;
+  insightFailRun: (reason: string) => void;
+  insightSetActiveSessionId: (id: string | null) => void;
 }
 
 /** Zustand setter / getter types for slices */


### PR DESCRIPTION
## Summary
\`CenterPanel\` renders Insight conditionally (\`{tab === "insight" && <InsightPanel />}\`), so switching to Chat / Workflow unmounts the panel. The live \`running\` / \`progressLines\` state was held in \`useState\`, which meant a mid-run tab excursion discarded the entire progress UI on return — even though the Tauri background command (\`run_insight_analysis\`) kept executing. Users saw the "분석 실행" button reset with no way to observe the ongoing run.

## Fix
Pull the three pieces of state that must outlive the panel lifecycle into a small new zustand slice (\`insightSlice\`):

| Field | Purpose |
|---|---|
| \`insightRunning\` | True while an analysis / revalidation is in flight |
| \`insightProgressLines\` | Append-only log shown in the progress panel |
| \`insightActiveSessionId\` | Anchors the findings list to the most recent run on remount |

Progress callbacks and start / finish / fail transitions route through store actions (\`insightStartRun\`, \`insightAppendProgress\`, \`insightFinishRun\`, \`insightFailRun\`). On remount, \`InsightPanel\` picks the persisted session id before falling back to \`sessions[0]\`.

Everything else (sessions list, findings, filters, accordion state) stays local because it is either re-derivable from the DB on mount or scoped to one viewing session.

## Behavior
- Start analysis → switch to Chat → return to Insight: progress log + "분석 중..." indicator still present.
- Completion updates the store's \`insightActiveSessionId\` → remount anchors findings list to the new session.
- Failure path appends the error line to the persisted log; the running flag clears so the user can retry.

## Test plan
- [x] \`npx tsc --noEmit\` — 0 errors
- [x] \`npx vitest run\` — 241 passed (baseline)
- [ ] CI green
- [ ] Manual smoke: start analysis, excurse to Chat/Workflow, return — log + running indicator still visible

## Out of scope
- Backend \`insight:progress\` event emission (would let a fresh browser restart also recover in-flight runs from DB — larger change)
- Cross-session progress de-duplication
- Unifying progress state with workflow / RT live indicators

🤖 Generated with [Claude Code](https://claude.com/claude-code)