### PR TITLE
fix(beta-e2e): adopt body + mark-all-read empty json — 5/5 pass

### DIFF
--- a/scripts/beta-e2e/03-branch-lifecycle.mjs
+++ b/scripts/beta-e2e/03-branch-lifecycle.mjs
@@ -80,7 +80,8 @@ runScenario("scenario-03 branch-lifecycle", async () => {
   });
   await api(`/api/v1/branches/${br2.id}/adopt`, {
     method: "POST",
-    body: JSON.stringify({ targetConversationId: conv.id }),
+    // AdoptInput.conversation_id → serde camelCase → `conversationId`
+    body: JSON.stringify({ conversationId: conv.id }),
   });
   const detail4 = await api(`/api/v1/branches/${br2.id}`);
   assert(detail4.status === "adopted", `adopt failed, got ${detail4.status}`);

--- a/scripts/beta-e2e/05-meta-inbox.mjs
+++ b/scripts/beta-e2e/05-meta-inbox.mjs
@@ -8,8 +8,12 @@ runScenario("scenario-05 meta-inbox", async () => {
   const baseline = await api("/api/v1/meta-notifications?limit=10");
   log.info(`baseline notification count: ${baseline.length}`);
 
-  // mark-all-read is idempotent, safe on empty DB
-  await api("/api/v1/meta-notifications/mark-all-read", { method: "POST" });
+  // mark-all-read requires a JSON body (ProjectScopeInput); empty object =
+  // global scope. Without body, axum returns 400 "EOF while parsing JSON".
+  await api("/api/v1/meta-notifications/mark-all-read", {
+    method: "POST",
+    body: JSON.stringify({}),
+  });
   log.ok("mark-all-read ok");
 
   // Find any unread, mark it read explicitly


### PR DESCRIPTION
## Summary
Beta E2E 직접 실행에서 드러난 마지막 2건의 payload 스키마 오류 수정. **5/5 전부 pass 확인**.

- **scenario-03 adopt**: \`AdoptInput\` 필드명을 \`targetConversationId\` → \`conversationId\` 로 수정 (serde \`camelCase\` 적용 후 실제 키).
- **scenario-05 mark-all-read**: 빈 POST → \`{}\` body 전송. \`ProjectScopeInput\` extractor 가 JSON 을 요구함.

## Test plan
- [x] \`npm run e2e:beta\` 5/5 pass 확인
- [x] scenario-01: agent:completed 이벤트 7.7초 수신
- [x] scenario-03: create/list/detail/rename/archive/adopt/delete 전체 경로
- [x] scenario-05: mark-all-read + list/read/dismiss
- [x] scenario-06: insight surface 확인
- [x] scenario-08: branch:created → disconnect → branch:archived replay

🤖 Generated with [Claude Code](https://claude.com/claude-code)