### PR TITLE
feat(harness): Phase 4 — proposer 2-track output 구조 강제

### DIFF
--- a/src-tauri/src/commands/roundtable_helpers/types.rs
+++ b/src-tauri/src/commands/roundtable_helpers/types.rs
@@ -94,15 +94,24 @@ fn role_guidance(role: &str) -> &'static str {
         "proposer" => {
             "**Proposer guidelines:**\n\
              - Form your analysis independently — do not converge toward other participants' views.\n\
-             - Lead with your conclusion, then provide supporting evidence.\n\
              - Flag assumptions explicitly; do not treat them as facts.\n\
-             - **Emit an `## Invariants` section** listing constraints the implementation MUST NEVER violate.\n\
-             - Format each invariant as: `- [INV-N] <short statement> — <why it matters>`\n\
-             - Examples:\n\
-               - [INV-1] Do not call db.write.lock() inside broadcast_event — same-thread re-entrant deadlock risk.\n\
-               - [INV-2] Do not release streaming subscription during adopt — message loss risk.\n\
-             - Prefer 0 to 7 invariants. If you cannot state any concrete invariant, write `None` and explain why.\n\
-             - Invariants must be checkable by reading code or running a test — not subjective quality claims."
+             - **Output structure (required — four sections, in this exact order):**\n\
+               1. `## TL;DR for Developer` — 5~20 lines. Execution-only directives. What to change, where, in what\n\
+                  order. No rationale, no alternatives. This is the section Developer actually reads.\n\
+               2. `## Specification` — concrete contracts: function signatures, file paths, expected behavior,\n\
+                  edge cases. Enough for Developer to implement without questions.\n\
+               3. `## Invariants` — constraints the implementation MUST NEVER violate. Format each as:\n\
+                  `- [INV-N] <short statement> — <why it matters>`\n\
+                  Examples:\n\
+                  - [INV-1] Do not call db.write.lock() inside broadcast_event — same-thread re-entrant deadlock.\n\
+                  - [INV-2] Do not release streaming subscription during adopt — message loss risk.\n\
+                  Prefer 0 to 7 invariants. If none apply, write `None` and explain briefly.\n\
+                  Each invariant must be checkable by reading code or running a test — not subjective quality.\n\
+               4. `## Rationale (reviewer-only)` — design decisions, alternatives considered, trade-offs, why\n\
+                  this approach over others. This section is NOT included in the Developer ContextPack; it is\n\
+                  reviewed by the Reviewer/Verifier for audit purposes.\n\
+             - Lead with the conclusion in TL;DR — not in Rationale.\n\
+             - Do NOT duplicate content between sections. TL;DR stays terse; put full reasoning in Rationale."
         }
         "reviewer" | "critic" => {
             "**Reviewer guidelines:**\n\
@@ -468,5 +477,54 @@ mod tests {
         let r = make_participant("R", Some("codex"), false, Some("reviewer"));
         let id_r = participant_identity(&r);
         assert!(!id_r.contains("divergence"), "reviewer must not inherit divergence guidance");
+    }
+
+    // ─── Architect 2-track output (Phase 4 of harnessVerificationGapPlan) ──────
+
+    #[test]
+    fn proposer_guidance_requires_tldr_section() {
+        let p = make_participant("P", Some("claude"), false, Some("proposer"));
+        let id = participant_identity(&p);
+        assert!(id.contains("## TL;DR for Developer"), "proposer must emit TL;DR section");
+        assert!(id.contains("5~20 lines") || id.contains("5-20 lines"),
+            "proposer must know TL;DR length bound");
+    }
+
+    #[test]
+    fn proposer_guidance_requires_specification_section() {
+        let p = make_participant("P", Some("claude"), false, Some("proposer"));
+        let id = participant_identity(&p);
+        assert!(id.contains("## Specification"), "proposer must emit Specification section");
+    }
+
+    #[test]
+    fn proposer_guidance_requires_rationale_reviewer_only() {
+        let p = make_participant("P", Some("claude"), false, Some("proposer"));
+        let id = participant_identity(&p);
+        assert!(id.contains("## Rationale"), "proposer must emit Rationale section");
+        assert!(
+            id.contains("reviewer-only") || id.contains("NOT included in the Developer"),
+            "Rationale must be flagged as reviewer-only (excluded from Developer ContextPack)"
+        );
+    }
+
+    #[test]
+    fn proposer_guidance_forbids_content_duplication() {
+        let p = make_participant("P", Some("claude"), false, Some("proposer"));
+        let id = participant_identity(&p);
+        assert!(
+            id.contains("Do NOT duplicate") || id.contains("duplicate content"),
+            "proposer must be told not to duplicate TL;DR and Rationale"
+        );
+    }
+
+    #[test]
+    fn proposer_guidance_keeps_invariants_in_structure() {
+        // Phase 4 reorganizes the structure but invariants guidance must remain intact
+        let p = make_participant("P", Some("claude"), false, Some("proposer"));
+        let id = participant_identity(&p);
+        assert!(id.contains("## Invariants"), "invariants section still required");
+        assert!(id.contains("[INV-"), "INV-N format still required");
+        assert!(id.contains("0 to 7 invariants"), "invariant count bound still applies");
     }
 }


