### PR TITLE
feat(harness): Phase 1 — RT invariants checklist 강제

### DIFF
--- a/src-tauri/src/commands/roundtable_helpers/types.rs
+++ b/src-tauri/src/commands/roundtable_helpers/types.rs
@@ -95,7 +95,14 @@ fn role_guidance(role: &str) -> &'static str {
             "**Proposer guidelines:**\n\
              - Form your analysis independently — do not converge toward other participants' views.\n\
              - Lead with your conclusion, then provide supporting evidence.\n\
-             - Flag assumptions explicitly; do not treat them as facts."
+             - Flag assumptions explicitly; do not treat them as facts.\n\
+             - **Emit an `## Invariants` section** listing constraints the implementation MUST NEVER violate.\n\
+             - Format each invariant as: `- [INV-N] <short statement> — <why it matters>`\n\
+             - Examples:\n\
+               - [INV-1] Do not call db.write.lock() inside broadcast_event — same-thread re-entrant deadlock risk.\n\
+               - [INV-2] Do not release streaming subscription during adopt — message loss risk.\n\
+             - Prefer 0 to 7 invariants. If you cannot state any concrete invariant, write `None` and explain why.\n\
+             - Invariants must be checkable by reading code or running a test — not subjective quality claims."
         }
         "reviewer" | "critic" => {
             "**Reviewer guidelines:**\n\
@@ -103,20 +110,30 @@ fn role_guidance(role: &str) -> &'static str {
              - Score each dimension 1–5. Include the scores in your response.\n\
              - For each finding, include: file path, line range (if applicable), defect type, severity.\n\
              - Put improvement suggestions in a separate `recommendations` section, not in `findings`.\n\
-             - If verdict is `fail`, list failed subtask numbers as: `failed_subtask_ids: [N, M]`."
+             - If verdict is `fail`, list failed subtask numbers as: `failed_subtask_ids: [N, M]`.\n\
+             - **Invariants verification (required when proposer declared any):** for each INV-N in the proposer's\n\
+               output, emit an entry in an `invariant_checks` array with shape:\n\
+               `{ \"id\": \"INV-N\", \"status\": \"pass|fail|cannot_verify\", \"evidence\": \"<file:line or reasoning>\" }`\n\
+             - If ANY invariant_check is `fail`, verdict MUST be `fail`.\n\
+             - If multiple invariants are `cannot_verify`, mark verdict `fail` and request proposer to add tests or\n\
+               narrow the invariant scope."
         }
         "verifier" | "judge" => {
             "**Verifier guidelines:**\n\
              - Focus on concrete evidence — do not rely on other participants' assessments.\n\
              - State your verdict first, then justify with specific references.\n\
-             - Distinguish clearly between observed facts and inferences."
+             - Distinguish clearly between observed facts and inferences.\n\
+             - If proposer declared invariants, cross-check each one independently and record the result in\n\
+               `invariant_checks` — do not trust the reviewer's check."
         }
         "synthesizer" | "lead" => {
             "**Synthesizer guidelines:**\n\
              - Organize findings into three sections: `consensus`, `contested`, `dissent`.\n\
              - Preserve each reviewer's original verdict — do not overwrite it.\n\
              - Final verdict must be consistent with the vote tally across participants.\n\
-             - If no clear consensus exists, state that explicitly rather than forcing agreement."
+             - If no clear consensus exists, state that explicitly rather than forcing agreement.\n\
+             - If any participant's invariant_check status is `fail`, final verdict MUST be `fail` regardless of\n\
+               dimension scores."
         }
         _ => "",
     }
@@ -269,5 +286,83 @@ mod tests {
     fn cap_directive_without_cap() {
         let d = output_cap_directive(None);
         assert!(d.is_empty());
+    }
+
+    // ─── Invariants checklist (Phase 1 of harnessVerificationGapPlan) ──────────
+
+    #[test]
+    fn proposer_guidance_requires_invariants_section() {
+        let p = make_participant("Proposer", Some("claude"), false, Some("proposer"));
+        let id = participant_identity(&p);
+        assert!(id.contains("## Invariants"), "proposer must be told to emit ## Invariants section");
+        assert!(id.contains("[INV-"), "proposer must be shown the INV-N format");
+    }
+
+    #[test]
+    fn proposer_guidance_mentions_bounded_invariant_count() {
+        let p = make_participant("Proposer", Some("claude"), false, Some("proposer"));
+        let id = participant_identity(&p);
+        assert!(
+            id.contains("0 to 7 invariants") || id.contains("0-7"),
+            "proposer guidance must bound invariant count to avoid reviewer overload"
+        );
+    }
+
+    #[test]
+    fn reviewer_guidance_requires_invariant_checks() {
+        let p = make_participant("Reviewer", Some("codex"), false, Some("reviewer"));
+        let id = participant_identity(&p);
+        assert!(id.contains("invariant_checks"), "reviewer must emit invariant_checks array");
+        assert!(id.contains("pass|fail|cannot_verify"), "reviewer must know the 3 statuses");
+    }
+
+    #[test]
+    fn reviewer_invariant_fail_forces_verdict_fail() {
+        let p = make_participant("Reviewer", Some("codex"), false, Some("reviewer"));
+        let id = participant_identity(&p);
+        assert!(
+            id.contains("any invariant_check") || id.contains("ANY invariant_check"),
+            "reviewer guidance must state that failed invariant forces verdict=fail"
+        );
+    }
+
+    #[test]
+    fn critic_alias_also_has_invariant_checks() {
+        let p = make_participant("Critic", Some("codex"), false, Some("critic"));
+        let id = participant_identity(&p);
+        assert!(id.contains("invariant_checks"), "critic (alias of reviewer) must also have invariant_checks");
+    }
+
+    #[test]
+    fn verifier_guidance_crosschecks_invariants_independently() {
+        let p = make_participant("Verifier", Some("gemini"), false, Some("verifier"));
+        let id = participant_identity(&p);
+        assert!(
+            id.contains("cross-check") || id.contains("crosscheck") || id.contains("independently"),
+            "verifier must independently cross-check invariants, not trust reviewer"
+        );
+    }
+
+    #[test]
+    fn synthesizer_guidance_honors_invariant_failures() {
+        let p = make_participant("Synth", Some("claude"), false, Some("synthesizer"));
+        let id = participant_identity(&p);
+        assert!(
+            id.contains("invariant_check"),
+            "synthesizer must honor any participant's failed invariant_check"
+        );
+        assert!(
+            id.contains("final verdict MUST be `fail`") || id.contains("final verdict MUST be fail"),
+            "synthesizer must override final verdict to fail when any invariant fails"
+        );
+    }
+
+    #[test]
+    fn non_invariant_roles_do_not_get_invariant_noise() {
+        // proposer and reviewer/critic/verifier/synthesizer all get invariant guidance.
+        // Any unknown role should NOT get invariant guidance (keeps guidance narrow).
+        let p = make_participant("Other", Some("claude"), false, Some("commentator"));
+        let id = participant_identity(&p);
+        assert!(!id.contains("invariant"), "unknown roles must not inherit invariant guidance");
     }
 }


