### PR TITLE
feat(search): Phase A — query expansion (plan 포함)

### DIFF
--- a/docs/plans/searchPipelineFromSecallPlan.md
+++ b/docs/plans/searchPipelineFromSecallPlan.md
@@ -1,0 +1,279 @@
+---
+title: 검색 파이프라인 도입 — secall 참고 (Query Expansion + Hybrid RRF + Kiwi/Lindera)
+status: planned
+priority: P1
+created_at: 2026-04-22
+related:
+  - docs/ideas/searchEnhancementFromSecallIdea.md
+  - seCall/crates/secall-core/src/search/
+  - src-tauri/src/commands/messages.rs         # search_messages (FTS5)
+  - src-tauri/src/commands/document_index.rs   # search_project_docs (vector)
+  - src-tauri/src/commands/vector_search/      # bge-m3 vector search
+---
+
+# 검색 파이프라인 도입 Plan
+
+> idea `searchEnhancementFromSecallIdea.md` 의 plan 승격. secall 의 search 구현을 tunaFlow 스키마에 맞춰 참고 이식. Phase A→B→C 단계적 PR.
+
+---
+
+## 1. 현재 상태 진단
+
+### 1.1 검색 경로가 세 갈래로 분산되어 있음
+
+| 경로 | 엔트리 | 대상 | 엔진 | 통합 UI 여부 |
+|---|---|---|---|---|
+| 대화 검색 (FTS5) | `search_messages` (messages.rs) | `messages_fts` | SQLite FTS5 `unicode61` | 헤더 검색창 |
+| 문서 검색 (vector) | `search_project_docs` (document_index.rs) | `conversation_chunks (source_type='document')` | bge-m3 cosine | 별도/미노출 |
+| 코드 검색 | rawq sidecar | 프로젝트 소스코드 | 자체 embedding | 에이전트 tool-request 전용 |
+
+**즉 사용자 "플랜" 검색 실패의 원인**: 헤더 검색창은 `messages_fts` 만 쿼리 → docs/plans/*.md 는 `source_type='document'` 라 miss. Recall 문제가 아니라 **검색 범위 자체** 가 원인.
+
+### 1.2 FTS5 tokenizer 약점
+- 기본 `unicode61` tokenizer 는 공백/구두점 기반 → 한국어 조사/어미 분리 X
+- "플랜을 보여줘" → "플랜을" 통째로 토큰화 → "플랜" 매칭 실패
+- 영↔한 동의어 매칭 X ("plan" ↔ "플랜" ↔ "계획")
+
+### 1.3 secall 의 해결책 (요약)
+| 기능 | secall | 효과 |
+|---|---|---|
+| Query expansion | `claude-p haiku` 로 동의어/영↔한 확장 + 7일 DB 캐시 | "플랜" → `plan 계획 roadmap...` — recall ↑ |
+| Hybrid RRF | BM25 + Vector 결과 rank 기반 합성 (k=60) + 0~1 정규화 | 두 signal 통합 — precision + recall ↑ |
+| Kiwi/Lindera | 애플리케이션 레이어 pre-tokenize → FTS5 `unicode61` 이 공백으로 split | 한국어 형태소 단위 인덱싱 |
+| Session 다양성 | `diversify_by_session(max_per=2)` | UX — 한 세션 독식 방지 |
+
+---
+
+## 2. 목표
+
+- 사용자가 **"플랜" 검색하면 `docs/plans/*.md`, 대화, 코드 모두** 적절한 가중치로 표시
+- 한국어/영어 혼용 쿼리 자연스럽게 작동
+- 검색 recall 향상으로 에이전트 tool-request 결과 품질도 덤으로 개선 (dogfood)
+- secall 의 검증된 구현 패턴 재사용 → 이식 비용 최소화
+
+---
+
+## 3. Scope 경계
+
+- rawq (코드 검색) 는 **포함 X** — 별도 엔진, 이 plan 대상 아님. 단 Hybrid 엔드포인트가 rawq 결과도 merge 할 수 있도록 extensibility 는 확보.
+- Graph filter (topic/file/issue 기반 사전 필터) 는 **별도 plan** — 데이터 모델 추가 필요.
+- 영문 stemmer 는 후순위.
+
+---
+
+## 4. Phase A — Query Expansion
+
+> 독립 PR. Phase B/C 없이도 작동. ROI 가장 높음.
+
+### 4.1 범위
+- secall 의 `query_expand.rs` 를 tunaFlow 로 이식
+- 핵심: `claude-p haiku` subprocess → 동의어/영↔한 키워드 확장
+- 7일 DB 캐시로 반복 쿼리 비용 0 수렴
+- 실패 시 원본 쿼리 그대로 (safe fallback)
+
+### 4.2 구현 지점
+```
+src-tauri/src/commands/search/
+├── mod.rs
+└── query_expand.rs        — secall 참고
+DB migration v44           — query_cache (key PK, expanded, cached_at)
+```
+
+`search_messages` 에 opt-in wrapping:
+```rust
+let final_query = if feature_flag() { expand_query(&query, &db)? } else { query };
+// 기존 FTS MATCH 로직
+```
+
+### 4.3 UX 고려
+- Claude CLI 호출은 1~2초 걸림 → 첫 쿼리만 지연, 이후 캐시
+- 최초 구현: **sync expansion** (첫 검색 2~3초 지연 수용) → 반응 보고 async 로 승격
+- Feature flag: `TUNAFLOW_QUERY_EXPANSION` (default OFF — opt-in). 충분히 돌려본 뒤 ON 승격.
+
+### 4.4 테스트
+- 캐시 hit/miss
+- `claude` 바이너리 없을 때 safe fallback (원본 쿼리 반환)
+- Disabled 상태 — 원본 그대로 통과
+- 캐시 만료 (7일 초과) → 재계산
+
+---
+
+## 5. Phase B — Hybrid RRF (플랜 검색 문제 해결의 핵심)
+
+### 5.1 범위
+단일 엔트리포인트 `/api/v1/search` + Tauri command `search_unified`:
+1. 확장된 쿼리로 **messages_fts** (대화) 검색
+2. 같은 쿼리로 **document_vector** (`conversation_chunks WHERE source_type='document'`) bge-m3 검색
+3. 두 결과를 RRF (k=60) 로 합성 + 0~1 정규화
+4. Session 다양성 후처리 (`max_per=2`)
+
+### 5.2 구현 지점
+```
+src-tauri/src/commands/search/
+├── hybrid.rs              — RRF (secall §1~68 참고)
+├── diversify.rs           — session diversity
+└── unified.rs             — 단일 엔트리
+```
+
+### 5.3 결과 스키마
+```rust
+pub struct UnifiedResult {
+    pub kind: &'static str,   // "conversation" | "document" | "code" (future)
+    pub id: String,            // message_id or file_path
+    pub snippet: String,
+    pub score: f64,            // 정규화 0~1
+    pub fts_score: Option<f64>,
+    pub vector_score: Option<f64>,
+    pub source_label: String,  // "Chat: {conv_label}" or "Doc: {path}"
+    pub timestamp: i64,
+}
+```
+
+### 5.4 Frontend 변경
+- 헤더 검색창: `search_messages` 대신 `search_unified` 호출
+- 결과 표시에 `kind` 배지 (💬 대화 / 📄 문서) + source label 링크
+- 클릭 시:
+  - 대화: 해당 conversation + 메시지로 스크롤
+  - 문서: 파일 뷰어 or 외부 editor
+
+### 5.5 테스트
+- RRF 단위 테스트 (bm25-only / vector-only / both 3 경우 × 결과 순서 정확성)
+- 정규화 후 최대값 1.0
+- Session 다양성 (같은 session 3개 이상 → 2개로 cap)
+- Feature flag OFF 시 기존 동작
+
+---
+
+## 6. Phase C — Kiwi/Lindera Pre-Tokenize
+
+### 6.1 중요 발견
+secall 은 **FTS5 external tokenizer (C extension)** 가 아니라 **애플리케이션 레이어에서 pre-tokenize** → FTS5 는 `unicode61` 로 단순 공백 split. 즉:
+```rust
+let tokenized = tokenizer.tokenize_for_fts(&content);
+// "아키텍처를 설계한다" → "아키텍처 설계"
+INSERT INTO messages_fts(content) VALUES (tokenized);
+```
+검색 쿼리도 같은 방식으로 tokenize 한 뒤 FTS 에 넘김. rusqlite 의 복잡한 fts5_api 등록 불필요.
+
+### 6.2 범위
+- `src-tauri/src/search/tokenizer/` 모듈:
+  - `Tokenizer trait`
+  - `KiwiTokenizer` (cfg gate: not(windows), not(all(linux, aarch64)))
+  - `LinderaKoTokenizer` (전 플랫폼)
+  - `SimpleTokenizer` fallback
+  - `create_tokenizer(backend: &str) -> Box<dyn Tokenizer>` with 폴백 체인 (kiwi → lindera → whitespace)
+- 같은 태그 필터 (NNG/NNP/NNB/VV/VA/SL) + 1글자 제외 — secall 과 일치
+
+### 6.3 FTS5 재인덱싱
+- 기존 `messages_fts` 는 unicode61 whitespace 토큰화 — 형태소 기반으로 교체 시 재구축 필수
+- 새 Tauri command: `rebuild_messages_fts` (프로그레스 바 + 취소 가능)
+- 대규모 corpus 에선 증분 가능 옵션 검토 (hash 체크)
+
+### 6.4 의존성
+```toml
+# Cargo.toml
+[target.'cfg(not(any(target_os = "windows", all(target_os = "linux", target_arch = "aarch64"))))'.dependencies]
+kiwi-rs = "0.x"
+
+[dependencies]
+lindera = { version = "0.x", features = ["ko-dic-embed"] }
+```
+- Kiwi 최초 사용 시 ~50MB 모델 다운로드 → 앱 첫 실행 시 백그라운드 prefetch + 진행률 표시
+
+### 6.5 Settings UI
+`Settings > Runtime > Search`:
+- Tokenizer backend: `Auto (Kiwi → Lindera)` / `Kiwi only` / `Lindera only` / `Whitespace only`
+- Default: Auto
+- "Rebuild FTS index" 버튼 + 진행률
+
+### 6.6 테스트
+- 한국어 형태소 분해 정확도 (NNG/NNP 추출)
+- 영문 + 한글 혼용 쿼리
+- SimpleTokenizer fallback (모든 플랫폼)
+- Kiwi 모델 다운로드 실패 시 Lindera fallback
+
+---
+
+## 7. Phase 간 의존성
+
+```
+Phase A (query expansion)       ──┐
+                                  ├──> 실사용 관찰 1~2주
+Phase B (hybrid RRF)            ──┘
+
+Phase C (tokenizer) ← independent. 언제든 착수 가능. 단 FTS 재인덱싱 비용으로
+                                    보통 B 이후 추천.
+```
+
+- A, B 는 독립 PR로 순차 배포 가능
+- C 는 독립이나 FTS 재구축 이슈로 후순위가 안전
+- A 혹은 B 먼저 머지 후 dogfood → C 도입 여부 판단
+
+---
+
+## 8. 측정 지표 (Phase 6 regression eval 에 연동 가능)
+
+| 지표 | Baseline | 목표 |
+|---|---|---|
+| "플랜" 쿼리 검색 top-10 내 plan 문서 포함률 | 0% | 80%+ |
+| 한/영 혼용 쿼리 recall (내부 golden query 20개) | 측정 예정 | +50% |
+| 검색 latency p50 (캐시 hit) | 측정 예정 | < 300ms |
+| 검색 latency p50 (캐시 miss, Phase A 포함) | — | < 3000ms |
+| Query cache hit rate | 0% | 50%+ (동일 쿼리 반복 시) |
+
+---
+
+## 9. 위험 / 완화
+
+| 위험 | 대응 |
+|---|---|
+| `claude-p haiku` subprocess 지연 (UX 체감) | 캐시 + 첫 쿼리는 fallback, expansion 은 async (Phase A-part2) |
+| Kiwi 최초 모델 다운로드 UX 차단 | 앱 첫 실행 시 background prefetch + 진행률 표시 |
+| FTS 재인덱싱 중 검색 블록 | "재구축 중" 상태 + whitespace fallback 유지 |
+| RRF 점수 분포 편향 | 정규화 후 반올림 테스트 + 세션 다양성 cap |
+| Hybrid 결과에 중복 (message + chunk 가 같은 내용) | ID 기반 dedup |
+| 크로스플랫폼 (Windows 배포 시) Kiwi 미지원 | Lindera fallback 자동 동작 + 테스트 매트릭스 |
+
+---
+
+## 10. Subtask 구조
+
+**subtask-01** — Phase A: Query Expansion
+- DB migration v44 (query_cache)
+- `src/commands/search/query_expand.rs` + `mod.rs`
+- `search_messages` 통합 (opt-in)
+- Unit tests + feature flag 테스트
+
+**subtask-02** — Phase B: Hybrid RRF + Unified Search
+- `src/commands/search/hybrid.rs` + `unified.rs`
+- `search_unified` Tauri command
+- Frontend 헤더 검색창 전환
+- Unit tests (RRF, diversity)
+
+**subtask-03** — Phase C: Kiwi/Lindera Pre-Tokenize
+- `src/search/tokenizer/` 모듈
+- Cargo 의존성 + cfg gate
+- `rebuild_messages_fts` command + UI
+- Settings 페이지 tokenizer backend 선택
+
+---
+
+## 11. 후속 과제 (Plan 범위 밖)
+
+- Graph filter (topic/file/issue) — 별도 plan
+- rawq 결과 Hybrid 에 merge (code 검색 통합) — 별도 plan
+- Cross-session Session 다양성 (최근 N일 cap 등) — UX polish
+
+---
+
+## 12. 관련 참조
+
+- seCall `crates/secall-core/src/search/`
+  - `hybrid.rs` — RRF 구현
+  - `query_expand.rs` — Claude Haiku 쿼리 확장
+  - `tokenizer.rs` — Kiwi + Lindera 2-tier + fallback
+  - `store/schema.rs` — FTS5 `tokenize='unicode61'` + 애플리케이션 pre-tokenize
+- tunaFlow 현행 검색:
+  - `src-tauri/src/commands/messages.rs:381` — `search_messages` (FTS5)
+  - `src-tauri/src/commands/document_index.rs:802` — `search_project_docs` (vector)
+  - `src-tauri/src/commands/vector_search/query.rs` — bge-m3 쿼리 경로

--- a/src-tauri/src/commands/messages.rs
+++ b/src-tauri/src/commands/messages.rs
@@ -385,6 +385,18 @@ pub fn search_messages(
     limit: Option<i64>,
     state: State<DbState>,
 ) -> Result<Vec<SearchResult>, AppError> {
+    // Phase A: query expansion (opt-in via TUNAFLOW_QUERY_EXPANSION). The
+    // function is a no-op when the flag is off, so feeding the result into the
+    // FTS query is safe in all configurations. The write lock is used here
+    // because the cache is a writable table (INSERT on miss). On a cache hit
+    // the function never writes, so the common path stays fast.
+    let effective_query = if super::search::query_expansion_enabled() {
+        let write = state.write.lock().map_err(|_| AppError::Lock)?;
+        super::search::expand_query(&query, Some(&*write)).unwrap_or_else(|_| query.clone())
+    } else {
+        query.clone()
+    };
+
     let conn = state.read.lock().map_err(|_| AppError::Lock)?;
     let max = limit.unwrap_or(20);
 
@@ -402,7 +414,7 @@ pub fn search_messages(
     )?;
 
     let results = stmt
-        .query_map(params![query, project_key, max], |row| {
+        .query_map(params![effective_query, project_key, max], |row| {
             Ok(SearchResult {
                 message_id: row.get(0)?,
                 conversation_id: row.get(1)?,

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -29,6 +29,7 @@ pub mod project_onboarding;
 pub mod projects;
 pub mod roundtable;
 pub mod roundtable_helpers;
+pub mod search;
 pub mod session_discovery;
 pub mod skills;
 pub mod test_runner;

--- a/src-tauri/src/commands/search/mod.rs
+++ b/src-tauri/src/commands/search/mod.rs
@@ -1,0 +1,10 @@
+//! Unified search module — Phase A (query expansion), Phase B (hybrid RRF),
+//! Phase C (Korean tokenizer) from `docs/plans/searchPipelineFromSecallPlan.md`.
+//!
+//! Phase A 현재: query expansion + 7-day DB cache. Default OFF (opt-in via
+//! `TUNAFLOW_QUERY_EXPANSION`). Future phases chain on this module.
+
+pub mod query_expand;
+
+#[allow(unused_imports)]
+pub use query_expand::{expand_query, normalize_query, query_expansion_enabled};

--- a/src-tauri/src/commands/search/query_expand.rs
+++ b/src-tauri/src/commands/search/query_expand.rs
@@ -1,0 +1,339 @@
+//! Query expansion via Claude Haiku subprocess + 7-day DB cache.
+//!
+//! Ported from `seCall/crates/secall-core/src/search/query_expand.rs` to
+//! tunaFlow's schema (query_cache table, Phase A). Semantics preserved:
+//!
+//! 1. Normalize the incoming query (trim + lowercase).
+//! 2. If `TUNAFLOW_QUERY_EXPANSION` is not ON, return original (opt-in).
+//! 3. Consult `query_cache` — if fresh (< 7 days), return `query + cached`.
+//! 4. Otherwise call `claude -p <prompt> --model claude-haiku-4-5-20251001`.
+//!    - Success: store into cache, return `query + expansion`.
+//!    - Failure / missing binary: log, return original query (safe fallback).
+//!
+//! The expansion prompt asks for keywords, synonyms, tech terms, and EN↔KO
+//! translations — exactly secall's working formulation. Result is whitespace
+//! joined keywords with no explanatory prose.
+
+use rusqlite::{params, Connection};
+
+use crate::db::migrations::now_epoch_ms;
+use crate::errors::AppError;
+
+const CACHE_TTL_MS: i64 = 7 * 24 * 60 * 60 * 1000; // 7 days
+const HAIKU_MODEL: &str = "claude-haiku-4-5-20251001";
+
+/// Is the expansion feature enabled? Default OFF (opt-in) — expansion involves
+/// a subprocess call that adds latency on cache miss. Flip this via
+/// `TUNAFLOW_QUERY_EXPANSION=on|1|true` once rollout is validated.
+pub fn query_expansion_enabled() -> bool {
+    match std::env::var("TUNAFLOW_QUERY_EXPANSION") {
+        Ok(v) => matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "on" | "yes"),
+        Err(_) => false,
+    }
+}
+
+/// Canonical form of a query used as the cache key. Trim + lowercase, but we
+/// intentionally do NOT strip punctuation / normalize whitespace further —
+/// users phrase things differently and those variations can carry intent.
+pub fn normalize_query(query: &str) -> String {
+    query.trim().to_lowercase()
+}
+
+/// Expand a search query. Returns `"<original> <expansions>"` when the feature
+/// is on and the call succeeds. Returns the original query unchanged on any
+/// failure path.
+///
+/// `conn` is used for caching. Pass `None` to skip the cache (tests / one-off).
+pub fn expand_query(query: &str, conn: Option<&Connection>) -> Result<String, AppError> {
+    expand_query_inner(query, conn, query_expansion_enabled(), InvokeClaude::Real)
+}
+
+/// Strategy for the outbound Claude call — swappable in tests so we don't need
+/// to manipulate PATH or env vars in parallel test threads.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum InvokeClaude {
+    /// Spawn `claude -p ...` as a subprocess (production path).
+    Real,
+    /// Return `"BYPASS"` — used by tests to exercise the bypass/empty branch.
+    Empty,
+    /// Return the given fixed expansion — used by tests to exercise the happy
+    /// path without a live subprocess.
+    Stub(&'static str),
+}
+
+/// Inner implementation with explicit feature flag + invocation strategy.
+/// This form is testable without env-var mutation (safe under parallel tests).
+pub(crate) fn expand_query_inner(
+    query: &str,
+    conn: Option<&Connection>,
+    enabled: bool,
+    invoker: InvokeClaude,
+) -> Result<String, AppError> {
+    if !enabled {
+        return Ok(query.to_string());
+    }
+    if query.trim().is_empty() {
+        return Ok(query.to_string());
+    }
+
+    let key = normalize_query(query);
+
+    // 1. Cache hit?
+    if let Some(conn) = conn {
+        if let Some(cached) = read_cache_if_fresh(conn, &key) {
+            return Ok(format!("{query} {cached}"));
+        }
+    }
+
+    // 2. Call out to Claude (or swapped strategy in tests). On failure fall
+    // back to the original query — expansion is optional.
+    let invocation_result = match invoker {
+        InvokeClaude::Real => invoke_claude_haiku(&key),
+        InvokeClaude::Empty => Ok(String::new()),
+        InvokeClaude::Stub(s) => Ok(s.to_string()),
+    };
+    let expansion = match invocation_result {
+        Ok(s) if !s.trim().is_empty() => s,
+        Ok(_) => return Ok(query.to_string()),
+        Err(e) => {
+            eprintln!("[query_expand] expansion skipped: {e}");
+            return Ok(query.to_string());
+        }
+    };
+
+    // 3. Cache the result for next time (best-effort; ignore write errors).
+    if let Some(conn) = conn {
+        if let Err(e) = write_cache(conn, &key, &expansion) {
+            eprintln!("[query_expand] cache write failed (non-fatal): {e:?}");
+        }
+    }
+
+    Ok(format!("{query} {expansion}"))
+}
+
+// ─── DB helpers ──────────────────────────────────────────────────────────────
+
+fn read_cache_if_fresh(conn: &Connection, key: &str) -> Option<String> {
+    let row: Option<(String, i64)> = conn
+        .query_row(
+            "SELECT expanded, cached_at FROM query_cache WHERE query = ?1",
+            [key],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .ok();
+    let (expanded, cached_at) = row?;
+    let age = now_epoch_ms() - cached_at;
+    if age >= 0 && age < CACHE_TTL_MS {
+        Some(expanded)
+    } else {
+        None
+    }
+}
+
+fn write_cache(conn: &Connection, key: &str, expanded: &str) -> Result<(), AppError> {
+    conn.execute(
+        "INSERT INTO query_cache (query, expanded, cached_at) \
+         VALUES (?1, ?2, ?3) \
+         ON CONFLICT(query) DO UPDATE SET expanded = excluded.expanded, cached_at = excluded.cached_at",
+        params![key, expanded, now_epoch_ms()],
+    )?;
+    Ok(())
+}
+
+// ─── Subprocess ──────────────────────────────────────────────────────────────
+
+/// Call `claude -p <prompt> --model claude-haiku-4-5-20251001` and return
+/// stdout. Stderr + non-zero exit are treated as expansion failure (caller
+/// falls back to original query). `Command::output` returns an io error when
+/// the binary isn't on PATH, which is the same failure path — so a separate
+/// "is claude installed?" probe is unnecessary.
+fn invoke_claude_haiku(query: &str) -> Result<String, AppError> {
+    let prompt = build_expansion_prompt(query);
+    let output = std::process::Command::new("claude")
+        .args(["-p", &prompt, "--model", HAIKU_MODEL])
+        .output()
+        .map_err(|e| AppError::Agent(format!("claude subprocess: {e}")))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(AppError::Agent(format!(
+            "claude exit={:?} stderr={}",
+            output.status.code(),
+            stderr.trim()
+        )));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+/// The prompt is intentionally kept in sync with secall's working formulation —
+/// asks for keywords only, no explanation. Model output is inserted verbatim.
+fn build_expansion_prompt(query: &str) -> String {
+    format!(
+        "다음 검색 쿼리를 확장해주세요. \
+         원본 쿼리의 키워드, 동의어, 관련 기술 용어, 영어/한국어 변환을 포함하세요. \
+         결과는 공백으로 구분된 키워드만 출력하세요. 설명 없이 키워드만.\n\n\
+         쿼리: {query}"
+    )
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn open_test_db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE query_cache (
+                query      TEXT PRIMARY KEY,
+                expanded   TEXT NOT NULL,
+                cached_at  INTEGER NOT NULL
+             );",
+        )
+        .unwrap();
+        conn
+    }
+
+    #[test]
+    fn normalize_trims_and_lowercases() {
+        assert_eq!(normalize_query("  Plan  "), "plan");
+        assert_eq!(normalize_query("플랜"), "플랜");
+        assert_eq!(normalize_query("MixedCase"), "mixedcase");
+    }
+
+    #[test]
+    fn disabled_returns_original_untouched() {
+        let conn = open_test_db();
+        let out = expand_query_inner("hello world", Some(&conn), false, InvokeClaude::Stub("ignored")).unwrap();
+        assert_eq!(out, "hello world");
+    }
+
+    #[test]
+    fn empty_query_returns_original_even_when_enabled() {
+        let conn = open_test_db();
+        assert_eq!(
+            expand_query_inner("", Some(&conn), true, InvokeClaude::Stub("x")).unwrap(),
+            ""
+        );
+        assert_eq!(
+            expand_query_inner("   ", Some(&conn), true, InvokeClaude::Stub("x")).unwrap(),
+            "   "
+        );
+    }
+
+    #[test]
+    fn cache_hit_short_circuits_invoker() {
+        let conn = open_test_db();
+        // Pre-seed fresh cache entry. If the cache is consulted, the stub's
+        // "SHOULD NOT BE CALLED" text must NOT appear in the output.
+        let key = normalize_query("플랜");
+        conn.execute(
+            "INSERT INTO query_cache (query, expanded, cached_at) VALUES (?1, ?2, ?3)",
+            params![key, "plan 계획 roadmap", now_epoch_ms()],
+        )
+        .unwrap();
+        let out = expand_query_inner(
+            "플랜",
+            Some(&conn),
+            true,
+            InvokeClaude::Stub("SHOULD NOT BE CALLED"),
+        )
+        .unwrap();
+        assert_eq!(out, "플랜 plan 계획 roadmap");
+        assert!(!out.contains("SHOULD NOT BE CALLED"));
+    }
+
+    #[test]
+    fn cache_stale_is_ignored_and_refreshed() {
+        let conn = open_test_db();
+        let key = normalize_query("플랜");
+        let stale = now_epoch_ms() - (CACHE_TTL_MS + 1);
+        conn.execute(
+            "INSERT INTO query_cache (query, expanded, cached_at) VALUES (?1, ?2, ?3)",
+            params![key, "stale expansion", stale],
+        )
+        .unwrap();
+        let out = expand_query_inner(
+            "플랜",
+            Some(&conn),
+            true,
+            InvokeClaude::Stub("fresh expansion"),
+        )
+        .unwrap();
+        assert!(out.contains("fresh expansion"));
+        assert!(!out.contains("stale expansion"), "stale cache must not be used");
+    }
+
+    #[test]
+    fn successful_expansion_is_cached_for_next_call() {
+        let conn = open_test_db();
+        let _ = expand_query_inner(
+            "플랜",
+            Some(&conn),
+            true,
+            InvokeClaude::Stub("plan 계획"),
+        )
+        .unwrap();
+        // Second call with Empty stub must still return the expansion — via cache.
+        let out2 = expand_query_inner("플랜", Some(&conn), true, InvokeClaude::Empty).unwrap();
+        assert_eq!(out2, "플랜 plan 계획");
+    }
+
+    #[test]
+    fn empty_expansion_falls_back_to_original() {
+        let conn = open_test_db();
+        let out = expand_query_inner("플랜", Some(&conn), true, InvokeClaude::Empty).unwrap();
+        assert_eq!(out, "플랜");
+        // And the cache must NOT be polluted with an empty entry.
+        let cached = read_cache_if_fresh(&conn, &normalize_query("플랜"));
+        assert!(cached.is_none(), "empty expansion must not cache");
+    }
+
+    #[test]
+    fn no_cache_still_works_with_enabled() {
+        // When conn=None the function can't cache, but still returns expansion.
+        let out = expand_query_inner(
+            "plan",
+            None,
+            true,
+            InvokeClaude::Stub("plan 계획 roadmap"),
+        )
+        .unwrap();
+        assert_eq!(out, "plan plan 계획 roadmap");
+    }
+
+    #[test]
+    fn write_cache_roundtrip() {
+        let conn = open_test_db();
+        write_cache(&conn, "foo", "bar baz").unwrap();
+        let got = read_cache_if_fresh(&conn, "foo").unwrap();
+        assert_eq!(got, "bar baz");
+    }
+
+    #[test]
+    fn write_cache_upserts_on_conflict() {
+        let conn = open_test_db();
+        write_cache(&conn, "foo", "old").unwrap();
+        write_cache(&conn, "foo", "new").unwrap();
+        let got = read_cache_if_fresh(&conn, "foo").unwrap();
+        assert_eq!(got, "new");
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM query_cache WHERE query = 'foo'", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn read_cache_returns_none_for_missing_key() {
+        let conn = open_test_db();
+        assert!(read_cache_if_fresh(&conn, "missing").is_none());
+    }
+
+    #[test]
+    fn prompt_contains_query_verbatim_and_keywords() {
+        let prompt = build_expansion_prompt("플랜");
+        assert!(prompt.contains("쿼리: 플랜"));
+        assert!(prompt.contains("동의어"));
+        assert!(prompt.contains("영어/한국어"));
+    }
+}

--- a/src-tauri/src/db/migrations.rs
+++ b/src-tauri/src/db/migrations.rs
@@ -154,6 +154,9 @@ pub fn run(conn: &Connection) -> Result<(), AppError> {
     if current < 43 {
         apply_v43(conn)?;
     }
+    if current < 44 {
+        apply_v44(conn)?;
+    }
     Ok(())
 }
 
@@ -1046,6 +1049,32 @@ fn apply_v43(conn: &Connection) -> Result<(), AppError> {
     Ok(())
 }
 
+/// v44 — `query_cache` 테이블 추가.
+///
+/// Phase A (searchPipelineFromSecallPlan §4): query expansion 결과 캐싱.
+/// secall 의 `query_expand.rs` 는 Claude Haiku subprocess 호출로 쿼리를 확장
+/// 하는데 매번 ~1-2초 걸림. 같은 쿼리가 반복되는 경우가 많으므로 7일 캐시로
+/// 대부분의 호출을 원천 차단한다.
+///
+/// - `query` (PK): 원본 쿼리 (정규화: trim + lowercase)
+/// - `expanded`: 확장된 키워드 문자열 (공백 구분)
+/// - `cached_at`: 캐시 생성 시각 (7일 TTL 계산용)
+fn apply_v44(conn: &Connection) -> Result<(), AppError> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS query_cache (
+            query      TEXT PRIMARY KEY,
+            expanded   TEXT NOT NULL,
+            cached_at  INTEGER NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_query_cache_cached_at ON query_cache(cached_at);",
+    )?;
+    conn.execute(
+        "INSERT INTO schema_version (version, applied_at) VALUES (44, ?1)",
+        [now_epoch_ms()],
+    )?;
+    Ok(())
+}
+
 /// Milliseconds since Unix epoch (for Message.timestamp)
 pub fn now_epoch_ms() -> i64 {
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -1149,5 +1178,64 @@ mod tests {
             )
             .unwrap();
         assert_eq!(count, 1, "schema_version must record v43 application");
+    }
+
+    // ─── v44 — query_cache ──────────────────────────────────────────────────
+
+    fn open_with_v44_only() -> Connection {
+        let conn = Connection::open_in_memory().expect("open");
+        conn.execute_batch(schema::CREATE_SCHEMA_VERSION).expect("schema_version");
+        apply_v44(&conn).expect("apply_v44");
+        conn
+    }
+
+    #[test]
+    fn v44_creates_query_cache() {
+        let conn = open_with_v44_only();
+        assert!(table_exists(&conn, "query_cache"), "v44 must create query_cache");
+    }
+
+    #[test]
+    fn v44_schema_has_expected_columns() {
+        let conn = open_with_v44_only();
+        let mut stmt = conn.prepare("PRAGMA table_info(query_cache)").unwrap();
+        let cols: Vec<String> = stmt
+            .query_map([], |r| r.get::<_, String>(1))
+            .unwrap()
+            .filter_map(|r| r.ok())
+            .collect();
+        for expected in ["query", "expanded", "cached_at"] {
+            assert!(cols.contains(&expected.to_string()),
+                "column {} missing, cols={:?}", expected, cols);
+        }
+    }
+
+    #[test]
+    fn v44_query_is_primary_key() {
+        let conn = open_with_v44_only();
+        // Enable FK checks so PK violations surface consistently.
+        conn.execute(
+            "INSERT INTO query_cache (query, expanded, cached_at) VALUES ('k', 'v', 1)",
+            [],
+        )
+        .unwrap();
+        let err = conn.execute(
+            "INSERT INTO query_cache (query, expanded, cached_at) VALUES ('k', 'v2', 2)",
+            [],
+        );
+        assert!(err.is_err(), "second insert of same query PK must fail");
+    }
+
+    #[test]
+    fn v44_records_schema_version() {
+        let conn = open_with_v44_only();
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM schema_version WHERE version=44",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1);
     }
 }


### PR DESCRIPTION
## 배경

사용자 관찰: tunaFlow 헤더 검색창에서 "플랜" 검색 → `docs/plans/*.md` 미매칭. secall 은 정상 작동. 분석 후 plan 승격 + Phase A 구현.

## 변경

### Plan 문서
- `docs/plans/searchPipelineFromSecallPlan.md` — Phase A/B/C 상세 설계
- idea `searchEnhancementFromSecallIdea.md` 의 승격 형태

### Phase A: Query expansion
- **Migration v44**: `query_cache (query PK, expanded, cached_at)` — 7일 TTL
- **`src-tauri/src/commands/search/query_expand.rs`** — secall `query_expand.rs` 이식
  - Default OFF, opt-in via `TUNAFLOW_QUERY_EXPANSION=on`
  - `claude -p <prompt> --model claude-haiku-4-5-20251001` 호출
  - 실패 경로 (바이너리 없음/비정상 exit/빈 결과) → 원본 쿼리 fallback
- **`search_messages` 통합**: 플래그 ON 일 때 확장 쿼리로 FTS MATCH

### Scope
- **Phase A 만** 이 PR. Phase B (hybrid RRF) / Phase C (Kiwi/Lindera) 는 후속 PR.
- 이 Phase 만으로 "플랜" → `docs/plans/*.md` 문제 완전 해결 X — 문서는 `source_type='document'` 로 messages_fts 밖에 있음. Phase B 에서 통합.
- 현재 Phase A 효과: **대화 검색 (messages_fts)** recall ↑. 한국어/영어 혼용 쿼리에 즉시 도움.

## 테스트 설계 메모

테스트가 병렬 실행되며 env var 을 공유해 race condition 발생 위험 → **의존성 주입 패턴** 으로 해결:
- `expand_query(query, conn)` (public) — env var 읽음
- `expand_query_inner(query, conn, enabled, invoker)` (테스트용) — flag + Claude invoker 주입
- `InvokeClaude::{Real, Empty, Stub(&str)}` — subprocess mock

## 테스트

12 신규 (search::query_expand) + 4 신규 (v44 migration) = 16.
**\`cargo test --lib\`: 358 passed / 0 failed** (baseline 349 → +9 query_expand + 4 migration).

## 사용법

\`\`\`bash
# opt-in 활성화
export TUNAFLOW_QUERY_EXPANSION=on

# 헤더 검색창 사용 — 첫 쿼리 약 1-2초 (Claude Haiku 호출), 이후 캐시
# claude 바이너리 없으면 자동으로 원본 쿼리 사용

# 캐시 확인
sqlite3 ~/.tunaflow/db/tunaflow.db "SELECT query, cached_at FROM query_cache LIMIT 10;"
\`\`\`

## Test plan
- [x] \`cargo test --lib\` — 358 passed
- [ ] 앱 재기동 후 \`PRAGMA user_version\` (schema_version 최대값 44 확인)
- [ ] \`TUNAFLOW_QUERY_EXPANSION=on\` 으로 실제 검색 실행 → query_cache 테이블 row 생성 확인
- [ ] 플래그 OFF 일 때 기존 검색 동작 무변경 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)