### PR TITLE
feat(phase6): prompt regression eval suite (MVP)

### DIFF
--- a/.github/workflows/eval-regression.yml
+++ b/.github/workflows/eval-regression.yml
@@ -1,0 +1,68 @@
+name: Eval Regression
+
+# Selective trigger: avoids burning LLM quota on every PR.
+#   1. Manual dispatch (always available)
+#   2. PR touching prompt/context/eval-related code
+#   3. PR explicitly labeled `eval:run`
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'src-tauri/src/agents/**'
+      - 'src-tauri/src/commands/agents_helpers/**'
+      - 'src/lib/workflowOrchestration.ts'
+      - 'evals/golden/**'
+      - 'evals/judge/**'
+      - 'evals/scripts/**'
+      - '.github/workflows/eval-regression.yml'
+  pull_request_target:
+    types: [labeled]
+
+jobs:
+  eval:
+    # Only run on labeled event when the label is specifically `eval:run`.
+    # Other triggers (dispatch, matching-path PR) always run.
+    if: >
+      github.event_name != 'pull_request_target' ||
+      github.event.label.name == 'eval:run'
+    runs-on: [self-hosted, Linux]
+    # The eval script needs a running tunaFlow instance with reachable
+    # HTTP API. The self-hosted runner is assumed to either share the
+    # developer's instance or have a dedicated headless instance bound
+    # to TUNAFLOW_BASE (set in runner env or via `secrets.EVAL_TUNAFLOW_BASE`).
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+
+      - name: Run prompt regression
+        env:
+          TUNAFLOW_BASE: ${{ secrets.EVAL_TUNAFLOW_BASE || 'http://127.0.0.1:19840' }}
+          TUNAFLOW_TOKEN: ${{ secrets.EVAL_API_TOKEN }}
+          EVAL_ENGINE: ${{ vars.EVAL_ENGINE || 'claude' }}
+          JUDGE_ENGINE: ${{ vars.JUDGE_ENGINE || 'claude' }}
+          JUDGE_MODEL: ${{ vars.JUDGE_MODEL || 'claude-haiku-4-5-20251001' }}
+        run: |
+          if [ -z "$TUNAFLOW_TOKEN" ]; then
+            echo "::warning::EVAL_API_TOKEN secret missing — eval skipped"
+            echo "# Prompt Regression Eval" >> $GITHUB_STEP_SUMMARY
+            echo "**Skipped** — \`EVAL_API_TOKEN\` not configured." >> $GITHUB_STEP_SUMMARY
+            exit 0
+          fi
+          node evals/scripts/run-eval.mjs || EVAL_EXIT=$?
+          node evals/scripts/report.mjs >> $GITHUB_STEP_SUMMARY
+          # Warning-only gate for the first 2-4 weeks. Flip to `exit $EVAL_EXIT`
+          # once threshold calibration stabilizes (see docs/reference/
+          # harnessMaturityAudit_2026-04-16.md §5.2 item 5).
+          echo "::notice::eval exit code was ${EVAL_EXIT:-0} (warning-only; not blocking)"
+
+      - name: Upload results snapshot
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: eval-results
+          path: evals/results/
+          retention-days: 30

