### PR TITLE
feat(api): Phase 2 REST v1 foundation — 2-1 through 2-5

### DIFF
--- a/docs/api/v1.md
+++ b/docs/api/v1.md
@@ -1,0 +1,128 @@
+# tunaFlow HTTP API v1
+
+> Status: draft · Phase 2 Finding 2-1~2-5
+> Last updated: 2026-04-21
+> Canonical prefix: `/api/v1/...`
+> Legacy prefix: `/api/...` (same handlers, response includes `X-API-Deprecated: use /api/v1`)
+
+## Auth
+
+All REST endpoints require `Authorization: Bearer <token>` **except**:
+
+- `GET /api/v1/health` (no auth)
+- WebSocket `wss://<host>/ws/events` — accepts either the `Authorization` header **or** a `?token=<token>` query parameter (browsers can't send headers on a WS handshake).
+
+The token is persisted at `~/.tunaflow/api-token` and is stable across app restarts. Rotating means deleting that file and restarting the app.
+
+## Conventions
+
+- All JSON uses `camelCase`.
+- Timestamps are milliseconds since Unix epoch unless stated otherwise.
+- `404` for a resource that doesn't exist. `400` for a well-formed request with bad arguments (e.g. unknown status enum). `500` for server errors.
+
+## Endpoints added in Phase 2
+
+### `GET /api/v1/health`
+Public. Returns `200 OK` with `{ "ok": true }` once the server is ready.
+
+### `GET /api/v1/branches/{id}` *(new in 2-2)*
+Single-branch detail for the mobile δ-Branch screen.
+
+Response:
+```json
+{
+  "id": "b-abc",
+  "label": "Review RT",
+  "customLabel": null,
+  "status": "active" | "archived" | "discarded" | "adopted",
+  "mode": "chat" | "roundtable",
+  "checkpointId": "msg-...",
+  "parentBranchId": null,
+  "subtaskId": null,
+  "adoptedMessageId": "msg-sum-..." | null,
+  "parentConversationId": "conv-...",
+  "shadowConversationId": "branch:b-abc",
+  "participants": [...] | null,
+  "createdAt": 1737500000000
+}
+```
+
+- `adoptedMessageId` is `null` until the branch is adopted — at that point the `adopt_branch` handler records the summary message id produced in the parent conversation.
+- `participants` is parsed from the shadow conversation's `rt_config`; `null` for non-roundtable branches.
+
+Errors: `404` for unknown branch id.
+
+### `GET /api/v1/branches/{id}/rounds` *(new in 2-3)*
+Roundtable branch rounds aggregated by parsing the system header messages (`--- Round N · mode · names ---`) that `commands/roundtable.rs` writes into the shadow conversation.
+
+Response:
+```json
+{
+  "rounds": [
+    {
+      "roundNumber": 1,
+      "mode": "sequential",
+      "names": ["Reviewer-A", "Reviewer-B"],
+      "startedAt": 1737500001000,
+      "completedAt": 1737500090000,
+      "participantResponses": [
+        {
+          "persona": "Reviewer-A",
+          "engine": "claude",
+          "model": "sonnet-4-6",
+          "messageIds": ["msg-1", "msg-2"],
+          "contentPreview": "verdict: pass …"
+        }
+      ]
+    }
+  ]
+}
+```
+
+- Participants are bucketed by `persona`, falling back to `engine` or the literal `"(unknown)"` when both are absent.
+- `contentPreview` is truncated to 240 chars of the most recent turn per participant. Use `GET /api/v1/conversations/{shadowId}/messages` for full bodies.
+- `completedAt` is the timestamp of the last assistant turn in the round (may equal `startedAt` for rounds that haven't produced a response yet).
+
+Errors: no 404 — an unknown branch id returns `{ "rounds": [] }` because the shadow conversation simply has no messages yet.
+
+### `GET /api/v1/conversations/{id}/active-plan` *(new in 2-5)*
+Returns the most recent non-done / non-abandoned plan on the conversation, or `null`.
+
+Response:
+```json
+{ "planId": "p-...", "phase": "drafting" | "approval" | "implementation" | "review" | "rework" | "done", "title": "…" }
+```
+or:
+```json
+null
+```
+
+### `POST /api/v1/plans/{id}/subtasks/{sid}/status` *(new in 2-4)*
+Changes a subtask's status. Emits `plan:subtask_status_changed` on WS so mobile doesn't have to poll.
+
+Body:
+```json
+{ "status": "todo" | "approved" | "in_progress" | "done" | "abandoned",
+  "outcome": "…" | null,
+  "updatedBy": "user" | "developer" | "reviewer" | "system" | null }
+```
+
+Response:
+```json
+{ "planId": "p-...", "subtaskId": "st-...", "status": "done", "updatedAt": 1737500000000 }
+```
+
+Errors:
+- `400` for unknown status enum (see allowed values) or when `plan_id`/`subtask_id` don't match.
+- `404` for unknown subtask id.
+
+WS side effect:
+```json
+{ "type": "plan:subtask_status_changed", "planId": "...", "subtaskId": "...", "status": "..." }
+```
+
+## Out of scope for this document
+
+- Phase 2 Finding 2-6 (WS `?since=` replay + `ws_event_log` TTL cleanup) — separate PR, separate doc update.
+- Phase 3+ endpoints.
+- Legacy `/api/...` path responses include `X-API-Deprecated: use /api/v1` and are otherwise identical — they will be removed after 1–2 releases following mobile client migration.

--- a/src-tauri/src/commands/branches.rs
+++ b/src-tauri/src/commands/branches.rs
@@ -78,7 +78,8 @@ pub fn list_branches(
     let conn = state.read.lock().map_err(|_| AppError::Lock)?;
     let mut stmt = conn.prepare(
         "SELECT id, conversation_id, label, custom_label, status,
-                checkpoint_id, parent_branch_id, session_id, git_branch, mode, subtask_id, created_at
+                checkpoint_id, parent_branch_id, session_id, git_branch, mode, subtask_id,
+                adopted_message_id, created_at
          FROM branches WHERE conversation_id = ?1 ORDER BY created_at ASC",
     )?;
     let rows = stmt
@@ -95,7 +96,8 @@ pub fn list_branches(
                 git_branch: row.get(8)?,
                 mode: row.get(9)?,
                 subtask_id: row.get(10)?,
-                created_at: row.get(11)?,
+                adopted_message_id: row.get(11)?,
+                created_at: row.get(12)?,
             })
         })?
         .collect::<Result<Vec<_>, _>>()?;
