### PR TITLE
fix(db+e2e): recover meta_notifications via v42 + rename field check

### DIFF
--- a/scripts/beta-e2e/03-branch-lifecycle.mjs
+++ b/scripts/beta-e2e/03-branch-lifecycle.mjs
@@ -48,17 +48,17 @@ runScenario("scenario-03 branch-lifecycle", async () => {
   assert(detail.id === br.id, "detail id mismatch");
   log.ok(`branch detail ok`);
 
-  // Rename
+  // Rename — writes to `custom_label`; original `label` stays for history.
   await api(`/api/v1/branches/${br.id}/rename`, {
     method: "POST",
     body: JSON.stringify({ label: "test-branch-renamed" }),
   });
   const detail2 = await api(`/api/v1/branches/${br.id}`);
   assert(
-    detail2.label === "test-branch-renamed",
-    `rename failed, got ${detail2.label}`
+    detail2.customLabel === "test-branch-renamed",
+    `rename failed, customLabel=${detail2.customLabel}`
   );
-  log.ok(`rename ok`);
+  log.ok(`rename ok (customLabel updated)`);
 
   // Archive
   await api(`/api/v1/branches/${br.id}/archive`, { method: "POST" });

--- a/src-tauri/src/db/migrations.rs
+++ b/src-tauri/src/db/migrations.rs
@@ -148,6 +148,9 @@ pub fn run(conn: &Connection) -> Result<(), AppError> {
     if current < 41 {
         apply_v41(conn)?;
     }
+    if current < 42 {
+        apply_v42(conn)?;
+    }
     Ok(())
 }
 
@@ -971,6 +974,39 @@ fn apply_v41(conn: &Connection) -> Result<(), AppError> {
     )?;
     conn.execute(
         "INSERT INTO schema_version (version, applied_at) VALUES (41, ?1)",
+        [now_epoch_ms()],
+    )?;
+    Ok(())
+}
+
+/// v42 — `meta_notifications` 복구 migration.
+///
+/// 실제 필드에서 발견된 불일치: 일부 DB 는 schema_version = 41 로 기록되어
+/// 있지만 `meta_notifications` 테이블이 존재하지 않는 상태였다. `.pre-v38.bak`
+/// 으로부터의 복원이나 과거 v38 실행 중 부분 실패로 추정됨. 결과적으로 베타
+/// 시점 HTTP API `GET /meta-notifications` 가 `db: no such table` 500 에러.
+///
+/// 해결: `CREATE TABLE IF NOT EXISTS` 를 v42 로 다시 돌려 idempotent 하게 복구.
+/// 신규 DB 는 이미 v38 이 같은 DDL 을 찍었으므로 영향 없음 (멱등).
+fn apply_v42(conn: &Connection) -> Result<(), AppError> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS meta_notifications (
+            id            TEXT PRIMARY KEY,
+            project_key   TEXT,
+            kind          TEXT NOT NULL,
+            title         TEXT NOT NULL,
+            summary       TEXT,
+            route_json    TEXT,
+            created_at    INTEGER NOT NULL,
+            read_at       INTEGER,
+            dismissed_at  INTEGER,
+            FOREIGN KEY (project_key) REFERENCES projects(key) ON DELETE CASCADE
+        );
+        CREATE INDEX IF NOT EXISTS idx_meta_notif_project ON meta_notifications(project_key);
+        CREATE INDEX IF NOT EXISTS idx_meta_notif_created ON meta_notifications(created_at DESC);",
+    )?;
+    conn.execute(
+        "INSERT INTO schema_version (version, applied_at) VALUES (42, ?1)",
         [now_epoch_ms()],
     )?;
     Ok(())

--- a/src-tauri/tests/db_integration.rs
+++ b/src-tauri/tests/db_integration.rs
@@ -33,6 +33,35 @@ fn migrations_apply_cleanly() {
 }
 
 #[test]
+fn v42_meta_notifications_recovered() {
+    // v42 가 누락된 meta_notifications 를 idempotent 하게 복구한다.
+    // 신규 DB 라도 v38 + v42 둘 다 CREATE IF NOT EXISTS 라 충돌 없이 테이블이 존재해야 함.
+    let conn = setup_db();
+    let has_table: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='meta_notifications'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(has_table, 1, "meta_notifications table must exist after v42");
+
+    // Simulate the real-world broken state: DB at v41 with the table missing.
+    // Drop the table, roll schema_version back to 41, then re-run migrations.
+    conn.execute("DROP TABLE meta_notifications", []).unwrap();
+    conn.execute("DELETE FROM schema_version WHERE version IN (42)", []).unwrap();
+    db::migrations::run(&conn).unwrap();
+    let recovered: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='meta_notifications'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(recovered, 1, "v42 must recover meta_notifications on stale DB");
+}
+
+#[test]
 fn migrations_are_idempotent() {
     let conn = setup_db();
     // Run again — should not fail


### PR DESCRIPTION
## Summary

Beta E2E 2차 실행에서 드러난 2건 수정.

### v42 — meta_notifications 복구 migration

사용자 DB 가 \`schema_version=41\` 임에도 \`meta_notifications\` 테이블이 없는 상태. \`.pre-v38.bak\` 파일 존재로 보아 과거 복원/조작 후 version 레코드만 남은 것으로 추정. 결과: \`GET /api/v1/meta-notifications\` 가 500 \`db: no such table\`.

v42 가 v38 과 동일한 \`CREATE TABLE IF NOT EXISTS\` 를 한 번 더 돌려 idempotent 복구. 신규 DB 에도 무해.

### scenario-03 rename 검증 수정

\`/branches/{id}/rename\` 은 \`custom_label\` 을 업데이트하고 원본 \`label\` 은 유지. 시나리오가 \`label\` 로 비교해 항상 fail → \`customLabel\` 로 수정.

## Test plan
- [x] \`cargo test --test db_integration\` 31 passed (v42 recovery test 포함)
- [x] \`cargo test --lib\` 305 passed
- [ ] 머지 후 **앱 재시작** → v42 자동 적용 → \`npm run e2e:beta\` 재실행

> **중요**: 사용자는 머지 후 tunaFlow 앱을 재시작해야 migration 이 적용됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)