### PR TITLE
feat(docs): force-reindex + stale cleanup for doc RAG

### DIFF
--- a/docs/how-to/doc-indexing.md
+++ b/docs/how-to/doc-indexing.md
@@ -1,0 +1,98 @@
+---
+title: Document Indexing Operations
+updated_at: 2026-04-22
+canonical: true
+status: active
+owner: tunaFlow-core
+---
+
+# Document Indexing Operations
+
+tunaFlow 의 project 문서 RAG 인덱스 운영 가이드. 검색 품질의 전제 = **file system 과 DB 인덱스가 일치** 하는 것.
+
+## 개념
+
+- 인덱싱 대상: 프로젝트 root 의 `CLAUDE.md`, `README.md` 등 top-level `*.md` + `docs/**/*.md` 전부.
+- 저장 위치: `conversation_chunks` (source_type='document'), `vec_chunks` (embedding), `document_edges`, `document_index_status`.
+- 검색: `POST /api/v1/projects/{key}/documents/search` 또는 Tauri `search_project_docs`.
+
+## 일상 동작
+
+- 프로젝트 선택 시 1회 `ensure_rawq_index` 호출 → incremental indexing (SHA change detection).
+- fs watcher 가 파일 변경 감지 시 자동 재인덱싱 (일부 이벤트 놓칠 수 있음).
+- 따라서 **대규모 reorganization 이후** 에는 수동 재인덱싱 권장.
+
+## 재인덱싱 (bulk sync)
+
+문서 대량 이동 / 삭제 / 생성 후 DB 재동기화:
+
+```bash
+# 기본: cleanup (stale 정리) + force reindex (SHA check 우회)
+export TUNAFLOW_TOKEN=<Settings > Mobile 에서 복사>
+node scripts/reindex-docs.mjs tunaflow
+
+# stale cleanup 만 skip (파일이 실제로 정리된 게 아닐 때)
+node scripts/reindex-docs.mjs tunaflow --no-cleanup
+
+# force 끄고 incremental 만 (SHA 변경된 파일만)
+node scripts/reindex-docs.mjs tunaflow --no-force
+```
+
+응답 202 accepted 후 background 진행. 결과는 WS event `document:indexed` 로 발행.
+
+## 검증
+
+재인덱싱 후 지표 확인:
+
+```bash
+# 1. fs 의 .md 파일 수
+find docs -name "*.md" | wc -l
+# 프로젝트 root 의 README, CLAUDE.md 등은 별도 카운트
+
+# 2. DB 에 인덱싱된 고유 파일 수
+sqlite3 ~/.tunaflow/db/tunaflow.db \
+  "SELECT COUNT(DISTINCT file_path) FROM conversation_chunks
+   WHERE project_key='tunaflow' AND source_type='document';"
+
+# 3. chunks 수
+sqlite3 ~/.tunaflow/db/tunaflow.db \
+  "SELECT COUNT(*) FROM conversation_chunks
+   WHERE project_key='tunaflow' AND source_type='document';"
+
+# 4. stale 후보 (DB 에는 있지만 fs 에는 없는 것)
+sqlite3 ~/.tunaflow/db/tunaflow.db \
+  "SELECT DISTINCT file_path FROM conversation_chunks
+   WHERE project_key='tunaflow' AND source_type='document'" \
+  | while read p; do
+      [ ! -f "$p" ] && echo "STALE: $p"
+    done | head -20
+```
+
+정상 지표:
+- fs 파일 수 ≈ DB distinct file_path 수 (차이 ±5 내외는 OK — indexing 중일 수도)
+- stale 파일 수 = 0 (cleanup 후)
+- 파일당 chunks 는 문서 길이에 비례 (보통 3-50 chunks)
+
+## 문제 진단
+
+**"인덱싱됐다고 보고하지만 DB 에는 적다"**:
+- rawq daemon 죽었는지 확인: `rawq daemon status`
+- embedder 초기화 실패: dev terminal 의 `[embedder]` 로그
+- 파일 읽기 권한: `ls -la <file>`
+
+**"stale chunks 가 계속 남는다"**:
+- fs watcher 가 삭제 이벤트를 놓쳤을 가능성. `--cleanup` 포함 재인덱싱 실행.
+
+**"embedding=NULL 로 남는 chunks"**:
+- bge-m3 ONNX 추론 실패. `crate::commands::vector_search::backfill` 가 앱 시작 시 자동 복구 시도.
+- 수동 복구: 해당 project 재인덱싱 (`--force`).
+
+## 관련 명령
+
+| 계층 | 엔드포인트 |
+|------|-----------|
+| Tauri | `index_project_docs({ projectKey, force })` |
+| Tauri | `cleanup_project_stale_docs({ projectKey })` |
+| HTTP | `POST /api/v1/projects/{key}/documents/index?force=true&cleanup=true` |
+| HTTP | `POST /api/v1/projects/{key}/documents/search` (body: `{ query, limit }`) |
+| HTTP | `GET /api/v1/projects/{key}/documents/status` |

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "e2e:beta:cleanup": "node scripts/beta-e2e/cleanup.mjs --force",
     "eval:regression": "node evals/scripts/run-eval.mjs",
     "eval:extract": "node evals/scripts/extract-from-trace.mjs",
