### PR TITLE
feat(ws): event replay via ws_event_log + /ws/events?since= (2-6)

### DIFF
--- a/docs/api/v1.md
+++ b/docs/api/v1.md
@@ -121,8 +121,53 @@ WS side effect:
 { "type": "plan:subtask_status_changed", "planId": "...", "subtaskId": "...", "status": "..." }
 ```
 
+## WebSocket
+
+`wss://<host>/ws/events` — canonical URL. Stays at the root (not under `/api/v1/`) so the mobile WS contract is stable.
+
+### Auth
+Either `Authorization: Bearer <token>` header or `?token=<token>` query param. Browsers can't set WS headers, so mobile uses the query form.
+
+### `?since=<epoch_ms>` replay *(new in 2-6)*
+When present, the server replays every event in `ws_event_log` with `created_at >= since_ms` before attaching the live subscription. Ordered oldest-first and capped at 2 000 rows. Use it to recover from a brief reconnect gap without falling back to REST refetch.
+
+```
+wss://<host>/ws/events?token=<token>&since=1737500000000
+```
+
+Retention: rows older than **24 h** are trimmed hourly by a background job. Reconnect windows past that limit cannot rely on replay — fall back to `GET /api/v1/conversations/{id}/messages`, `GET /api/v1/plans`, etc.
+
+Non-goals: at-least-once delivery, exactly-once, distributed replay. A client that sees the same event twice should be idempotent (match on `messageId` / `planId` / `subtaskId`).
+
+### Event envelope
+
+All events share this shape:
+```json
+{ "type": "plan:subtask_status_changed", ... domain-specific fields ... }
+```
+
+Tauri-sourced events wrap the inner payload under `payload`:
+```json
+{ "type": "message:new", "payload": { "conversationId": "…", "messageId": "…" } }
+```
+HTTP-sourced events emit the fields inline (flat). Both forms are appended to the same log.
+
+### Event catalog (today)
+
+| Event type | Source | Shape (after `type`) |
+|---|---|---|
+| `message:new` | HTTP / Tauri | `conversationId`, `messageId`, `role` |
+| `agent:completed` | HTTP / Tauri | `conversationId`, `messageId` |
+| `agent:error` | HTTP / Tauri | `conversationId`, `error` |
+| `roundtable:progress` | Tauri | `payload.*` |
+| `roundtable:participant_status` | HTTP / Tauri | `payload.{conversationId, name, status}` |
+| `plan:created`, `plan:phase_changed`, `plan:status_changed` | HTTP / Tauri | `planId`, `toStatus` / `toPhase` |
+| `plan:subtask_status_changed` | HTTP | `planId`, `subtaskId`, `status` |
+| `branch:created`, `branch:archived`, `branch:adopted` | HTTP / Tauri | `branchId` + variant-specific fields |
+| `meta:new`, `meta:read`, `meta:dismissed` | HTTP / Tauri | `notificationId` |
+| `document:indexed`, `document:error` | HTTP | `projectKey`, `result` / `error` |
+
 ## Out of scope for this document
 
-- Phase 2 Finding 2-6 (WS `?since=` replay + `ws_event_log` TTL cleanup) — separate PR, separate doc update.
 - Phase 3+ endpoints.
 - Legacy `/api/...` path responses include `X-API-Deprecated: use /api/v1` and are otherwise identical — they will be removed after 1–2 releases following mobile client migration.

--- a/src-tauri/src/db/migrations.rs
+++ b/src-tauri/src/db/migrations.rs
@@ -145,6 +145,9 @@ pub fn run(conn: &Connection) -> Result<(), AppError> {
     if current < 40 {
         apply_v40(conn)?;
     }
+    if current < 41 {
+        apply_v41(conn)?;
+    }
     Ok(())
 }
 
