### PR TITLE
feat(harness): Phase 3a — AgentSessionTx scaffold + v43 migration

### DIFF
--- a/src-tauri/src/commands/agents_helpers/send_common/agent_session_tx.rs
+++ b/src-tauri/src/commands/agents_helpers/send_common/agent_session_tx.rs
@@ -1,0 +1,288 @@
+//! Transactional session boundary (Phase 3a of harnessVerificationGapPlan §4).
+//!
+//! `AgentSessionTx` wraps a write-path agent session in a SQLite `SAVEPOINT` so
+//! that mid-session failure (panic, timeout, user cancel) leaves no half-formed
+//! rows in `plans`, `artifacts`, `conversation_memory`, etc.
+//!
+//! **Important**: this module is scaffold only (3a). `persistence.rs` is NOT
+//! yet wrapped — Phase 3b introduces the actual call-site integration.
+//! Streaming chunk rows (partial assistant messages) are intentionally designed
+//! to live OUTSIDE the savepoint so that a user sees what the agent produced
+//! before failure.
+//!
+//! Each session is audited in `agent_session_audit` (migration v43).
+
+use rusqlite::{params, Connection};
+use uuid::Uuid;
+
+use crate::db::migrations::now_epoch_ms;
+use crate::errors::AppError;
+
+/// Outcome values stored in `agent_session_audit.outcome`.
+pub const OUTCOME_IN_PROGRESS: &str = "in_progress";
+pub const OUTCOME_COMMITTED: &str = "committed";
+pub const OUTCOME_ROLLED_BACK: &str = "rolled_back";
+pub const OUTCOME_PANIC: &str = "panic";
+
+/// Wraps a single agent write session in a SQLite SAVEPOINT.
+///
+/// Use `commit` on success and `rollback` on explicit failure. If the value is
+/// dropped without calling either (i.e. a panic unwinds past it), the `Drop`
+/// impl records `outcome='panic'` but does NOT emit a SAVEPOINT ROLLBACK — the
+/// outer transaction/connection owner is responsible for that. This design is
+/// chosen because we cannot hand a Connection reference to Drop safely.
+#[must_use = "AgentSessionTx must be explicitly committed or rolled back — drop leaves the savepoint dangling"]
+pub struct AgentSessionTx {
+    session_id: String,
+    savepoint_name: String,
+    /// Prevents Drop from double-writing the audit row after commit/rollback.
+    finalized: bool,
+}
+
+impl AgentSessionTx {
+    /// Begin a new agent session. Creates a SAVEPOINT and inserts an audit row
+    /// with `outcome='in_progress'`.
+    pub fn begin(conn: &Connection, conversation_id: Option<&str>) -> Result<Self, AppError> {
+        let session_id = Uuid::new_v4().to_string();
+        let savepoint_name = derive_savepoint_name(&session_id);
+
+        // Insert audit row first so that even if SAVEPOINT fails we have a trace
+        conn.execute(
+            "INSERT INTO agent_session_audit \
+             (session_id, conversation_id, started_at, outcome, savepoint_name) \
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![
+                session_id,
+                conversation_id,
+                now_epoch_ms(),
+                OUTCOME_IN_PROGRESS,
+                savepoint_name,
+            ],
+        )?;
+
+        conn.execute(&format!("SAVEPOINT {}", savepoint_name), [])?;
+
+        Ok(Self { session_id, savepoint_name, finalized: false })
+    }
+
+    /// Session id assigned at `begin` — useful for logging and correlating with
+    /// WS events.
+    pub fn session_id(&self) -> &str {
+        &self.session_id
+    }
+
+    /// Release the SAVEPOINT and mark the audit row `committed`.
+    pub fn commit(mut self, conn: &Connection) -> Result<(), AppError> {
+        conn.execute(&format!("RELEASE SAVEPOINT {}", self.savepoint_name), [])?;
+        conn.execute(
+            "UPDATE agent_session_audit SET ended_at = ?1, outcome = ?2 WHERE session_id = ?3",
+            params![now_epoch_ms(), OUTCOME_COMMITTED, self.session_id],
+        )?;
+        self.finalized = true;
+        Ok(())
+    }
+
+    /// Roll back to the SAVEPOINT and mark the audit row with a reason.
+    pub fn rollback(mut self, conn: &Connection, reason: &str) -> Result<(), AppError> {
+        // Two statements — SQLite requires explicit RELEASE after ROLLBACK TO
+        // SAVEPOINT, otherwise the savepoint stays on the stack.
+        conn.execute(&format!("ROLLBACK TO SAVEPOINT {}", self.savepoint_name), [])?;
+        conn.execute(&format!("RELEASE SAVEPOINT {}", self.savepoint_name), [])?;
+        conn.execute(
+            "UPDATE agent_session_audit \
+             SET ended_at = ?1, outcome = ?2, rollback_reason = ?3 \
+             WHERE session_id = ?4",
+            params![now_epoch_ms(), OUTCOME_ROLLED_BACK, reason, self.session_id],
+        )?;
+        self.finalized = true;
+        Ok(())
+    }
+}
+
+impl Drop for AgentSessionTx {
+    fn drop(&mut self) {
+        // Panic-safety marker only. We deliberately do NOT touch the DB here
+        // (no Connection available) — the next session begin will see a stale
+        // `in_progress` row, which a startup cleanup routine can detect and
+        // mark `panic`. Phase 3b will add that sweeper.
+        if !self.finalized {
+            eprintln!(
+                "[agent-session-tx] WARNING: session {} dropped without commit/rollback. \
+                 Audit row remains 'in_progress' — Phase 3b startup sweeper will reconcile.",
+                self.session_id
+            );
+        }
+    }
+}
+
+/// SQLite savepoint names must be valid identifiers. UUIDs contain hyphens
+/// which are fine if quoted, but we prefer a clean unquoted name. Strip hyphens
+/// and prefix with `sp_` so it starts with a letter.
+fn derive_savepoint_name(session_id: &str) -> String {
+    let cleaned: String = session_id.chars().filter(|c| c.is_ascii_alphanumeric()).collect();
+    format!("sp_{}", cleaned)
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+
+    /// Minimal schema for the audit table — mirrors migration v43 but inline so
+    /// the test is self-contained.
+    fn open_test_db() -> Connection {
+        let conn = Connection::open_in_memory().expect("open in-memory");
+        conn.execute_batch(
+            "CREATE TABLE agent_session_audit (
+                session_id    TEXT PRIMARY KEY,
+                conversation_id TEXT,
+                started_at    INTEGER NOT NULL,
+                ended_at      INTEGER,
+                outcome       TEXT NOT NULL DEFAULT 'in_progress',
+                rollback_reason TEXT,
+                savepoint_name TEXT
+             );
+             CREATE TABLE sandbox (id INTEGER PRIMARY KEY, value TEXT);",
+        ).expect("create audit + sandbox");
+        conn
+    }
+
+    #[test]
+    fn derive_savepoint_name_strips_hyphens() {
+        let name = derive_savepoint_name("abc-123-def");
+        assert_eq!(name, "sp_abc123def");
+    }
+
+    #[test]
+    fn begin_inserts_audit_row_and_opens_savepoint() {
+        let conn = open_test_db();
+        let tx = AgentSessionTx::begin(&conn, Some("conv-1")).expect("begin");
+        let sid = tx.session_id().to_string();
+
+        // audit row exists with in_progress outcome
+        let (outcome, conv, sp): (String, Option<String>, Option<String>) = conn
+            .query_row(
+                "SELECT outcome, conversation_id, savepoint_name FROM agent_session_audit WHERE session_id = ?1",
+                [&sid],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .expect("query audit");
+        assert_eq!(outcome, OUTCOME_IN_PROGRESS);
+        assert_eq!(conv.as_deref(), Some("conv-1"));
+        assert!(sp.is_some());
+
+        // commit succeeds to release the savepoint (otherwise it'd linger)
+        tx.commit(&conn).expect("commit");
+    }
+
+    #[test]
+    fn commit_updates_outcome_and_releases_savepoint() {
+        let conn = open_test_db();
+        let tx = AgentSessionTx::begin(&conn, None).expect("begin");
+        let sid = tx.session_id().to_string();
+
+        conn.execute("INSERT INTO sandbox (value) VALUES ('inside')", []).expect("insert");
+        tx.commit(&conn).expect("commit");
+
+        let outcome: String = conn
+            .query_row("SELECT outcome FROM agent_session_audit WHERE session_id = ?1", [&sid], |r| r.get(0))
+            .expect("outcome");
+        assert_eq!(outcome, OUTCOME_COMMITTED);
+
+        // committed write is visible
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM sandbox WHERE value = 'inside'", [], |r| r.get(0))
+            .expect("count");
+        assert_eq!(count, 1);
+
+        // ended_at set
+        let ended_at: Option<i64> = conn
+            .query_row("SELECT ended_at FROM agent_session_audit WHERE session_id = ?1", [&sid], |r| r.get(0))
+            .expect("ended_at");
+        assert!(ended_at.is_some());
+    }
+
+    #[test]
+    fn rollback_reverts_writes_and_records_reason() {
+        let conn = open_test_db();
+        let tx = AgentSessionTx::begin(&conn, Some("conv-A")).expect("begin");
+        let sid = tx.session_id().to_string();
+
+        conn.execute("INSERT INTO sandbox (value) VALUES ('will-revert')", []).expect("insert");
+        tx.rollback(&conn, "test failure").expect("rollback");
+
+        // the sandbox write must be gone
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM sandbox WHERE value = 'will-revert'", [], |r| r.get(0))
+            .expect("count");
+        assert_eq!(count, 0, "rollback did not revert sandbox write");
+
+        // audit row updated correctly
+        let (outcome, reason): (String, Option<String>) = conn
+            .query_row(
+                "SELECT outcome, rollback_reason FROM agent_session_audit WHERE session_id = ?1",
+                [&sid],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .expect("query");
+        assert_eq!(outcome, OUTCOME_ROLLED_BACK);
+        assert_eq!(reason.as_deref(), Some("test failure"));
+    }
+
+    #[test]
+    fn nested_sessions_are_independent() {
+        // Two concurrent-ish sessions on the same connection. SQLite allows
+        // nested SAVEPOINTs, so an inner rollback must NOT affect the outer.
+        let conn = open_test_db();
+
+        let outer = AgentSessionTx::begin(&conn, None).expect("outer begin");
+        conn.execute("INSERT INTO sandbox (value) VALUES ('outer')", []).expect("outer insert");
+
+        let inner = AgentSessionTx::begin(&conn, None).expect("inner begin");
+        conn.execute("INSERT INTO sandbox (value) VALUES ('inner')", []).expect("inner insert");
+        inner.rollback(&conn, "inner fail").expect("inner rollback");
+
+        // inner reverted but outer still holds its write
+        let has_outer: i64 = conn
+            .query_row("SELECT COUNT(*) FROM sandbox WHERE value = 'outer'", [], |r| r.get(0))
+            .expect("count outer");
+        let has_inner: i64 = conn
+            .query_row("SELECT COUNT(*) FROM sandbox WHERE value = 'inner'", [], |r| r.get(0))
+            .expect("count inner");
+        assert_eq!(has_outer, 1);
+        assert_eq!(has_inner, 0);
+
+        outer.commit(&conn).expect("outer commit");
+    }
+
+    #[test]
+    fn drop_without_finalize_emits_warning_but_does_not_panic() {
+        // We can't assert stderr easily, but we can assert that dropping without
+        // commit/rollback doesn't panic the test binary itself. This is a
+        // safety guard — Phase 3b will add a startup sweeper.
+        let conn = open_test_db();
+        {
+            let _tx = AgentSessionTx::begin(&conn, None).expect("begin");
+            // implicit drop here — must not panic
+        }
+        // The audit row should still be in_progress (Phase 3b reconciles)
+        let outcomes: Vec<String> = conn
+            .prepare("SELECT outcome FROM agent_session_audit")
+            .unwrap()
+            .query_map([], |r| r.get::<_, String>(0))
+            .unwrap()
+            .filter_map(|r| r.ok())
+            .collect();
+        assert_eq!(outcomes, vec![OUTCOME_IN_PROGRESS.to_string()]);
+    }
+
+    #[test]
+    fn derive_savepoint_name_is_valid_sqlite_identifier() {
+        // Must start with letter/underscore and contain only alphanumerics
+        let name = derive_savepoint_name("12345-abcde-67890");
+        assert!(name.starts_with("sp_"));
+        assert!(name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_'));
+    }
+}

--- a/src-tauri/src/commands/agents_helpers/send_common/mod.rs
+++ b/src-tauri/src/commands/agents_helpers/send_common/mod.rs
@@ -2,6 +2,7 @@ mod context_loading;
 mod prompt_assembly;
 mod persistence;
 pub mod session_freshness;
+pub mod agent_session_tx;
 
 // Re-export everything so external `use crate::commands::agents_helpers::send_common::*` still works
 #[allow(unused_imports)]

--- a/src-tauri/src/db/migrations.rs
+++ b/src-tauri/src/db/migrations.rs
@@ -151,6 +151,9 @@ pub fn run(conn: &Connection) -> Result<(), AppError> {
     if current < 42 {
         apply_v42(conn)?;
     }
+    if current < 43 {
+        apply_v43(conn)?;
+    }
     Ok(())
 }
 
@@ -1012,6 +1015,37 @@ fn apply_v42(conn: &Connection) -> Result<(), AppError> {
     Ok(())
 }
 
+/// v43 — `agent_session_audit` 테이블 추가.
+///
+/// Phase 3a (harnessVerificationGapPlan §4) — 에이전트 세션의 commit/rollback
+/// 이력을 기록. 중간 실패 시 어떤 세션이 어떤 상태로 끝났는지 추적 가능해야
+/// State Pollution (half-formed row 잔존) 디버깅이 실현된다.
+///
+/// 본 migration 은 **스키마만 추가**. 실제 persistence.rs 와 연결하는 로직은
+/// Phase 3b 에서 wrapper 와 함께 도입.
+fn apply_v43(conn: &Connection) -> Result<(), AppError> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS agent_session_audit (
+            session_id    TEXT PRIMARY KEY,
+            conversation_id TEXT,
+            started_at    INTEGER NOT NULL,
+            ended_at      INTEGER,
+            outcome       TEXT NOT NULL DEFAULT 'in_progress',
+            -- 'committed' | 'rolled_back' | 'in_progress' | 'panic'
+            rollback_reason TEXT,
+            savepoint_name TEXT
+        );
+        CREATE INDEX IF NOT EXISTS idx_asa_outcome ON agent_session_audit(outcome);
+        CREATE INDEX IF NOT EXISTS idx_asa_conv ON agent_session_audit(conversation_id);
+        CREATE INDEX IF NOT EXISTS idx_asa_started ON agent_session_audit(started_at DESC);",
+    )?;
+    conn.execute(
+        "INSERT INTO schema_version (version, applied_at) VALUES (43, ?1)",
+        [now_epoch_ms()],
+    )?;
+    Ok(())
+}
+
 /// Milliseconds since Unix epoch (for Message.timestamp)
 pub fn now_epoch_ms() -> i64 {
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -1019,4 +1053,101 @@ pub fn now_epoch_ms() -> i64 {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_millis() as i64
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+
+    /// Apply ONLY v43 in isolation — `run()` triggers earlier migrations that
+    /// depend on sqlite-vec `vec0` module which isn't loaded in the unit-test
+    /// harness. We prepare `schema_version` manually then call `apply_v43`
+    /// directly.
+    fn open_with_v43_only() -> Connection {
+        let conn = Connection::open_in_memory().expect("open");
+        conn.execute_batch(schema::CREATE_SCHEMA_VERSION).expect("schema_version");
+        apply_v43(&conn).expect("apply_v43");
+        conn
+    }
+
+    fn table_exists(conn: &Connection, name: &str) -> bool {
+        conn.query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=?1",
+            [name],
+            |r| r.get::<_, i64>(0),
+        )
+        .map(|n| n > 0)
+        .unwrap_or(false)
+    }
+
+    #[test]
+    fn v43_creates_agent_session_audit() {
+        let conn = open_with_v43_only();
+        assert!(table_exists(&conn, "agent_session_audit"),
+            "v43 migration must create agent_session_audit table");
+    }
+
+    #[test]
+    fn v43_schema_has_expected_columns() {
+        let conn = open_with_v43_only();
+        let mut stmt = conn.prepare("PRAGMA table_info(agent_session_audit)").unwrap();
+        let cols: Vec<String> = stmt
+            .query_map([], |r| r.get::<_, String>(1))
+            .unwrap()
+            .filter_map(|r| r.ok())
+            .collect();
+        for expected in ["session_id", "conversation_id", "started_at", "ended_at", "outcome", "rollback_reason", "savepoint_name"] {
+            assert!(cols.contains(&expected.to_string()),
+                "column {} missing from agent_session_audit, cols={:?}", expected, cols);
+        }
+    }
+
+    #[test]
+    fn v43_indexes_exist() {
+        let conn = open_with_v43_only();
+        for idx in ["idx_asa_outcome", "idx_asa_conv", "idx_asa_started"] {
+            let count: i64 = conn
+                .query_row(
+                    "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name=?1",
+                    [idx],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            assert_eq!(count, 1, "index {} missing", idx);
+        }
+    }
+
+    #[test]
+    fn v43_default_outcome_is_in_progress() {
+        let conn = open_with_v43_only();
+        conn.execute(
+            "INSERT INTO agent_session_audit (session_id, started_at) VALUES (?1, ?2)",
+            params!["s1", now_epoch_ms()],
+        )
+        .expect("insert with defaults");
+        let outcome: String = conn
+            .query_row(
+                "SELECT outcome FROM agent_session_audit WHERE session_id='s1'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(outcome, "in_progress", "default outcome should be in_progress");
+    }
+
+    #[test]
+    fn v43_records_schema_version() {
+        let conn = open_with_v43_only();
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM schema_version WHERE version=43",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1, "schema_version must record v43 application");
+    }
 }


### PR DESCRIPTION
## 배경

harnessVerificationGapPlan §4. State Pollution (에이전트 중간 실패 시 half-formed row 잔존) 방어.

Phase 3 는 DB migration + persistence 리팩 + SAVEPOINT wrapper 가 섞여있어 3 단계로 쪼갬:
- **Phase 3a (이 PR)**: scaffold 만 — migration + helper 구조. 기존 동작 변화 0.
- **Phase 3b (후속)**: `persistence.rs` 의 A1/A3 write 지점에 wrapper 적용. 런타임 영향 있음.
- **Phase 3c (추후)**: UI 실패 세션 badge, startup sweeper (in_progress → panic 재조정).

## 변경 요약

### Migration v43
`agent_session_audit` 테이블 추가:
```sql
CREATE TABLE agent_session_audit (
    session_id    TEXT PRIMARY KEY,
    conversation_id TEXT,
    started_at    INTEGER NOT NULL,
    ended_at      INTEGER,
    outcome       TEXT NOT NULL DEFAULT 'in_progress',
    -- 'committed' | 'rolled_back' | 'in_progress' | 'panic'
    rollback_reason TEXT,
    savepoint_name TEXT
);
CREATE INDEX idx_asa_outcome ON agent_session_audit(outcome);
CREATE INDEX idx_asa_conv ON agent_session_audit(conversation_id);
CREATE INDEX idx_asa_started ON agent_session_audit(started_at DESC);
```

### AgentSessionTx (`agent_session_tx.rs`)

```rust
let tx = AgentSessionTx::begin(&conn, Some("conv-1"))?;
// ... writes happen inside SAVEPOINT ...
tx.commit(&conn)?;   // or tx.rollback(&conn, "reason")?
```

- SQLite SAVEPOINT 기반
- `#[must_use]` 로 drop 경고 — finalize 안 하고 drop 시 stderr 경고 + audit 에 in_progress 잔존 (Phase 3b startup sweeper 가 panic 으로 재조정)
- Nested session 독립성 (SQLite nested SAVEPOINT 활용)
- SAVEPOINT 이름은 session_id 에서 hyphen 제거 + `sp_` 접두사

## 테스트

12 개 신규:
- `agent_session_tx.rs`: begin / commit / rollback / nested / drop 경고 / name sanitize (7건)
- `migrations::tests`: 테이블 / 컬럼 / 인덱스 / default / schema_version (5건)

**`cargo test --lib`: 329 passed / 0 failed** (baseline 317 → +12).

### 테스트 제약
`run()` 전체 migration 은 sqlite-vec `vec0` 모듈 의존이라 in-memory test 에서 로드 안 됨. 따라서 v43 만 단독 호출하는 harness 사용 (`open_with_v43_only`). Phase 3b 에서 integration 테스트 필요.

## Scope 경계 (명확히)

| 이번 PR | 다음 PR (3b) | 추후 (3c) |
|---|---|---|
| migration v43 | `prepare_engine_run` 래핑 | UI 실패 세션 badge |
| `AgentSessionTx` 구조체 | `finalize_engine_run` 래핑 (deadlock 주의) | startup sweeper |
| unit tests | streaming chunk 는 의도적 OUTSIDE | |
| **기존 동작 변화 없음** | | |

## Test plan
- [x] `cargo test --lib db::migrations` — 5 passed
- [x] `cargo test --lib commands::agents_helpers::send_common::agent_session_tx` — 7 passed
- [x] `cargo test --lib` — 329 passed
- [ ] 앱 재기동 후 `~/.tunaflow/db/tunaflow.db` 에 `agent_session_audit` 테이블 존재 확인
- [ ] `sqlite3 ... "PRAGMA user_version"` / schema_version 최신값 43 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)