-    "eval:report": "node evals/scripts/report.mjs"
+    "eval:report": "node evals/scripts/report.mjs",
+    "docs:reindex": "node scripts/reindex-docs.mjs"
   },
   "dependencies": {
     "@radix-ui/react-context-menu": "^2.2.16",

--- a/scripts/reindex-docs.mjs
+++ b/scripts/reindex-docs.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+// Force-reindex project documents + cleanup stale entries.
+//
+// Usage:
+//   TUNAFLOW_TOKEN=<token> node scripts/reindex-docs.mjs <projectKey>
+//   (optional) TUNAFLOW_BASE=http://127.0.0.1:19840
+//   (optional) --no-cleanup   # skip stale cleanup
+//   (optional) --no-force     # use SHA change detection (incremental)
+//
+// docs/reference/work-safety.md, etc. 처럼 bulk 재조직 후 DB 재동기화 용.
+// 기본: cleanup + force. result 는 `document:indexed` WS event 로 발행됨.
+
+const base = process.env.TUNAFLOW_BASE ?? "http://127.0.0.1:19840";
+const token = process.env.TUNAFLOW_TOKEN ?? "";
+if (!token) {
+  console.error("[reindex-docs] TUNAFLOW_TOKEN not set — Settings > Mobile 에서 복사 후 export");
+  process.exit(2);
+}
+
+const args = process.argv.slice(2);
+const projectKey = args.find((a) => !a.startsWith("--"));
+const noCleanup = args.includes("--no-cleanup");
+const noForce = args.includes("--no-force");
+
+if (!projectKey) {
+  console.error("[reindex-docs] usage: node scripts/reindex-docs.mjs <projectKey> [--no-cleanup] [--no-force]");
+  process.exit(2);
+}
+
+const params = new URLSearchParams({
+  force: String(!noForce),
+  cleanup: String(!noCleanup),
+});
+const url = `${base}/api/v1/projects/${encodeURIComponent(projectKey)}/documents/index?${params}`;
+
+console.log(`[reindex-docs] project=${projectKey} force=${!noForce} cleanup=${!noCleanup}`);
+console.log(`[reindex-docs] POST ${url}`);
+
+const res = await fetch(url, {
+  method: "POST",
+  headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+});
+const body = await res.text();
+if (!res.ok) {
+  console.error(`[reindex-docs] FAILED ${res.status}: ${body}`);
+  process.exit(1);
+}
+console.log(`[reindex-docs] ${res.status}`);
+console.log(body);
+console.log(
+  "\n[reindex-docs] 작업은 background 에서 진행됩니다. WS event 'document:indexed' 로 결과 확인 가능.\n" +
+  "  또는 잠시 뒤 다음 SQL 로 지표 확인:\n" +
+  "  sqlite3 ~/.tunaflow/db/tunaflow.db \"SELECT COUNT(DISTINCT file_path) FROM conversation_chunks WHERE project_key='" +
+  projectKey + "' AND source_type='document';\""
+);

--- a/src-tauri/src/commands/document_index.rs
+++ b/src-tauri/src/commands/document_index.rs
@@ -190,6 +190,19 @@ pub fn index_project_documents(
     project_key: &str,
     project_path: &str,
 ) -> Result<IndexResult, AppError> {
+    index_project_documents_with_options(db, project_key, project_path, false)
+}
+
+/// Same as `index_project_documents` but with `force` option. When force=true,
+/// SHA-256 change detection is bypassed — every file is re-indexed. Used by
+/// the reindex CLI / HTTP endpoint for resyncing stale DB state after bulk
+/// document reorganization.
+pub fn index_project_documents_with_options(
+    db: &crate::db::DbState,
+    project_key: &str,
+    project_path: &str,
+    force: bool,
+) -> Result<IndexResult, AppError> {
     let base = Path::new(project_path);
     let mut result = IndexResult {
         files_scanned: 0,
@@ -254,8 +267,8 @@ pub fn index_project_documents(
 
         let hash = sha256_hex(&content);
 
-        // Change detection: skip if hash unchanged
-        let needs_index = {
+        // Change detection: skip if hash unchanged (unless force=true).
+        let needs_index = force || {
             let conn = db.read.lock().map_err(|_| AppError::Lock)?;
             let stored_hash: Option<String> = conn.query_row(
                 "SELECT content_hash FROM document_index_status WHERE project_key = ?1 AND file_path = ?2",
@@ -642,9 +655,13 @@ pub fn get_index_status(
 // ═══════════════════════════════════════════════════════════════════════════
 
 /// Index project documents (docs/*.md + CLAUDE.md).
+///
+/// `force=true` 면 SHA change detection 우회 — 모든 파일 재인덱싱. bulk 문서
+/// 재조직 후 DB 재동기화 용도.
 #[tauri::command]
 pub async fn index_project_docs(
     project_key: String,
+    force: Option<bool>,
     state: tauri::State<'_, crate::db::DbState>,
 ) -> Result<IndexResult, AppError> {
     let db = state.inner().clone();
@@ -656,10 +673,129 @@ pub async fn index_project_docs(
         ).map_err(|_| AppError::NotFound("project not found".into()))?
             .ok_or_else(|| AppError::NotFound("project has no path".into()))?
     };
+    let force = force.unwrap_or(false);
 
     tokio::task::spawn_blocking(move || {
-        index_project_documents(&db, &project_key, &project_path)
+        index_project_documents_with_options(&db, &project_key, &project_path, force)
     }).await.map_err(|e| AppError::Agent(format!("task join error: {}", e)))?
+}
+
+/// Result of a stale cleanup pass.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CleanupResult {
+    pub files_checked: usize,
+    pub files_removed: usize,
+    pub chunks_removed: usize,
+    pub edges_removed: usize,
+}
+
+/// Remove DB rows (chunks / edges / index_status) for files that no longer
+/// exist on disk. Called after bulk document reorganization (e.g. mv plans
+/// to archive) to keep the DB in sync with the file system.
+pub fn cleanup_stale_documents(
+    db: &crate::db::DbState,
+    project_key: &str,
+    project_path: &str,
+) -> Result<CleanupResult, AppError> {
+    let base = Path::new(project_path);
+    let mut result = CleanupResult {
+        files_checked: 0,
+        files_removed: 0,
+        chunks_removed: 0,
+        edges_removed: 0,
+    };
+
+    // 1. 모든 indexed file_path 수집
+    let file_paths: Vec<String> = {
+        let conn = db.read.lock().map_err(|_| AppError::Lock)?;
+        let mut stmt = conn.prepare(
+            "SELECT DISTINCT file_path FROM conversation_chunks
+             WHERE project_key = ?1 AND source_type = 'document' AND file_path IS NOT NULL",
+        )?;
+        let rows: Vec<String> = stmt
+            .query_map([project_key], |r| r.get::<_, String>(0))?
+            .filter_map(|r| r.ok())
+            .collect();
+        rows
+    };
+    result.files_checked = file_paths.len();
+
+    // 2. fs 존재 확인 → missing 목록
+    let missing: Vec<String> = file_paths
+        .into_iter()
+        .filter(|rel| !base.join(rel).is_file())
+        .collect();
+    result.files_removed = missing.len();
+
+    if missing.is_empty() {
+        return Ok(result);
+    }
+
+    // 3. chunks + vec_chunks + edges + status 삭제
+    let conn = db.write.lock().map_err(|_| AppError::Lock)?;
+    for path in &missing {
+        // vec_chunks 는 rowid 로 conversation_chunks 와 연결
+        let rowids: Vec<i64> = conn.prepare(
+            "SELECT rowid FROM conversation_chunks
+             WHERE project_key = ?1 AND source_type = 'document' AND file_path = ?2",
+        )
+        .and_then(|mut s| {
+            s.query_map(params![project_key, path], |r| r.get(0))
+                .map(|rows| rows.filter_map(|r| r.ok()).collect())
+        })
+        .unwrap_or_default();
+        for rid in &rowids {
+            conn.execute("DELETE FROM vec_chunks WHERE rowid = ?1", [rid]).ok();
+        }
+        let chunks = conn.execute(
+            "DELETE FROM conversation_chunks
+             WHERE project_key = ?1 AND source_type = 'document' AND file_path = ?2",
+            params![project_key, path],
+        ).unwrap_or(0);
+        result.chunks_removed += chunks;
+
+        // edges: source_path 또는 target_path 이 missing 이면 삭제
+        let edges = conn.execute(
+            "DELETE FROM document_edges
+             WHERE project_key = ?1 AND (source_path = ?2 OR target_path = ?2)",
+            params![project_key, path],
+        ).unwrap_or(0);
+        result.edges_removed += edges;
+
+        conn.execute(
+            "DELETE FROM document_index_status WHERE project_key = ?1 AND file_path = ?2",
+            params![project_key, path],
+        ).ok();
+    }
+    eprintln!(
+        "[doc-index] cleanup project={}: removed {} stale files, {} chunks, {} edges",
+        project_key, result.files_removed, result.chunks_removed, result.edges_removed
+    );
+    Ok(result)
+}
+
+/// Clean up stale document entries for a project (files removed from disk).
+/// 보통 `reindex_project_docs` 직전에 호출하는 걸 권장.
+#[tauri::command]
+pub async fn cleanup_project_stale_docs(
+    project_key: String,
+    state: tauri::State<'_, crate::db::DbState>,
+) -> Result<CleanupResult, AppError> {
+    let db = state.inner().clone();
+    let project_path = {
+        let conn = db.read.lock().map_err(|_| AppError::Lock)?;
+        conn.query_row(
+            "SELECT path FROM projects WHERE key = ?1",
+            [&project_key], |r| r.get::<_, Option<String>>(0),
+        ).map_err(|_| AppError::NotFound("project not found".into()))?
+            .ok_or_else(|| AppError::NotFound("project has no path".into()))?
+    };
+    tokio::task::spawn_blocking(move || {
+        cleanup_stale_documents(&db, &project_key, &project_path)
+    })
+    .await
+    .map_err(|e| AppError::Agent(format!("task join error: {}", e)))?
 }
 
 /// Search project documents by query.

--- a/src-tauri/src/http_api/state.rs
+++ b/src-tauri/src/http_api/state.rs
@@ -58,9 +58,21 @@ pub async fn create_project(
 
 // ─── Document RAG endpoints ───────────────────────────────────────────
 
+#[derive(Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct IndexQuery {
+    /// force=true 면 SHA change detection 우회 → 전체 재인덱싱.
+    #[serde(default)]
+    pub force: bool,
+    /// cleanup=true 면 인덱싱 전에 stale (파일 사라진) chunks 삭제.
+    #[serde(default)]
+    pub cleanup: bool,
+}
+
 pub async fn index_project_documents(
     State(state): State<ApiState>,
     Path(project_key): Path<String>,
+    axum::extract::Query(q): axum::extract::Query<IndexQuery>,
 ) -> impl IntoResponse {
     let db = state.db.clone();
     let pk = project_key.clone();
@@ -76,9 +88,20 @@ pub async fn index_project_documents(
 
     let event_tx = state.event_tx.clone();
     let pk2 = project_key.clone();
+    let force = q.force;
+    let cleanup = q.cleanup;
     std::thread::spawn(move || {
+        if cleanup {
+            match crate::commands::document_index::cleanup_stale_documents(&db, &project_key, &project_path) {
+                Ok(c) => eprintln!("[doc-index] cleanup before reindex: removed {} files / {} chunks",
+                    c.files_removed, c.chunks_removed),
+                Err(e) => eprintln!("[doc-index] cleanup error: {}", e),
+            }
+        }
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            crate::commands::document_index::index_project_documents(&db, &project_key, &project_path)
+            crate::commands::document_index::index_project_documents_with_options(
+                &db, &project_key, &project_path, force,
+            )
         }));
         match result {
             Ok(Ok(r)) => {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -296,6 +296,7 @@ pub fn run() {
 
             // Document Index (docs/ RAG)
             commands::document_index::index_project_docs,
+            commands::document_index::cleanup_project_stale_docs,
             commands::document_index::search_project_docs,
             commands::document_index::get_project_document_graph,
             commands::document_index::get_orphan_documents,


### PR DESCRIPTION
## Summary
문서 RAG 인덱스를 file system 과 동기화하는 도구. Phase A (docs 재조직) 착수 전에 baseline 측정 + 재조직 후 DB 재동기화 용.

## Problem
- \`docs/\` 에 426 md 파일, DB 에는 tunaflow 프로젝트 53 files 만 인덱싱 (12%).
- stale state — 초기 indexing 후 추가된 파일 대부분 누락.
- 사용자 기대: "검색이 완벽" = 모든 문서 indexing + file_path 유효.

## New
- \`force=true\` 옵션 — SHA change detection 우회.
- \`cleanup_stale_documents\` — 파일 삭제된 DB rows 정리.
- HTTP API \`?force=...&cleanup=...\` 쿼리.
- CLI \`npm run docs:reindex <projectKey>\`.

## Usage
\`\`\`bash
TUNAFLOW_TOKEN=<...> npm run docs:reindex tunaflow
# → 202 accepted, background 진행, document:indexed WS event 로 결과
# → 검증: sqlite3 로 DB chunks 의 DISTINCT file_path 수 vs fs md 파일 수
\`\`\`

## Test plan
- [x] cargo test --lib: 305 passed
- [x] tsc --noEmit: 0 errors
- [ ] 머지 후 실측: tunaflow 재인덱싱 → 인덱싱 수 증가 확인
- [ ] 재조직 PR 후 다시 실행 → 최종 100% 보장

🤖 Generated with [Claude Code](https://claude.com/claude-code)