### PR DESCRIPTION
## 배경

Phase 1, 2 (PR #116, #119) 위에 **토큰 효율 + 역할 분리** 추가. Opus Architect 의 산출물은 근거·대안·tradeoff 까지 verbose → Developer 는 실행 지침만 필요. 지금은 통째로 받아서 읽음.

원 플랜: `docs/plans/harnessVerificationGapPlan.md` §5.

## 변경 요약 — proposer 4-섹션 강제 구조

| 섹션 | 독자 | 내용 |
|---|---|---|
| `## TL;DR for Developer` | **Developer** (ContextPack) | 5~20 줄. 실행 지침만. "무엇/어디/어떤 순서" |
| `## Specification` | **Developer** (ContextPack) | 계약: signatures, paths, behavior, edge cases |
| `## Invariants` | Developer + Reviewer + Verifier | `[INV-N]` 필수 (Phase 1 유지), 0~7개 |
| `## Rationale (reviewer-only)` | **Reviewer/Verifier 만** (audit) | 설계 근거, 대안, tradeoff |

**핵심 원칙**: TL;DR 과 Rationale 에 **같은 내용을 중복 서술하지 않는다**. TL;DR 은 terse, 근거는 Rationale 로 완전 분리.

## 기대 효과

- Developer 가 읽는 토큰 양 감소 (verbose 근거 따로)
- Rationale 은 reviewer audit 에만 로드 → ContextPack 압축 여지
- "무엇을 하라" 와 "왜 그렇게" 의 역할 분리 → 집행 정확도 향상 예상

## 테스트

5 개 신규 (29 total in types.rs):
- `proposer_guidance_requires_tldr_section`
- `proposer_guidance_requires_specification_section`
- `proposer_guidance_requires_rationale_reviewer_only`
- `proposer_guidance_forbids_content_duplication`
- `proposer_guidance_keeps_invariants_in_structure` (regression guard)

**`cargo test --lib`: 322 passed / 0 failed**.

## Scope 경계

- **프롬프트 레벨만** 이번 PR. Architect 가 4-섹션을 emit 하도록 강제.
- **ContextPack 단계에서 Rationale 제외 필터링 로직** 은 Phase 4b 별도 PR (`prompt_assembly.rs` 수정 필요, 런타임 영향 있음).
- 다음 Phase:
  - Phase 3 (Transactional Session Boundary, DB migration + persistence 리팩) — 별도 세션에서 독립 진행
  - Phase 5 (Dual-Reviewer A/B) — 구조 이미 존재, 비용 측정 필요

## Test plan
- [x] `cargo test --lib` — 322 passed
- [ ] 실제 RT 실행으로 proposer 가 4-섹션 모두 emit 하는지 확인
- [ ] TL;DR 만으로 Developer 가 구현 가능한지 샘플 PR 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)