### PR TITLE
fix(ui): explicit focus:outline-none on chat textarea

### DIFF
--- a/src/components/tunaflow/NewMessageInput.tsx
+++ b/src/components/tunaflow/NewMessageInput.tsx
@@ -518,7 +518,12 @@ export function NewMessageInput({ threadMode = false, onCreateRT }: NewMessageIn
           disabled={!selectedConversationId}
           rows={1}
           className={cn(
-            "w-full px-2.5 py-2 text-[13px] bg-transparent resize-none outline-none text-foreground placeholder:text-muted-foreground/40 leading-relaxed disabled:opacity-40 transition-colors",
+            // `focus:outline-none` + `focus-visible:outline-none` 명시 — macOS
+            // 기본 textarea focus outline 과 Tailwind v4 `@layer base { * {
+            // outline-ring/50 }}` 가 겹쳐서 파란 테두리가 다시 나타나는 회귀
+            // (2026-04-22 사용자 제보). `outline-none` 만으로는 state-
+            // specific rule 이 override 할 수 있어 전부 명시적으로 해제.
+            "w-full px-2.5 py-2 text-[13px] bg-transparent resize-none outline-none focus:outline-none focus-visible:outline-none text-foreground placeholder:text-muted-foreground/40 leading-relaxed disabled:opacity-40 transition-colors",
             isDragOver && "ring-2 ring-primary/40 rounded",
           )}
         />


### PR DESCRIPTION
## Summary
채팅 입력창 포커싱 시 파란 테두리 재등장 회귀 (CLAUDE.md 분리 PR #112 이후 사용자 제보).

## Cause
textarea 의 \`outline-none\` 만으로는 Tailwind v4 의 \`@layer base { * { @apply outline-ring/50 } }\` + macOS 기본 textarea focus outline 과 결합 시 state-specific rule 에 의해 다시 그려짐.

## Fix
\`focus:outline-none focus-visible:outline-none\` 을 명시적으로 추가 — 모든 focus state 에서 outline 제거 보장.

index.css 의 전역 \`:focus-visible\` selector 에는 textarea 를 이미 제외했지만, 컴포넌트 단에서 한 번 더 막음.

## Test plan
- [x] \`tsc --noEmit\` 0 errors
- [ ] 수동: 채팅 입력창 클릭 → 파란 테두리 안 뜨는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)