--- a/docs/plans/promptRegressionEvalPlan.md
+++ b/docs/plans/promptRegressionEvalPlan.md
@@ -1,0 +1,149 @@
+---
+title: Prompt Regression Eval Plan (Phase 6)
+status: active
+canonical: true
+created_at: 2026-04-21
+owner: architect
+related:
+  - docs/reference/harnessMaturityAudit_2026-04-16.md  # §2.2 Evaluation harness (3/10 → target 7/10)
+  - evals/README.md
+  - docs/reference/aistartkit-harness-evaluation_2026-04-21.md
+---
+
+# Phase 6 — Prompt Regression Eval Suite
+
+> 프롬프트 / 모델 / ContextPack 변경이 과거 성공 케이스의 품질을 무너뜨리지 않는지
+> 자동으로 감시하는 회귀 테스트.
+
+## 목적
+
+Harness Maturity Audit §2.2 에서 "Regression Evaluation Harness 3/10 (하)" 로 판정된 영역을 MVP 수준으로 끌어올린다. 루브릭만 있고 회귀 측정 수단이 없었던 상태 → 20개 정도의 golden 기준점 + LLM-as-a-Judge + CI 게이트.
+
+## 설계 요약
+
+### 3단계 구조
+
+1. **Golden Dataset** (`evals/golden/*.jsonl`)
+   - 과거 성공한 (prompt, output) 쌍 + `expected_behaviors`
+   - 5 카테고리: plan-generation / dev-implementation / review-verdict / rt-verdict / branch-adopt
+   - `extract-from-trace.mjs` 로 DB 에서 seed 후 사람이 `expected_behaviors` 수작업
+
+2. **LLM-as-a-Judge**
+   - Judge 프롬프트: `evals/judge/prompts/semantic-equivalence.md`
+   - Judge 모델: Haiku (기본 `claude-haiku-4-5-20251001`) — Sonnet 대비 10배 저렴
+   - 출력: 0.0-1.0 score + verdict + covered/missing/regressions/improvements
+
+3. **CI 게이트** (`.github/workflows/eval-regression.yml`)
+   - Trigger: workflow_dispatch / 관련 경로 PR / `eval:run` label
+   - Warning-only 정책으로 2-4주 운영 → threshold 튜닝 후 hard gate 로 전환
+
+### 파일 구조
+
+```
+evals/
+├─ README.md
+├─ golden/                    # 카테고리별 JSONL
+├─ judge/prompts/semantic-equivalence.md
+├─ scripts/
+│  ├─ extract-from-trace.mjs  # DB → JSONL seed (6-1)
+│  ├─ run-eval.mjs            # 전체 runner (6-3)
+│  └─ report.mjs              # markdown diff (6-4)
+└─ results/                   # 회차별 JSON 스냅샷
+```
+
+## 산출물
+
+### 6-1 extract-from-trace.mjs ✅
+
+`~/.tunaflow/db/tunaflow.db` 의 `messages` 테이블에서 persona 기준으로 성공 케이스 추출. 4가지 persona 카테고리 + branches.adopted 조인으로 branch-adopt 지원. user_prompt 페어링 실패 시 직전 assistant 메시지로 fallback (auto-invoked Reviewer/Synthesizer 커버).
+
+실측 결과 (2026-04-21):
+- plan-generation: 5
+- dev-implementation: 5
+- review-verdict: 3
+- rt-verdict: 2 (DB 에 실 데이터 2개)
+- branch-adopt: 0 (adopted_message_id 있는 엔트리 없음)
+
+### 6-2 Golden Dataset Seed (WIP — 사람 작업)
+
+수작업으로 진행:
+1. `npm run eval:extract 10 > evals/golden/candidates.jsonl`
+2. JSONL 을 카테고리별 파일로 분리 (`plan-generation-01.jsonl` …)
+3. 각 항목에 `expected_behaviors` 3-5줄 수작업 (must-cover 행동)
+4. `context_hint` 프로젝트 스택/상태 간단 1-2줄
+5. 1항목당 5-10분 × 15-20개 = 2-3시간 작업
+
+LLM 자동 생성 금지 — baseline 을 LLM 이 정의하면 regression 측정이 원리적으로 불가.
+
+### 6-3 run-eval.mjs ✅
+
+각 golden 항목에 대해:
+1. 스크래치 project + conversation 생성
+2. `POST /api/v1/conversations/{id}/send` + WS 구독
+3. `agent:completed` 대기 (기본 180s 타임아웃)
+4. 최신 assistant 메시지 fetch
+5. Judge 에 system prompt + (CATEGORY/PROMPT/REFERENCE/CANDIDATE/EXPECTED_BEHAVIORS) 전달
+6. Judge JSON 결과 파싱 → 결과 누적
+7. 스냅샷 JSON 저장: `evals/results/<ISO>-<engine>-<model>.json`
+
+환경 변수:
+- `TUNAFLOW_BASE` / `TUNAFLOW_TOKEN`
+- `EVAL_ENGINE` / `EVAL_MODEL`
+- `JUDGE_ENGINE` / `JUDGE_MODEL`
+- `EVAL_FILTER` (정규식; id 또는 category 매치)
+- `EVAL_TIMEOUT_MS` (기본 180000)
+
+### 6-4 report.mjs + CI workflow ✅
+
+`report.mjs` — 최신 스냅샷 읽어 markdown 출력. 4단계 게이트 라벨:
+
+| Pass Rate | 레이블 |
+|-----------|--------|
+| ≥85% | 🟢 PASS |
+| 70-84% | 🟡 WARNING |
+| 50-69% | 🟠 FAILING |
+| <50% | 🔴 BLOCK |
+
+카테고리별 브레이크다운 + per-item 스코어 테이블 포함. `--baseline` 모드에서 회차간 diff 제공.
+
+`.github/workflows/eval-regression.yml` — 선택적 트리거:
+- `workflow_dispatch` (항상)
+- 프롬프트/ContextPack/eval 경로 변경 PR
+- `eval:run` 라벨 수동
+
+Warning-only 운영 (2-4주) → 데이터 축적 후 hard gate.
+
+## 비용 추산
+
+- Golden 20개 × (생성 Sonnet + Judge Haiku) = 40 LLM 호출
+- 토큰: 생성 ~2k × 20 + Judge ~3k × 20 ≈ 100k 토큰
+- 금액: $0.3-0.5 / run
+- 실행: 주 1회 수동 + 관련 PR 시 → 월 $5-10 미만
+
+## 운영 정책
+
+### 초기 2-4주 (Calibration)
+
+- 모든 결과는 warning-only (merge 블록 하지 않음)
+- 매 실행 후 `missing` / `regressions` 수동 검토 → expected_behaviors 보정
+- 오탐률 > 20% 면 threshold 0.7 → 0.65 조정 고려
+
+### 이후 (Enforcement)
+
+- Pass rate <50% 면 merge block (exit 1)
+- 50-69% 는 failing check, 리뷰어 override 가능
+- `expected_behaviors` 변경은 별도 PR 로 분리 (baseline 조작 방지)
+
+## 확장 (v2)
+
+- **Regression 추세 시각화**: `TracePanel` 에 eval 탭 추가, 최근 10회 pass율 sparkline
+- **Failure bucket 자동 분류**: Judge 의 `regressions[]` 토픽 모델링 → 회귀 축 알림
+- **Auto-seed 후보 큐**: plan done + review pass 케이스를 golden 후보 자동 큐잉, 사람 검수 후 승격
+
+## 다음 행동
+
+1. `npm run eval:extract 10 > /tmp/candidates.jsonl` 실행
+2. JSONL 을 사람이 카테고리별 파일로 분리 + `expected_behaviors` 수작업 (2-3시간)
+3. 첫 실행: `npm run eval:regression`
+4. 결과 확인 후 threshold / prompt 조정
+5. 3-5회 실행으로 기준점 확립 → CI workflow hard gate 전환

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,81 @@
+# Prompt Regression Eval Suite (Phase 6)
+
+> 프롬프트 / 모델 / ContextPack 변경이 과거 성공 케이스의 품질을 **무너뜨리지 않는지** 자동으로 감시하는 회귀 테스트.
+
+## 설계 요약
+
+1. **Golden Dataset** (`golden/*.jsonl`) — 과거 성공한 input/output 쌍 + 필수 행동 리스트. 사람이 한 번 작성, 이후 자동 실행
+2. **LLM-as-a-Judge** (`judge/prompts/`) — 새 응답과 reference 를 세만틱 동등성 기준으로 채점 (값싼 Haiku 모델 사용)
+3. **CI 게이트** (`.github/workflows/eval-regression.yml`) — 프롬프트/엔진 파일 변경 또는 `eval:run` 라벨 시 자동 실행
+
+상세 설계: `docs/plans/promptRegressionEvalPlan.md` (예정)
+
+## 디렉터리
+
+```
+evals/
+├─ golden/                # 카테고리별 JSONL (5 카테고리 × 4 = 20개)
+│  ├─ plan-generation-*.jsonl
+│  ├─ dev-implementation-*.jsonl
+│  ├─ review-verdict-*.jsonl
+│  ├─ rt-verdict-*.jsonl
+│  └─ branch-adopt-*.jsonl
+├─ judge/
+│  └─ prompts/semantic-equivalence.md
+├─ scripts/
+│  ├─ extract-from-trace.mjs    # DB 에서 seed 추출
+│  ├─ run-eval.mjs              # 전체 runner
+│  └─ report.mjs                # 결과 diff → markdown
+└─ results/                     # 회차별 JSON 스냅샷
+```
+
+## 실행
+
+```bash
+# seed (한 번만)
+node evals/scripts/extract-from-trace.mjs --limit 50 > evals/golden/candidates.jsonl
+
+# 수동 실행
+export TUNAFLOW_TOKEN=<Settings > Mobile>
+export EVAL_ENGINE=claude
+export JUDGE_ENGINE=claude
+export JUDGE_MODEL=claude-haiku-4-5-20251001
+node evals/scripts/run-eval.mjs
+
+# 결과 리포트
+node evals/scripts/report.mjs
+```
+
+## 게이트 정책
+
+| Pass율 | 처리 |
+|--------|------|
+| ≥ 85% | 그린 |
+| 70-85% | warning comment, 머지 가능 |
+| 50-70% | failing check, 리뷰어 override |
+| < 50% | block |
+
+초기 2~4주는 전부 warning 운영 → 오탐률 측정 → threshold 조정.
+
+## JSONL 스키마
+
+각 항목 1줄:
+
+```json
+{
+  "id": "plan-generation-01",
+  "category": "plan-generation",
+  "prompt": "사용자 요청 원문",
+  "context_hint": "프로젝트 스택/상태",
+  "engine_ref": "claude",
+  "model_ref": "claude-sonnet-4-6",
+  "reference_output": "<과거 성공 응답>",
+  "expected_behaviors": [
+    "must-cover 행동 1",
+    "must-cover 행동 2"
+  ],
+  "rubric_threshold": 0.7,
+  "created_at": 1713567890000,
+  "source_trace_id": "trace-abc123"
+}
+```