@@ -936,6 +939,38 @@ fn apply_v40(conn: &Connection) -> Result<(), AppError> {
     add_column_if_missing(conn, "branches", "adopted_message_id", "TEXT")?;
     conn.execute(
         "INSERT INTO schema_version (version, applied_at) VALUES (40, ?1)",
+        [now_epoch_ms()],
+    )?;
+    Ok(())
+}
+
+fn apply_v41(conn: &Connection) -> Result<(), AppError> {
+    // Phase 2 Finding 2-6: append-only log of WS events, so a mobile
+    // client that reconnects after a brief drop can ask for `?since=<ms>`
+    // and replay the events it missed instead of forcing a full refetch.
+    //
+    // Schema is intentionally thin — `id` autoincrements for monotonic
+    // ordering; `event_type` duplicates whatever the payload's `type`
+    // field says, but having it as a column makes future filtering /
+    // indexing possible without re-parsing JSON. The index on
+    // `created_at` supports the `WHERE created_at >= ?` replay query.
+    //
+    // TTL: a background task (see http_api::events::spawn_ttl_cleanup)
+    // trims rows older than 24 h every hour. Non-goal: at-least-once
+    // delivery guarantees; reconnect windows past the TTL must re-sync
+    // from the DB through the regular REST endpoints.
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS ws_event_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            event_type TEXT NOT NULL,
+            payload TEXT NOT NULL,
+            created_at INTEGER NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_ws_event_log_created_at
+            ON ws_event_log(created_at);",
+    )?;
+    conn.execute(
+        "INSERT INTO schema_version (version, applied_at) VALUES (41, ?1)",
         [now_epoch_ms()],
     )?;
     Ok(())

--- a/src-tauri/src/http_api/agents.rs
+++ b/src-tauri/src/http_api/agents.rs
@@ -57,12 +57,12 @@ pub async fn send_message(
     }
 
     // Notify WS clients of the new user message
