### PR TITLE
fix(http-api): let /ws/events bypass header-only auth middleware

### DIFF
--- a/src-tauri/src/http_api/auth.rs
+++ b/src-tauri/src/http_api/auth.rs
@@ -15,8 +15,17 @@ pub async fn auth_middleware(
     request: axum::extract::Request,
     next: middleware::Next,
 ) -> impl IntoResponse {
-    // Skip auth for health check
-    if request.uri().path() == "/api/health" {
+    // Skip this middleware for:
+    //   - /api/health (public probe)
+    //   - /ws/events (handles its own auth, accepting either the Authorization
+    //     header OR a `?token=` query param; see `ws.rs:24-35`). Browsers
+    //     cannot attach custom headers to a WebSocket handshake, so the query
+    //     path is the only way mobile clients can authenticate. Running this
+    //     header-only middleware in front of `ws_events` short-circuits with
+    //     401 before the handler's query-parsing logic can ever execute,
+    //     turning the ws.rs code path into dead code for query callers.
+    let path = request.uri().path();
+    if path == "/api/health" || path == "/ws/events" {
         return next.run(request).await;
     }
 


### PR DESCRIPTION
## Summary
\`http_api/auth.rs\` only reads the \`Authorization\` header, while \`http_api/ws.rs:24-35\` accepts either the header or a \`?token=\` query param (the groundwork for browser WebSocket clients, which cannot attach custom headers to an upgrade request).

Problem: the middleware runs **before** the \`/ws/events\` handler, so every query-authenticated upgrade short-circuits to 401 "invalid token" without ever reaching the handler's query-parsing logic. That branch in \`ws.rs\` has been effectively dead code since session 30 — command-line tools naturally attach a Bearer header and thus pass the middleware, which is why desktop testing never caught the regression.

## Fix
Skip the middleware for \`/ws/events\` alongside \`/api/health\`. \`ws.rs\` already enforces auth for both paths and returns the same 401 body for invalid tokens, so security is unchanged. Query-param auth simply becomes reachable.

\`\`\`diff
-    if request.uri().path() == "/api/health" {
+    let path = request.uri().path();
+    if path == "/api/health" || path == "/ws/events" {
         return next.run(request).await;
     }
\`\`\`

## Symptom that triggered this
Mobile client console repeatedly logging:
\`\`\`
WebSocket connection to 'wss://tunaflow.d9ng.site/ws/events?token=93308089-…' failed
\`\`\`

curl reproduced the exact same 401 "invalid token" whether the request went through Cloudflare tunnel **or** directly to \`http://localhost:19840\`. Token in \`~/.tunaflow/api-token\` matched byte-for-byte. The middleware short-circuit was the only thing discriminating between header and query callers.

## Test plan
- [x] \`cargo check --lib\` — 0 errors (3 pre-existing warnings unchanged)
- [x] \`cargo test --lib\` — 295 passed
- [x] \`cargo test --tests\` — 25 passed
- [ ] CI green
- [ ] Manual (user): browser \`new WebSocket('wss://tunaflow.d9ng.site/ws/events?token=<value>')\` upgrades to 101 instead of closing 1006

## Out of scope
- Expanding the middleware itself to read query params (would duplicate work ws.rs already does)
- Session-30 style follow-up tests — a middleware-level unit test requires an integration harness that currently doesn't exist; happy to add one in a follow-up PR if desired

🤖 Generated with [Claude Code](https://claude.com/claude-code)