### PR TITLE
fix(http-api): continue Claude/Codex/Gemini session across mobile turns

### DIFF
--- a/src-tauri/src/http_api/agents.rs
+++ b/src-tauri/src/http_api/agents.rs
@@ -71,20 +71,28 @@ pub async fn send_message(
         }))).into_response();
     }
 
-    // Resolve project path from DB
-    let project_path = {
+    // Resolve project path + previous resume_token from DB. The mobile HTTP
+    // path must continue the same Claude/Codex/Gemini session across requests
+    // — without the prior session id the adapter starts a fresh `-p` style
+    // run each time and the agent has no memory of earlier turns.
+    let (project_path, prior_resume_token): (Option<String>, Option<String>) = {
         let conn = lock_conn(&state.db.read);
         conn.query_row(
-            "SELECT p.path FROM projects p JOIN conversations c ON c.project_key = p.key WHERE c.id = ?1",
-            [&conv_id], |r| r.get::<_, Option<String>>(0),
-        ).unwrap_or(None)
+            "SELECT p.path, c.resume_token FROM projects p JOIN conversations c ON c.project_key = p.key WHERE c.id = ?1",
+            [&conv_id],
+            |r| Ok((r.get::<_, Option<String>>(0)?, r.get::<_, Option<String>>(1)?)),
+        ).unwrap_or((None, None))
     };
 
     let db = state.db.clone();
     let db_post = state.db.clone();
     let conv_id_clone = conv_id.clone();
     let prompt = input.prompt.clone();
-    let model = input.model.clone();
+    // Separate clones for the blocking task (RunInput) and the DB-insert path
+    // — the former moves into `spawn_blocking`, so the outer match needs its
+    // own copy to record the real model name on the assistant message.
+    let model_for_run = input.model.clone();
+    let model_for_db = input.model.clone();
     let event_tx = state.event_tx.clone();
 
     let engine_for_db = engine.clone();
@@ -110,14 +118,16 @@ pub async fn send_message(
                 )
             };
 
-            eprintln!("[http-api] ContextPack built: prompt={}chars system={}chars",
-                enriched_prompt.len(), system_prompt.as_ref().map(|s| s.len()).unwrap_or(0));
+            eprintln!("[http-api] ContextPack built: prompt={}chars system={}chars resume={}",
+                enriched_prompt.len(),
+                system_prompt.as_ref().map(|s| s.len()).unwrap_or(0),
+                prior_resume_token.as_deref().unwrap_or("<none>"));
 
             let run_input = claude::RunInput {
                 prompt: enriched_prompt,
-                model,
+                model: model_for_run,
                 system_prompt,
-                resume_token: None,
+                resume_token: prior_resume_token,
                 project_path: project_path.clone(),
                 image_paths: Vec::new(),
             };
@@ -136,10 +146,24 @@ pub async fn send_message(
                 let now = crate::db::migrations::now_epoch_ms();
                 let conn = match db_post.write.lock() { Ok(c) => c, Err(p) => p.into_inner() };
                 {
+                    // Assistant row: `model` column holds the actual model name
+                    // (was polluted with session_id before, which broke model
+                    // badges and caused confusion when mobile clients rendered
+                    // the column as a chat-message UUID).
                     conn.execute(
                         "INSERT INTO messages (id, conversation_id, role, content, engine, model, timestamp, status) VALUES (?1, ?2, 'assistant', ?3, ?4, ?5, ?6, 'done')",
-                        rusqlite::params![msg_id, conv_id_clone, out.content, engine_for_db, out.session_id, now],
+                        rusqlite::params![msg_id, conv_id_clone, out.content, engine_for_db, model_for_db, now],
                     ).ok();
+                    // Persist session_id as the conversation's resume token so
+                    // the NEXT /api/conversations/{id}/send call hands it back
+                    // to the adapter via `RunInput.resume_token`, keeping the
+                    // Claude/Codex/Gemini session alive across mobile turns.
+                    if let Some(sid) = &out.session_id {
+                        conn.execute(
+                            "UPDATE conversations SET resume_token = ?1 WHERE id = ?2",
+                            rusqlite::params![sid, conv_id_clone],
+                        ).ok();
+                    }
                 }
                 drop(conn);
                 let _ = event_tx.send(serde_json::json!({


### PR DESCRIPTION
## Summary
\`POST /api/conversations/{id}/send\` (consumed by the mobile client) was hardcoding \`resume_token: None\`, so every turn started a fresh \`-p\` style CLI run with no memory of earlier turns. Observed symptom: the agent claimed its own last message was "truncated from context" immediately after posting it. The user summarized it as "-p 모드처럼" — precisely right.

## Root causes (two coupled bugs)
### 1. No session continuity
\`http_api/agents.rs:116-123\` → \`RunInput { resume_token: None, … }\` on every call, no read/update of \`conversations.resume_token\`. Each HTTP send spawned a brand-new Claude CLI session.

### 2. \`messages.model\` polluted with \`session_id\`
\`agents.rs:141\` was binding \`out.session_id\` into the \`model\` column of the INSERT. That is why each mobile response rendered with a different UUID-shaped model badge and looked like a different session — because downstream UI reads \`messages.model\` as "the model this turn ran on." The actual model name the caller sent (\`input.model\`) was silently dropped.

## Fix
- **Read** \`conversations.resume_token\` during the project-path lookup; pass it into \`RunInput.resume_token\`.
- **Update** \`conversations.resume_token\` with \`out.session_id\` on successful completion so the NEXT send hands it back to the adapter.
- **Assistant INSERT** now stores \`input.model\` in the \`model\` column. Session id goes to the dedicated \`resume_token\` column where it belongs.
- Desktop path (\`start_claude_stream\` + \`runtimeSlice\`) was already correct and is untouched.

## Scope
All four engines benefit from the same fix because they share \`RunInput\`:
\`\`\`rust
match engine.as_str() {
    "claude" => claude::run(run_input),
    "codex" => crate::agents::codex::run(run_input),
    "gemini" => crate::agents::gemini::run(run_input),
    "ollama" => crate::agents::openai_compat::run(run_input),
    _ => claude::run(run_input),
}
\`\`\`

## Test plan
- [x] \`cargo check --lib\` — 0 errors (3 pre-existing warnings unchanged)
- [x] \`cargo test --lib\` — 295 passed
- [x] \`cargo test --tests\` — 25 passed
- [ ] CI green
- [ ] Manual (mobile): send two prompts in the same conversation, confirm the second response references the first and \`conversations.resume_token\` updates each turn

## Not included
- Backfill/migration for historical rows where \`messages.model\` is polluted with a UUID — separate decision; the column is purely display metadata, so a migration isn't strictly required. Open a follow-up if we want the old mobile sessions' badges to render correctly.
- ContextPack \`status\` filter tweak (separate Explore finding for \`load_recent_messages_with_author\`). Session resume alone should eliminate the "직전 응답을 모르는" symptom; the status filter is a defense-in-depth improvement for a different race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)