### PR TITLE
docs(phase5): beta readiness gate — E2E + release docs

### DIFF
--- a/docs/beta/announcement.md
+++ b/docs/beta/announcement.md
@@ -1,0 +1,179 @@
+---
+title: tunaFlow Beta — Announcement Draft
+updated_at: 2026-04-20
+canonical: true
+status: draft
+owner: tunaFlow-core
+---
+
+# tunaFlow Beta 공개 — 공지 초안
+
+> GitHub Release, 블로그 포스트, 트위터/X 스레드에 재활용할 수 있도록 세 가지 톤으로 준비했습니다. 배포 직전에 버전/날짜를 확정하세요.
+
+---
+
+## A. GitHub Release 본문
+
+```markdown
+# tunaFlow v0.1.0-beta
+
+> **Of the agent, By the agent, For the agent**
+> 도메인 전문가가 여러 AI 에이전트를 하나의 작업 흐름 안에서 운영하기 위한 데스크톱 클라이언트
+
+## 이런 분들께
+
+- Claude Code / Codex / Gemini CLI 를 쓰지만 **대화 이상의 구조**가 필요한 개발자
+- 에이전트에게 실행은 맡기되 **방향과 판단은 직접** 유지하고 싶은 사람
+- AI 에이전트를 일상 워크플로우에 넣으려는 소규모 팀 또는 개인
+
+## 핵심 기능
+
+- **Plan → Develop → Review** 3-role 워크플로우 (Architect / Developer / Reviewer)
+- **Branch / Roundtable** 대화 분기 + 다엔진 토론
+- **ContextPack** 4개 엔진 공통 프롬프트 (Lite/Standard/Full 자동 Tiering)
+- **Insight** 프로젝트 품질 분석 6개 카테고리
+- **PTY Terminal** CLI 에이전트 인터랙티브 세션
+- **모바일 클라이언트** HTTP + WS + 재연결 복구
+
+## 설치 (macOS)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/hang-in/tunaFlow/main/install.sh | bash
+xattr -cr /Applications/tunaFlow.app   # Gatekeeper 해제
+```
+
+## 알려진 제약
+
+- macOS 전용 (Windows/Linux 추후)
+- ad-hoc 서명 (Developer ID 인증서 취득 진행 중)
+- RT 중간 스트리밍 미지원
+- JSONL 완료 감지 실패 간헐 발생
+
+전체 목록: [docs/beta/known-issues.md](./docs/beta/known-issues.md)
+
+## 피드백
+
+- **Bug**: https://github.com/hang-in/tunaFlow/issues
+- **Email**: d9ng@outlook.com
+- **크래시 리포트**: Settings > Help 패널에서 바로 확인
+
+## 감사
+
+tunaFlow 는 **100% AI 작성** 프로젝트입니다. Claude Code 가 코드를 쓰고, 사람은 방향만 결정했습니다. 같은 방식으로 일하는 모두에게 도움이 되길 바랍니다.
+
+---
+
+**Changelog**: [release-notes.md](./docs/beta/release-notes.md)
+**Roadmap**: [refactorRoadmap_2026-04-20.md](./docs/plans/refactorRoadmap_2026-04-20.md)
+```
+
+---
+
+## B. 블로그 포스트 초안
+
+### 제목 후보
+
+1. **tunaFlow 베타 — AI 에이전트 오케스트레이션 클라이언트**
+2. **에이전트가 편해야 결과가 좋다 — tunaFlow 베타 공개**
+3. **Claude Code, Codex, Gemini 를 한 흐름 안에 — tunaFlow 베타**
+
+### 본문
+
+**왜 만들었나**
+
+Claude Code, Codex, Gemini CLI 를 매일 쓴다. 각자 강점이 다르고, 복잡한 작업 하나를 맡기려면 여러 에이전트를 번갈아 부르거나 교차 검증을 시켜야 한다. 그런데 터미널만 보고 있으면:
+
+- 대화가 일자 흐름이라 실험과 본줄기가 섞이고
+- 에이전트가 설계한 Plan 을 다른 에이전트가 검증하게 하기 어렵고
+- 내가 원하는 도메인 컨텍스트를 매번 다시 설명하게 된다
+
+tunaFlow 는 이 세 가지를 해결한다.
+
+**에이전트가 편해야 결과가 좋다**
+
+설계 원칙은 "agent-first". 에이전트에게 매번 필요한 컨텍스트를 토큰 효율적으로, 역할 혼동 없이, 정확한 형식으로 전달하는 데 집중했다.
+
+- **ContextPack** 이 매 요청마다 프로젝트 문서 / 기억 / 도구 결과를 조립한다. Lite/Standard/Full 자동 Tiering 으로 토큰을 낭비하지 않는다
+- **3-Role Workflow** — Architect 가 Plan 을 설계하고, Developer 가 구현하고, Reviewer 가 검증한다. 실패하면 findings 로 rev.N+1 Plan 을 자동 제안한다
+- **Branch 와 Roundtable** — 본줄기 대화에서 분기해 독립 실험을 하고, 결과만 요약으로 삽입한다. RT 는 여러 엔진이 같은 주제로 토론한다
+
+**이번 베타는**
+
+지난 40여 번의 세션 동안 누적된 기능을 정리하고, 베타 공개를 앞두고 5-Phase 리팩토링을 거쳐 **테스트 basline 을 Rust 305 + Frontend 293 까지 올렸다**. API 는 `/api/v1/` 로 버저닝했고, WebSocket 은 재연결 시 missed event 를 replay 한다.
+
+**100% AI 가 썼다**
+
+이 앱의 코드는 전부 Claude Code 가 작성했다. 사람은 "무엇을 만들지 / 어떤 방향으로 갈지" 만 정했다. 리팩토링 라운드에서 잘못된 가정을 지적해준 것도, 베타 직전에 dead code 의 실제 원인을 재해석한 것도 에이전트였다.
+
+**써보기**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/hang-in/tunaFlow/main/install.sh | bash
+```
+
+macOS 전용, ad-hoc 서명이라 Gatekeeper 경고가 뜬다. `xattr -cr /Applications/tunaFlow.app` 로 해제.
+
+**피드백은 GitHub Issues 로**. 앱 내부 Settings > Help 에서 단축키/기능/문제 해결을 확인할 수 있고, 크래시가 나면 같은 페이지에 리포트 파일 위치가 표시된다.
+
+---
+
+## C. 트위터/X 스레드 (짧은 버전)
+
+### 버전 1 — 기술 중심
+
+1/ tunaFlow 베타 공개 🎉
+macOS 데스크탑 앱. Claude Code, Codex, Gemini CLI 를 하나의 작업 흐름 안에서 오케스트레이션.
+100% AI 가 쓴 코드.
+
+2/ 핵심은 "agent-first"
+- ContextPack: 매 요청마다 프로젝트 컨텍스트를 토큰 효율적으로 조립
+- 3-Role Workflow: Architect 가 Plan 설계 → Developer 구현 → Reviewer 검증
+- Branch / Roundtable: 대화 분기 + 다엔진 토론
+
+3/ 수치
+- Rust 305 tests
+- Frontend 293 tests
+- WAL SQLite v41
+- 4-engine parity (Claude/Codex/Gemini/Ollama)
+
+4/ 설치 (macOS)
+```
+curl -fsSL https://raw.githubusercontent.com/hang-in/tunaFlow/main/install.sh | bash
+xattr -cr /Applications/tunaFlow.app
+```
+
+5/ 공개 채널
+- GitHub: https://github.com/hang-in/tunaFlow
+- Issues & 피드백 환영
+
+### 버전 2 — 철학 중심
+
+1/ "에이전트가 편해야 결과가 좋다"
+tunaFlow 베타를 공개합니다. AI 에이전트 오케스트레이션 데스크탑 클라이언트.
+
+2/ 설계 원칙은 한 줄:
+에이전트가 불필요한 토큰 낭비 없이, 정확한 맥락으로, 역할 혼동 없이 작업할 수 있는가.
+
+모든 기능은 이 기준으로 판단했습니다.
+
+3/ 결과물:
+- 3-role workflow (Architect/Dev/Reviewer)
+- ContextPack 자동 조립
+- Branch + Roundtable
+- 4-engine parity
+
+4/ 그리고 이 앱 자체의 코드도 100% AI 가 썼습니다. 베타까지 이끈 것은 agent-first 철학과, 리팩토링 라운드에서 잘못된 가정을 지적해준 리뷰어 에이전트들입니다.
+
+5/ macOS, ad-hoc 서명:
+https://github.com/hang-in/tunaFlow
+
+---
+
+## 배포 전 체크리스트
+
+- [ ] 버전 번호 확정 (`v0.1.0-beta` 또는 RC 표기?)
+- [ ] `install.sh` 가 최신 release 를 가리키는지 확인
+- [ ] GitHub Release 태그 생성
+- [ ] release-notes.md / known-issues.md 문서가 main 에 머지됐는지
+- [ ] README 의 설치 섹션이 최신 경로와 일치
+- [ ] 공개 후 피드백 수집 채널 준비 (Issue template?)

