### PR TITLE
refactor(ui-router): move focus-plan from window event to slice (Finding 1-4)

### DIFF
--- a/src/components/tunaflow/MetaFloatingChat.tsx
+++ b/src/components/tunaflow/MetaFloatingChat.tsx
@@ -158,8 +158,12 @@ export function MetaFloatingChat({ projectKey }: MetaFloatingChatProps) {
     if (!r) return;
     if (r.tab) window.dispatchEvent(new CustomEvent("tunaflow:switch-tab", { detail: r.tab }));
     if (r.stage) window.dispatchEvent(new CustomEvent("tunaflow:switch-stage", { detail: r.stage }));
-    if (r.planId) window.dispatchEvent(new CustomEvent("tunaflow:focus-plan", { detail: r.planId }));
-    if (r.messageId) window.dispatchEvent(new CustomEvent("tunaflow:scroll-to-message", { detail: r.messageId }));
+    // Domain-level focus goes through uiRouterSlice rather than a window
+    // event — PlansPanel subscribes to the store directly (Finding 1-4).
+    if (r.planId) useChatStore.getState().focusPlan(r.planId);
+    // `scroll-to-message` window event had no subscribers and has been
+    // dropped. If a future UI ever needs to scroll to a specific
+    // message we'll add it to uiRouterSlice instead.
     if (!pinned) setOpen(false);
   }, [pinned]);
 

