### PR TITLE
feat(search): Phase B — hybrid RRF + unified search command

### DIFF
--- a/src-tauri/src/commands/search/hybrid.rs
+++ b/src-tauri/src/commands/search/hybrid.rs
@@ -1,0 +1,171 @@
+//! Reciprocal Rank Fusion (RRF) — secall `search/hybrid.rs` 이식.
+//!
+//! Merges independent ranked lists (FTS and vector) into a single score-based
+//! ranking without needing comparable absolute scores. Each list contributes
+//! `1 / (k + rank)` per result; sums are normalized to [0, 1].
+//!
+//! RRF is robust to score-scale mismatches (FTS rank vs vector cosine), which
+//! is exactly our situation here.
+
+use std::collections::HashMap;
+
+/// Standard RRF constant from the original paper — secall uses 60, same here.
+pub const RRF_K: f64 = 60.0;
+
+/// A candidate result identified by a stable key. Different sources (FTS /
+/// vector / future rawq) use different key spaces (`msg:<id>`, `doc:<path>`)
+/// so collisions are not expected — but if they DO collide, the scores sum,
+/// which naturally boosts results that appear in multiple sources.
+pub trait RankedCandidate: Clone {
+    fn key(&self) -> String;
+}
+
+/// Fuse two (or more) ranked lists via reciprocal rank fusion. The returned
+/// `Vec<(T, f64)>` is sorted by score descending and the max score is 1.0
+/// (normalization). Lower rank in either input list = better.
+///
+/// The first occurrence of each key wins for the returned candidate payload —
+/// callers should pass the more-informative list first if payloads differ.
+pub fn reciprocal_rank_fusion<T: RankedCandidate>(
+    lists: &[&[T]],
+    k: f64,
+) -> Vec<(T, f64)> {
+    let mut score_map: HashMap<String, f64> = HashMap::new();
+    let mut candidate_map: HashMap<String, T> = HashMap::new();
+
+    for list in lists {
+        for (rank, item) in list.iter().enumerate() {
+            let key = item.key();
+            let rrf_score = 1.0 / (k + rank as f64 + 1.0);
+            *score_map.entry(key.clone()).or_insert(0.0) += rrf_score;
+            candidate_map.entry(key).or_insert_with(|| item.clone());
+        }
+    }
+
+    let mut merged: Vec<(T, f64)> = candidate_map
+        .into_iter()
+        .map(|(k, v)| (v, score_map[&k]))
+        .collect();
+
+    merged.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+
+    // Normalize so top result = 1.0
+    if let Some(&(_, max)) = merged.first() {
+        if max > 0.0 {
+            for entry in merged.iter_mut() {
+                entry.1 /= max;
+            }
+        }
+    }
+
+    merged
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, Clone, PartialEq)]
+    struct Item {
+        id: String,
+        payload: String,
+    }
+
+    impl RankedCandidate for Item {
+        fn key(&self) -> String {
+            self.id.clone()
+        }
+    }
+
+    fn item(id: &str) -> Item {
+        Item { id: id.into(), payload: format!("payload-{id}") }
+    }
+
+    #[test]
+    fn empty_lists_produce_empty_result() {
+        let out = reciprocal_rank_fusion::<Item>(&[], RRF_K);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn single_list_preserves_order() {
+        let list = vec![item("a"), item("b"), item("c")];
+        let out = reciprocal_rank_fusion(&[list.as_slice()], RRF_K);
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[0].0.id, "a");
+        assert_eq!(out[1].0.id, "b");
+        assert_eq!(out[2].0.id, "c");
+    }
+
+    #[test]
+    fn top_result_normalized_to_one() {
+        let list = vec![item("a"), item("b")];
+        let out = reciprocal_rank_fusion(&[list.as_slice()], RRF_K);
+        assert!((out[0].1 - 1.0).abs() < 1e-9);
+        assert!(out[1].1 < 1.0);
+        assert!(out[1].1 > 0.0);
+    }
+
+    #[test]
+    fn disjoint_lists_are_merged() {
+        let a = vec![item("a"), item("b")];
+        let b = vec![item("c"), item("d")];
+        let out = reciprocal_rank_fusion(&[a.as_slice(), b.as_slice()], RRF_K);
+        let ids: Vec<&str> = out.iter().map(|(i, _)| i.id.as_str()).collect();
+        assert_eq!(ids.len(), 4);
+        assert!(ids.contains(&"a"));
+        assert!(ids.contains(&"b"));
+        assert!(ids.contains(&"c"));
+        assert!(ids.contains(&"d"));
+    }
+
+    #[test]
+    fn overlapping_key_sums_contributions() {
+        // Same key in both lists → score is SUM of rrf contributions.
+        // This should rank higher than keys that appear in only one list.
+        let a = vec![item("shared"), item("a-only")];
+        let b = vec![item("shared"), item("b-only")];
+        let out = reciprocal_rank_fusion(&[a.as_slice(), b.as_slice()], RRF_K);
+        assert_eq!(out[0].0.id, "shared", "overlapping key must rank first");
+    }
+
+    #[test]
+    fn first_list_wins_payload_on_overlap() {
+        // When the same key appears in multiple lists, the FIRST occurrence
+        // wins — callers should pass the more-informative list first.
+        let a = vec![Item { id: "x".into(), payload: "from_a".into() }];
+        let b = vec![Item { id: "x".into(), payload: "from_b".into() }];
+        let out = reciprocal_rank_fusion(&[a.as_slice(), b.as_slice()], RRF_K);
+        assert_eq!(out[0].0.payload, "from_a");
+    }
+
+    #[test]
+    fn sort_is_stable_under_ties() {
+        // Construct a case where two keys get exactly the same RRF score by
+        // appearing only in one list at the same position of different lists.
+        let a = vec![item("x")];
+        let b = vec![item("y")];
+        let out = reciprocal_rank_fusion(&[a.as_slice(), b.as_slice()], RRF_K);
+        // Both "x" and "y" are at rank 0 of their list — same contribution.
+        // After normalization, both end up at 1.0. Result includes both.
+        assert_eq!(out.len(), 2);
+        assert!((out[0].1 - 1.0).abs() < 1e-9);
+        // The second one should be at 1.0 as well since scores were equal
+        // before normalization, then divided by the same max.
+        assert!((out[1].1 - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn k_value_affects_score_magnitude() {
+        let list = vec![item("a"), item("b")];
+        let out_small = reciprocal_rank_fusion(&[list.as_slice()], 10.0);
+        let out_large = reciprocal_rank_fusion(&[list.as_slice()], 1000.0);
+        // Larger k compresses score differences; after normalization the first
+        // entry is still 1.0 but the ratio differs.
+        // Small k: 1/11 vs 1/12 → ratio ~0.917
+        // Large k: 1/1001 vs 1/1002 → ratio ~0.999
+        assert!(out_large[1].1 > out_small[1].1);
+    }
+}

--- a/src-tauri/src/commands/search/mod.rs
+++ b/src-tauri/src/commands/search/mod.rs
@@ -1,10 +1,11 @@
 //! Unified search module — Phase A (query expansion), Phase B (hybrid RRF),
 //! Phase C (Korean tokenizer) from `docs/plans/searchPipelineFromSecallPlan.md`.
-//!
-//! Phase A 현재: query expansion + 7-day DB cache. Default OFF (opt-in via
-//! `TUNAFLOW_QUERY_EXPANSION`). Future phases chain on this module.
 
+pub mod hybrid;
 pub mod query_expand;
+pub mod unified;
 
 #[allow(unused_imports)]
 pub use query_expand::{expand_query, normalize_query, query_expansion_enabled};
+#[allow(unused_imports)]
+pub use unified::{search_unified, UnifiedResult};

--- a/src-tauri/src/commands/search/unified.rs
+++ b/src-tauri/src/commands/search/unified.rs
@@ -1,0 +1,289 @@
+//! Unified search — `search_unified` Tauri command.
+//!
+//! Phase B of `searchPipelineFromSecallPlan.md`. Combines:
+//!   1. FTS5 over `messages` (via existing `messages_fts`)
+//!   2. bge-m3 vector similarity over `conversation_chunks WHERE source_type='document'`
+//!
+//! The two independent ranked lists are fused via RRF (`hybrid.rs`). Query
+//! expansion (Phase A) runs first when enabled, and session-diversity cap is
+//! applied afterwards so one noisy conversation doesn't monopolize the top-N.
+
+use rusqlite::params;
+use serde::Serialize;
+use tauri::State;
+
+use crate::db::DbState;
+use crate::errors::AppError;
+
+use super::hybrid::{reciprocal_rank_fusion, RankedCandidate, RRF_K};
+use super::query_expand::{expand_query, query_expansion_enabled};
+
+/// Default cap for per-conversation result diversity, matches secall.
+const DEFAULT_MAX_PER_CONVERSATION: usize = 2;
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UnifiedResult {
+    /// "conversation" | "document"
+    pub kind: &'static str,
+    /// Unique id inside its space — message_id for conversation, file_path for document.
+    pub id: String,
+    /// Label for the UI header ("Chat: {conv_label}" or "Doc: {path}").
+    pub source_label: String,
+    pub snippet: String,
+    /// Normalized 0~1 RRF-fused score. 1.0 = best.
+    pub score: f64,
+    pub fts_score: Option<f64>,
+    pub vector_score: Option<f64>,
+    pub timestamp: Option<i64>,
+    /// Conversation id for "conversation" results — used for diversity capping
+    /// and for click-to-navigate UX. `None` for "document" results.
+    pub conversation_id: Option<String>,
+}
+
+impl RankedCandidate for UnifiedResult {
+    fn key(&self) -> String {
+        format!("{}:{}", self.kind, self.id)
+    }
+}
+
+/// Unified search across conversation FTS + document vector. Returns
+/// `limit` best results sorted by fused score descending.
+#[tauri::command]
+pub fn search_unified(
+    query: String,
+    project_key: String,
+    limit: Option<i64>,
+    max_per_conversation: Option<usize>,
+    state: State<DbState>,
+) -> Result<Vec<UnifiedResult>, AppError> {
+    let max = limit.unwrap_or(20) as usize;
+    let div_cap = max_per_conversation.unwrap_or(DEFAULT_MAX_PER_CONVERSATION);
+    // We pull 3x the final target from each source so RRF has room to rerank.
+    let per_source = (max * 3).max(10);
+
+    // Phase A — query expansion (opt-in). Takes the write lock only when
+    // enabled, because the cache table is writable on miss.
+    let effective_query = if query_expansion_enabled() {
+        let write = state.write.lock().map_err(|_| AppError::Lock)?;
+        expand_query(&query, Some(&*write)).unwrap_or_else(|_| query.clone())
+    } else {
+        query.clone()
+    };
+
+    let fts_results = fts_conversation_search(&state, &effective_query, &project_key, per_source)?;
+    let vec_results = document_vector_search(&state, &effective_query, &project_key, per_source);
+
+    let fused = reciprocal_rank_fusion(&[fts_results.as_slice(), vec_results.as_slice()], RRF_K);
+
+    let mut out: Vec<UnifiedResult> = fused
+        .into_iter()
+        .map(|(mut r, score)| {
+            r.score = score;
+            r
+        })
+        .collect();
+
+    if div_cap > 0 {
+        diversify_by_conversation(&mut out, div_cap);
+    }
+    out.truncate(max);
+    Ok(out)
+}
+
+// ─── Source: conversation FTS ─────────────────────────────────────────────────
+
+fn fts_conversation_search(
+    state: &DbState,
+    query: &str,
+    project_key: &str,
+    limit: usize,
+) -> Result<Vec<UnifiedResult>, AppError> {
+    let conn = state.read.lock().map_err(|_| AppError::Lock)?;
+    let mut stmt = conn.prepare(
+        "SELECT m.id, m.conversation_id,
+                COALESCE(c.custom_label, c.label, ''),
+                snippet(messages_fts, 0, '**', '**', '…', 40),
+                m.timestamp,
+                rank AS fts_rank
+         FROM messages_fts fts
+         JOIN messages m ON m.rowid = fts.rowid
+         JOIN conversations c ON c.id = m.conversation_id
+         WHERE messages_fts MATCH ?1
+           AND c.project_key = ?2
+         ORDER BY rank
+         LIMIT ?3",
+    )?;
+
+    let results: Vec<UnifiedResult> = stmt
+        .query_map(params![query, project_key, limit as i64], |row| {
+            let msg_id: String = row.get(0)?;
+            let conv_id: String = row.get(1)?;
+            let conv_label: String = row.get(2)?;
+            let snippet: String = row.get(3)?;
+            let ts: i64 = row.get(4)?;
+            let fts_rank: f64 = row.get(5)?;
+            let label = if conv_label.is_empty() { "Chat".to_string() } else { format!("Chat: {}", conv_label) };
+            Ok(UnifiedResult {
+                kind: "conversation",
+                id: msg_id,
+                source_label: label,
+                snippet,
+                score: 0.0, // filled in by RRF
+                fts_score: Some(fts_rank),
+                vector_score: None,
+                timestamp: Some(ts),
+                conversation_id: Some(conv_id),
+            })
+        })?
+        .filter_map(|r| r.ok())
+        .collect();
+    Ok(results)
+}
+
+// ─── Source: document vector ──────────────────────────────────────────────────
+
+fn document_vector_search(
+    state: &DbState,
+    query: &str,
+    project_key: &str,
+    limit: usize,
+) -> Vec<UnifiedResult> {
+    // Document vector search internally embeds the query (bge-m3), so we just
+    // adapt its output to UnifiedResult. Errors here are NOT fatal — we prefer
+    // to return FTS-only results over a 500 when the embedder or vec0 is down.
+    match crate::commands::document_index::search_documents(state, project_key, query, limit) {
+        Ok(docs) => docs
+            .into_iter()
+            .map(|d| UnifiedResult {
+                kind: "document",
+                id: d.file_path.clone(),
+                source_label: format!("Doc: {}", d.file_path),
+                snippet: d.text_preview,
+                score: 0.0,
+                fts_score: None,
+                vector_score: Some(d.score as f64),
+                timestamp: None,
+                conversation_id: None,
+            })
+            .collect(),
+        Err(e) => {
+            eprintln!("[search_unified] document vector search skipped: {e:?}");
+            Vec::new()
+        }
+    }
+}
+
+// ─── Session diversity ────────────────────────────────────────────────────────
+
+/// Cap the number of results per conversation to `max_per`. Document results
+/// (conversation_id=None) are unaffected. The relative order of retained
+/// results is preserved.
+pub fn diversify_by_conversation(results: &mut Vec<UnifiedResult>, max_per: usize) {
+    use std::collections::HashMap;
+    let mut counts: HashMap<String, usize> = HashMap::new();
+    results.retain(|r| match &r.conversation_id {
+        Some(cid) => {
+            let c = counts.entry(cid.clone()).or_insert(0);
+            if *c < max_per {
+                *c += 1;
+                true
+            } else {
+                false
+            }
+        }
+        None => true, // documents are not capped
+    });
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn conv_result(conv_id: &str, msg_id: &str) -> UnifiedResult {
+        UnifiedResult {
+            kind: "conversation",
+            id: msg_id.into(),
+            source_label: "Chat".into(),
+            snippet: String::new(),
+            score: 0.0,
+            fts_score: Some(1.0),
+            vector_score: None,
+            timestamp: Some(0),
+            conversation_id: Some(conv_id.into()),
+        }
+    }
+
+    fn doc_result(path: &str) -> UnifiedResult {
+        UnifiedResult {
+            kind: "document",
+            id: path.into(),
+            source_label: format!("Doc: {path}"),
+            snippet: String::new(),
+            score: 0.0,
+            fts_score: None,
+            vector_score: Some(0.9),
+            timestamp: None,
+            conversation_id: None,
+        }
+    }
+
+    #[test]
+    fn ranked_candidate_key_disambiguates_by_kind() {
+        let c = conv_result("conv-1", "msg-x");
+        let d = doc_result("docs/plans/foo.md");
+        assert_eq!(c.key(), "conversation:msg-x");
+        assert_eq!(d.key(), "document:docs/plans/foo.md");
+    }
+
+    #[test]
+    fn diversify_caps_per_conversation() {
+        let mut results = vec![
+            conv_result("conv-a", "m1"),
+            conv_result("conv-a", "m2"),
+            conv_result("conv-a", "m3"), // should be dropped (cap=2)
+            conv_result("conv-b", "m4"),
+            conv_result("conv-a", "m5"), // should be dropped
+            doc_result("p1.md"),
+            doc_result("p2.md"),
+        ];
+        diversify_by_conversation(&mut results, 2);
+        let ids: Vec<&str> = results.iter().map(|r| r.id.as_str()).collect();
+        assert_eq!(ids, vec!["m1", "m2", "m4", "p1.md", "p2.md"]);
+    }
+
+    #[test]
+    fn diversify_zero_cap_is_a_noop() {
+        let mut results = vec![conv_result("a", "m1"), conv_result("a", "m2")];
+        let before_len = results.len();
+        diversify_by_conversation(&mut results, 0);
+        // cap=0 would mean "zero per conversation" — our docs say >0 is cap.
+        // But passing 0 should not crash; current impl treats it as "no keep".
+        // Document the semantic: cap=0 filters everything with conv_id.
+        assert!(results.len() < before_len || results.is_empty());
+    }
+
+    #[test]
+    fn diversify_does_not_affect_documents() {
+        let mut results = vec![doc_result("a.md"), doc_result("b.md"), doc_result("c.md")];
+        diversify_by_conversation(&mut results, 1);
+        // Documents are never capped — all three should remain.
+        assert_eq!(results.len(), 3);
+    }
+
+    #[test]
+    fn diversify_preserves_relative_order() {
+        let mut results = vec![
+            conv_result("a", "m1"),
+            conv_result("b", "m2"),
+            conv_result("a", "m3"),
+            conv_result("b", "m4"),
+            conv_result("a", "m5"), // dropped
+        ];
+        diversify_by_conversation(&mut results, 2);
+        let ids: Vec<&str> = results.iter().map(|r| r.id.as_str()).collect();
+        assert_eq!(ids, vec!["m1", "m2", "m3", "m4"]);
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -102,6 +102,7 @@ pub fn run() {
             commands::messages::save_progress_content,
             commands::messages::delete_message_pair,
             commands::messages::search_messages,
+            commands::search::unified::search_unified,
             // Branch
             commands::branches::list_branches,
             commands::branches::create_branch,


### PR DESCRIPTION
## 배경

searchPipelineFromSecallPlan.md Phase B. FTS5 대화 검색 + bge-m3 문서 벡터 검색을 **단일 엔드포인트**에서 RRF 로 합성.

## 변경

### `search_unified` (신규 Tauri command)
1. Phase A query expansion (opt-in)
2. FTS5 대화 검색 (`messages_fts`, per_source = max*3)
3. bge-m3 문서 벡터 검색 (`conversation_chunks WHERE source_type='document'`)
4. RRF 로 두 결과 합성 (k=60)
5. `diversify_by_conversation(max_per=2)` — 한 대화 독식 방지

### 스키마
\`\`\`ts
{
  kind: "conversation" | "document",
  id: string,         // message_id or file_path
  sourceLabel: string, // "Chat: {label}" or "Doc: {path}"
  snippet: string,
  score: number,      // RRF-fused 0~1 (1.0 = best)
  ftsScore?: number,
  vectorScore?: number,
  timestamp?: number,
  conversationId?: string
}
\`\`\`

### 사용자 "플랜" 검색 문제 해결
- 이전: 헤더 검색창 → `search_messages` (FTS only, documents 제외) → miss
- Phase B 이후: 문서 벡터 결과 합성 → `docs/plans/*.md` 가 결과에 나타남
- Phase A (expansion) 켜면 한/영 동의어까지 recall ↑

## 보존
- 기존 `search_messages` 는 변경 없음 — 프론트엔드가 준비될 때까지 둘 다 공존
- Frontend 전환 (헤더 검색창을 `search_unified` 로 바꾸는 것) 은 별도 PR

## 테스트

- **hybrid::tests** (8): empty, single list, normalization, disjoint merge, overlapping key sum, first-wins payload, stable tie, k-sensitivity
- **unified::tests** (5): key disambiguation, diversity cap, 0-cap edge, documents-uncapped, preserve-order

**\`cargo test --lib\`: 371 passed / 0 failed** (baseline 358 → +13).

## Scope 경계
- Frontend 전환 미포함 (backend only)
- Phase C (Kiwi/Lindera tokenizer) 는 다음 PR

## Test plan
- [x] cargo test all pass
- [ ] 앱 재기동 후 IPC 호출 테스트:
      \`\`\`js
      await invoke('search_unified', { query: '플랜', projectKey: 'tunaflow', limit: 20 })
      \`\`\`
      → docs/plans/*.md 결과 포함 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)