--- a/docs/beta/known-issues.md
+++ b/docs/beta/known-issues.md
@@ -1,0 +1,164 @@
+---
+title: tunaFlow Beta — Known Issues
+updated_at: 2026-04-20
+canonical: true
+status: draft
+owner: tunaFlow-core
+---
+
+# tunaFlow Beta — Known Issues
+
+베타 시점에 알려진 제약입니다. 각 항목에 **회피 방법**과 **후속 계획**을 같이 표기합니다. 새 문제가 발견되면 [GitHub Issues](https://github.com/hang-in/tunaFlow/issues) 로 알려주세요.
+
+심각도 기준:
+
+- **P0** — 베타에서 사용 불가. 현재 없음.
+- **P1** — 주요 기능에서 간헐적으로 발생. 회피 가능.
+- **P2** — 특정 조건에서만 재현. 사용성 불편.
+- **P3** — 시각적/문구 수준.
+
+---
+
+## 플랫폼 / 배포
+
+### 🔸 P1 — macOS 전용
+
+Windows / Linux 빌드는 아직 제공하지 않습니다. Tauri 2 + Rust 빌드 파이프라인이 크로스 컴파일을 지원하지만 PTY / cloudflared sidecar / 키체인 의존성을 다른 OS 에서 검증하지 못했습니다.
+
+- **회피**: 소스에서 빌드 (`npm run tauri dev`) — 작동은 하지만 보증하지 않음
+- **계획**: 0.2 시점에 Windows 빌드 우선 확장
+
+### 🔸 P1 — ad-hoc 서명 (Gatekeeper 경고)
+
+공식 Developer ID 인증서가 아니라 self-signed 로 배포합니다.
+
+- **회피**: `xattr -cr /Applications/tunaFlow.app`
+- **계획**: Developer ID 인증서 취득 후 notarization
+
+---
+
+## Roundtable / Streaming
+
+### 🔸 P1 — RT 중간 스트리밍 미지원
+
+Roundtable(RT) 은 라운드 단위로만 결과를 표시합니다. 각 참가자의 응답은 완료 후 한 번에 UI 에 반영됩니다.
+
+- **영향**: RT 진행 중 "에이전트가 살아있는가" 확인이 어려움
+- **회피**: RT 대신 단일 Branch 에서 대화를 진행
+- **계획**: streaming aggregator 재설계 필요 — 0.2 대상
+
+### 🔸 P1 — JSONL 완료 감지 실패 (간헐적)
+
+PTY 세션에서 에이전트 응답이 DB 에는 기록되지만 UI 에 반영되지 않는 경우가 있습니다. 원인은 JSONL 빠른 완료 메시지 감지 타이밍 문제.
+
+- **빈도**: 세션당 1~2회 수준
+- **회피**: 메시지 전송 후 응답이 오지 않으면 대화를 닫았다 다시 열기 → DB 에서 최신 메시지 복구됨
+- **계획**: PTY parser 재검토 (0.1.x 패치)
+
+---
+
+## Performance / Resource
+
+### 🔸 P2 — 대규모 프로젝트 최초 인덱싱 시 CPU 스파이크
+
+bge-m3 임베딩 + code-review-graph 초기화가 동시에 돌면 수 분간 CPU 가 높습니다. s35 에서 ONNX 스레드 제한 + 세마포어 + 점진적 인덱싱으로 일부 완화.
+
+- **증상**: 프로젝트 전환 직후 수 분간 팬 속도 ↑
+- **회피**: Settings > Runtime 에서 "증분 인덱싱 전용" 모드 전환 가능
+- **계획**: 백그라운드 우선순위 조정 + 진행 UI 표시
+
+### 🔸 P2 — 매우 긴 대화에서 compression 소요 시간
+
+480 메시지 기준 compression 에 약 6.1초. 1000 메시지 초과 시 10초대로 증가할 수 있습니다.
+
+- **회피**: 주기적으로 새 대화로 checkpoint
+- **계획**: incremental compression + 백그라운드 처리
+
+---
+
+## 모바일 클라이언트
+
+### 🔸 P2 — iOS Safari 에서 WS 연결이 PWA 설치 후에만 안정
+
+브라우저 탭에서는 상태바 켜짐 → 꺼짐 전환 시 WS 가 끊기는 경우가 있음. PWA 로 설치하면 유지됨.
+
+- **회피**: iOS Safari 공유 메뉴 > 홈 화면에 추가
+- **계획**: heartbeat 간격 조정
+
+### 🔸 P3 — cloudflared tunnel URL 이 재시작마다 변경
+
+Free tier 사용 중에는 매번 새 URL 이 할당됩니다.
+
+- **회피**: 유료 named tunnel 사용 또는 재시작 후 Settings > Mobile 에서 URL 재복사
+- **계획**: named tunnel 설정 가이드 문서 보강
+
+---
+
+## UI / UX
+
+### 🔸 P2 — dev 모드에서 Ctrl+C 종료 시 window state 미저장
+
+`npm run tauri dev` 중 터미널에서 Ctrl+C 로 종료하면 사이드바/드로어 너비가 저장되지 않습니다. 정식 빌드에서는 발생하지 않음.
+
+- **회피**: 앱 창을 먼저 닫고 터미널 종료
+- **계획**: tauri-plugin-window-state 업스트림 이슈
+
+### 🔸 P3 — 다크/라이트 모드 일부 구간 대비 부족
+
+다크 테마의 `--prose-muted`, `--prose-faint` 가 작은 폰트에서 WCAG AA 4.5:1 기준을 일부 구간에서 미달합니다.
+
+- **영향**: Lighthouse Accessibility 점수 90+ 달성을 막는 주 원인
+- **회피**: 해당 없음 (사용에는 지장 없음)
+- **계획**: Phase 4 accessibility-audit.md §2-4 참조, 0.1.x 에서 튜닝
+
+---
+
+## 에이전트 연동
+
+### 🔸 P2 — Codex CLI 에서 모델명이 `models_cache.json` 에 없으면 400
+
+과거 tunaFlow 가 하드코딩된 fallback(`gpt-5-codex` 등) 을 주입해 발생했던 문제. 현재는 명시적 에러로 표면화하며, 에러 메시지에 실제 허용 모델 목록을 포함합니다.
+
+- **회피**: Settings > Agents 에서 Reviewer / Developer 프로필의 model 을 명시 선택
+- **계획**: 모델 자동 감지 → 기본값 제안 UX
+
+### 🔸 P2 — Claude CLI resume_token 주입 타이밍
+
+세션 이어가기 시 `~/.tunaflow/api-token` 을 저장/재주입하는데, 첫 메시지 직후 resume_token 이 아직 파일에 쓰이기 전인 상태에서 두 번째 메시지를 보내면 새 세션으로 시작될 수 있습니다.
+
+- **영향**: 컨텍스트 유실
+- **회피**: 첫 응답이 완료된 후 다음 메시지 전송
+- **계획**: write-back 동기화 보강
+
+---
+
+## 데이터 / 마이그레이션
+
+### 🔸 P2 — 단일 DB 구조
+
+현재 모든 프로젝트가 단일 SQLite DB 를 공유합니다. 베타 공개는 이 구조로 진행하되, 프로덕션은 프로젝트별 DB 분리가 예정되어 있습니다.
+
+- **영향**: 프로젝트 간 데이터 격리가 논리적 (project_key 필터) 수준
+- **회피**: 프로젝트별 tunaFlow 인스턴스 별도 실행 불가
+- **계획**: 0.2 시점에 Project-per-window 아키텍처 검토 — `docs/ideas/projectPerWindowIdea.md`
+
+### 🔸 P3 — 삭제된 문서의 DB chunks/edges 잔존 정리 미구현
+
+Document RAG 에서 파일을 삭제해도 DB 의 chunk/edge 가 즉시 정리되지 않습니다.
+
+- **영향**: 검색 결과에 stale chunk 가 포함될 수 있음
+- **회피**: rawq reindex 실행
+- **계획**: fs watcher 에 삭제 이벤트 hook
+
+---
+
+## 보고 방법
+
+버그를 발견하면:
+
+1. **크래시 리포트 첨부** — `~/.tunaflow/crash-reports/` 폴더의 최근 `.log` 파일
+2. **재현 순서** — 클릭 순서와 입력 내용
+3. **환경** — macOS 버전, tunaFlow 버전, 사용 에이전트
+4. **GitHub Issue 생성** — https://github.com/hang-in/tunaFlow/issues
+
+Settings > Help 패널에도 최근 크래시 리포트 목록이 표시됩니다.

--- a/docs/beta/release-notes.md
+++ b/docs/beta/release-notes.md
@@ -1,0 +1,148 @@
+---
+title: tunaFlow Beta — Release Notes
+updated_at: 2026-04-20
+canonical: true
+status: draft
+owner: tunaFlow-core
+---
+
+# tunaFlow Beta — Release Notes
+
+> 버전: **v0.1.0-beta** · 플랫폼: **macOS** · 서명: ad-hoc
+> 배포일: 2026-04-XX (E2E 통과 후 확정)
+
+tunaFlow 의 첫 공개 베타입니다. 지난 40여 번의 세션 동안 누적된 기능과, 베타 공개를 앞두고 진행한 5-Phase 리팩토링/하드닝의 결과를 담았습니다.
+
+---
+
+## 하이라이트
+
+### 1. 3-Role Workflow — Architect · Developer · Reviewer
+
+Plan 기반 작업 흐름의 핵심이 완성됐습니다.
+
+- Architect 가 Plan 을 설계하고 drafting 문서를 작성
+- Developer 가 구현 Branch 에서 코드 작성
+- Reviewer 가 Review Branch 에서 검증 → pass / fail verdict
+- 실패 시 findings 를 읽고 rev.N+1 Plan 자동 제안
+- Quick / Deep Review 선택 가능 (Deep 은 다엔진 RT + 테스트 자동 주입)
+
+### 2. Branch / Roundtable
+
+- Branch 는 대화 분기 — 드로어 안에서 독립 실험 후 `adopt` 로 부모 대화에 요약 삽입
+- Roundtable(RT) 은 Branch 의 확장 모드 — Sequential / Deliberative 두 가지 토론 형식
+- RT 전용 페르소나 (`role_guidance`) 가 참가자에게 주입
+
+### 3. ContextPack — 4-Engine Parity
+
+- Claude / Codex / Gemini / Ollama 공통 프롬프트 조립 엔진
+- Lite / Standard / Full 자동 Tiering 으로 토큰 예산 동적 배분
+- rawq 코드 검색, 장기기억, 실패 학습, 사용자 프로필 주입
+
+### 4. Insight — 프로젝트 품질 분석
+
+- 안정성 · 테스트 · 아키텍처 · 성능 · 보안 · 기술부채 6개 카테고리
+- rawq + code-review-graph 가 사전 추출한 데이터를 에이전트가 분석
+- `fix_difficulty` 표시, Quick Wins 자동 수정 지원
+- Phase I: `tool-request:insight` 마커로 에이전트가 분석 자율 호출
+
+### 5. PTY Terminal
+
+- CLI 에이전트와 `-p` 플래그 없이 인터랙티브 세션 유지
+- PTY write queue (FIFO) 로 순서 보장, per-conversation spawn lock 으로 race 방지
+
+### 6. 모바일 클라이언트
+
+- HTTP API (`/api/v1/*` 버저닝) + WebSocket 실시간 이벤트
+- `?since=<ms>` 쿼리로 WS 재연결 시 missed event replay
+- Claude/Codex/Gemini 세션이 모바일↔데스크톱 간 이어짐
+- cloudflared tunnel 로 외부 접속
+
+### 7. UX / 접근성 / 안정성 (Phase 3~4)
+
+- 에러 메시지 한국어 매핑 (AppError 7 variant + 주요 message pattern)
+- Focus-visible 표준화 + ARIA landmark (Sidebar/Main/Drawer/Meta)
+- Settings > Help 패널 신설 (단축키 · 기능 · 문제 해결 · 크래시 리포트)
+- Rust panic hook + JS error hook → `~/.tunaflow/crash-reports/`
+
+---
+
+## 주요 수정 (Phase 1~4, PR #86~#101)
+
+| 영역 | 내용 |
+|------|------|
+| Refactoring | send pipeline 단일화, slice 경계 정리, workflow 서비스 레이어, lib.rs 부트스트랩 분해, uiRouter slice |
+| API | `/api/v1/` 버저닝, Branch detail endpoint (v40), rounds aggregate, subtask status, active plan pointer, WS event replay (v41) |
+| Production | 에러 메시지 UX, observability 감사, performance baseline |
+| Beta gate | Accessibility, 문서, 크래시 리포트 |
+
+자세한 변경 이력은 [refactorRoadmap_2026-04-20.md](../plans/refactorRoadmap_2026-04-20.md) 와 각 PR 을 참조하세요.
+
+---
+
+## 지원 엔진
+
+| 엔진 | 방식 | 요구사항 |
+|------|------|----------|
+| Claude (Anthropic) | CLI subprocess | `@anthropic-ai/claude-code` 설치 + 로그인 |
+| Codex (OpenAI) | CLI subprocess | `@openai/codex` 설치 + 로그인 |
+| Gemini (Google) | CLI subprocess | `@google/gemini-cli` 설치 + 로그인 |
+| Ollama / LM Studio / vLLM | HTTP SSE | 로컬 서버 실행 |
+
+---
+
+## 설치 / 업그레이드
+
+### 신규 설치 (macOS)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/hang-in/tunaFlow/main/install.sh | bash
+```
+
+ad-hoc 서명이라 Gatekeeper 가 경고를 표시합니다:
+```bash
+xattr -cr /Applications/tunaFlow.app
+```
+
+### 소스 빌드
+
+```bash
+git clone https://github.com/hang-in/tunaFlow.git
+cd tunaFlow
+npm install
+npm run tauri dev   # 개발
+./scripts/build.sh  # 빌드
+```
+
+### 기존 사용자 (세션 33 이후 dev 빌드)
+
+DB 스키마는 v41 로 자동 마이그레이션됩니다. 첫 실행 시 수 초 추가 소요됩니다.
+
+---
+
+## 기술 스택
+
+Tauri 2 + React 18 + TypeScript + Zustand 5 + Tailwind CSS 4 + Rust + SQLite (WAL, v41)
+
+- 코드 검색: rawq sidecar (bge-m3 1024-dim)
+- 그래프: code-review-graph
+- 외부 연동: HTTP + WS · MCP 서버 `tunaflow-mcp`
+
+---
+
+## 수치 — Beta 시점 baseline
+
+- Rust unit tests: **305**
+- Frontend vitest: **293**
+- TSC: **0 errors**
+- cargo warnings: **0**
+- Vec 검색 (11k chunks): 15.5ms (vec0) / 28.7ms (brute-force)
+- Long message scroll (1000 msgs): **60fps steady**
+
+---
+
+## 감사의 말
+
+tunaFlow 는 **100% AI 작성** 프로젝트입니다. Claude Code 가 코드를 작성하고, 사람은 방향과 판단만 담당했습니다. 베타까지 이끈 것은 "에이전트가 편해야 결과가 좋아진다" 는 agent-first 철학과, 여러 리팩토링 라운드에서 잘못된 가정을 지적해준 코드 리뷰어 에이전트들입니다.
+
+피드백은 [GitHub Issues](https://github.com/hang-in/tunaFlow/issues) 또는 d9ng@outlook.com 로 부탁드립니다.

--- a/docs/reference/beta-e2e-checklist.md
+++ b/docs/reference/beta-e2e-checklist.md
@@ -1,0 +1,201 @@
+---
+title: Beta E2E Scenario Checklist (Phase 5 Finding 5-1)
+updated_at: 2026-04-20
+canonical: true
+status: active
+owner: tunaFlow-core
+---
+
+# Beta E2E Scenario Checklist
+
+베타 공개 직전 **필수 수동 검증** 10개 시나리오. 모두 pass 해야 release notes 를 확정하고 announcement 를 낼 수 있다.
+
+## 검증 원칙
+
+- **실제 프로젝트에서 실행** — test project(tunaInsight) 는 보조, 본 검증은 실제 개발 중인 코드 대상
+- **엔진별 반복** — Claude / Codex / Gemini 중 최소 2개 엔진에서 각 시나리오 실행
+- **실패 시 즉시 정지** — bypass 금지. 원인 파악 → hotfix → 재검증
+- **로그 보존** — 실패 케이스는 `~/.tunaflow/crash-reports/` + 콘솔 로그 캡처
+
+---
+
+## 1. 프로젝트 첫 생성 → Main 대화 → 첫 응답
+
+**목표**: 초기 사용자가 앱을 처음 켰을 때 막히는 지점이 없는지 확인.
+
+체크 항목:
+- [ ] 프로젝트 없는 상태에서 `ProjectStartup` 렌더
+- [ ] 새 프로젝트 생성 (경로 선택 → 스택 감지)
+- [ ] ProjectOnboardingModal 에이전트 감지 목록 표시
+- [ ] "메인 대화" 선택 → 첫 메시지 전송
+- [ ] 에이전트 응답 스트리밍 정상 (streaming 중단 없음)
+- [ ] 응답 완료 후 메시지 DB 영속화 (앱 재시작 시 남아있음)
+
+**실패 시 확인**: `conversations` 테이블, `messages` 테이블, `bootstrap::db::init_db` 로그
+
+---
+
+## 2. Plan → Architect → Subtask 검토 → Dev → Review → Done
+
+**목표**: 핵심 3-role 워크플로우 전체 사이클.
+
+체크 항목:
+- [ ] Architect 호출 → Plan proposal 생성 (plan-proposal 마커 파싱 성공)
+- [ ] Plan 승인 → `plans` 테이블 row 생성
+- [ ] Architect 에게 drafting 문서 작성 요청 → 문서 생성 확인
+- [ ] "Subtask 검토" 버튼 활성화 (문서 작성 완료 후에만)
+- [ ] Subtask 검토 Branch 생성 → 승인
+- [ ] Developer 호출 → 구현 Branch (linkedPlan.implementationBranchId)
+- [ ] 구현 완료 → Review Branch 자동 생성 / Reviewer 호출
+- [ ] Review verdict = pass → Plan 상태 "done"
+- [ ] Review verdict = fail → findings → rev.N+1 Plan 제안
+
+**실패 시 확인**: PlansPanel 상태, `plans.status`, `branches.mode`, role_guidance 파이프라인
+
+---
+
+## 3. Branch 생성 → adopt / archive
+
+**목표**: 대화 분기 핵심 기능.
+
+체크 항목:
+- [ ] 메시지 checkpoint 에서 Branch 생성 → 드로어 열림
+- [ ] Branch 안에서 대화 진행 → 메시지 shadow conversation 에 쌓임
+- [ ] `adopt` → 부모 conversation 에 요약 메시지 삽입
+- [ ] `archive` → Branch 가 "archived" 상태로 표시 + 드로어 닫힘
+- [ ] 드로어 pin/unpin 토글
+- [ ] Branch 라벨 rename (slug 충돌 방지 확인)
+- [ ] Branch 삭제 (cascade: messages, branches)
+
+**실패 시 확인**: `branches.status`, `adoptBranch` 로직, streamingUtils shadow conv ID 매핑
+
+---
+
+## 4. RT (Roundtable) 다중 참가자 → verdict 집계
+
+**목표**: RT 전용 페르소나 + verdict aggregation.
+
+체크 항목:
+- [ ] Branch 에서 "RT 모드로 전환" → 참가자 추가 (Claude + Codex + Gemini)
+- [ ] Sequential 모드: 순차 발언 → 각 에이전트 응답 영속화
+- [ ] Deliberative 모드: 동시 발언 → 메시지 타임스탬프 순서 정합
+- [ ] 각 참가자에게 role_guidance 주입 확인 (RT 전용 페르소나)
+- [ ] verdict 수집 → aggregation 결과 표시
+- [ ] RT 종료 → adopt 가능
+
+**실패 시 확인**: `rt_rounds`, `rt_verdicts` 테이블, RT sequential orchestrator
+
+---
+
+## 5. Meta inbox 알림 수신 → askMeta
+
+**목표**: 메타 에이전트 플로우팅 채팅.
+
+체크 항목:
+- [ ] Meta 알림 발생 이벤트 (예: Plan done) → MetaFloatingChat 배지 +1
+- [ ] Bot 버튼 클릭 → inbox 탭에 알림 목록
+- [ ] 알림 클릭 → 연관 Plan/Conversation 으로 네비게이션
+- [ ] "chat" 탭 전환 → Meta conversation 에서 질문 전송
+- [ ] Meta 에이전트 응답 스트리밍 정상
+- [ ] localStorage 알림 persist 확인 (앱 재시작 후 미읽음 유지)
+
+**실패 시 확인**: `meta-notifications-v1` localStorage, `getOrCreateMetaConversation`, `tunaflow:meta-task` event
+
+---
+
+## 6. Insight 분석 실행 → findings → 상태 업데이트
+
+**목표**: Insight 탭 재설계 후 전체 사이클.
+
+체크 항목:
+- [ ] Insight 탭 진입 → 카테고리 6개 표시 (안정성/테스트/아키텍처/성능/보안/기술부채)
+- [ ] "전체 선택" → 분석 실행
+- [ ] 진행 로그 실시간 표시 (Insight slice 에 progressLines 누적)
+- [ ] 분석 중 다른 탭 이동 → 돌아와도 진행 상태 유지 (unmount 내구성)
+- [ ] findings 결과 표시 → fix_difficulty 표시
+- [ ] finding 상태 업데이트 (open → resolved)
+- [ ] Plan done 트리거 → 관련 finding 자동 resolved
+
+**실패 시 확인**: `insight_findings` 테이블, `insightSlice`, `count_open_insight_findings`
+
+---
+
+## 7. Settings 에서 agent 프로필 생성 → 사용
+
+**목표**: Personas / Agents / Profile 연계.
+
+체크 항목:
+- [ ] Settings > Agents → 사용 가능한 CLI 자동 감지
+- [ ] Settings > Personas → 새 persona 생성 (role + engine + model 조합)
+- [ ] Settings > Profile → 사용자 프로필 작성 → ContextPack 에 주입 확인
+- [ ] 메인 대화에서 persona 선택 → 해당 engine/model 로 요청
+- [ ] Skills 섹션 → vendor snapshot 표시, 선택 가능
+- [ ] Runtime 섹션 → rawq daemon 상태 확인
+- [ ] Help 섹션 → 단축키/기능/문제해결/크래시 리포트 배지
+
+**실패 시 확인**: `personas`, `user_profile` 설정, resolveModel 로직
+
+---
+
+## 8. 모바일 client 연결 → HTTP 소비 → WS 구독 → 재연결 복구
+
+**목표**: HTTP API + WebSocket event replay.
+
+체크 항목:
+- [ ] Settings > Mobile → API 토큰 생성 / cloudflared tunnel URL 복사
+- [ ] 모바일 브라우저에서 접속 → conversations 목록 로딩
+- [ ] 대화 선택 → messages 렌더
+- [ ] 메시지 전송 → WS 로 실시간 수신
+- [ ] WS 끊김 시뮬레이션 (Wi-Fi 토글) → `?since=<ms>` 로 재연결 + 놓친 이벤트 replay
+- [ ] 긴 응답 스트리밍 중 재연결 → 이후 chunk 모두 수신
+- [ ] 모바일에서 보낸 메시지 → 데스크톱에서도 동일 session 으로 이어짐 (session_id 오염 없음)
+
+**실패 시 확인**: `ws_event_log` 테이블, `auth_middleware` skip list, `http_api::events::broadcast_event`
+
+---
+
+## 9. 긴 대화 (1000+ 메시지) 스크롤 + 검색
+
+**목표**: Virtuoso 가상 스크롤 + retrieval.
+
+체크 항목:
+- [ ] 메시지 1000개 이상 conversation 열기 (기존 대화 또는 seed)
+- [ ] 스크롤 60fps 유지 (Chrome DevTools Performance 녹화)
+- [ ] 상단/하단 경계 메시지 정상 렌더 (overdraw 누락 없음)
+- [ ] 검색 (Cmd+K → 메시지 검색) → hit 위치로 점프
+- [ ] 스트리밍 중 스크롤해도 auto-scroll lock 유지 (끝에서만 따라감)
+- [ ] vizMarkers (tool-request 등) 토글 → 즉시 반영
+
+**실패 시 확인**: MessageList Virtuoso, `_staleConversations`, streamingUtils 중복 방지
+
+---
+
+## 10. 앱 재시작 → 세션 이어가기
+
+**목표**: 재시작 후 상태 복구.
+
+체크 항목:
+- [ ] 마지막 열었던 프로젝트 자동 선택 (`lastProjectKey`)
+- [ ] 마지막 대화 자동 선택 (`lastConversationId`)
+- [ ] 사이드바 너비/드로어 너비/테마 복구
+- [ ] PTY 세션: 재시작 시 이전 세션 resume 또는 깨끗이 종료 (고아 PTY 없음)
+- [ ] 미완료 run: `cleanup_stale_jobs` 가 정리 → UI 에 "실행중" 잔존 없음
+- [ ] Claude resume_token: 다음 메시지 시 `~/.tunaflow/api-token` 재주입 확인
+- [ ] 크래시 리포트 배지: 이전 세션에 panic 있었다면 Help 섹션에 표시
+
+**실패 시 확인**: `AppShell` init flow, `runningThreadIds` 리셋, `pty_kill_all` HMR cleanup
+
+---
+
+## 종합 Pass 조건
+
+- [ ] 10개 시나리오 모두 pass (블로커 없음)
+- [ ] 각 시나리오마다 최소 2개 엔진에서 검증
+- [ ] 발견된 P0/P1 버그는 모두 hotfix 머지 후 재검증
+- [ ] 크래시 리포트 디렉터리에 이 세션 발생 panic 0 건
+
+## Fail 허용 기준
+
+- P2/P3 (사용성 불편, 시각적 사소한 문제): known issues 에 등록하고 pass
+- RT 중간 스트리밍 미지원: CLAUDE.md 기등록 이슈, pass
+- JSONL 완료 감지 실패(P1): 기등록, pass (단, 발생 빈도가 이전보다 높아지면 fail)


### PR DESCRIPTION
## Summary
Phase 5 Beta Gate 의 4개 문서 번들. 모두 **draft** 상태 — E2E 수동 검증 결과와 자동화 스크립트(별도 PR) 결과에 따라 확정.

- **5-1** `docs/reference/beta-e2e-checklist.md` — 10개 시나리오 수동 검증 체크리스트
- **5-2** `docs/beta/release-notes.md` — Phase 1~4 변경 요약
- **5-3** `docs/beta/known-issues.md` — P0~P3 제약사항 + 회피 방법
- **5-4** `docs/beta/announcement.md` — GitHub/블로그/트위터 3종 초안

## 관련
- Phase 4 (#101) 머지됨
- 후속: E2E 자동화 스크립트 + Insight HTTP endpoint (별도 PR)

## Test plan
- [x] 모든 문서가 canonical/draft 메타데이터 포함
- [x] 참조 링크 유효
- [ ] 수동 E2E 검증 결과 반영 (머지 후 follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)