--- a/evals/judge/prompts/semantic-equivalence.md
+++ b/evals/judge/prompts/semantic-equivalence.md
@@ -1,0 +1,68 @@
+# Semantic Equivalence Judge — Prompt Regression
+
+You are a **semantic equivalence judge** for a LLM prompt regression suite.
+Your job is to decide whether a new assistant response achieves the same
+functional outcome as a past successful response, **independent of wording**.
+
+## Inputs you will receive
+
+- `CATEGORY` — one of: plan-generation, dev-implementation, review-verdict,
+  rt-verdict, branch-adopt
+- `PROMPT` — user request or (for auto-invoked roles) the prior assistant
+  output that triggered the response
+- `REFERENCE` — past assistant response that was verified as good
+- `CANDIDATE` — new response being evaluated
+- `EXPECTED_BEHAVIORS` — list of must-cover items (may be empty; treat as
+  soft signal only when non-empty)
+- `SOURCE_PROMPT_KIND` — `user` | `prior_assistant` (latter = automated
+  invocation context)
+
+## Scoring rubric (0.0 – 1.0)
+
+| Band | Score | Meaning |
+|------|-------|---------|
+| Exact | 0.95–1.00 | Fully covers all expected behaviors; no functional gap |
+| Strong | 0.80–0.94 | Covers primary intent; cosmetic / ordering differences only |
+| Partial | 0.60–0.79 | Covers main outcome but misses 1+ expected behaviors |
+| Weak | 0.40–0.59 | Substantial divergence; only overlapping bits |
+| Regression | 0.00–0.39 | Misses core intent OR introduces contradictions vs reference |
+
+## Rules
+
+1. **Judge functional outcome, not wording.** The same plan described in
+   different words is equivalent. Reformatted tables are equivalent. Extra
+   polite fluff is ignored.
+2. **Expected behaviors are hard constraints when non-empty.** Each missed
+   item drops score by at least 0.1. If the list is empty, rely on the
+   reference content alone.
+3. **Never punish candidate for being better.** If CANDIDATE adds a valid
+   improvement not in REFERENCE, do not penalize — note it under
+   `improvements` but score ≥ reference would get.
+4. **Structural divergence matters for plan-generation and
+   review-verdict.** If a plan drops a subtask or a reviewer drops a
+   verdict category, treat as regression.
+5. **RT-verdict / Synthesizer responses** should preserve the decision
+   (pass / fail / needs-rework). Wording of reasoning is flexible.
+6. **Branch-adopt summaries** are judged on coverage of the branch's
+   conclusions, not style. Shorter is fine if all key points land.
+
+## Output — strict JSON (no prose before or after)
+
+```json
+{
+  "score": 0.85,
+  "verdict": "strong",
+  "covered": ["<expected_behavior text>", "..."],
+  "missing": ["<expected_behavior text>", "..."],
+  "regressions": ["<concrete concern>", "..."],
+  "improvements": ["<concrete gain, if any>"],
+  "reasoning": "<1-2 sentence summary, Korean ok>",
+  "pass": true
+}
+```
+
+- `pass = score >= rubric_threshold` (caller supplies threshold; you just
+  fill `score` honestly).
+- `covered` / `missing` only populated when `EXPECTED_BEHAVIORS` is
+  non-empty; else return empty arrays.
+- `regressions` non-empty ⇒ `verdict` must be `weak` or `regression`.