@@ -225,6 +227,7 @@ pub fn create_branch(
         git_branch,
         mode: Some(branch_mode.to_string()),
         subtask_id: input.subtask_id,
+        adopted_message_id: None,
         created_at: now,
     })
 }
@@ -563,6 +566,15 @@ pub fn adopt_branch(
         "INSERT INTO messages (id, conversation_id, role, content, timestamp, status, engine, model)
          VALUES (?1, ?2, 'assistant', ?3, ?4, 'done', ?5, ?6)",
         params![msg_id, input.conversation_id, content, now, last_engine, last_model],
+    )?;
+
+    // v40: record the summary message id on the branch row so mobile
+    // δ-Branch detail can look up "which turn landed in the parent
+    // conversation when this branch was adopted" without re-scanning
+    // messages.
+    conn.execute(
+        "UPDATE branches SET adopted_message_id = ?1 WHERE id = ?2",
+        params![msg_id, input.branch_id],
     )?;
 
     Ok(Message {

--- a/src-tauri/src/db/migrations.rs
+++ b/src-tauri/src/db/migrations.rs
@@ -142,6 +142,9 @@ pub fn run(conn: &Connection) -> Result<(), AppError> {
     if current < 39 {
         apply_v39(conn)?;
     }
+    if current < 40 {
+        apply_v40(conn)?;
+    }
     Ok(())
 }
 
@@ -920,6 +923,21 @@ fn apply_v39(conn: &Connection) -> Result<(), AppError> {
     )?;
     eprintln!("[migration v39] cleaned up {} stale anchor/pair chunks (NULL embedding)", deleted);
     conn.execute("INSERT INTO schema_version (version, applied_at) VALUES (39, ?1)", [now_epoch_ms()])?;
+    Ok(())
+}
+
+fn apply_v40(conn: &Connection) -> Result<(), AppError> {
+    // Phase 2 Finding 2-2: `adopt_branch` command currently inserts a
+    // system message into the parent conversation to mark the adoption
+    // but never records which message id that was. The mobile δ-Branch
+    // screen needs a cheap lookup for "was this branch adopted, and
+    // where does the summary live?" — so record the id on the row
+    // itself. Null = not adopted.
+    add_column_if_missing(conn, "branches", "adopted_message_id", "TEXT")?;
+    conn.execute(
+        "INSERT INTO schema_version (version, applied_at) VALUES (40, ?1)",
+        [now_epoch_ms()],
+    )?;
     Ok(())
 }
 

--- a/src-tauri/src/db/models.rs
+++ b/src-tauri/src/db/models.rs
@@ -226,6 +226,10 @@ pub struct Branch {
     pub mode: Option<String>,
     /// Link to plan subtask — developer lane uses this to track which task a branch implements.
     pub subtask_id: Option<String>,
+    /// Parent-conversation message id of the adoption summary turn.
+    /// Populated by `adopt_branch`; null when the branch isn't adopted
+    /// yet. Added in v40 for the mobile δ-Branch detail endpoint.
+    pub adopted_message_id: Option<String>,
     pub created_at: i64,
 }
 

--- a/src-tauri/src/http_api/auth.rs
+++ b/src-tauri/src/http_api/auth.rs
@@ -25,7 +25,10 @@ pub async fn auth_middleware(
     //     401 before the handler's query-parsing logic can ever execute,
     //     turning the ws.rs code path into dead code for query callers.
     let path = request.uri().path();
-    if path == "/api/health" || path == "/ws/events" {
+    if path == "/api/health"
+        || path == "/api/v1/health"
+        || path == "/ws/events"
+    {
         return next.run(request).await;
     }
 

--- a/src-tauri/src/http_api/conversations.rs
+++ b/src-tauri/src/http_api/conversations.rs
@@ -141,6 +141,33 @@ pub async fn list_branches(
     Json(serde_json::json!(rows)).into_response()
 }
 
+/// Phase 2 Finding 2-5: active plan pointer for the conversation.
+/// Returns `{ planId, phase, title }` for the most recent non-done /
+/// non-abandoned plan on this conversation, or `null` when none.
+/// Mirrors `commands::plans::get_active_plan_phase` but includes the
+/// plan id and title so mobile can route directly to the plan view.
+pub async fn get_active_plan(
+    State(state): State<ApiState>,
+    Path(conv_id): Path<String>,
+) -> impl IntoResponse {
+    let conn = lock_conn(&state.db.read);
+    let row: Option<(String, String, String)> = conn
+        .query_row(
+            "SELECT id, title, phase FROM plans
+             WHERE conversation_id = ?1 AND status != 'done' AND status != 'abandoned'
+             ORDER BY updated_at DESC LIMIT 1",
+            [&conv_id],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+        )
+        .ok();
+    match row {
+        Some((id, title, phase)) => Json(serde_json::json!({
+            "planId": id, "title": title, "phase": phase,
+        })).into_response(),
+        None => Json(serde_json::json!(null)).into_response(),
+    }
+}
+
 /// Phase 2 Finding 2-2: branch detail endpoint for mobile δ-Branch.
 /// Consolidates the fields a single-branch detail view needs in one
 /// call: labels / status / mode / parent, the rt_config (participants)

--- a/src-tauri/src/http_api/conversations.rs
+++ b/src-tauri/src/http_api/conversations.rs
@@ -141,6 +141,76 @@ pub async fn list_branches(
     Json(serde_json::json!(rows)).into_response()
 }
 
+/// Phase 2 Finding 2-2: branch detail endpoint for mobile δ-Branch.
+/// Consolidates the fields a single-branch detail view needs in one
+/// call: labels / status / mode / parent, the rt_config (participants)
+/// if this branch is a roundtable, and the `adopted_message_id` for
+/// display of the adoption summary.
+pub async fn get_branch_detail(
+    State(state): State<ApiState>,
+    Path(branch_id): Path<String>,
+) -> impl IntoResponse {
+    let conn = lock_conn(&state.db.read);
+    type Row = (
+        String, String, Option<String>, String, Option<String>, Option<String>,
+        Option<String>, Option<String>, Option<String>, Option<String>, i64,
+    );
+    let row: Result<Row, _> = conn.query_row(
+        "SELECT id, label, custom_label, status, checkpoint_id, mode,
+                parent_branch_id, subtask_id, adopted_message_id, conversation_id,
+                created_at
+         FROM branches WHERE id = ?1",
+        [&branch_id],
+        |r| Ok((
+            r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?,
+            r.get(5)?, r.get(6)?, r.get(7)?, r.get(8)?, r.get(9)?, r.get(10)?,
+        )),
+    );
+    let (
+        id, label, custom_label, status, checkpoint_id, mode,
+        parent_branch_id, subtask_id, adopted_message_id, parent_conv_id, created_at,
+    ) = match row {
+        Ok(v) => v,
+        Err(_) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({"error": "branch not found"})),
+            )
+                .into_response()
+        }
+    };
+    // rt_config lives on the shadow conversation row — present only for
+    // roundtable-mode branches. Absent → null.
+    let shadow_id = format!("branch:{}", id);
+    let rt_config: Option<String> = conn
+        .query_row(
+            "SELECT rt_config FROM conversations WHERE id = ?1",
+            [&shadow_id],
+            |r| r.get(0),
+        )
+        .ok()
+        .flatten();
+    let participants: Option<serde_json::Value> = rt_config
+        .as_deref()
+        .and_then(|s| serde_json::from_str::<serde_json::Value>(s).ok())
+        .and_then(|v| v.get("participants").cloned());
+    Json(serde_json::json!({
+        "id": id,
+        "label": label,
+        "customLabel": custom_label,
+        "status": status,
+        "mode": mode,
+        "checkpointId": checkpoint_id,
+        "parentBranchId": parent_branch_id,
+        "subtaskId": subtask_id,
+        "adoptedMessageId": adopted_message_id,
+        "parentConversationId": parent_conv_id,
+        "shadowConversationId": shadow_id,
+        "participants": participants,
+        "createdAt": created_at,
+    })).into_response()
+}
+
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateBranchInput {

--- a/src-tauri/src/http_api/conversations.rs
+++ b/src-tauri/src/http_api/conversations.rs
@@ -141,6 +141,129 @@ pub async fn list_branches(
     Json(serde_json::json!(rows)).into_response()
 }
 
+/// Phase 2 Finding 2-3: aggregate roundtable messages on a branch's
+/// shadow conversation into a `rounds[]` view. System messages of the
+/// form `--- Round N · mode · names ---` act as round boundaries (see
+/// `commands/roundtable.rs`), and assistant messages between boundaries
+/// are bucketed by persona.
+pub async fn get_branch_rounds(
+    State(state): State<ApiState>,
+    Path(branch_id): Path<String>,
+) -> impl IntoResponse {
+    let shadow_id = format!("branch:{}", branch_id);
+    let conn = lock_conn(&state.db.read);
+    let mut stmt = match conn.prepare(
+        "SELECT id, role, engine, persona, model, content, timestamp
+         FROM messages
+         WHERE conversation_id = ?1 AND status = 'done'
+         ORDER BY timestamp ASC",
+    ) {
+        Ok(s) => s,
+        Err(e) => return db_error(e),
+    };
+    let rows: Vec<(String, String, Option<String>, Option<String>, Option<String>, String, i64)> = match stmt
+        .query_map([&shadow_id], |r| {
+            Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?, r.get(5)?, r.get(6)?))
+        })
+    {
+        Ok(rows) => rows.filter_map(|r| r.ok()).collect(),
+        Err(e) => return db_error(e),
+    };
+
+    let header_re = match regex::Regex::new(r"^---\s*Round\s+(\d+)\s*·\s*([^·]+?)\s*·\s*(.+?)\s*---$") {
+        Ok(r) => r,
+        Err(_) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": "regex compile failed"})),
+            )
+                .into_response()
+        }
+    };
+
+    #[derive(serde::Serialize)]
+    #[serde(rename_all = "camelCase")]
+    struct Participant {
+        persona: Option<String>,
+        engine: Option<String>,
+        model: Option<String>,
+        message_ids: Vec<String>,
+        content_preview: String,
+    }
+    #[derive(serde::Serialize)]
+    #[serde(rename_all = "camelCase")]
+    struct Round {
+        round_number: i32,
+        mode: String,
+        names: Vec<String>,
+        started_at: i64,
+        completed_at: Option<i64>,
+        participant_responses: Vec<Participant>,
+    }
+
+    let mut rounds: Vec<Round> = Vec::new();
+    let mut current_participants: std::collections::HashMap<String, Participant> = std::collections::HashMap::new();
+    let mut last_assistant_ts: Option<i64> = None;
+
+    fn flush_current(
+        rounds: &mut Vec<Round>,
+        parts_map: &mut std::collections::HashMap<String, Participant>,
+        last_ts: Option<i64>,
+    ) {
+        if let Some(last) = rounds.last_mut() {
+            last.completed_at = last_ts;
+            last.participant_responses = parts_map.drain().map(|(_, v)| v).collect();
+        }
+    }
+
+    for (id, role, engine, persona, model, content, ts) in rows {
+        if role == "system" {
+            if let Some(caps) = header_re.captures(&content) {
+                // Close out the previous round (if any) with whatever
+                // participant rows we collected.
+                flush_current(&mut rounds, &mut current_participants, last_assistant_ts);
+                last_assistant_ts = None;
+                let round_number: i32 = caps.get(1).and_then(|m| m.as_str().parse().ok()).unwrap_or(0);
+                let mode = caps.get(2).map(|m| m.as_str().to_string()).unwrap_or_default();
+                let names: Vec<String> = caps
+                    .get(3)
+                    .map(|m| m.as_str().split(',').map(|s| s.trim().to_string()).collect())
+                    .unwrap_or_default();
+                rounds.push(Round {
+                    round_number,
+                    mode,
+                    names,
+                    started_at: ts,
+                    completed_at: None,
+                    participant_responses: Vec::new(),
+                });
+            }
+            continue;
+        }
+        if role != "assistant" {
+            continue;
+        }
+        // Group by persona when present, fall back to engine, then "(unknown)".
+        let key = persona.clone().or_else(|| engine.clone()).unwrap_or_else(|| "(unknown)".into());
+        let preview = content.chars().take(240).collect::<String>();
+        let entry = current_participants.entry(key).or_insert_with(|| Participant {
+            persona: persona.clone(),
+            engine: engine.clone(),
+            model: model.clone(),
+            message_ids: Vec::new(),
+            content_preview: preview.clone(),
+        });
+        entry.message_ids.push(id);
+        // Keep the newest preview — most recent turn usually carries the
+        // final verdict / summary.
+        entry.content_preview = preview;
+        last_assistant_ts = Some(ts);
+    }
+    flush_current(&mut rounds, &mut current_participants, last_assistant_ts);
+
+    Json(serde_json::json!({ "rounds": rounds })).into_response()
+}
+
 /// Phase 2 Finding 2-5: active plan pointer for the conversation.
 /// Returns `{ planId, phase, title }` for the most recent non-done /
 /// non-abandoned plan on this conversation, or `null` when none.