### PR DESCRIPTION
## 배경

**Opus 수준의 결함을 하위 모델이 실제로 catch 한 사례 드묾**. 원인: 구조가 아니라 **입력 명세 부재** — reviewer 에게 "무엇을 봐야 하는지" 가 구체적으로 전달되지 않음.

tunaFlow 는 이미 4역할 RT (proposer / reviewer / verifier / synthesizer) + blind + token cap 차등을 보유. 이 PR 은 **기존 구조 확장**. 본격 설계 플랜은 `docs/plans/harnessVerificationGapPlan.md` (§2).

## 변경 요약

`src-tauri/src/commands/roundtable_helpers/types.rs` 의 `role_guidance()` 를 확장:

- **`proposer`**: 산출물에 `## Invariants` 섹션 필수. 형식 `[INV-N] <statement> — <why>`. 0~7개 상한. None 이면 이유 명시.
- **`reviewer`/`critic`**: 각 `INV-N` 에 대해 `invariant_checks` 배열 emit. `{ id, status: pass|fail|cannot_verify, evidence }`. **하나라도 `fail` 이면 verdict MUST=`fail`**.
- **`verifier`/`judge`**: reviewer 에 의존 말고 독립적으로 cross-check.
- **`synthesizer`/`lead`**: 어떤 참여자든 invariant fail 이면 **final verdict=fail 강제**. dimension score 무관.

## 예시 (proposer 출력)

```markdown
## Invariants
- [INV-1] Do not call db.write.lock() inside broadcast_event — same-thread re-entrant deadlock (PR #111 근거).
- [INV-2] Do not release streaming subscription during adopt — message loss (세션 25).
```

## 예시 (reviewer 출력)

```json
{
  "dimension_scores": { "plan_coverage": 5, "code_quality": 4, "test_coverage": 3, "convention": 5 },
  "invariant_checks": [
    { "id": "INV-1", "status": "pass", "evidence": "events.rs:67 detached thread 사용 확인" },
    { "id": "INV-2", "status": "fail", "evidence": "adoptBranch.ts:122 streaming 구독 해제 발견" }
  ],
  "verdict": "fail",
  "failed_subtask_ids": [3]
}
```
INV-2 fail → verdict fail 강제 → doom loop 방지 signal 확보.

## 테스트

신규 8개 추가 (총 24개):
- `proposer_guidance_requires_invariants_section`
- `proposer_guidance_mentions_bounded_invariant_count`
- `reviewer_guidance_requires_invariant_checks`
- `reviewer_invariant_fail_forces_verdict_fail`
- `critic_alias_also_has_invariant_checks`
- `verifier_guidance_crosschecks_invariants_independently`
- `synthesizer_guidance_honors_invariant_failures`
- `non_invariant_roles_do_not_get_invariant_noise`

**전체 lib test: 313 passed / 0 failed**.

## 효과 가설

- Opus 의 암묵적 invariants 가 텍스트로 강제 추출됨 → 하위 모델도 line-by-line 검증 가능
- Invariant 불가면 "기본으로 사용자가 확인" → human-in-the-loop 명확화
- `cannot_verify` 카운트가 곧 **테스트 커버리지 부족의 정량 지표** 로 재활용 가능

## Scope 경계

- **Phase 1 만 구현**. Divergence detector (Phase 2), transactional boundary (Phase 3), architect 2-track (Phase 4), dual-reviewer A/B (Phase 5) 는 후속 PR.
- 소형 LLM 내장 (Gemma/LiteRT-LM) 은 tunaFlow 범위 밖 — tunaMicro 분리.

## Test plan

- [x] `cargo test --lib` — 313 passed
- [ ] 실제 RT 실행으로 proposer 가 `## Invariants` 섹션 emit 하는지 확인
- [ ] reviewer 가 `invariant_checks` JSON 필드를 emit 하는지 확인
- [ ] 일부러 invariant 위반 구현 → reviewer 가 `fail` 로 catch 하는지 회귀 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)