--- a/evals/scripts/extract-from-trace.mjs
+++ b/evals/scripts/extract-from-trace.mjs
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+// Extract successful assistant messages from tunaFlow's messages table,
+// grouped by role (Architect / Implementer / Reviewer / Synthesizer), and
+// emit them as JSONL candidates for the golden dataset. Human then picks N
+// per category and fills in `expected_behaviors`.
+//
+// Usage:
+//   node evals/scripts/extract-from-trace.mjs [limit_per_category=10]
+//     > evals/golden/candidates.jsonl
+//
+//   TUNAFLOW_DB=/alt/path.db node evals/scripts/extract-from-trace.mjs
+//
+// Requires `sqlite3` CLI (macOS ships with it; Linux/Debian: `apt install
+// sqlite3`). No npm deps.
+
+import { execFileSync } from "node:child_process";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+import { existsSync } from "node:fs";
+
+const DB =
+  process.env.TUNAFLOW_DB ??
+  resolve(homedir(), ".tunaflow/db/tunaflow.db");
+const LIMIT = parseInt(process.argv[2] ?? "10", 10);
+
+if (!existsSync(DB)) {
+  console.error(`[extract] DB not found: ${DB}`);
+  console.error(`[extract] set TUNAFLOW_DB to override`);
+  process.exit(2);
+}
+
+// ─── Category → persona filter ───────────────────────────────────────────────
+// persona column values look like "Architect Claude · Architect" — the
+// second clause is the role; we match on LIKE '%Role%' for resilience.
+const CATEGORIES = {
+  "plan-generation": "AND m_a.persona LIKE '%Architect%'",
+  "dev-implementation":
+    "AND (m_a.persona LIKE '%Implementer%' OR m_a.persona LIKE '%Coder%')",
+  "review-verdict":
+    "AND m_a.persona LIKE '%Reviewer%' AND m_a.persona NOT LIKE '%Synthesizer%'",
+  "rt-verdict": "AND m_a.persona LIKE '%Synthesizer%'",
+};
+
+function sql(q) {
+  try {
+    const out = execFileSync("sqlite3", [DB, "-json", q], {
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    const text = out.toString();
+    return text ? JSON.parse(text) : [];
+  } catch (e) {
+    console.error(`[extract] sqlite3 failed: ${e.message}`);
+    process.exit(1);
+  }
+}
+
+// ─── Main ────────────────────────────────────────────────────────────────────
+
+let emitted = 0;
+for (const [cat, filter] of Object.entries(CATEGORIES)) {
+  const rows = sql(`
+    SELECT m_a.id AS id,
+           m_a.conversation_id AS conversationId,
+           m_a.content AS reference_output,
+           m_a.persona AS persona,
+           m_a.engine AS engine,
+           m_a.model AS model,
+           m_a.timestamp AS timestamp,
+           (SELECT m_u.content FROM messages m_u
+              WHERE m_u.conversation_id = m_a.conversation_id
+                AND m_u.role = 'user'
+                AND m_u.timestamp < m_a.timestamp
+              ORDER BY m_u.timestamp DESC LIMIT 1) AS user_prompt
+    FROM messages m_a
+    WHERE m_a.role = 'assistant'
+      AND m_a.status = 'done'
+      AND length(m_a.content) > 200
+      ${filter}
+    ORDER BY m_a.timestamp DESC
+    LIMIT ${LIMIT};
+  `);
+
+  for (const [idx, r] of rows.entries()) {
+    let promptKind = "user";
+    let prompt = r.user_prompt;
+    // Reviewer / Synthesizer are often auto-invoked (no direct user msg).
+    // Fall back to the prior assistant message as the "input" — imperfect
+    // but lets the regression judge see what the model was reacting to.
+    if (!prompt) {
+      const prior = sql(`
+        SELECT content FROM messages
+        WHERE conversation_id = '${r.conversationId}'
+          AND role = 'assistant'
+          AND id != '${r.id}'
+          AND timestamp < ${r.timestamp}
+        ORDER BY timestamp DESC LIMIT 1;
+      `);
+      if (prior[0] && prior[0].content) {
+        prompt = `[auto-invoked; prior assistant output]\n${prior[0].content}`;
+        promptKind = "prior_assistant";
+      } else {
+        continue; // truly orphan → skip
+      }
+    }
+    const entry = {
+      id: `${cat}-${String(idx + 1).padStart(2, "0")}`,
+      category: cat,
+      prompt,
+      source_prompt_kind: promptKind,
+      context_hint: "",
+      engine_ref: r.engine ?? "claude",
+      model_ref: r.model ?? "",
+      reference_output: r.reference_output,
+      expected_behaviors: [],
+      rubric_threshold: 0.7,
+      created_at: r.timestamp,
+      source_message_id: r.id,
+      source_conversation_id: r.conversationId,
+      source_persona: r.persona,
+    };
+    process.stdout.write(JSON.stringify(entry) + "\n");
+    emitted++;
+  }
+}
+
+// ─── Branch-adopt: separate query (reads from branches + adopted_message_id)
+const adopt = sql(`
+  SELECT m.id AS id,
+         m.conversation_id AS conversationId,
+         m.content AS reference_output,
+         m.timestamp AS timestamp,
+         b.label AS branch_label,
+         b.id AS branch_id,
+         (SELECT content FROM messages
+            WHERE conversation_id = 'branch:' || b.id
+              AND role = 'user'
+            ORDER BY timestamp ASC LIMIT 1) AS user_prompt
+  FROM branches b
+  JOIN messages m ON m.id = b.adopted_message_id
+  WHERE b.status = 'adopted'
+    AND b.adopted_message_id IS NOT NULL
+    AND length(m.content) > 100
+  ORDER BY m.timestamp DESC
+  LIMIT ${LIMIT};
+`);
+
+for (const [idx, r] of adopt.entries()) {
+  if (!r.user_prompt) continue;
+  const entry = {
+    id: `branch-adopt-${String(idx + 1).padStart(2, "0")}`,
+    category: "branch-adopt",
+    prompt: r.user_prompt,
+    context_hint: `branch label: ${r.branch_label}`,
+    engine_ref: "claude",
+    model_ref: "",
+    reference_output: r.reference_output,
+    expected_behaviors: [],
+    rubric_threshold: 0.6, // summaries are judged on coverage, not exactness
+    created_at: r.timestamp,
+    source_message_id: r.id,
+    source_conversation_id: r.conversationId,
+    source_branch_id: r.branch_id,
+  };
+  process.stdout.write(JSON.stringify(entry) + "\n");
+  emitted++;
+}
+
+console.error(`[extract] emitted ${emitted} candidates across 5 categories`);

--- a/evals/scripts/report.mjs
+++ b/evals/scripts/report.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+// Read the latest result snapshot (or one passed as argv[2]) and emit a
+// markdown diff-style report suitable for GITHUB_STEP_SUMMARY.
+//
+// Usage:
+//   node evals/scripts/report.mjs                 # latest snapshot
+//   node evals/scripts/report.mjs <path.json>     # specific snapshot
+//   node evals/scripts/report.mjs --baseline prev.json current.json
+//     → side-by-side diff
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const RESULTS_DIR = resolve(HERE, "..", "results");
+
+function latestSnapshot() {
+  const files = readdirSync(RESULTS_DIR)
+    .filter((f) => f.endsWith(".json"))
+    .map((f) => ({
+      path: join(RESULTS_DIR, f),
+      mtime: statSync(join(RESULTS_DIR, f)).mtimeMs,
+    }))
+    .sort((a, b) => b.mtime - a.mtime);
+  return files[0]?.path;
+}
+
+function load(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function verdictIcon(score, pass) {
+  if (!pass) return "✗";
+  if (score >= 0.95) return "✓✓";
+  if (score >= 0.85) return "✓";
+  return "~";
+}
+
+function formatTable(results) {
+  const rows = results.map((r) => {
+    const score = (r.score ?? 0).toFixed(2);
+    const icon = verdictIcon(r.score ?? 0, r.pass);
+    const note = r.error
+      ? `ERROR: ${r.error}`
+      : r.verdict?.missing?.length
+        ? `missing: ${r.verdict.missing.slice(0, 2).join(", ")}`
+        : r.verdict?.verdict ?? "";
+    return `| ${icon} | \`${r.id}\` | ${r.category} | ${score} | ${note} |`;
+  });
+  return [
+    "| | ID | Category | Score | Notes |",
+    "|---|----|----------|------:|-------|",
+    ...rows,
+  ].join("\n");
+}
+
+function categoryBreakdown(results) {
+  const byCat = new Map();
+  for (const r of results) {
+    const c = r.category;
+    if (!byCat.has(c)) byCat.set(c, { pass: 0, fail: 0, scores: [] });
+    const b = byCat.get(c);
+    if (r.pass) b.pass++;
+    else b.fail++;
+    b.scores.push(r.score ?? 0);
+  }
+  const rows = [];
+  for (const [cat, b] of byCat) {
+    const total = b.pass + b.fail;
+    const avg = b.scores.reduce((s, x) => s + x, 0) / b.scores.length;
+    const rate = ((b.pass / total) * 100).toFixed(0);
+    rows.push(`| ${cat} | ${b.pass}/${total} | ${rate}% | ${avg.toFixed(2)} |`);
+  }
+  return [
+    "| Category | Pass | Rate | Avg Score |",
+    "|----------|:----:|:----:|----------:|",
+    ...rows,
+  ].join("\n");
+}
+
+function diffTable(prev, curr) {
+  const prevById = new Map(prev.results.map((r) => [r.id, r]));
+  const rows = [];
+  for (const c of curr.results) {
+    const p = prevById.get(c.id);
+    const pScore = p ? (p.score ?? 0).toFixed(2) : "—";
+    const cScore = (c.score ?? 0).toFixed(2);
+    const delta = p ? (c.score - p.score).toFixed(2) : "new";
+    const signal =
+      p && c.score < p.score - 0.05
+        ? "🔻"
+        : p && c.score > p.score + 0.05
+          ? "🔺"
+          : "·";
+    rows.push(
+      `| ${signal} | \`${c.id}\` | ${c.category} | ${pScore} → ${cScore} | ${delta} |`
+    );
+  }
+  return [
+    "| | ID | Category | Prev → Curr | Δ |",
+    "|---|----|----------|-------------|--:|",
+    ...rows,
+  ].join("\n");
+}
+
+// ─── Main ────────────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+let data, baseline;
+if (args[0] === "--baseline") {
+  baseline = load(args[1]);
+  data = load(args[2]);
+} else {
+  const path = args[0] ?? latestSnapshot();
+  if (!path) {
+    console.error(`[report] no snapshot in ${RESULTS_DIR}`);
+    process.exit(2);
+  }
+  data = load(path);
+}
+
+const out = [];
+out.push(`# Prompt Regression Eval — ${data.ran_at}`);
+out.push("");
+out.push(
+  `**Engine**: \`${data.engine}${data.model ? `:${data.model}` : ""}\` · **Judge**: \`${data.judge_engine}:${data.judge_model}\``
+);
+out.push("");
+out.push(
+  `**Total**: ${data.total} · **Pass**: ${data.passed} · **Fail**: ${data.failed} · **Avg Score**: ${data.avg_score.toFixed(3)}`
+);
+out.push("");
+
+const passRate = data.passed / data.total;
+if (passRate >= 0.85) out.push("🟢 **PASS** — above green threshold (≥85%)");
+else if (passRate >= 0.7)
+  out.push("🟡 **WARNING** — below green (85%), above yellow (70%)");
+else if (passRate >= 0.5)
+  out.push("🟠 **FAILING** — below yellow (70%), above red (50%)");
+else out.push("🔴 **BLOCK** — below red threshold (<50%)");
+out.push("");
+
+out.push("## Category breakdown");
+out.push(categoryBreakdown(data.results));
+out.push("");
+
+if (baseline) {
+  out.push("## Diff vs baseline");
+  out.push(`baseline: \`${baseline.ran_at}\` · ${baseline.passed}/${baseline.total} · avg ${baseline.avg_score.toFixed(2)}`);
+  out.push("");
+  out.push(diffTable(baseline, data));
+  out.push("");
+}
+
+out.push("## Per-item");
+out.push(formatTable(data.results));
+
+console.log(out.join("\n"));

--- a/evals/scripts/run-eval.mjs
+++ b/evals/scripts/run-eval.mjs
@@ -1,0 +1,370 @@
+#!/usr/bin/env node
+// Prompt regression runner.
+//
+// For each item in `evals/golden/*.jsonl`:
+//   1. Submit `prompt` to a fresh scratch conversation via `/api/v1/*`
+//   2. Wait for `agent:completed` WS event
+//   3. Fetch the final assistant message content
+//   4. Ask the judge (Haiku) to score semantic equivalence vs reference
+//   5. Accumulate results; write JSON snapshot to `evals/results/`
+//
+// Env:
+//   TUNAFLOW_BASE        default http://127.0.0.1:19840
+//   TUNAFLOW_TOKEN       required (Settings > Mobile)
+//   EVAL_ENGINE          generation engine, default `claude`
+//   EVAL_MODEL           generation model, default = item.model_ref
+//   JUDGE_ENGINE         judge engine, default `claude`
+//   JUDGE_MODEL          judge model, default `claude-haiku-4-5-20251001`
+//   EVAL_GOLDEN_DIR      default `evals/golden`
+//   EVAL_RESULTS_DIR     default `evals/results`
+//   EVAL_FILTER          regex on item.id / item.category (optional)
+//   EVAL_TIMEOUT_MS      per-scenario generation timeout, default 180000
+
+import {
+  readdirSync,
+  readFileSync,
+  mkdirSync,
+  writeFileSync,
+  existsSync,
+} from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO = resolve(HERE, "..", "..");
+const GOLDEN_DIR = resolve(
+  REPO,
+  process.env.EVAL_GOLDEN_DIR ?? "evals/golden"
+);
+const RESULTS_DIR = resolve(
+  REPO,
+  process.env.EVAL_RESULTS_DIR ?? "evals/results"
+);
+const JUDGE_PROMPT_PATH = resolve(
+  REPO,
+  "evals/judge/prompts/semantic-equivalence.md"
+);
+
+const BASE = process.env.TUNAFLOW_BASE ?? "http://127.0.0.1:19840";
+const TOKEN = process.env.TUNAFLOW_TOKEN ?? "";
+const EVAL_ENGINE = process.env.EVAL_ENGINE ?? "claude";
+const EVAL_MODEL = process.env.EVAL_MODEL ?? "";
+const JUDGE_ENGINE = process.env.JUDGE_ENGINE ?? "claude";
+const JUDGE_MODEL =
+  process.env.JUDGE_MODEL ?? "claude-haiku-4-5-20251001";
+const FILTER = process.env.EVAL_FILTER ? new RegExp(process.env.EVAL_FILTER) : null;
+const GEN_TIMEOUT_MS = parseInt(
+  process.env.EVAL_TIMEOUT_MS ?? "180000",
+  10
+);
+
+if (!TOKEN) {
+  console.error("[eval] TUNAFLOW_TOKEN not set");
+  process.exit(2);
+}
+if (!existsSync(JUDGE_PROMPT_PATH)) {
+  console.error(`[eval] judge prompt missing: ${JUDGE_PROMPT_PATH}`);
+  process.exit(2);
+}
+const JUDGE_SYSTEM = readFileSync(JUDGE_PROMPT_PATH, "utf8");
+
+// ─── HTTP + WS helpers (slimmer copy of scripts/beta-e2e/lib.mjs) ────────────
+
+async function api(path, init = {}) {
+  const url = path.startsWith("http") ? path : `${BASE}${path}`;
+  const res = await fetch(url, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${TOKEN}`,
+      ...(init.headers ?? {}),
+    },
+  });
+  const text = await res.text();
+  const body = text ? tryJson(text) : null;
+  if (!res.ok) {
+    const err = new Error(`${init.method ?? "GET"} ${url} → ${res.status}`);
+    err.status = res.status;
+    err.body = body;
+    throw err;
+  }
+  return body;
+}
+
+function tryJson(s) {
+  try {
+    return JSON.parse(s);
+  } catch {
+    return s;
+  }
+}
+
+function openWs({ onEvent } = {}) {
+  const wsBase = BASE.replace(/^http/, "ws");
+  const qs = new URLSearchParams({ token: TOKEN });
+  const socket = new WebSocket(`${wsBase}/ws/events?${qs}`);
+  const events = [];
+  socket.addEventListener("message", (e) => {
+    const evt = tryJson(e.data);
+    if (evt && typeof evt === "object") {
+      events.push(evt);
+      onEvent?.(evt);
+    }
+  });
+  return {
+    socket,
+    events,
+    close: () => socket.close(),
+    waitFor: (predicate, timeoutMs) =>
+      new Promise((resolvePromise, reject) => {
+        const prior = events.find(predicate);
+        if (prior) return resolvePromise(prior);
+        const t = setTimeout(() => {
+          socket.removeEventListener("message", handler);
+          reject(new Error(`WS waitFor timeout (${timeoutMs}ms)`));
+        }, timeoutMs);
+        const handler = (e) => {
+          const evt = tryJson(e.data);
+          if (evt && predicate(evt)) {
+            clearTimeout(t);
+            socket.removeEventListener("message", handler);
+            resolvePromise(evt);
+          }
+        };
+        socket.addEventListener("message", handler);
+      }),
+  };
+}
+
+async function waitSocketOpen(socket, timeoutMs = 5000) {
+  if (socket.readyState === WebSocket.OPEN) return;
+  await new Promise((res, rej) => {
+    const t = setTimeout(() => rej(new Error("WS open timeout")), timeoutMs);
+    socket.addEventListener("open", () => {
+      clearTimeout(t);
+      res();
+    });
+    socket.addEventListener("error", (e) => {
+      clearTimeout(t);
+      rej(new Error(`WS error: ${e.message ?? "?"}`));
+    });
+  });
+}
+
+// ─── Scaffolding: scratch project + conversation for a single item ───────────
+
+async function scratchConv(label) {
+  const suffix = Date.now();
+  const projectKey = `eval-${suffix}`;
+  await api("/api/v1/projects", {
+    method: "POST",
+    body: JSON.stringify({
+      key: projectKey,
+      name: `[eval] ${label}`,
+      path: "/tmp/tunaflow-eval",
+    }),
+  });
+  const conv = await api("/api/v1/conversations", {
+    method: "POST",
+    body: JSON.stringify({
+      projectKey,
+      label: `[eval] ${label}`,
+      mode: "chat",
+    }),
+  });
+  return { projectKey, conv };
+}
+
+async function generate({ convId, prompt, engine, model }) {
+  const socket = openWs();
+  await waitSocketOpen(socket.socket);
+  const payload = { prompt, engine };
+  if (model) payload.model = model;
+  api(`/api/v1/conversations/${convId}/send`, {
+    method: "POST",
+    body: JSON.stringify(payload),
+  }).catch(() => {
+    // 202 "queued" is expected; real errors surface via WS / fetchMessages
+  });
+  const done = await socket.waitFor(
+    (e) => e.type === "agent:completed" && e.conversationId === convId,
+    GEN_TIMEOUT_MS
+  );
+  socket.close();
+
+  const msgs = await api(`/api/v1/conversations/${convId}/messages`);
+  // Final assistant message (highest timestamp, role=assistant, status=done)
+  const assistant = [...msgs]
+    .filter((m) => m.role === "assistant" && m.status === "done")
+    .sort((a, b) => b.timestamp - a.timestamp)[0];
+  if (!assistant) throw new Error("no assistant message after agent:completed");
+  return { content: assistant.content, doneEvent: done };
+}
+
+// ─── Judge call ──────────────────────────────────────────────────────────────
+
+function judgeUserPrompt(item, candidate) {
+  return [
+    `CATEGORY: ${item.category}`,
+    `SOURCE_PROMPT_KIND: ${item.source_prompt_kind ?? "user"}`,
+    "",
+    "EXPECTED_BEHAVIORS:",
+    (item.expected_behaviors && item.expected_behaviors.length
+      ? item.expected_behaviors.map((b, i) => `  ${i + 1}. ${b}`).join("\n")
+      : "  (none)"),
+    "",
+    "PROMPT:",
+    "```",
+    item.prompt,
+    "```",
+    "",
+    "REFERENCE:",
+    "```",
+    item.reference_output,
+    "```",
+    "",
+    "CANDIDATE:",
+    "```",
+    candidate,
+    "```",
+    "",
+    "Output the strict JSON now.",
+  ].join("\n");
+}
+
+async function askJudge(item, candidate) {
+  const { projectKey, conv } = await scratchConv("judge");
+  const fullPrompt =
+    `# SYSTEM\n${JUDGE_SYSTEM}\n\n# TASK\n${judgeUserPrompt(item, candidate)}`;
+  const { content } = await generate({
+    convId: conv.id,
+    prompt: fullPrompt,
+    engine: JUDGE_ENGINE,
+    model: JUDGE_MODEL,
+  });
+  // Best-effort JSON extraction from judge's reply.
+  const match = content.match(/\{[\s\S]*\}/);
+  if (!match) {
+    return {
+      score: 0,
+      verdict: "parse_error",
+      reasoning: `no JSON object in judge reply: ${content.slice(0, 200)}`,
+      pass: false,
+    };
+  }
+  try {
+    return JSON.parse(match[0]);
+  } catch (e) {
+    return {
+      score: 0,
+      verdict: "parse_error",
+      reasoning: `JSON.parse failed: ${e.message}`,
+      pass: false,
+    };
+  }
+}
+
+// ─── Main ────────────────────────────────────────────────────────────────────
+
+function loadGolden() {
+  if (!existsSync(GOLDEN_DIR)) {
+    console.error(`[eval] golden dir missing: ${GOLDEN_DIR}`);
+    process.exit(2);
+  }
+  const files = readdirSync(GOLDEN_DIR).filter((f) => f.endsWith(".jsonl"));
+  const items = [];
+  for (const f of files) {
+    const lines = readFileSync(join(GOLDEN_DIR, f), "utf8")
+      .split("\n")
+      .filter(Boolean);
+    for (const line of lines) {
+      try {
+        const o = JSON.parse(line);
+        if (FILTER && !FILTER.test(o.id) && !FILTER.test(o.category)) continue;
+        items.push({ ...o, _file: f });
+      } catch (e) {
+        console.error(`[eval] skip malformed line in ${f}: ${e.message}`);
+      }
+    }
+  }
+  return items;
+}
+
+(async () => {
+  const items = loadGolden();
+  if (items.length === 0) {
+    console.error(`[eval] no golden items (filter=${FILTER ?? "none"})`);
+    process.exit(2);
+  }
+  console.log(
+    `[eval] running ${items.length} items · engine=${EVAL_ENGINE} · judge=${JUDGE_ENGINE}:${JUDGE_MODEL}`
+  );
+
+  const results = [];
+  for (const [i, item] of items.entries()) {
+    const label = `[${i + 1}/${items.length}] ${item.id}`;
+    const t0 = Date.now();
+    try {
+      const scaffold = await scratchConv(item.id);
+      const { content: candidate } = await generate({
+        convId: scaffold.conv.id,
+        prompt: item.prompt,
+        engine: EVAL_ENGINE,
+        model: EVAL_MODEL || item.model_ref,
+      });
+      const verdict = await askJudge(item, candidate);
+      const threshold = item.rubric_threshold ?? 0.7;
+      const pass = (verdict.score ?? 0) >= threshold;
+      results.push({
+        id: item.id,
+        category: item.category,
+        score: verdict.score ?? 0,
+        threshold,
+        pass,
+        verdict,
+        candidate,
+        reference: item.reference_output,
+        duration_ms: Date.now() - t0,
+      });
+      console.log(
+        `  ${pass ? "✓" : "✗"} ${label} score=${(verdict.score ?? 0).toFixed(2)} (${Date.now() - t0}ms)`
+      );
+    } catch (e) {
+      results.push({
+        id: item.id,
+        category: item.category,
+        score: 0,
+        threshold: item.rubric_threshold ?? 0.7,
+        pass: false,
+        error: e.message,
+        duration_ms: Date.now() - t0,
+      });
+      console.log(`  ✗ ${label} ERROR: ${e.message}`);
+    }
+  }
+
+  mkdirSync(RESULTS_DIR, { recursive: true });
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const out = join(
+    RESULTS_DIR,
+    `${stamp}-${EVAL_ENGINE}-${EVAL_MODEL || "default"}.json`
+  );
+  const summary = {
+    ran_at: new Date().toISOString(),
+    engine: EVAL_ENGINE,
+    model: EVAL_MODEL || null,
+    judge_engine: JUDGE_ENGINE,
+    judge_model: JUDGE_MODEL,
+    total: results.length,
+    passed: results.filter((r) => r.pass).length,
+    failed: results.filter((r) => !r.pass).length,
+    avg_score:
+      results.reduce((s, r) => s + (r.score ?? 0), 0) / results.length,
+    results,
+  };
+  writeFileSync(out, JSON.stringify(summary, null, 2));
+  console.log(
+    `\n[eval] ${summary.passed}/${summary.total} passed · avg=${summary.avg_score.toFixed(2)} · wrote ${out}`
+  );
+  process.exit(summary.failed > 0 ? 1 : 0);
+})();

--- a/evals/scripts/run-eval.mjs
+++ b/evals/scripts/run-eval.mjs
@@ -366,5 +366,23 @@ function loadGolden() {
   console.log(
     `\n[eval] ${summary.passed}/${summary.total} passed · avg=${summary.avg_score.toFixed(2)} · wrote ${out}`
   );
+
+  // Cleanup scratch `eval-*` projects created during this run.
+  // Opt-in via --cleanup or EVAL_CLEANUP=1 — default off so post-mortem
+  // inspection of a specific failing run is possible.
+  if (process.argv.includes("--cleanup") || process.env.EVAL_CLEANUP === "1") {
+    console.log("\n[eval] cleaning up scratch projects");
+    const { spawnSync } = await import("node:child_process");
+    spawnSync(
+      "node",
+      [
+        resolve(REPO, "scripts/beta-e2e/cleanup.mjs"),
+        "--force",
+        "--pattern",
+        "eval-",
+      ],
+      { stdio: "inherit" }
+    );
+  }
   process.exit(summary.failed > 0 ? 1 : 0);
 })();

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "e2e:beta": "node scripts/beta-e2e/run-all.mjs",
+    "e2e:beta:cleanup": "node scripts/beta-e2e/cleanup.mjs --force",
     "eval:regression": "node evals/scripts/run-eval.mjs",
     "eval:extract": "node evals/scripts/extract-from-trace.mjs",
     "eval:report": "node evals/scripts/report.mjs"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "e2e:beta": "node scripts/beta-e2e/run-all.mjs"
+    "e2e:beta": "node scripts/beta-e2e/run-all.mjs",
+    "eval:regression": "node evals/scripts/run-eval.mjs",
+    "eval:extract": "node evals/scripts/extract-from-trace.mjs",
+    "eval:report": "node evals/scripts/report.mjs"
   },
   "dependencies": {
     "@radix-ui/react-context-menu": "^2.2.16",

--- a/scripts/beta-e2e/README.md
+++ b/scripts/beta-e2e/README.md
@@ -65,5 +65,10 @@ node scripts/beta-e2e/08-ws-replay.mjs
 ## 주의
 
 - **실제 DB 에 쓰기를 수행합니다** — 테스트 프로젝트 인스턴스에서만 실행하세요
-- 스크립트는 생성한 프로젝트/대화를 **자동 정리하지 않습니다**. 세션 후 Sidebar 에서 `[E2E-*]` 라벨 항목을 수동 삭제하세요
+- 스크립트는 기본적으로 생성한 프로젝트를 남겨둡니다 (실패 디버깅 목적). 정리 방법:
+  ```bash
+  npm run e2e:beta -- --cleanup       # 실행 후 자동 soft-hide
+  npm run e2e:beta:cleanup            # 또는 사후 일괄 hide
+  E2E_CLEANUP=1 npm run e2e:beta      # env 로도 제어 가능
+  ```
 - 시나리오 1 은 실제 LLM 호출 → API 비용 발생 가능

--- a/scripts/beta-e2e/cleanup.mjs
+++ b/scripts/beta-e2e/cleanup.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+// Soft-hide test projects created by beta-e2e / eval runners.
+//
+// E2E scripts create projects with keys matching `e2e-p-<timestamp>` and
+// `eval-<timestamp>` and don't clean them up on their own (intentional —
+// so post-mortem debugging can inspect the actual DB state). This runs
+// after a successful session to keep the sidebar uncluttered.
+//
+// Usage:
+//   node scripts/beta-e2e/cleanup.mjs           # dry-run — list matches only
+//   node scripts/beta-e2e/cleanup.mjs --force   # actually hide
+//   node scripts/beta-e2e/cleanup.mjs --force --pattern '^e2e-'  # custom regex
+//
+// Direct-DB write is safe under WAL even while the app is running, but
+// the UI reflects the change only after the sidebar re-queries projects
+// (switch tabs or restart the app). No API endpoint is available for
+// project hide — so we go straight to SQLite.
+
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+
+const DB =
+  process.env.TUNAFLOW_DB ??
+  resolve(homedir(), ".tunaflow/db/tunaflow.db");
+
+const args = process.argv.slice(2);
+const force = args.includes("--force");
+const patternIdx = args.indexOf("--pattern");
+// Default: anything starting with `e2e-p-` or `eval-`. Two separate LIKEs
+// so SQLite uses the primary key index on `key` efficiently.
+const sqlFilter = (() => {
+  if (patternIdx >= 0 && args[patternIdx + 1]) {
+    const p = args[patternIdx + 1].replace(/'/g, "''");
+    return `key GLOB '${p}*'`;
+  }
+  return "(key LIKE 'e2e-p-%' OR key LIKE 'eval-%')";
+})();
+
+if (!existsSync(DB)) {
+  console.error(`[cleanup] DB not found: ${DB}`);
+  process.exit(2);
+}
+
+function sql(q) {
+  try {
+    const out = execFileSync("sqlite3", [DB, "-json", q], {
+      maxBuffer: 32 * 1024 * 1024,
+    });
+    const text = out.toString();
+    return text ? JSON.parse(text) : [];
+  } catch (e) {
+    console.error(`[cleanup] sqlite3 failed: ${e.message}`);
+    process.exit(1);
+  }
+}
+
+const matches = sql(
+  `SELECT key, name FROM projects WHERE ${sqlFilter} AND hidden = 0;`
+);
+
+if (matches.length === 0) {
+  console.log("[cleanup] no test projects to hide");
+  process.exit(0);
+}
+
+console.log(`[cleanup] ${matches.length} test project(s) match:`);
+for (const p of matches) {
+  console.log(`  ${p.key}  ·  ${p.name}`);
+}
+
+if (!force) {
+  console.log(
+    "\n[cleanup] dry-run — pass --force to actually soft-hide (sets hidden=1)"
+  );
+  process.exit(0);
+}
+
+const now = Date.now();
+// `-batch` suppresses the interactive prompt `sqlite3` sometimes uses.
+execFileSync("sqlite3", [
+  DB,
+  "-batch",
+  `UPDATE projects SET hidden = 1, updated_at = ${now} WHERE ${sqlFilter} AND hidden = 0;`,
+]);
+
+console.log(`\n[cleanup] soft-hid ${matches.length} project(s)`);
+console.log(
+  "[cleanup] sidebar may need a refresh (switch tabs or restart) to reflect"
+);

--- a/scripts/beta-e2e/run-all.mjs
+++ b/scripts/beta-e2e/run-all.mjs
@@ -1,6 +1,11 @@
 // Runs every scenario sequentially and prints a pass/fail table at the end.
 // Each scenario is spawned as a separate Node process so exit codes are
 // isolated and a single failure doesn't poison the remaining runs.
+//
+// Flags:
+//   --cleanup    after the run, soft-hide every scratch project created
+//                by the scenarios (forwards to cleanup.mjs --force).
+//   Or set E2E_CLEANUP=1 to enable without editing the command line.
 
 import { spawnSync } from "node:child_process";
 import { readdirSync } from "node:fs";
@@ -11,6 +16,8 @@ const here = dirname(fileURLToPath(import.meta.url));
 const scenarios = readdirSync(here)
   .filter((f) => /^\d{2}-.*\.mjs$/.test(f))
   .sort();
+const shouldCleanup =
+  process.argv.includes("--cleanup") || process.env.E2E_CLEANUP === "1";
 
 const results = [];
 for (const [idx, file] of scenarios.entries()) {
@@ -30,6 +37,14 @@ for (const r of results) {
 }
 
 const failed = results.filter((r) => !r.ok).length;
+
+if (shouldCleanup) {
+  console.log("\n═══════ Cleanup ═══════");
+  spawnSync("node", [join(here, "cleanup.mjs"), "--force"], {
+    stdio: "inherit",
+  });
+}
+
 if (failed > 0) {
   console.log(`\n${failed}/${results.length} failed`);
   process.exit(1);


### PR DESCRIPTION
## Summary
Harness Maturity Audit §2.2 Regression Evaluation Harness **3/10 → 7/10** 목표.

4개 산출물:

- **6-1 \`extract-from-trace.mjs\`** — sqlite3 CLI 기반 DB seed 추출 (npm deps 없음). persona 기준 4 카테고리 + branch-adopt. auto-invoked Reviewer/Synthesizer 에 직전 assistant fallback.
- **6-2 Golden Dataset 작성 가이드** — 사람 작업. LLM 자동 생성 금지 (baseline 오염 방지). 2-3시간 수작업.
- **6-3 \`run-eval.mjs\`** — 각 golden → 스크래치 conv → POST/send + WS → agent:completed → Judge 에 (CATEGORY/PROMPT/REFERENCE/CANDIDATE/EXPECTED_BEHAVIORS) 전달 → JSON 스냅샷.
- **6-4 \`report.mjs\` + CI workflow** — 🟢85% / 🟡70% / 🟠50% 게이트. trigger: workflow_dispatch / 관련 경로 / \`eval:run\` 라벨. 2-4주 warning-only 운영.

## 비용
20 items × (Sonnet 생성 + Haiku Judge) ≈ **$0.3-0.5 / run**. 월 $5-10.

## Test plan
- [x] \`npx tsc --noEmit\` 0 errors
- [x] \`npx vitest run\` 293 passed
- [x] \`npm run eval:extract 3\` 실제 DB 에서 15개 추출 확인
- [ ] 6-2 수작업 후 첫 \`npm run eval:regression\` 실행 (사람 주도)

## 다음 행동
1. 이 PR 머지
2. \`npm run eval:extract 10 > /tmp/candidates.jsonl\`
3. JSONL 카테고리별 분리 + \`expected_behaviors\` 수작업
4. 첫 \`npm run eval:regression\` → threshold 튜닝
5. 3-5회 실행 후 CI hard gate 전환

🤖 Generated with [Claude Code](https://claude.com/claude-code)