--- a/src-tauri/src/http_api/mod.rs
+++ b/src-tauri/src/http_api/mod.rs
@@ -219,6 +219,7 @@ fn build_router(state: ApiState) -> Router {
         .route("/plans/{id}/events", get(plans::list_plan_events))
         .route("/plans/{id}/approve", post(plans::approve_plan))
         .route("/plans/{id}/reject", post(plans::reject_plan))
+        .route("/plans/{id}/subtasks/{sid}/status", post(plans::update_subtask_status))
         .route("/artifacts", get(plans::list_artifacts))
         // Meta notification endpoints (v38 table → mobile inbox)
         .route("/meta-notifications", get(meta::list_meta_notifications))

--- a/src-tauri/src/http_api/mod.rs
+++ b/src-tauri/src/http_api/mod.rs
@@ -211,6 +211,7 @@ fn build_router(state: ApiState) -> Router {
         .route("/conversations/{id}/chunks/index", post(conversations::index_chunks))
         .route("/conversations/{id}/chunks/search", post(conversations::search_chunks))
         .route("/conversations/{id}/traces", get(conversations::list_conv_traces))
+        .route("/conversations/{id}/active-plan", get(conversations::get_active_plan))
         // Plan / artifact endpoints
         .route("/plans", get(plans::list_plans))
         .route("/plans/{id}", get(plans::get_plan))

--- a/src-tauri/src/http_api/mod.rs
+++ b/src-tauri/src/http_api/mod.rs
@@ -200,6 +200,7 @@ fn build_router(state: ApiState) -> Router {
         .route("/branches", post(conversations::create_branch))
         .route("/branches/{id}", get(conversations::get_branch_detail))
         .route("/branches/{id}", delete(conversations::delete_branch))
+        .route("/branches/{id}/rounds", get(conversations::get_branch_rounds))
         .route("/branches/{id}/archive", post(conversations::archive_branch))
         .route("/branches/{id}/adopt", post(conversations::adopt_branch))
         .route("/branches/{id}/rename", post(conversations::rename_branch))

--- a/src-tauri/src/http_api/mod.rs
+++ b/src-tauri/src/http_api/mod.rs
@@ -155,58 +155,88 @@ fn generate_token() -> String {
     token
 }
 
+/// Tag `/api/*` legacy responses with `X-API-Deprecated: use /api/v1`.
+/// Mobile and other programmatic clients surface this header to nudge
+/// callers onto the versioned path ahead of removing the legacy prefix.
+async fn deprecation_header_middleware(
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    let path = req.uri().path().to_string();
+    let is_legacy = path.starts_with("/api/") && !path.starts_with("/api/v1/");
+    let mut res = next.run(req).await;
+    if is_legacy {
+        res.headers_mut().insert(
+            "X-API-Deprecated",
+            axum::http::HeaderValue::from_static("use /api/v1"),
+        );
+    }
+    res
+}
+
 fn build_router(state: ApiState) -> Router {
-    Router::new()
+    // Single definition of the REST surface. Every route is authored
+    // without any `/api` prefix and then mounted under BOTH `/api/v1`
+    // (canonical) and `/api` (legacy, deprecation-tagged). Removing the
+    // legacy mount later is a single-line edit; adding a new endpoint
+    // adds it to both at once.
+    let rest: Router<ApiState> = Router::new()
         // State / project endpoints
-        .route("/api/health", get(state::health))
-        .route("/api/projects", get(state::list_projects))
-        .route("/api/projects", post(state::create_project))
-        .route("/api/projects/{key}/documents/index", post(state::index_project_documents))
-        .route("/api/projects/{key}/documents/search", post(state::search_project_documents))
-        .route("/api/projects/{key}/documents/graph", get(state::get_document_graph))
-        .route("/api/projects/{key}/documents/orphans", get(state::get_orphan_documents))
-        .route("/api/projects/{key}/documents/status", get(state::get_document_index_status))
+        .route("/health", get(state::health))
+        .route("/projects", get(state::list_projects))
+        .route("/projects", post(state::create_project))
+        .route("/projects/{key}/documents/index", post(state::index_project_documents))
+        .route("/projects/{key}/documents/search", post(state::search_project_documents))
+        .route("/projects/{key}/documents/graph", get(state::get_document_graph))
+        .route("/projects/{key}/documents/orphans", get(state::get_orphan_documents))
+        .route("/projects/{key}/documents/status", get(state::get_document_index_status))
         // Conversation / message endpoints
-        .route("/api/conversations", get(conversations::list_conversations))
-        .route("/api/conversations", post(conversations::create_conversation))
-        .route("/api/conversations/{id}/messages", get(conversations::list_messages))
-        .route("/api/conversations/{id}/delete", post(conversations::delete_conversation))
+        .route("/conversations", get(conversations::list_conversations))
+        .route("/conversations", post(conversations::create_conversation))
+        .route("/conversations/{id}/messages", get(conversations::list_messages))
+        .route("/conversations/{id}/delete", post(conversations::delete_conversation))
         // Branch endpoints
-        .route("/api/conversations/{id}/branches", get(conversations::list_branches))
-        .route("/api/branches", post(conversations::create_branch))
-        .route("/api/branches/{id}", delete(conversations::delete_branch))
-        .route("/api/branches/{id}/archive", post(conversations::archive_branch))
-        .route("/api/branches/{id}/adopt", post(conversations::adopt_branch))
-        .route("/api/branches/{id}/rename", post(conversations::rename_branch))
+        .route("/conversations/{id}/branches", get(conversations::list_branches))
+        .route("/branches", post(conversations::create_branch))
+        .route("/branches/{id}", delete(conversations::delete_branch))
+        .route("/branches/{id}/archive", post(conversations::archive_branch))
+        .route("/branches/{id}/adopt", post(conversations::adopt_branch))
+        .route("/branches/{id}/rename", post(conversations::rename_branch))
         // Memory & search endpoints
-        .route("/api/conversations/{id}/memory/status", get(conversations::memory_status))
-        .route("/api/conversations/{id}/memory/compress", post(conversations::compress_memory))
-        .route("/api/conversations/{id}/session-links", get(conversations::list_session_links))
-        .route("/api/conversations/{id}/session-links/refresh", post(conversations::refresh_session_links))
-        .route("/api/conversations/{id}/chunks/index", post(conversations::index_chunks))
-        .route("/api/conversations/{id}/chunks/search", post(conversations::search_chunks))
-        .route("/api/conversations/{id}/traces", get(conversations::list_conv_traces))
+        .route("/conversations/{id}/memory/status", get(conversations::memory_status))
+        .route("/conversations/{id}/memory/compress", post(conversations::compress_memory))
+        .route("/conversations/{id}/session-links", get(conversations::list_session_links))
+        .route("/conversations/{id}/session-links/refresh", post(conversations::refresh_session_links))
+        .route("/conversations/{id}/chunks/index", post(conversations::index_chunks))
+        .route("/conversations/{id}/chunks/search", post(conversations::search_chunks))
+        .route("/conversations/{id}/traces", get(conversations::list_conv_traces))
         // Plan / artifact endpoints
-        .route("/api/plans", get(plans::list_plans))
-        .route("/api/plans/{id}", get(plans::get_plan))
-        .route("/api/plans/{id}/events", get(plans::list_plan_events))
-        .route("/api/plans/{id}/approve", post(plans::approve_plan))
-        .route("/api/plans/{id}/reject", post(plans::reject_plan))
-        .route("/api/artifacts", get(plans::list_artifacts))
+        .route("/plans", get(plans::list_plans))
+        .route("/plans/{id}", get(plans::get_plan))
+        .route("/plans/{id}/events", get(plans::list_plan_events))
+        .route("/plans/{id}/approve", post(plans::approve_plan))
+        .route("/plans/{id}/reject", post(plans::reject_plan))
+        .route("/artifacts", get(plans::list_artifacts))
         // Meta notification endpoints (v38 table → mobile inbox)
-        .route("/api/meta-notifications", get(meta::list_meta_notifications))
-        .route("/api/meta-notifications/mark-all-read", post(meta::mark_all_read))
-        .route("/api/meta-notifications/clear", post(meta::clear))
-        .route("/api/meta-notifications/{id}/read", post(meta::mark_read))
-        .route("/api/meta-notifications/{id}/dismiss", post(meta::dismiss))
+        .route("/meta-notifications", get(meta::list_meta_notifications))
+        .route("/meta-notifications/mark-all-read", post(meta::mark_all_read))
+        .route("/meta-notifications/clear", post(meta::clear))
+        .route("/meta-notifications/{id}/read", post(meta::mark_read))
+        .route("/meta-notifications/{id}/dismiss", post(meta::dismiss))
         // Agent endpoints
-        .route("/api/agents/status", get(agents::agents_status))
-        .route("/api/conversations/{id}/send", post(agents::send_message))
-        .route("/api/roundtables/run", post(agents::start_rt_run))
-        .route("/api/roundtables/{id}/cancel", post(agents::cancel_rt))
-        // WebSocket
+        .route("/agents/status", get(agents::agents_status))
+        .route("/conversations/{id}/send", post(agents::send_message))
+        .route("/roundtables/run", post(agents::start_rt_run))
+        .route("/roundtables/{id}/cancel", post(agents::cancel_rt));
+
+    Router::new()
+        .nest("/api/v1", rest.clone())
+        .nest("/api", rest)
+        // WebSocket stays at the root; it's cheap to add /api/v1/ws later
+        // but existing /ws/events contract is stable for mobile.
         .route("/ws/events", get(ws::ws_events))
         .layer(middleware::from_fn_with_state(state.clone(), auth::auth_middleware))
+        .layer(middleware::from_fn(deprecation_header_middleware))
         .layer(CorsLayer::permissive())
         .with_state(state)
 }

--- a/src-tauri/src/http_api/mod.rs
+++ b/src-tauri/src/http_api/mod.rs
@@ -198,6 +198,7 @@ fn build_router(state: ApiState) -> Router {
         // Branch endpoints
         .route("/conversations/{id}/branches", get(conversations::list_branches))
         .route("/branches", post(conversations::create_branch))
+        .route("/branches/{id}", get(conversations::get_branch_detail))
         .route("/branches/{id}", delete(conversations::delete_branch))
         .route("/branches/{id}/archive", post(conversations::archive_branch))
         .route("/branches/{id}/adopt", post(conversations::adopt_branch))

--- a/src-tauri/src/http_api/plans.rs
+++ b/src-tauri/src/http_api/plans.rs
@@ -240,6 +240,87 @@ pub async fn reject_plan(
     }
 }
 
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateSubtaskStatusInput {
+    pub status: String,
+    pub outcome: Option<String>,
+    pub updated_by: Option<String>,
+}
+
+/// Phase 2 Finding 2-4: change a subtask's status over HTTP and
+/// broadcast `plan:subtask_status_changed` to WS subscribers so mobile
+/// clients don't need to poll.
+pub async fn update_subtask_status(
+    State(state): State<ApiState>,
+    Path((plan_id, subtask_id)): Path<(String, String)>,
+    Json(input): Json<UpdateSubtaskStatusInput>,
+) -> impl IntoResponse {
+    // Guard: the known states match the desktop enum in `types/index.ts`.
+    // Reject unknown values up front instead of letting them land in the
+    // DB where they'd confuse every reader.
+    const VALID: &[&str] = &["todo", "approved", "in_progress", "done", "abandoned"];
+    if !VALID.contains(&input.status.as_str()) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "invalid status", "allowed": VALID})),
+        )
+            .into_response();
+    }
+    // Verify the subtask actually belongs to this plan — `update_subtask_status`
+    // on the Tauri command path doesn't enforce this because the desktop
+    // UI can't send a mismatched pair, but HTTP callers can.
+    let conn = lock_conn(&state.db.write);
+    let owner_check: Result<String, _> = conn.query_row(
+        "SELECT plan_id FROM plan_subtasks WHERE id = ?1",
+        [&subtask_id],
+        |r| r.get(0),
+    );
+    let owner = match owner_check {
+        Ok(v) => v,
+        Err(_) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({"error": "subtask not found"})),
+            )
+                .into_response()
+        }
+    };
+    if owner != plan_id {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "subtask does not belong to plan"})),
+        )
+            .into_response();
+    }
+    let now = crate::db::migrations::now_epoch_ms();
+    if let Err(e) = conn.execute(
+        "UPDATE plan_subtasks SET status = ?1, outcome = ?2, last_updated_by = ?3, updated_at = ?4 WHERE id = ?5",
+        rusqlite::params![input.status, input.outcome, input.updated_by, now, subtask_id],
+    ) {
+        return db_error(e);
+    }
+    drop(conn);
+
+    let _ = state.event_tx.send(
+        serde_json::json!({
+            "type": "plan:subtask_status_changed",
+            "planId": plan_id,
+            "subtaskId": subtask_id,
+            "status": input.status,
+        })
+        .to_string(),
+    );
+
+    Json(serde_json::json!({
+        "planId": plan_id,
+        "subtaskId": subtask_id,
+        "status": input.status,
+        "updatedAt": now,
+    }))
+    .into_response()
+}
+
 pub async fn list_artifacts(
     State(state): State<ApiState>,
     Query(q): Query<ArtifactQuery>,

--- a/src-tauri/tests/db_integration.rs
+++ b/src-tauri/tests/db_integration.rs
@@ -157,6 +157,64 @@ fn subtask_create_and_status_cycle() {
     assert_eq!(status, "done");
 }
 
+// ─── v40: branches.adopted_message_id ───────────────────────────────────────
+
+#[test]
+fn v40_adopted_message_id_column_exists() {
+    let conn = setup_db();
+    // `PRAGMA table_info(branches)` returns one row per column.
+    let mut stmt = conn
+        .prepare("PRAGMA table_info(branches)")
+        .unwrap();
+    let names: Vec<String> = stmt
+        .query_map([], |r| r.get::<_, String>(1))
+        .unwrap()
+        .filter_map(|r| r.ok())
+        .collect();
+    assert!(
+        names.iter().any(|n| n == "adopted_message_id"),
+        "expected branches.adopted_message_id column after v40 migration; got {:?}",
+        names,
+    );
+}
+
+#[test]
+fn v40_adopted_message_id_starts_null() {
+    let conn = setup_db();
+    let now = now_epoch_ms();
+    create_api_project(&conn, "proj1", "P1", None);
+    create_api_conversation(&conn, "conv1", "proj1", "Main");
+    conn.execute(
+        "INSERT INTO branches (id, conversation_id, label, status, mode, created_at)
+         VALUES ('br-v40', 'conv1', 'test', 'active', 'chat', ?1)",
+        params![now],
+    )
+    .unwrap();
+    let adopted: Option<String> = conn
+        .query_row(
+            "SELECT adopted_message_id FROM branches WHERE id = 'br-v40'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert!(adopted.is_none(), "fresh branch should have null adopted_message_id");
+
+    // Simulate adopt_branch writing the summary id back.
+    conn.execute(
+        "UPDATE branches SET adopted_message_id = 'sum-123' WHERE id = 'br-v40'",
+        [],
+    )
+    .unwrap();
+    let adopted2: String = conn
+        .query_row(
+            "SELECT adopted_message_id FROM branches WHERE id = 'br-v40'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(adopted2, "sum-123");
+}
+
 // ─── Branch plan lookup ──────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary
Phase 2 of the roadmap starts here — every REST endpoint is now mounted under \`/api/v1/\` (legacy \`/api/\` stays live with \`X-API-Deprecated\` header), plus the four new endpoints mobile δ-Branch / Plans / Workflow need.

Five sub-tasks from \`docs/plans/refactorRoadmap_2026-04-20.md\` shipped as one PR, split into revertable commits.

## Commits (in order)

1. **feat(api): /api/v1 prefix + legacy deprecation header** — \`build_router\` rewritten so every route is authored without prefix and then nested under both \`/api/v1\` (canonical) and \`/api\` (legacy). \`deprecation_header_middleware\` tags legacy responses. \`auth_middleware\` whitelist extended with \`/api/v1/health\`.
2. **feat(db): v40 migration — branches.adopted_message_id** — new nullable TEXT column; \`adopt_branch\` writes the summary message id back. \`Branch\` model + \`list_branches\` SELECT + \`create_branch\` return path all updated.
3. **feat(api): GET /api/v1/branches/{id}** — single-branch detail with \`adoptedMessageId\`, \`participants\` (parsed from \`rt_config\`), \`shadowConversationId\`. 404 on unknown id.
4. **feat(api): GET /api/v1/conversations/{id}/active-plan** — \`{ planId, phase, title } | null\` for the mobile plan badge / routing.
5. **feat(api): GET /api/v1/branches/{id}/rounds** — parses \`--- Round N · mode · names ---\` system headers into a \`rounds[]\` view with \`participantResponses\` bucketed by persona.
6. **feat(api): POST /api/v1/plans/{id}/subtasks/{sid}/status** — status update with strict enum validation + ownership check; emits \`plan:subtask_status_changed\` on WS.
7. **docs+tests: API v1 contract + v40 integration coverage** — \`docs/api/v1.md\` draft and two integration cases around the new column.

## Test plan
- [x] \`cargo check --lib\` — 0 errors (3 pre-existing warnings unchanged)
- [x] \`cargo test --lib\` — **303 passed** (baseline)
- [x] \`cargo test --tests\` — **27 passed** (baseline 25 + 2 new v40 cases)
- [ ] CI green
- [ ] Manual: \`curl -H "Authorization: Bearer \$TOKEN" http://localhost:19840/api/v1/health\` → 200; \`curl .../api/health\` → 200 with \`X-API-Deprecated\` header; adopt_branch → \`adopted_message_id\` populated; /rounds returns expected shape on an existing review RT branch.

## Deliberately out of scope
- **2-6 WS event replay / since cursor** — separate PR (requires new \`ws_event_log\` table + TTL cleanup + every \`event_tx.send\` wrap; 2-day estimate on its own).
- Legacy \`/api/\` removal — lives until 1-2 releases after mobile migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)