-    let _ = state.event_tx.send(serde_json::json!({
+    super::broadcast_event(&state.event_tx, &state.db, serde_json::json!({
         "type": "message:new",
         "conversationId": conv_id,
         "messageId": user_msg_id,
         "role": "user",
-    }).to_string());
+    }));
 
     if input.dry_run.unwrap_or(false) {
         return (StatusCode::OK, Json(serde_json::json!({
@@ -220,15 +220,12 @@ pub async fn send_message(
                             .ok();
                         }
                     }
-                    let _ = event_tx.send(
-                        serde_json::json!({
-                            "type": "message:new",
-                            "conversationId": conv_id_clone,
-                            "messageId": assistant_msg_id,
-                            "role": "assistant",
-                        })
-                        .to_string(),
-                    );
+                    super::broadcast_event(&event_tx, &db_post, serde_json::json!({
+                        "type": "message:new",
+                        "conversationId": conv_id_clone,
+                        "messageId": assistant_msg_id,
+                        "role": "assistant",
+                    }));
                     last_assistant_msg_id = Some(assistant_msg_id.clone());
 
                     // Did the agent end its turn with tool-request markers?
@@ -263,29 +260,23 @@ pub async fn send_message(
                         )
                         .ok();
                     }
-                    let _ = event_tx.send(
-                        serde_json::json!({
-                            "type": "message:new",
-                            "conversationId": conv_id_clone,
-                            "messageId": sys_msg_id,
-                            "role": "system",
-                        })
-                        .to_string(),
-                    );
+                    super::broadcast_event(&event_tx, &db_post, serde_json::json!({
+                        "type": "message:new",
+                        "conversationId": conv_id_clone,
+                        "messageId": sys_msg_id,
+                        "role": "system",
+                    }));
 
                     current_prompt = follow_up_text;
                     depth += 1;
                 }
                 Ok(Err(e)) => {
                     eprintln!("[http-api] agent error: {}", e);
-                    let _ = event_tx.send(
-                        serde_json::json!({
-                            "type": "agent:error",
-                            "conversationId": conv_id_clone,
-                            "error": format!("{}", e),
-                        })
-                        .to_string(),
-                    );
+                    super::broadcast_event(&event_tx, &db_post, serde_json::json!({
+                        "type": "agent:error",
+                        "conversationId": conv_id_clone,
+                        "error": format!("{}", e),
+                    }));
                     return;
                 }
                 Err(e) => {
@@ -300,14 +291,11 @@ pub async fn send_message(
         // pointing at the final assistant message for any WS consumers
         // waiting on that signal.
         if let Some(final_id) = last_assistant_msg_id {
-            let _ = event_tx.send(
-                serde_json::json!({
-                    "type": "agent:completed",
-                    "conversationId": conv_id_clone,
-                    "messageId": final_id,
-                })
-                .to_string(),
-            );
+            super::broadcast_event(&event_tx, &db_post, serde_json::json!({
+                "type": "agent:completed",
+                "conversationId": conv_id_clone,
+                "messageId": final_id,
+            }));
         }
         crate::commands::agents_helpers::send_common::spawn_post_completion_tasks(
             db_post,
@@ -390,10 +378,10 @@ pub async fn start_rt_run(
                 let model = participant.model.clone();
                 let name = &participant.name;
 
-                let _ = event_tx.send(serde_json::json!({
+                super::broadcast_event(&event_tx, &db, serde_json::json!({
                     "type": "roundtable:participant_status",
                     "payload": {"conversationId": rt_input.conversation_id, "name": name, "status": "running"}
-                }).to_string());
+                }));
 
                 let run_result = {
                     use crate::agents::claude;
@@ -422,10 +410,10 @@ pub async fn start_rt_run(
                             "INSERT INTO messages (id, conversation_id, role, content, engine, model, persona, timestamp, status) VALUES (?1, ?2, 'assistant', ?3, ?4, ?5, ?6, ?7, 'done')",
                             rusqlite::params![msg_id, rt_input.conversation_id, out.content, engine, out.session_id, name, now_epoch_ms()],
                         ).ok();
-                        let _ = event_tx.send(serde_json::json!({
+                        super::broadcast_event(&event_tx, &db, serde_json::json!({
                             "type": "roundtable:participant_status",
                             "payload": {"conversationId": rt_input.conversation_id, "name": name, "status": "done"}
-                        }).to_string());
+                        }));
                     }
                     Err(e) => {
                         eprintln!("[http-api] RT participant {} error: {}", name, e);
@@ -435,18 +423,18 @@ pub async fn start_rt_run(
                             "INSERT INTO messages (id, conversation_id, role, content, timestamp, status) VALUES (?1, ?2, 'system', ?3, ?4, 'done')",
                             rusqlite::params![err_msg_id, rt_input.conversation_id, format!("[{}] 에이전트 실패: {}", name, e), now_epoch_ms()],
                         ).ok();
-                        let _ = event_tx.send(serde_json::json!({
+                        super::broadcast_event(&event_tx, &db, serde_json::json!({
                             "type": "agent:error",
                             "payload": {"conversationId": rt_input.conversation_id, "name": name, "error": format!("{}", e)}
-                        }).to_string());
+                        }));
                     }
                 }
             }
 
-            let _ = event_tx.send(serde_json::json!({
+            super::broadcast_event(&event_tx, &db, serde_json::json!({
                 "type": "agent:completed",
                 "payload": {"conversationId": rt_input.conversation_id}
-            }).to_string());
+            }));
 
             Ok(())
         })();

--- a/src-tauri/src/http_api/conversations.rs
+++ b/src-tauri/src/http_api/conversations.rs
@@ -397,10 +397,10 @@ pub async fn create_branch(
     }
     drop(conn);
 
-    let _ = state.event_tx.send(serde_json::json!({
+    super::broadcast_event(&state.event_tx, &state.db, serde_json::json!({
         "type": "branch:created",
         "branchId": id, "conversationId": input.conversation_id, "mode": mode
-    }).to_string());
+    }));
 
     (StatusCode::CREATED, Json(serde_json::json!({
         "id": id, "label": label, "mode": mode, "shadowConversationId": shadow_id
@@ -431,9 +431,9 @@ pub async fn archive_branch(
     let updated = conn.execute("UPDATE branches SET status = 'archived' WHERE id = ?1", [&branch_id]).unwrap_or(0);
     if updated > 0 {
         drop(conn);
-        let _ = state.event_tx.send(serde_json::json!({
+        super::broadcast_event(&state.event_tx, &state.db, serde_json::json!({
             "type": "branch:archived", "branchId": branch_id
-        }).to_string());
+        }));
         Json(serde_json::json!({"archived": true, "branchId": branch_id})).into_response()
     } else {
         (StatusCode::NOT_FOUND, Json(serde_json::json!({"error": "branch not found"}))).into_response()
@@ -487,11 +487,11 @@ pub async fn adopt_branch(
     ).ok();
     drop(conn);
 
-    let _ = state.event_tx.send(serde_json::json!({
+    super::broadcast_event(&state.event_tx, &state.db, serde_json::json!({
         "type": "branch:adopted",
         "branchId": branch_id, "summaryMessageId": msg_id,
         "conversationId": input.conversation_id
-    }).to_string());
+    }));
 
     Json(serde_json::json!({"adopted": true, "branchId": branch_id, "summaryMessageId": msg_id})).into_response()
 }

--- a/src-tauri/src/http_api/events.rs
+++ b/src-tauri/src/http_api/events.rs
@@ -1,0 +1,121 @@
+//! WebSocket event broadcasting with persistent log + replay (Finding 2-6).
+//!
+//! Every outbound WS event goes through `broadcast_event`, which
+//!   1. appends the payload to `ws_event_log` (best-effort DB write), and
+//!   2. fans it out to the live `tokio::sync::broadcast` channel.
+//!
+//! Mobile clients that reconnect with `?since=<ms>` ask the server to
+//! dump everything from the log newer than that timestamp before the
+//! live subscription begins. See `http_api::ws::handle_ws`.
+//!
+//! Non-goals: at-least-once guarantees, exactly-once, or distributed
+//! replay. The log is a convenience for short reconnect windows
+//! (default retention 24h, trimmed hourly by `spawn_ttl_cleanup`).
+use tokio::sync::broadcast;
+
+use crate::db::DbState;
+
+/// How long rows live in `ws_event_log` before the background TTL
+/// cleanup removes them. 24h is comfortably longer than realistic
+/// mobile reconnect windows; bumping this trades storage for coverage.
+pub const WS_EVENT_LOG_RETENTION_MS: i64 = 24 * 3600 * 1000;
+
+/// Interval at which the TTL cleanup task runs. 1h is frequent enough
+/// that the table never drifts much past the retention window, and
+/// sparse enough to be invisible on the write-lock profile.
+pub const WS_EVENT_LOG_CLEANUP_INTERVAL: std::time::Duration =
+    std::time::Duration::from_secs(3600);
+
+/// Upper bound on rows `/ws/events?since=` replays in one connection.
+/// A burst of thousands of events within the reconnect window is
+/// unusual; capping at 2 000 keeps the initial replay bounded while
+/// still covering reasonable multi-minute gaps.
+pub const WS_REPLAY_MAX_ROWS: i64 = 2_000;
+
+/// Persist the event to `ws_event_log` and broadcast it to every
+/// currently-connected WebSocket subscriber. DB write is best-effort —
+/// a lock contention miss is logged to stderr but never blocks the
+/// broadcast.
+///
+/// Callers pass a `serde_json::Value` rather than a pre-stringified
+/// payload so the helper can read the `type` field for the column
+/// (avoids re-parsing JSON for a 1-depth lookup).
+pub fn broadcast_event(
+    tx: &broadcast::Sender<String>,
+    db: &DbState,
+    payload: serde_json::Value,
+) {
+    let event_type = payload
+        .get("type")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown")
+        .to_string();
+    let json_str = payload.to_string();
+    let now = crate::db::migrations::now_epoch_ms();
+    match db.write.lock() {
+        Ok(conn) => {
+            if let Err(e) = conn.execute(
+                "INSERT INTO ws_event_log (event_type, payload, created_at) VALUES (?1, ?2, ?3)",
+                rusqlite::params![event_type, json_str, now],
+            ) {
+                eprintln!("[ws-event-log] insert failed (type={event_type}): {e}");
+            }
+        }
+        Err(e) => {
+            eprintln!("[ws-event-log] lock poisoned: {e}");
+        }
+    }
+    let _ = tx.send(json_str);
+}
+
+/// Fetch recent events newer than `since_ms` for WS replay. Ordered
+/// oldest-first so the client receives events in their original
+/// emission order. Capped at `WS_REPLAY_MAX_ROWS`.
+pub fn fetch_events_since(db: &DbState, since_ms: i64) -> Vec<String> {
+    let conn = match db.read.lock() {
+        Ok(c) => c,
+        Err(p) => p.into_inner(),
+    };
+    let mut stmt = match conn.prepare(
+        "SELECT payload FROM ws_event_log
+         WHERE created_at >= ?1
+         ORDER BY created_at ASC, id ASC
+         LIMIT ?2",
+    ) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("[ws-event-log] fetch_events_since prepare failed: {e}");
+            return Vec::new();
+        }
+    };
+    stmt.query_map(rusqlite::params![since_ms, WS_REPLAY_MAX_ROWS], |r| {
+        r.get::<_, String>(0)
+    })
+    .map(|rows| rows.filter_map(|r| r.ok()).collect())
+    .unwrap_or_default()
+}
+
+/// Spawn a background task that trims rows older than
+/// `WS_EVENT_LOG_RETENTION_MS` every `WS_EVENT_LOG_CLEANUP_INTERVAL`.
+/// Runs for the lifetime of the server; Tauri shuts it down with the
+/// process.
+pub fn spawn_ttl_cleanup(db: DbState) {
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(WS_EVENT_LOG_CLEANUP_INTERVAL).await;
+            let cutoff = crate::db::migrations::now_epoch_ms() - WS_EVENT_LOG_RETENTION_MS;
+            let deleted = match db.write.lock() {
+                Ok(conn) => conn
+                    .execute("DELETE FROM ws_event_log WHERE created_at < ?1", [cutoff])
+                    .unwrap_or(0),
+                Err(p) => p
+                    .into_inner()
+                    .execute("DELETE FROM ws_event_log WHERE created_at < ?1", [cutoff])
+                    .unwrap_or(0),
+            };
+            if deleted > 0 {
+                eprintln!("[ws-event-log] trimmed {deleted} rows older than 24h");
+            }
+        }
+    });
+}

--- a/src-tauri/src/http_api/events.rs
+++ b/src-tauri/src/http_api/events.rs
@@ -99,8 +99,14 @@ pub fn fetch_events_since(db: &DbState, since_ms: i64) -> Vec<String> {
 /// `WS_EVENT_LOG_RETENTION_MS` every `WS_EVENT_LOG_CLEANUP_INTERVAL`.
 /// Runs for the lifetime of the server; Tauri shuts it down with the
 /// process.
+///
+/// Uses `tauri::async_runtime::spawn` so callers can invoke this from
+/// the main thread during `start_server` — before the axum task has
+/// created its own runtime. Plain `tokio::spawn` would panic here
+/// ("no reactor running") because `start_server` runs synchronously
+/// on the bootstrap thread.
 pub fn spawn_ttl_cleanup(db: DbState) {
-    tokio::spawn(async move {
+    tauri::async_runtime::spawn(async move {
         loop {
             tokio::time::sleep(WS_EVENT_LOG_CLEANUP_INTERVAL).await;
             let cutoff = crate::db::migrations::now_epoch_ms() - WS_EVENT_LOG_RETENTION_MS;

--- a/src-tauri/src/http_api/meta.rs
+++ b/src-tauri/src/http_api/meta.rs
@@ -87,8 +87,9 @@ pub async fn mark_read(
         params![now, id],
     ).unwrap_or(0);
 
-    let msg = serde_json::json!({"type": "meta:read", "notificationId": id}).to_string();
-    let _ = state.event_tx.send(msg);
+    super::broadcast_event(&state.event_tx, &state.db, serde_json::json!({
+        "type": "meta:read", "notificationId": id,
+    }));
 
     Json(serde_json::json!({"read": updated > 0, "id": id})).into_response()
 }
@@ -134,8 +135,9 @@ pub async fn dismiss(
         params![now, id],
     ).unwrap_or(0);
 
-    let msg = serde_json::json!({"type": "meta:dismissed", "notificationId": id}).to_string();
-    let _ = state.event_tx.send(msg);
+    super::broadcast_event(&state.event_tx, &state.db, serde_json::json!({
+        "type": "meta:dismissed", "notificationId": id,
+    }));
 
     if updated > 0 {
         Json(serde_json::json!({"dismissed": true, "id": id})).into_response()

--- a/src-tauri/src/http_api/mod.rs
+++ b/src-tauri/src/http_api/mod.rs
@@ -10,10 +10,13 @@
 mod auth;
 mod agents;
 mod conversations;
+mod events;
 mod meta;
 mod plans;
 mod state;
 mod ws;
+
+pub(crate) use events::broadcast_event;
 
 use axum::{
     Router,
@@ -108,9 +111,14 @@ pub fn start_server(db: DbState, app_handle: tauri::AppHandle, cancel: CancelArc
         cancel,
     };
 
-    // Bridge Tauri events → broadcast channel
+    // Bridge Tauri events → broadcast channel. The bridge forwards through
+    // `broadcast_event`, so every event ends up in `ws_event_log` regardless
+    // of whether it originated from a Tauri command or an HTTP handler.
     let tx = event_tx.clone();
-    ws::bridge_tauri_events(app_handle, tx);
+    ws::bridge_tauri_events(app_handle, tx, db.clone());
+
+    // Background TTL cleanup for ws_event_log (Finding 2-6).
+    events::spawn_ttl_cleanup(db.clone());
 
     tauri::async_runtime::spawn(async move {
         let app = build_router(state);

--- a/src-tauri/src/http_api/plans.rs
+++ b/src-tauri/src/http_api/plans.rs
@@ -189,14 +189,14 @@ pub async fn approve_plan(
             rusqlite::params![event_id, plan_id, now],
         ).ok();
         drop(conn);
-        let _ = state.event_tx.send(serde_json::json!({
+        super::broadcast_event(&state.event_tx, &state.db, serde_json::json!({
             "type": "plan:status_changed",
             "planId": plan_id, "toStatus": "active"
-        }).to_string());
-        let _ = state.event_tx.send(serde_json::json!({
+        }));
+        super::broadcast_event(&state.event_tx, &state.db, serde_json::json!({
             "type": "plan:phase_changed",
             "planId": plan_id, "toPhase": "implementation"
-        }).to_string());
+        }));
         Json(serde_json::json!({"approved": true, "planId": plan_id})).into_response()
     } else {
         (StatusCode::NOT_FOUND, Json(serde_json::json!({"error": "plan not found or already done"}))).into_response()
@@ -226,14 +226,14 @@ pub async fn reject_plan(
             rusqlite::params![event_id, plan_id, now],
         ).ok();
         drop(conn);
-        let _ = state.event_tx.send(serde_json::json!({
+        super::broadcast_event(&state.event_tx, &state.db, serde_json::json!({
             "type": "plan:status_changed",
             "planId": plan_id, "toStatus": "rejected"
-        }).to_string());
-        let _ = state.event_tx.send(serde_json::json!({
+        }));
+        super::broadcast_event(&state.event_tx, &state.db, serde_json::json!({
             "type": "plan:phase_changed",
             "planId": plan_id, "toPhase": "done"
-        }).to_string());
+        }));
         Json(serde_json::json!({"rejected": true, "planId": plan_id})).into_response()
     } else {
         (StatusCode::NOT_FOUND, Json(serde_json::json!({"error": "plan not found or already done"}))).into_response()
@@ -302,15 +302,12 @@ pub async fn update_subtask_status(
     }
     drop(conn);
 
-    let _ = state.event_tx.send(
-        serde_json::json!({
-            "type": "plan:subtask_status_changed",
-            "planId": plan_id,
-            "subtaskId": subtask_id,
-            "status": input.status,
-        })
-        .to_string(),
-    );
+    super::broadcast_event(&state.event_tx, &state.db, serde_json::json!({
+        "type": "plan:subtask_status_changed",
+        "planId": plan_id,
+        "subtaskId": subtask_id,
+        "status": input.status,
+    }));
 
     Json(serde_json::json!({
         "planId": plan_id,

--- a/src-tauri/src/http_api/state.rs
+++ b/src-tauri/src/http_api/state.rs
@@ -87,15 +87,15 @@ pub async fn index_project_documents(
                 if !r.errors.is_empty() {
                     for e in &r.errors[..r.errors.len().min(5)] { eprintln!("[doc-index]   error: {}", e); }
                 }
-                let _ = event_tx.send(serde_json::json!({
+                super::broadcast_event(&event_tx, &db, serde_json::json!({
                     "type": "document:indexed", "projectKey": pk2, "result": r,
-                }).to_string());
+                }));
             }
             Ok(Err(e)) => {
                 eprintln!("[doc-index] failed: {}", e);
-                let _ = event_tx.send(serde_json::json!({
+                super::broadcast_event(&event_tx, &db, serde_json::json!({
                     "type": "document:error", "projectKey": pk2, "error": e.to_string(),
-                }).to_string());
+                }));
             }
             Err(panic_err) => {
                 let msg = panic_err.downcast_ref::<String>()

--- a/src-tauri/src/http_api/ws.rs
+++ b/src-tauri/src/http_api/ws.rs
@@ -45,11 +45,16 @@ async fn handle_ws(mut socket: ws::WebSocket, event_tx: broadcast::Sender<String
     }
 }
 
-pub fn bridge_tauri_events(app: tauri::AppHandle, tx: broadcast::Sender<String>) {
+pub fn bridge_tauri_events(
+    app: tauri::AppHandle,
+    tx: broadcast::Sender<String>,
+    db: crate::db::DbState,
+) {
     use tauri::Listener;
     // Canonical event list for HTTP/WS clients. Refs: docs/api-inquiry-gamma-delta.md § E.
-    // HTTP handlers also emit directly via event_tx (bypass bridge); Tauri commands
-    // that emit these names will be automatically forwarded here.
+    // HTTP handlers also emit directly via broadcast_event (same log+fanout
+    // path), so both Tauri-originated and HTTP-originated events land in
+    // `ws_event_log` and reach live WS subscribers identically.
     let events = [
         // Messages & agents
         "message:new",
@@ -74,14 +79,19 @@ pub fn bridge_tauri_events(app: tauri::AppHandle, tx: broadcast::Sender<String>)
     ];
     for event_name in events {
         let tx = tx.clone();
+        let db = db.clone();
         let name = event_name.to_string();
         app.listen(event_name, move |event| {
-            let payload = event.payload();
-            let msg = serde_json::json!({
+            let raw = event.payload();
+            // Tauri payloads are already JSON strings; re-parse so the
+            // outer envelope carries the actual object, not a string.
+            let inner: serde_json::Value = serde_json::from_str(raw)
+                .unwrap_or_else(|_| serde_json::Value::String(raw.to_string()));
+            let envelope = serde_json::json!({
                 "type": name,
-                "payload": payload,
-            }).to_string();
-            let _ = tx.send(msg);
+                "payload": inner,
+            });
+            super::events::broadcast_event(&tx, &db, envelope);
         });
     }
 }

--- a/src-tauri/src/http_api/ws.rs
+++ b/src-tauri/src/http_api/ws.rs
@@ -13,6 +13,12 @@ use super::ApiState;
 #[derive(Deserialize, Default)]
 pub struct WsQuery {
     token: Option<String>,
+    /// Optional epoch-ms cursor. When provided, the server replays every
+    /// entry in `ws_event_log` newer than or equal to this timestamp
+    /// before attaching the live subscription. Clients use this to
+    /// recover from short reconnect gaps without refetching through
+    /// REST. See `events::fetch_events_since` for row cap + ordering.
+    since: Option<i64>,
 }
 
 pub async fn ws_events(
@@ -33,11 +39,42 @@ pub async fn ws_events(
     if provided != state.token {
         return (StatusCode::UNAUTHORIZED, "invalid token").into_response();
     }
-    ws.on_upgrade(move |socket| handle_ws(socket, state.event_tx)).into_response()
+    let since = query.since;
+    let db = state.db.clone();
+    ws.on_upgrade(move |socket| handle_ws(socket, state.event_tx, db, since)).into_response()
 }
 
-async fn handle_ws(mut socket: ws::WebSocket, event_tx: broadcast::Sender<String>) {
+async fn handle_ws(
+    mut socket: ws::WebSocket,
+    event_tx: broadcast::Sender<String>,
+    db: crate::db::DbState,
+    since: Option<i64>,
+) {
+    // Subscribe BEFORE the replay so events emitted while we drain the
+    // log still land in the receiver's queue. Events strictly before
+    // `since` are never replayed, so worst case a client sees a
+    // handful of duplicates — that's cheaper for the client than
+    // missing an event.
     let mut rx = event_tx.subscribe();
+
+    if let Some(since_ms) = since {
+        // Run the replay on a blocking thread: `fetch_events_since`
+        // acquires a sync sqlite lock and can take a few ms on a cold
+        // connection. Keeping the async task responsive matters because
+        // the socket send loop below needs to start pumping quickly.
+        let db_for_replay = db.clone();
+        let replay = tokio::task::spawn_blocking(move || {
+            super::events::fetch_events_since(&db_for_replay, since_ms)
+        })
+        .await
+        .unwrap_or_default();
+        for payload in replay {
+            if socket.send(ws::Message::Text(payload.into())).await.is_err() {
+                return;
+            }
+        }
+    }
+
     while let Ok(msg) = rx.recv().await {
         if socket.send(ws::Message::Text(msg.into())).await.is_err() {
             break;

--- a/src-tauri/tests/db_integration.rs
+++ b/src-tauri/tests/db_integration.rs
@@ -157,6 +157,80 @@ fn subtask_create_and_status_cycle() {
     assert_eq!(status, "done");
 }
 
+// ─── v41: ws_event_log ──────────────────────────────────────────────────────
+
+#[test]
+fn v41_ws_event_log_table_exists() {
+    let conn = setup_db();
+    let names: Vec<String> = conn
+        .prepare("PRAGMA table_info(ws_event_log)")
+        .unwrap()
+        .query_map([], |r| r.get::<_, String>(1))
+        .unwrap()
+        .filter_map(|r| r.ok())
+        .collect();
+    for expected in ["id", "event_type", "payload", "created_at"] {
+        assert!(
+            names.iter().any(|n| n == expected),
+            "ws_event_log is missing column {} after v41; got {:?}",
+            expected,
+            names
+        );
+    }
+}
+
+#[test]
+fn v41_ws_event_log_idx_created_at() {
+    let conn = setup_db();
+    let idx: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_ws_event_log_created_at'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(idx, 1, "expected idx_ws_event_log_created_at index after v41");
+}
+
+#[test]
+fn v41_ws_event_log_since_replay_ordering() {
+    let conn = setup_db();
+    // Seed three events spanning the cursor so we can verify ordering
+    // and the `>=` boundary.
+    conn.execute(
+        "INSERT INTO ws_event_log (event_type, payload, created_at) VALUES ('a', '{\"type\":\"a\"}', 1000)",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO ws_event_log (event_type, payload, created_at) VALUES ('b', '{\"type\":\"b\"}', 2000)",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO ws_event_log (event_type, payload, created_at) VALUES ('c', '{\"type\":\"c\"}', 3000)",
+        [],
+    )
+    .unwrap();
+
+    let payloads: Vec<String> = conn
+        .prepare(
+            "SELECT payload FROM ws_event_log
+             WHERE created_at >= ?1
+             ORDER BY created_at ASC, id ASC
+             LIMIT 2000",
+        )
+        .unwrap()
+        .query_map([2000i64], |r| r.get::<_, String>(0))
+        .unwrap()
+        .filter_map(|r| r.ok())
+        .collect();
+
+    assert_eq!(payloads.len(), 2, "since=2000 should include b and c");
+    assert!(payloads[0].contains("\"b\""), "first replayed event must be b, got {}", payloads[0]);
+    assert!(payloads[1].contains("\"c\""), "second replayed event must be c, got {}", payloads[1]);
+}
+
 // ─── v40: branches.adopted_message_id ───────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary
Phase 2 Finding 2-6 — the last item in Phase 2. A mobile client that reconnects after a brief drop can now request \`?since=<ms>\` on the WS handshake and the server replays every event it missed before attaching the live subscription. No more forced REST refetch for a 30-second tunnel blip.

## Design
- Every outbound WS event flows through a single helper (\`http_api::events::broadcast_event\`) that
  1. appends the payload to \`ws_event_log\` (best-effort DB write),
  2. fans it out via the existing broadcast channel.
- \`?since=\` fetches rows with \`created_at >= since_ms\`, ordered oldest-first, capped at 2 000 rows, and ships them to the socket before starting the live subscription loop. Subscribe-before-replay means a concurrent write lands in the rx queue instead of falling between phases (cheap dupe > missed event).
- A background task trims rows older than 24h every hour.

## Commits
1. **feat(db): v41 migration — ws_event_log append-only table** (id + event_type + payload + created_at, plus \`created_at\` index)
2. **feat(ws): broadcast helper logs every event** — \`http_api::events\` module, \`bridge_tauri_events\` rewritten to route through the helper, 21 call sites across agents/conversations/meta/plans/state replaced with \`broadcast_event\`, TTL cleanup spawned at server start.
3. **feat(ws): /ws/events?since=<ms> replay + docs + integration coverage** — WsQuery::since, handler routes through \`spawn_blocking\` for the sqlite replay, three integration cases (table/column presence, index presence, ordering + boundary), \`docs/api/v1.md\` WebSocket section with event catalog.

## Test plan
- [x] \`cargo check --lib\` — 0 errors (3 pre-existing warnings unchanged)
- [x] \`cargo test --lib\` — **303 passed** (baseline)
- [x] \`cargo test --tests\` — **30 passed** (baseline 27 + 3 new v41 cases)
- [ ] CI green
- [ ] Manual (mobile): connect, send a \`POST /api/v1/plans/.../approve\`, drop the network for 10s, reconnect with \`?since=<last_event_ms>\` — expect the approve / phase change events to replay.

## Non-goals
- At-least-once / exactly-once delivery guarantees
- Distributed replay (multi-node)
- Reconnect windows past the 24h retention — fall back to REST

## Phase 2 status after this merge
- [x] 2-1 /api/v1 prefix
- [x] 2-2 branch detail + v40 adopted_message_id
- [x] 2-3 branch rounds aggregate
- [x] 2-4 subtask status PATCH + WS broadcast
- [x] 2-5 active-plan endpoint
- [x] 2-6 WS event replay (이 PR)

**Phase 2 완료**. 다음: Phase 3 (프로덕션 비기능), Phase 4 (접근성/문서/크래시), Phase 5 (Beta readiness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)