### PR TITLE
fix(scaffold): agent template 드리프트 수정 — slug 규칙 + tiered message 도구

### DIFF
--- a/src-tauri/src/commands/project_tools.rs
+++ b/src-tauri/src/commands/project_tools.rs
@@ -392,6 +392,13 @@ After the plan is promoted, write documents directly in `docs/plans/`:
 - `{slug}-task-02.md` — Subtask 2 work instruction
 - Continue for each subtask
 
+**`{slug}` is not something you invent.** The ContextPack `## Active Plan` section
+includes `> **Plan slug (canonical):** `<value>`` — use that value verbatim.
+Do not abbreviate, truncate, or re-slugify the plan title yourself. tunaFlow
+(Reviewer context loader, result/review report writers) reads file names back
+using this exact slug; any deviation — including a stray trailing `-` — means
+your task files will be invisible to downstream agents.
+
 Each task file MUST contain:
 1. **Changed files** — exact paths verified against the codebase (new files: state explicitly)
 2. **Change description** — what to add/modify/remove and why
@@ -411,6 +418,11 @@ When you need to explore the codebase before designing:
 - `<!-- tunaflow:tool-request:docs:QUERY -->` — Search library/framework documentation
 - `<!-- tunaflow:tool-request:rawq:QUERY -->` — Search project codebase
 - `<!-- tunaflow:tool-request:graph:PATTERN TARGET -->` — Query code graph (callers_of, tests_for, etc.)
+
+Tiered message inspection (when `recent_turns` truncated a message you need to verify):
+- `<!-- tunaflow:tool-request:probe_message:MESSAGE_ID -->` — ~1 KB metadata probe (length + head/tail previews). Confirms DB has full content before you pay for the body.
+- `<!-- tunaflow:tool-request:fetch_slice:MESSAGE_ID:OFFSET:LEN -->` — Read a `[offset, offset+len)` char slice. LEN capped at 16 000.
+- `<!-- tunaflow:tool-request:full_message:MESSAGE_ID -->` — Entire content with no truncation. Heaviest — prefer probe/slice unless you really need the whole thing.
 
 tunaFlow will execute the request and provide results in the next turn.
 Include markers at the END of your response, after your main content.
@@ -482,6 +494,11 @@ When you need information during implementation:
 - `<!-- tunaflow:tool-request:docs:QUERY -->` — Search library/framework documentation
 - `<!-- tunaflow:tool-request:rawq:QUERY -->` — Search project codebase
 - `<!-- tunaflow:tool-request:graph:callers_of TARGET -->` — Find what calls a function
+
+Tiered message inspection (when a message appeared cut in `recent_turns`):
+- `<!-- tunaflow:tool-request:probe_message:MESSAGE_ID -->` — metadata + head/tail (~1 KB)
+- `<!-- tunaflow:tool-request:fetch_slice:MESSAGE_ID:OFFSET:LEN -->` — slice (LEN ≤ 16 000)
+- `<!-- tunaflow:tool-request:full_message:MESSAGE_ID -->` — full content (heavy)
 
 Include markers at the END of your response, after your main content.
 
@@ -562,3 +579,49 @@ When reviewing after rework:
 - **Result report is auto-generated**: Never judge `*-result.md` quality.
 - **Findings vs Recommendations**: Only actual defects go in findings. Everything else goes in recommendations.
 "#;
+
+
+// ─── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Guard against silent drift — scaffold templates ship features that
+    // live git files depend on. If these lines are removed from the const,
+    // every project selection overwrites the tracked doc with a stale copy.
+
+    #[test]
+    fn architect_template_includes_slug_canonical_rule() {
+        assert!(ARCHITECT_TEMPLATE.contains("Plan slug (canonical)"),
+            "architect template must preserve the canonical-slug rule");
+        assert!(ARCHITECT_TEMPLATE.contains("is not something you invent"),
+            "architect template must warn against re-slugifying");
+    }
+
+    #[test]
+    fn architect_template_includes_tiered_message_tools() {
+        assert!(ARCHITECT_TEMPLATE.contains("probe_message:MESSAGE_ID"),
+            "architect template must expose probe_message tool-request");
+        assert!(ARCHITECT_TEMPLATE.contains("fetch_slice:MESSAGE_ID"),
+            "architect template must expose fetch_slice tool-request");
+        assert!(ARCHITECT_TEMPLATE.contains("full_message:MESSAGE_ID"),
+            "architect template must expose full_message tool-request");
+    }
+
+    #[test]
+    fn developer_template_includes_tiered_message_tools() {
+        assert!(DEVELOPER_TEMPLATE.contains("probe_message:MESSAGE_ID"),
+            "developer template must expose probe_message tool-request");
+        assert!(DEVELOPER_TEMPLATE.contains("fetch_slice:MESSAGE_ID"),
+            "developer template must expose fetch_slice tool-request");
+        assert!(DEVELOPER_TEMPLATE.contains("full_message:MESSAGE_ID"),
+            "developer template must expose full_message tool-request");
+    }
+
+    #[test]
+    fn reviewer_template_not_empty() {
+        assert!(!REVIEWER_TEMPLATE.is_empty());
+        assert!(REVIEWER_TEMPLATE.contains("Reviewer"));
+    }
+}


### PR DESCRIPTION
## 문제
`ensure_workflow_templates` (project_tools.rs:254) 는 프로젝트 선택 시마다 `ARCHITECT_TEMPLATE`/`DEVELOPER_TEMPLATE` 상수로 `docs/agents/*.md` 를 **무조건 덮어씀**. 그런데 상수가 구버전이라 git 최신 파일을 매번 회귀시킴:

- `c9910a9` (slug = canonical source) — architect 에 있어야 할 규칙 누락
- `56ea341` (probe_message / fetch_slice / full_message tiered inspection) — 양쪽 다 누락

증상: 사용자가 tunaFlow 를 프로젝트로 열 때마다 `docs/agents/architect.md`, `docs/agents/developer.md` 가 "의문의 modified" 로 바뀜 → 원복해도 다시 덮어써짐.

## 수정
- `ARCHITECT_TEMPLATE` 에 slug canonical 블록 + tiered message inspection 블록 추가
- `DEVELOPER_TEMPLATE` 에 tiered message inspection 블록 추가
- 드리프트 재발 방지 가드 테스트 4건

## 테스트
`cargo test --lib commands::project_tools` → **4 passed**.

## 후속 설계 (별도 idea)
템플릿 상수 방식 자체가 "프로젝트별 로컬 수정을 매번 날림" 이라는 근본 문제 있음. `docs/ideas/agentTemplateVersioningIdea.md` 에 semver 기반 drift 허용 구조 설계 예정.

## Test plan
- [x] `cargo test --lib commands::project_tools`
- [ ] 앱 재기동 후 tunaflow 프로젝트 선택 시 `docs/agents/*.md` 가 **modified 로 안 뜨는지** 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)