--- a/src/components/tunaflow/context-panel/PlansPanel.tsx
+++ b/src/components/tunaflow/context-panel/PlansPanel.tsx
@@ -51,23 +51,25 @@ export function PlansPanel({ activeStage, onPhaseChanged, onStatusChanged, onSwi
   useEffect(() => { loadPlans(); }, [canonicalConvId]);
 
   // Meta 알림에서 "이동" 클릭 시 해당 plan 카드로 스크롤 + 하이라이트.
+  // Subscribe to `uiRouterSlice.focusedPlanId` directly — MetaFloatingChat
+  // writes the request via `focusPlan(id)` (Finding 1-4).
+  const focusedPlanId = useChatStore((s) => s.focusedPlanId);
+  const focusPlan = useChatStore((s) => s.focusPlan);
   useEffect(() => {
-    const handler = (e: Event) => {
-      const planId = (e as CustomEvent<string>).detail;
-      if (!planId) return;
-      loadPlans();
-      setTimeout(() => {
-        const el = containerRef.current?.querySelector(`[data-plan-id="${planId}"]`);
-        if (el) {
-          el.scrollIntoView({ behavior: "smooth", block: "center" });
-          el.classList.add("ring-2", "ring-primary/60");
-          setTimeout(() => el.classList.remove("ring-2", "ring-primary/60"), 2000);
-        }
-      }, 150);
-    };
-    window.addEventListener("tunaflow:focus-plan", handler);
-    return () => window.removeEventListener("tunaflow:focus-plan", handler);
-  }, []);
+    if (!focusedPlanId) return;
+    loadPlans();
+    const timer = setTimeout(() => {
+      const el = containerRef.current?.querySelector(`[data-plan-id="${focusedPlanId}"]`);
+      if (el) {
+        el.scrollIntoView({ behavior: "smooth", block: "center" });
+        el.classList.add("ring-2", "ring-primary/60");
+        setTimeout(() => el.classList.remove("ring-2", "ring-primary/60"), 2000);
+      }
+      // Clear after handling so re-selecting the same plan re-fires.
+      focusPlan(null);
+    }, 150);
+    return () => clearTimeout(timer);
+  }, [focusedPlanId, focusPlan]);
 
   // Reload when visible
   useEffect(() => {

--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -8,6 +8,7 @@ import { createRuntimeSlice } from "./slices/runtimeSlice";
 import { createAssetSlice } from "./slices/assetSlice";
 import { createEngineModelSlice } from "./slices/engineModelSlice";
 import { createInsightSlice } from "./slices/insightSlice";
+import { createUiRouterSlice } from "./slices/uiRouterSlice";
 
 export type { ChatState };
 
@@ -21,4 +22,5 @@ export const useChatStore = create<ChatState>((set, get) => ({
   ...createAssetSlice(set, get),
   ...createEngineModelSlice(set, get),
   ...createInsightSlice(set, get),
+  ...createUiRouterSlice(set, get),
 }));

--- a/src/stores/slices/types.ts
+++ b/src/stores/slices/types.ts
@@ -195,6 +195,10 @@ export interface ChatState {
    *  (profiles, skills, personas) are left alone. */
   clearConversationAssets: () => void;
 
+  // ─── UI router (Finding 1-4) — domain-level focus state ────────────
+  focusedPlanId: string | null;
+  focusPlan: (planId: string | null) => void;
+
   // ─── Insight panel runtime state (survives tab unmount) ─────────────
   insightRunning: boolean;
   insightProgressLines: string[];

--- a/src/stores/slices/uiRouterSlice.ts
+++ b/src/stores/slices/uiRouterSlice.ts
@@ -1,0 +1,31 @@
+/**
+ * UI router — state that represents "which domain object the UI is
+ * currently focusing on", as opposed to "which tab the user has open"
+ * (that one stays a CenterPanel-local concern driven by window events).
+ *
+ * Introduced for Finding 1-4 in `docs/plans/refactorRoadmap_2026-04-20.md`.
+ * Only `focusedPlanId` is domain-level (which plan row should scroll
+ * into view / pulse). The UI-scope events (`tunaflow:switch-tab`,
+ * `tunaflow:switch-stage`, `tunaflow:open-settings`) deliberately stay
+ * as window dispatches per the roadmap.
+ */
+import type { SetState, GetState } from "./types";
+
+export interface UiRouterSlice {
+  /**
+   * Id of the plan that a route request asked the UI to focus on.
+   * Subscribers (e.g. PlansPanel) read this and trigger their own scroll /
+   * highlight. Consumers clear it by calling `focusPlan(null)` after they
+   * handle the focus request so re-selecting the same plan still fires.
+   */
+  focusedPlanId: string | null;
+  /** Set or clear the focused plan id. */
+  focusPlan: (planId: string | null) => void;
+}
+
+export const createUiRouterSlice = (set: SetState, _get: GetState): UiRouterSlice => ({
+  focusedPlanId: null,
+  focusPlan: (planId: string | null) => {
+    set({ focusedPlanId: planId });
+  },
+});

--- a/src/tests/uiRouterSlice.test.ts
+++ b/src/tests/uiRouterSlice.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useChatStore } from "@/stores/chatStore";
+
+beforeEach(() => {
+  useChatStore.getState().focusPlan(null);
+});
+
+describe("uiRouterSlice.focusPlan", () => {
+  it("sets the focused plan id", () => {
+    useChatStore.getState().focusPlan("plan-xyz");
+    expect(useChatStore.getState().focusedPlanId).toBe("plan-xyz");
+  });
+
+  it("clears when called with null", () => {
+    useChatStore.getState().focusPlan("plan-xyz");
+    useChatStore.getState().focusPlan(null);
+    expect(useChatStore.getState().focusedPlanId).toBeNull();
+  });
+
+  it("overwrites a previous focus request", () => {
+    useChatStore.getState().focusPlan("plan-a");
+    useChatStore.getState().focusPlan("plan-b");
+    expect(useChatStore.getState().focusedPlanId).toBe("plan-b");
+  });
+});


### PR DESCRIPTION
## Summary
**Last item in Phase 1** of \`docs/plans/refactorRoadmap_2026-04-20.md\`. \`tunaflow:focus-plan\` was the only domain-level CustomEvent left on the window bus — every other dispatch (\`switch-tab\`, \`switch-stage\`, \`open-settings\`) is UI-scope and stays per the roadmap. Route it through a proper slice.

## Changes
- **New** \`src/stores/slices/uiRouterSlice.ts\` with \`focusedPlanId\` + \`focusPlan(id)\` action
- **\`MetaFloatingChat.routeTo\`** now calls \`useChatStore.getState().focusPlan(r.planId)\` instead of \`window.dispatchEvent(new CustomEvent("tunaflow:focus-plan", …))\`
- **\`PlansPanel\`** subscribes to \`focusedPlanId\` and calls \`focusPlan(null)\` after handling so re-selecting the same plan re-fires (preserves the event-driven semantic)
- **Drop** \`tunaflow:scroll-to-message\` dispatch — no subscriber anywhere in the codebase. If a future UI needs it, it goes on the same slice.

## Kept as window events (per roadmap)
\`switch-tab\`, \`switch-stage\`, \`open-settings\` — pure UI-scope, not domain.

## Test plan
- [x] \`npx tsc --noEmit\` — 0 errors
- [x] \`npx vitest run\` — **284 passed** (baseline 281 + 3 new)
  - \`uiRouterSlice\`: focusPlan set / null-clear / overwrite
- [ ] CI green
- [ ] Manual (HMR): Meta inbox entry with \`route.planId\` → PlansPanel scrolls + pulses exactly as before

## Phase 1 status after this merge
- [x] **1-6** lib.rs bootstrap
- [x] **1-3 Step 1** send pipeline pure fns
- [x] **1-3 Step 2** send pipeline lifecycle
- [x] **1-5** workflow services
- [x] **1-2** project bootstrap
- [x] **1-1** slice 경계 정리
- [x] **1-4** uiRouter slice (이 PR)

**Phase 1 완료**. 다음: Phase 2 (API 완성), Phase 3 (프로덕션 비기능), Phase 4 (접근성/문서/크래시), Phase 5 (Beta readiness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)