### PR TITLE
feat(harness): Phase 3b-part1 — audit lifecycle integration

### DIFF
--- a/src-tauri/src/commands/agents.rs
+++ b/src-tauri/src/commands/agents.rs
@@ -167,7 +167,7 @@ pub async fn start_claude_stream(
 
     let ret = prep.msg_id.clone();
     let ep = prep.enriched_prompt.clone();
-    let PreparedRun { msg_id, job_id, project_path, ctx_meta, .. } = prep;
+    let PreparedRun { msg_id, job_id, project_path, ctx_meta, audit_session_id, .. } = prep;
     let plen = pr.len() + system_prompt.as_ref().map_or(0, |s| s.len());
 
     // Claude 실행 경로 선택:
@@ -181,6 +181,7 @@ pub async fn start_claude_stream(
         let sp = system_prompt;
         let cid2 = cid.clone();
         let db_p = db_post.clone();
+        let aid = audit_session_id.clone();
         tokio::spawn(async move {
             let pa = app.clone(); let pi = msg_id.clone(); let pc = cid2.clone();
             let c2 = app.clone(); let ci = msg_id.clone(); let cc = cid2.clone();
@@ -193,7 +194,7 @@ pub async fn start_claude_stream(
             let dur = t0.elapsed().as_millis();
             guardrail::log_run("claude-sdk", mo.as_deref(), dur, plen, rr.is_ok());
             if let Ok(conn) = write_arc.lock() {
-                finalize_engine_run(&conn, "claude-code", &msg_id, &cid, &job_id, &rr, dur, &ctx_meta, &app);
+                finalize_engine_run(&conn, "claude-code", &msg_id, &cid, &job_id, &rr, dur, &ctx_meta, &app, aid.as_deref());
             }
             if rr.is_ok() { spawn_post_completion_tasks(db_p, cid); }
         });
@@ -201,6 +202,7 @@ pub async fn start_claude_stream(
         // --sdk-url WS 세션: 구조화 JSON + 슬래시 커맨드 지원
         let cid2 = cid.clone();
         let db_p = db_post.clone();
+        let aid = audit_session_id.clone();
         tokio::spawn(async move {
             let pa = app.clone(); let pi = msg_id.clone(); let pc = cid2.clone();
             let c2 = app.clone(); let ci = msg_id.clone(); let cc = cid2.clone();
@@ -215,12 +217,13 @@ pub async fn start_claude_stream(
             let dur = t0.elapsed().as_millis();
             guardrail::log_run("claude-sdk-url", mo.as_deref(), dur, plen, rr.is_ok());
             if let Ok(conn) = write_arc.lock() {
-                finalize_engine_run(&conn, "claude-code", &msg_id, &cid, &job_id, &rr, dur, &ctx_meta, &app);
+                finalize_engine_run(&conn, "claude-code", &msg_id, &cid, &job_id, &rr, dur, &ctx_meta, &app, aid.as_deref());
             }
             if rr.is_ok() { spawn_post_completion_tasks(db_p, cid); }
         });
     } else {
         // CLI -p fallback (TUNAFLOW_DISABLE_SDK_URL=1)
+        let aid = audit_session_id.clone();
         std::thread::spawn(move || {
             let pa = app.clone(); let pi = msg_id.clone(); let pc = cid.clone();
             let c2 = app.clone(); let ci = msg_id.clone(); let cc = cid.clone();
@@ -234,7 +237,7 @@ pub async fn start_claude_stream(
             let dur = t0.elapsed().as_millis();
             guardrail::log_run("claude-bg", mo.as_deref(), dur, plen, rr.is_ok());
             if let Ok(conn) = write_arc.lock() {
-                finalize_engine_run(&conn, "claude-code", &msg_id, &cid, &job_id, &rr, dur, &ctx_meta, &app);
+                finalize_engine_run(&conn, "claude-code", &msg_id, &cid, &job_id, &rr, dur, &ctx_meta, &app, aid.as_deref());
             }
             if rr.is_ok() { spawn_post_completion_tasks(db_post, cid); }
         });
@@ -261,13 +264,15 @@ pub async fn start_gemini_stream(
     }).await.map_err(|_| AppError::Lock)??;
 
     let ret = prep.msg_id.clone();
-    let PreparedRun { msg_id, job_id, enriched_prompt, project_path, ctx_meta, .. } = prep;
+    let system_prompt_opt = prep.system_context.clone();
+    let PreparedRun { msg_id, job_id, enriched_prompt, project_path, ctx_meta, audit_session_id, .. } = prep;
 
     if gemini_sdk::is_available() {
         // SDK path — async, native streaming, accurate token tracking
-        let system_prompt = prep.system_context;
+        let system_prompt = system_prompt_opt;
         let cid2 = cid.clone();
         let db_p = db_post.clone();
+        let aid = audit_session_id.clone();
         tokio::spawn(async move {
             let pa = app.clone(); let pi = msg_id.clone(); let pc = cid2.clone();
             let c2 = app.clone(); let ci = msg_id.clone(); let cc = cid2.clone();
@@ -279,12 +284,13 @@ pub async fn start_gemini_stream(
             ).await;
             let dur = t0.elapsed().as_millis();
             if let Ok(conn) = write_arc.lock() {
-                finalize_engine_run(&conn, "gemini", &msg_id, &cid, &job_id, &rr, dur, &ctx_meta, &app);
+                finalize_engine_run(&conn, "gemini", &msg_id, &cid, &job_id, &rr, dur, &ctx_meta, &app, aid.as_deref());
             }
             if rr.is_ok() { spawn_post_completion_tasks(db_p, cid); }
         });
     } else {
         // CLI fallback
+        let aid = audit_session_id.clone();
         std::thread::spawn(move || {
             let pa = app.clone(); let pi = msg_id.clone(); let pc = cid.clone();
             let c2 = app.clone(); let ci = msg_id.clone(); let cc = cid.clone();
@@ -297,7 +303,7 @@ pub async fn start_gemini_stream(
             );
             let dur = t0.elapsed().as_millis();
             if let Ok(conn) = write_arc.lock() {
-                finalize_engine_run(&conn, "gemini", &msg_id, &cid, &job_id, &rr, dur, &ctx_meta, &app);
+                finalize_engine_run(&conn, "gemini", &msg_id, &cid, &job_id, &rr, dur, &ctx_meta, &app, aid.as_deref());
             }
             if rr.is_ok() { spawn_post_completion_tasks(db_post, cid); }
         });
@@ -323,13 +329,15 @@ pub async fn start_codex_run(
     }).await.map_err(|_| AppError::Lock)??;
 
     let ret = prep.msg_id.clone();
-    let PreparedRun { msg_id, job_id, enriched_prompt, project_path, ctx_meta, .. } = prep;
+    let system_prompt_opt = prep.system_context.clone();
+    let PreparedRun { msg_id, job_id, enriched_prompt, project_path, ctx_meta, audit_session_id, .. } = prep;
 
     if openai_sdk::is_available() {
         // SDK path — OpenAI Chat Completions API
-        let system_prompt = prep.system_context;
+        let system_prompt = system_prompt_opt;
         let cid2 = cid.clone();
         let db_p = db_post.clone();
+        let aid = audit_session_id.clone();
         tokio::spawn(async move {
             let pa = app.clone(); let pi = msg_id.clone(); let pc = cid2.clone();
             let c2 = app.clone(); let ci = msg_id.clone(); let cc = cid2.clone();
@@ -341,13 +349,14 @@ pub async fn start_codex_run(
             ).await;
             let dur = t0.elapsed().as_millis();
             if let Ok(conn) = write_arc.lock() {
-                finalize_engine_run(&conn, "codex", &msg_id, &cid, &job_id, &rr, dur, &ctx_meta, &app);
+                finalize_engine_run(&conn, "codex", &msg_id, &cid, &job_id, &rr, dur, &ctx_meta, &app, aid.as_deref());
             }
             if rr.is_ok() { spawn_post_completion_tasks(db_p, cid); }
         });
     } else if codex_app_server::is_available() {
         // Codex app-server 지속 세션 (매번 재스폰 없음)
         let cid2 = cid.clone();
+        let aid = audit_session_id.clone();
         tokio::spawn(async move {
             let pa = app.clone(); let pi = msg_id.clone(); let pc = cid2.clone();
             let c2 = app.clone(); let ci = msg_id.clone(); let cc = cid2.clone();
@@ -361,12 +370,13 @@ pub async fn start_codex_run(
             ).await;
             let dur = t0.elapsed().as_millis();
             if let Ok(conn) = write_arc.lock() {
-                finalize_engine_run(&conn, "codex", &msg_id, &cid2, &job_id, &rr, dur, &ctx_meta, &app);
+                finalize_engine_run(&conn, "codex", &msg_id, &cid2, &job_id, &rr, dur, &ctx_meta, &app, aid.as_deref());
             }
             if rr.is_ok() { spawn_post_completion_tasks(db_post, cid2); }
         });
     } else {
         // Codex CLI fallback
+        let aid = audit_session_id.clone();
         std::thread::spawn(move || {
             let chunk_mid = msg_id.clone(); let chunk_app = app.clone(); let chunk_cid = cid.clone();
             let progress_mid = msg_id.clone(); let progress_app = app.clone(); let progress_cid = cid.clone();
@@ -378,7 +388,7 @@ pub async fn start_codex_run(
             );
             let dur = t0.elapsed().as_millis();
             if let Ok(conn) = write_arc.lock() {
-                finalize_engine_run(&conn, "codex", &msg_id, &cid, &job_id, &rr, dur, &ctx_meta, &app);
+                finalize_engine_run(&conn, "codex", &msg_id, &cid, &job_id, &rr, dur, &ctx_meta, &app, aid.as_deref());
             }
             if rr.is_ok() { spawn_post_completion_tasks(db_post, cid); }
         });
@@ -403,7 +413,7 @@ pub async fn start_opencode_run(
     }).await.map_err(|_| AppError::Lock)??;
 
     let ret = prep.msg_id.clone();
-    let PreparedRun { msg_id, job_id, enriched_prompt, project_path, ctx_meta, .. } = prep;
+    let PreparedRun { msg_id, job_id, enriched_prompt, project_path, ctx_meta, audit_session_id, .. } = prep;
 
     std::thread::spawn(move || {
         let _ = app.emit("opencode:progress", ChunkPayload { message_id: msg_id.clone(), conversation_id: cid.clone(), text: "OpenCode starting...".into() });
@@ -413,7 +423,7 @@ pub async fn start_opencode_run(
         );
         let dur = t0.elapsed().as_millis();
         if let Ok(conn) = write_arc.lock() {
-            finalize_engine_run(&conn, "opencode", &msg_id, &cid, &job_id, &rr, dur, &ctx_meta, &app);
+            finalize_engine_run(&conn, "opencode", &msg_id, &cid, &job_id, &rr, dur, &ctx_meta, &app, audit_session_id.as_deref());
         }
         if rr.is_ok() { spawn_post_completion_tasks(db_post, cid); }
     });
@@ -446,8 +456,8 @@ pub async fn start_openai_compat_stream(
     }).await.map_err(|_| AppError::Lock)??;
 
     let ret = prep.msg_id.clone();
-    let PreparedRun { msg_id, job_id, enriched_prompt, project_path, ctx_meta, .. } = prep;
-    let system_prompt = prep.system_context;
+    let system_prompt = prep.system_context.clone();
+    let PreparedRun { msg_id, job_id, enriched_prompt, project_path, ctx_meta, audit_session_id, .. } = prep;
     let base_url = if is_lmstudio { openai_compat::lmstudio_base_url() } else { std::env::var("OLLAMA_HOST").unwrap_or_else(|_| "http://localhost:11434".into()) };
 
     let cid2 = cid.clone();
@@ -465,7 +475,7 @@ pub async fn start_openai_compat_stream(
         let dur = t0.elapsed().as_millis();
         guardrail::log_run(&el, mo.as_deref(), dur, 0, rr.is_ok());
         if let Ok(conn) = write_arc.lock() {
-            finalize_engine_run(&conn, &el, &msg_id, &cid, &job_id, &rr, dur, &ctx_meta, &app);
+            finalize_engine_run(&conn, &el, &msg_id, &cid, &job_id, &rr, dur, &ctx_meta, &app, audit_session_id.as_deref());
         }
         if rr.is_ok() { spawn_post_completion_tasks(db_post, cid); }
     });

--- a/src-tauri/src/commands/agents_helpers/send_common/agent_session_tx.rs
+++ b/src-tauri/src/commands/agents_helpers/send_common/agent_session_tx.rs
@@ -24,6 +24,76 @@ pub const OUTCOME_COMMITTED: &str = "committed";
 pub const OUTCOME_ROLLED_BACK: &str = "rolled_back";
 pub const OUTCOME_PANIC: &str = "panic";
 
+// ─── Audit-only API (Phase 3b-part1) ───────────────────────────────────────────
+//
+// Records session lifecycle in `agent_session_audit` without opening a SAVEPOINT.
+// This gives us the observability half of transactional boundaries — "which
+// sessions finished? which hung? which panicked?" — with zero rollback cost and
+// zero write-lock contention added to the hot path. SAVEPOINT-backed rollback
+// is Phase 3b-part2 behind a feature flag; the audit record format is shared so
+// part2 can upgrade the same rows in place.
+
+/// Insert an audit row with `outcome='in_progress'` and return the session id.
+/// No SAVEPOINT is opened. Call `audit_commit` or `audit_rollback` to finalize.
+pub fn audit_begin(conn: &Connection, conversation_id: Option<&str>) -> Result<String, AppError> {
+    let session_id = Uuid::new_v4().to_string();
+    conn.execute(
+        "INSERT INTO agent_session_audit \
+         (session_id, conversation_id, started_at, outcome) \
+         VALUES (?1, ?2, ?3, ?4)",
+        params![
+            session_id,
+            conversation_id,
+            now_epoch_ms(),
+            OUTCOME_IN_PROGRESS,
+        ],
+    )?;
+    Ok(session_id)
+}
+
+/// Mark an audit row `committed`. No-op if the row is missing (legacy sessions
+/// that started before Phase 3b-part1 shipped).
+pub fn audit_commit(conn: &Connection, session_id: &str) -> Result<(), AppError> {
+    conn.execute(
+        "UPDATE agent_session_audit SET ended_at = ?1, outcome = ?2 WHERE session_id = ?3",
+        params![now_epoch_ms(), OUTCOME_COMMITTED, session_id],
+    )?;
+    Ok(())
+}
+
+/// Mark an audit row `rolled_back` with a reason. No-op if the row is missing.
+pub fn audit_rollback(conn: &Connection, session_id: &str, reason: &str) -> Result<(), AppError> {
+    conn.execute(
+        "UPDATE agent_session_audit \
+         SET ended_at = ?1, outcome = ?2, rollback_reason = ?3 \
+         WHERE session_id = ?4",
+        params![now_epoch_ms(), OUTCOME_ROLLED_BACK, reason, session_id],
+    )?;
+    Ok(())
+}
+
+/// Mark an audit row `panic` — used by cleanup logic after detecting a session
+/// that never finalized (startup sweeper, Phase 3c). Also safe to call from a
+/// catch_unwind handler with write lock access.
+pub fn audit_panic(conn: &Connection, session_id: &str, reason: &str) -> Result<(), AppError> {
+    conn.execute(
+        "UPDATE agent_session_audit \
+         SET ended_at = ?1, outcome = ?2, rollback_reason = ?3 \
+         WHERE session_id = ?4",
+        params![now_epoch_ms(), OUTCOME_PANIC, reason, session_id],
+    )?;
+    Ok(())
+}
+
+/// Is audit recording enabled? Default ON — the override env var lets
+/// operators disable if the audit INSERT itself ever becomes a bottleneck.
+pub fn audit_enabled() -> bool {
+    match std::env::var("TUNAFLOW_AGENT_SESSION_AUDIT") {
+        Ok(v) => !matches!(v.trim().to_ascii_lowercase().as_str(), "0" | "false" | "off"),
+        Err(_) => true,
+    }
+}
+
 /// Wraps a single agent write session in a SQLite SAVEPOINT.
 ///
 /// Use `commit` on success and `rollback` on explicit failure. If the value is
@@ -284,5 +354,108 @@ mod tests {
         let name = derive_savepoint_name("12345-abcde-67890");
         assert!(name.starts_with("sp_"));
         assert!(name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_'));
+    }
+
+    // ─── Audit-only API (Phase 3b-part1) ──────────────────────────────────────
+
+    #[test]
+    fn audit_begin_inserts_in_progress_row() {
+        let conn = open_test_db();
+        let sid = audit_begin(&conn, Some("conv-X")).expect("begin");
+        let (outcome, conv): (String, Option<String>) = conn
+            .query_row(
+                "SELECT outcome, conversation_id FROM agent_session_audit WHERE session_id = ?1",
+                [&sid],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(outcome, OUTCOME_IN_PROGRESS);
+        assert_eq!(conv.as_deref(), Some("conv-X"));
+    }
+
+    #[test]
+    fn audit_commit_flips_outcome_and_sets_ended_at() {
+        let conn = open_test_db();
+        let sid = audit_begin(&conn, None).unwrap();
+        audit_commit(&conn, &sid).expect("commit");
+        let (outcome, ended_at): (String, Option<i64>) = conn
+            .query_row(
+                "SELECT outcome, ended_at FROM agent_session_audit WHERE session_id = ?1",
+                [&sid],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(outcome, OUTCOME_COMMITTED);
+        assert!(ended_at.is_some(), "ended_at must be populated on commit");
+    }
+
+    #[test]
+    fn audit_rollback_records_reason() {
+        let conn = open_test_db();
+        let sid = audit_begin(&conn, None).unwrap();
+        audit_rollback(&conn, &sid, "engine timeout").expect("rollback");
+        let (outcome, reason): (String, Option<String>) = conn
+            .query_row(
+                "SELECT outcome, rollback_reason FROM agent_session_audit WHERE session_id = ?1",
+                [&sid],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(outcome, OUTCOME_ROLLED_BACK);
+        assert_eq!(reason.as_deref(), Some("engine timeout"));
+    }
+
+    #[test]
+    fn audit_panic_marks_outcome() {
+        let conn = open_test_db();
+        let sid = audit_begin(&conn, None).unwrap();
+        audit_panic(&conn, &sid, "thread panicked").expect("panic mark");
+        let outcome: String = conn
+            .query_row(
+                "SELECT outcome FROM agent_session_audit WHERE session_id = ?1",
+                [&sid],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(outcome, OUTCOME_PANIC);
+    }
+
+    #[test]
+    fn audit_update_on_missing_row_is_noop() {
+        // Updates targeting a nonexistent session_id must not error — they just
+        // affect zero rows. This lets legacy sessions (started before this code)
+        // flow through finalize without surprises.
+        let conn = open_test_db();
+        audit_commit(&conn, "nonexistent-session-id").expect("commit noop");
+        audit_rollback(&conn, "nonexistent-session-id", "reason").expect("rollback noop");
+    }
+
+    #[test]
+    fn audit_enabled_default_true() {
+        // When the env var is unset, auditing should default to ON.
+        // We can't safely mutate env inside tests (order dependency); instead
+        // this test documents the semantics + guards against accidental flip.
+        std::env::remove_var("TUNAFLOW_AGENT_SESSION_AUDIT");
+        assert!(audit_enabled(), "audit must default ON when env unset");
+    }
+
+    #[test]
+    fn audit_enabled_respects_off_values() {
+        // This test mutates env var, so we restore after.
+        let previous = std::env::var("TUNAFLOW_AGENT_SESSION_AUDIT").ok();
+
+        for off_value in ["0", "false", "off", "FALSE", "Off"] {
+            std::env::set_var("TUNAFLOW_AGENT_SESSION_AUDIT", off_value);
+            assert!(!audit_enabled(), "value '{}' must disable audit", off_value);
+        }
+        for on_value in ["1", "true", "on", "TRUE", "yes"] {
+            std::env::set_var("TUNAFLOW_AGENT_SESSION_AUDIT", on_value);
+            assert!(audit_enabled(), "value '{}' must enable audit", on_value);
+        }
+
+        match previous {
+            Some(v) => std::env::set_var("TUNAFLOW_AGENT_SESSION_AUDIT", v),
+            None => std::env::remove_var("TUNAFLOW_AGENT_SESSION_AUDIT"),
+        }
     }
 }

--- a/src-tauri/src/commands/agents_helpers/send_common/persistence.rs
+++ b/src-tauri/src/commands/agents_helpers/send_common/persistence.rs
@@ -47,6 +47,7 @@ fn post_completion_lock() -> std::sync::Arc<std::sync::Mutex<()>> {
 }
 
 use super::super::trace_log::{insert_trace_log, insert_trace_log_with_context, new_span_id, new_trace_id, SpanInfo, ContextPackMeta};
+use super::agent_session_tx;
 use super::context_loading::{load_context_data, load_project_path};
 use super::prompt_assembly::assemble_prompt;
 use super::session_freshness;
@@ -159,6 +160,10 @@ pub struct PreparedRun {
     pub system_context: Option<String>, // context only (for Claude system_prompt)
     pub project_path: Option<String>,
     pub ctx_meta: ContextPackMeta,
+    /// Phase 3b-part1: session audit id for lifecycle tracking. `None` when
+    /// `TUNAFLOW_AGENT_SESSION_AUDIT=0` disables auditing. Populated alongside
+    /// the Phase A3 write so only one lock acquisition is paid.
+    pub audit_session_id: Option<String>,
 }
 
 /// Phase 1: Persist user message, build context, pre-create streaming message, create job.
@@ -212,8 +217,11 @@ pub fn prepare_engine_run(
         (ctx_data, pp)
     };
 
-    // Phase A3: short write — pre-create streaming assistant message
-    let msg_id = {
+    // Phase A3: short write — pre-create streaming assistant message + audit begin
+    // Audit row is inserted under the same write lock as the streaming message to
+    // amortize lock-acquisition cost. If auditing is disabled, `audit_session_id`
+    // stays None and no extra write happens.
+    let (msg_id, audit_session_id) = {
         let conn = state.write.lock().map_err(|_| crate::errors::AppError::Lock)?;
         let mid = Uuid::new_v4().to_string();
         let now = now_epoch_ms();
@@ -222,7 +230,19 @@ pub fn prepare_engine_run(
              VALUES(?1,?2,'assistant','',?3,'streaming',?4,?5,?6)",
             params![mid, input.conversation_id, now, engine_key, input.model, input.persona_label],
         )?;
-        mid
+        let sid = if agent_session_tx::audit_enabled() {
+            match agent_session_tx::audit_begin(&conn, Some(&input.conversation_id)) {
+                Ok(s) => Some(s),
+                Err(e) => {
+                    // Audit is observability only — never fail the user turn for it
+                    eprintln!("[agent-session-tx] audit_begin failed: {:?}", e);
+                    None
+                }
+            }
+        } else {
+            None
+        };
+        (mid, sid)
     };
 
     // Session freshness: stateful 엔진(sdk-url, app-server)에서
@@ -261,12 +281,15 @@ pub fn prepare_engine_run(
         let _ = super::super::super::jobs::create_job(&conn, &job_id, &input.conversation_id, Some(&msg_id), engine_key, "agent");
     }
 
-    Ok(PreparedRun { msg_id, job_id, enriched_prompt, system_context, project_path, ctx_meta })
+    Ok(PreparedRun { msg_id, job_id, enriched_prompt, system_context, project_path, ctx_meta, audit_session_id })
 }
 
 /// Phase 3: Persist engine result, update conversation usage, emit events.
 ///
 /// Called from the background thread after the engine finishes.
+/// `audit_session_id` is the id returned from `prepare_engine_run` — `None`
+/// when auditing is disabled. The audit row is finalized (committed / rolled
+/// back) here based on `result`.
 pub fn finalize_engine_run(
     conn: &Connection,
     engine_key: &str,
@@ -277,6 +300,7 @@ pub fn finalize_engine_run(
     duration_ms: u128,
     ctx_meta: &ContextPackMeta,
     app: &tauri::AppHandle,
+    audit_session_id: Option<&str>,
 ) {
     let now = now_epoch_ms();
     match result {
@@ -321,6 +345,9 @@ pub fn finalize_engine_run(
                     operation: "agent.stream", engine: engine_key, duration_ms: duration_ms as i64, status: "ok" },
                 ctx_meta, Some(msg_id));
             let _ = super::super::super::jobs::complete_job(conn, job_id, "done", None);
+            if let Some(sid) = audit_session_id {
+                let _ = agent_session_tx::audit_commit(conn, sid);
+            }
             let _ = app.emit("agent:completed", serde_json::json!({
                 "messageId": msg_id, "conversationId": conversation_id, "engine": engine_key,
                 "durationMs": duration_ms as i64, "inputTokens": out.input_tokens,
@@ -354,6 +381,9 @@ pub fn finalize_engine_run(
                     duration_ms: duration_ms as i64, status: "error",
                 }, ctx_meta, Some(msg_id));
             let _ = super::super::super::jobs::complete_job(conn, job_id, "error", Some(&em));
+            if let Some(sid) = audit_session_id {
+                let _ = agent_session_tx::audit_rollback(conn, sid, &em);
+            }
             let _ = app.emit("agent:error", serde_json::json!({
                 "messageId": msg_id, "conversationId": conversation_id, "engine": engine_key, "error": em
             }));


### PR DESCRIPTION
## 배경

harnessVerificationGapPlan §4 Phase 3b **축소안**. 실제 persistence 경로에 session audit lifecycle 을 연결.

원 계획의 SAVEPOINT 기반 rollback 은 현재 A1/A3 write lock split 구조와 **lock contention trade-off** 가 있어 프로덕션 투입 전 관측 데이터 필요. 그래서 **Part1: audit 로그만** 먼저 도입하고, **Part2: SAVEPOINT** 는 별도 PR.

## 변경

### AgentSessionTx 모듈 확장
`agent_session_tx.rs` 에 audit-only 함수 4종 추가:
- `audit_begin(conn, conv_id) -> session_id`
- `audit_commit(conn, session_id)`
- `audit_rollback(conn, session_id, reason)`
- `audit_panic(conn, session_id, reason)` — startup sweeper 용 (Phase 3c)

### persistence.rs 통합
- `PreparedRun.audit_session_id: Option<String>` 추가
- `prepare_engine_run` Phase A3: streaming msg INSERT 와 **같은 write lock 안** 에서 audit_begin (추가 lock 없음)
- `finalize_engine_run(..., audit_session_id)`: 성공 시 `audit_commit`, 실패 시 `audit_rollback`

### 5개 엔진 경로 통합
`agents.rs` 의 `start_*` 함수 모두:
- Claude (SDK / sdk-url WS / CLI fallback)
- Gemini (SDK / CLI)
- Codex (SDK / app-server / CLI)
- OpenCode
- Ollama / LMStudio

각 spawn 클로저에 `audit_session_id` 전파, finalize_engine_run 호출에 추가.

### Feature flag
\`\`\`bash
# default: ON
TUNAFLOW_AGENT_SESSION_AUDIT=0    # 비활성화
TUNAFLOW_AGENT_SESSION_AUDIT=off  # 비활성화
# 그 외 (unset 포함): ON
\`\`\`

## 효과

**즉시 가능한 것**:
\`\`\`sql
-- 중간 실패로 끝난 세션 찾기
SELECT session_id, conversation_id, rollback_reason, started_at
FROM agent_session_audit
WHERE outcome IN ('rolled_back', 'in_progress')
ORDER BY started_at DESC;
\`\`\`

- Audit trail 확보 → state pollution 디버깅 가능
- \`in_progress\` 로 남은 row = panic/crash 세션 (Phase 3c sweeper 가 이를 사용)
- 평균 세션 길이 / 성공률 통계

**아직 없는 것** (Part2 에서):
- SAVEPOINT 로 실제 DB 상태 rollback (half-formed plans/artifacts row 자동 제거)

## Safety

- 기본 ON 이지만 INSERT 3번만 추가 — 성능 영향 미미
- audit 실패 시 eprintln 로그만 남기고 turn 은 정상 진행 (safe fallback)
- 기존 경로 동작 변화 없음 — audit 없이도 agent 완료 가능

## 테스트

\`cargo test --lib\` → **349 passed / 0 failed**

신규 audit API 테스트 7개:
- audit_begin 이 in_progress row 삽입
- audit_commit 이 outcome 플립 + ended_at 설정
- audit_rollback 이 reason 기록
- audit_panic 이 outcome=panic
- 존재하지 않는 session_id 업데이트는 no-op (legacy 세션 안전)
- audit_enabled default ON
- env var off 값 (0/false/off) 인식

## Test plan
- [x] \`cargo check\` + \`cargo test --lib\` 통과
- [ ] dev 앱 재기동 (또는 release 빌드) 후 Plan/Review 한 번 돌려서 audit row 생성 확인:
      \`\`\`
      sqlite3 ~/.tunaflow/db/tunaflow.db "SELECT outcome, COUNT(*) FROM agent_session_audit GROUP BY outcome;"
      \`\`\`
- [ ] \`TUNAFLOW_AGENT_SESSION_AUDIT=0\` 로 비활성화 후 audit 미생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)