### PR TITLE
feat(search): Phase C Part1 — Korean tokenizer (Lindera ko-dic)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -280,6 +280,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,6 +469,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "bytecheck"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0caa33a2c0edca0419d15ac723dff03f1956f7978329b1e3b5fdaaaed9d3ca8b"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "rancor",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89385e82b5d1821d2219e0b095efa2cc1f246cbf99080f3be46a1a85c0d392d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -556,6 +601,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -593,6 +640,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -613,6 +666,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
 dependencies = [
  "error-code",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -824,6 +886,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ctor"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -838,6 +921,12 @@ name = "cursor-icon"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
+
+[[package]]
+name = "daachorse"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f55d7153ba3b507595872a3874803f07a8a81d1e888abed8e5db7da0597d6e2"
 
 [[package]]
 name = "darling"
@@ -1190,12 +1279,85 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "encoding"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b0d943856b990d12d3b55b359144ff341533e516d94098b1d3fc1ac666d36ec"
+dependencies = [
+ "encoding-index-japanese",
+ "encoding-index-korean",
+ "encoding-index-simpchinese",
+ "encoding-index-singlebyte",
+ "encoding-index-tradchinese",
+]
+
+[[package]]
+name = "encoding-index-japanese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04e8b2ff42e9a05335dbf8b5c6f7567e5591d0d916ccef4e0b1710d32a0d0c91"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-korean"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dc33fb8e6bcba213fe2f14275f0963fd16f0a02c878e3095ecfdf5bee529d81"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-simpchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87a7194909b9118fc707194baa434a4e3b0fb6a5a757c73c3adb07aa25031f7"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-singlebyte"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3351d5acffb224af9ca265f435b859c7c01537c0849754d3db3fdf2bfe2ae84a"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-tradchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding_index_tests"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "encoding_rs_io"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+dependencies = [
+ "encoding_rs",
 ]
 
 [[package]]
@@ -1467,6 +1629,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "futf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1707,8 +1875,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1718,9 +1888,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2454,6 +2626,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2483,6 +2665,15 @@ checksum = "5dea2b27dd239b2556ed7a25ba842fe47fd602e7fc7433c2a8d6106d4d9edd70"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "kanaria"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f9d9652540055ac4fded998a73aca97d965899077ab1212587437da44196ff"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2594,6 +2785,169 @@ dependencies = [
 ]
 
 [[package]]
+name = "lindera"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb784bf51d22be2350667c35c0796250ca4dd6888ee98fe8a41f16f400f6c9b"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "csv",
+ "daachorse",
+ "kanaria",
+ "lindera-cc-cedict",
+ "lindera-dictionary",
+ "lindera-ipadic",
+ "lindera-ipadic-neologd",
+ "lindera-jieba",
+ "lindera-ko-dic",
+ "lindera-unidic",
+ "log",
+ "once_cell",
+ "percent-encoding",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_yaml_ng",
+ "strum",
+ "strum_macros",
+ "unicode-blocks",
+ "unicode-normalization",
+ "unicode-segmentation",
+ "url",
+]
+
+[[package]]
+name = "lindera-cc-cedict"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5814a81429c4d04d3becd1513fa62548b3ce22f11062e920911ddb205c1792c6"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "csv",
+ "lindera-dictionary",
+ "once_cell",
+ "rkyv",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "lindera-dictionary"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0aa640fbefa4b4251f8ab001e47f213fdecf7bbbd0ee4a17a27b2cbff5ef1"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "csv",
+ "daachorse",
+ "derive_builder",
+ "encoding",
+ "encoding_rs",
+ "encoding_rs_io",
+ "flate2",
+ "glob",
+ "log",
+ "md5",
+ "memmap2",
+ "num_cpus",
+ "once_cell",
+ "rand 0.10.1",
+ "regex",
+ "reqwest 0.13.2",
+ "rkyv",
+ "serde",
+ "serde_json",
+ "strum",
+ "strum_macros",
+ "tar",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
+name = "lindera-ipadic"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94c8eebbfaee36d6ebd674aa796decbbb186e42c8b7a919f3495ba610cc8fcb6"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "csv",
+ "lindera-dictionary",
+ "once_cell",
+ "rkyv",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "lindera-ipadic-neologd"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f1742862984f32c110a5ba88880969d5fcc642452678ec2e3346b69b0651546"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "csv",
+ "lindera-dictionary",
+ "once_cell",
+ "rkyv",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "lindera-jieba"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d7cccd7e88ef26c7a31db63079ad226ae7c54325cb3abca1d12ebd97044462d"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "csv",
+ "lindera-dictionary",
+ "once_cell",
+ "rkyv",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "lindera-ko-dic"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f7f33c519e1ad6a9fe66a7520288d4ef117e8ae357fdd64d33c67030e527ea"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "csv",
+ "lindera-dictionary",
+ "once_cell",
+ "rkyv",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "lindera-unidic"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65efa76d07bf5ab5b4a81f33238d4c3b8e9dbcf93e0bee96224d21287fb51759"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "csv",
+ "lindera-dictionary",
+ "once_cell",
+ "rkyv",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2619,6 +2973,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mac"
@@ -2713,10 +3073,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "md5"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memoffset"
@@ -2829,6 +3204,26 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "munge"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e17401f259eba956ca16491461b6e8f72913a0a114e39736ce404410f915a0c"
+dependencies = [
+ "munge_macro",
+]
+
+[[package]]
+name = "munge_macro"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2983,6 +3378,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -3757,6 +4162,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b9a0cf95a1196af61d4f1cbdab967179516d9a4a4312af1f31948f8f6224a79"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "pxfm"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3796,6 +4221,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3815,6 +4296,15 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rancor"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a063ea72381527c2a0561da9c80000ef822bdd7c3241b1cc1b12100e3df081ee"
+dependencies = [
+ "ptr_meta",
+]
 
 [[package]]
 name = "rand"
@@ -3849,6 +4339,15 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3907,6 +4406,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_hc"
@@ -4059,6 +4564,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rend"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4116,15 +4630,21 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -4172,6 +4692,36 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a30e631b7f4a03dee9056b8ef6982e8ba371dd5bedb74d3ec86df4499132c70"
+dependencies = [
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.16.1",
+ "indexmap 2.13.0",
+ "munge",
+ "ptr_meta",
+ "rancor",
+ "rend",
+ "rkyv_derive",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8100bb34c0a1d0f907143db3149e6b4eea3c33b9ee8b189720168e818303986f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4233,6 +4783,7 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "rustls-pki-types",
  "rustls-webpki",
@@ -4241,13 +4792,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -4255,6 +4846,7 @@ version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -4567,6 +5159,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml_ng"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
+dependencies = [
+ "indexmap 2.13.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "serial"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4750,6 +5355,12 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
@@ -4946,6 +5557,27 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "subtle"
@@ -5636,6 +6268,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokenizers"
 version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5986,6 +6633,7 @@ dependencies = [
  "futures-util",
  "keyring",
  "lazy_static",
+ "lindera",
  "ndarray",
  "ort",
  "parking_lot",
@@ -6119,10 +6767,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-blocks"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b12e05d9e06373163a9bb6bb8c263c261b396643a99445fe6b9811fd376581b"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-normalization-alignments"
@@ -6156,6 +6819,12 @@ name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -6552,6 +7221,16 @@ name = "web-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -44,6 +44,10 @@ base64 = "0.22"
 regex = "1"
 sha2 = "0.10"
 toml = "0.8"
+# Korean morphological tokenizer (Phase C of search pipeline plan). Embedded
+# ko-dic dictionary so no runtime model download is needed. Same version as
+# secall for parity.
+lindera = { version = "2.3", features = ["embed-ko-dic"] }
 reqwest = { version = "0.12", features = ["json", "stream", "blocking"] }
 futures-util = "0.3"
 tokio-tungstenite = "0.24"

--- a/src-tauri/src/commands/search/mod.rs
+++ b/src-tauri/src/commands/search/mod.rs
@@ -3,9 +3,15 @@
 
 pub mod hybrid;
 pub mod query_expand;
+pub mod tokenizer;
 pub mod unified;
 
 #[allow(unused_imports)]
 pub use query_expand::{expand_query, normalize_query, query_expansion_enabled};
+#[allow(unused_imports)]
+pub use tokenizer::{
+    global_tokenizer, morphological_query_enabled, tokenize_query_for_fts,
+    SimpleTokenizer, Tokenizer,
+};
 #[allow(unused_imports)]
 pub use unified::{search_unified, UnifiedResult};

--- a/src-tauri/src/commands/search/tokenizer.rs
+++ b/src-tauri/src/commands/search/tokenizer.rs
@@ -1,0 +1,273 @@
+//! Korean morphological tokenizer — Phase C of `searchPipelineFromSecallPlan.md`.
+//!
+//! Design follows secall's proven pattern: **application-layer pre-tokenize**
+//! rather than registering a custom FTS5 tokenizer. The output is a
+//! whitespace-separated token stream that SQLite's built-in `unicode61`
+//! tokenizer then splits trivially — no C extension plumbing needed.
+//!
+//! - `LinderaKoTokenizer` (embedded ko-dic) — production default. Cross-platform.
+//! - `SimpleTokenizer` — whitespace + punctuation fallback when everything else
+//!   fails.
+//!
+//! Both keep Korean POS tags `NNG / NNP / NNB / VV / VA / SL` and drop
+//! single-character tokens — matching secall exactly so indexes/queries can
+//! share corpus later.
+
+use std::collections::HashSet;
+use std::sync::OnceLock;
+
+use lindera::{
+    dictionary::{load_embedded_dictionary, DictionaryKind},
+    mode::Mode,
+    segmenter::Segmenter,
+    token_filter::{korean_keep_tags::KoreanKeepTagsTokenFilter, BoxTokenFilter},
+    tokenizer::Tokenizer as LinderaInner,
+};
+
+use crate::errors::AppError;
+
+pub trait Tokenizer: Send + Sync {
+    fn tokenize(&self, text: &str) -> Vec<String>;
+
+    /// Join tokens with a single space — the form SQLite's `unicode61` will
+    /// re-split on during FTS5 indexing / MATCH evaluation.
+    fn tokenize_for_fts(&self, text: &str) -> String {
+        self.tokenize(text).join(" ")
+    }
+}
+
+// ─── Lindera ko-dic ──────────────────────────────────────────────────────────
+
+pub struct LinderaKoTokenizer {
+    inner: LinderaInner,
+}
+
+impl LinderaKoTokenizer {
+    pub fn new() -> Result<Self, AppError> {
+        let dictionary = load_embedded_dictionary(DictionaryKind::KoDic)
+            .map_err(|e| AppError::Agent(format!("lindera ko-dic load failed: {e}")))?;
+        let segmenter = Segmenter::new(Mode::Normal, dictionary, None);
+        let mut tokenizer = LinderaInner::new(segmenter);
+
+        // Keep: NNG (일반명사), NNP (고유명사), NNB (의존명사),
+        //       VV (동사), VA (형용사), SL (외국어)
+        let tags: HashSet<String> = ["NNG", "NNP", "NNB", "VV", "VA", "SL"]
+            .iter()
+            .map(|s| (*s).to_string())
+            .collect();
+        let keep_filter = KoreanKeepTagsTokenFilter::new(tags);
+        tokenizer.append_token_filter(BoxTokenFilter::from(keep_filter));
+
+        Ok(Self { inner: tokenizer })
+    }
+}
+
+impl Tokenizer for LinderaKoTokenizer {
+    fn tokenize(&self, text: &str) -> Vec<String> {
+        let tokens = match self.inner.tokenize(text) {
+            Ok(t) => t,
+            Err(_) => return simple_tokenize(text),
+        };
+
+        let mut result: Vec<String> = Vec::new();
+        for token in tokens {
+            let surface = token.surface.to_lowercase();
+            if surface.chars().count() > 1 {
+                result.push(surface);
+            }
+        }
+
+        if result.is_empty() {
+            simple_tokenize(text)
+        } else {
+            result
+        }
+    }
+}
+
+// ─── Simple fallback ─────────────────────────────────────────────────────────
+
+pub struct SimpleTokenizer;
+
+impl Tokenizer for SimpleTokenizer {
+    fn tokenize(&self, text: &str) -> Vec<String> {
+        simple_tokenize(text)
+    }
+}
+
+fn simple_tokenize(text: &str) -> Vec<String> {
+    text.split(|c: char| c.is_whitespace() || c.is_ascii_punctuation())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_lowercase())
+        .filter(|s| s.chars().count() > 1)
+        .collect()
+}
+
+// ─── Global default ──────────────────────────────────────────────────────────
+
+/// Shared tokenizer instance — loading ko-dic costs a few MB of RAM and some
+/// init time, so we amortize across all callers. Falls back to `SimpleTokenizer`
+/// if Lindera initialization fails for any reason (OOM, corrupted dict, etc.).
+///
+/// `Box<dyn Tokenizer>` is `Send + Sync` because each impl is.
+static GLOBAL_TOKENIZER: OnceLock<Box<dyn Tokenizer>> = OnceLock::new();
+
+pub fn global_tokenizer() -> &'static dyn Tokenizer {
+    GLOBAL_TOKENIZER
+        .get_or_init(|| match LinderaKoTokenizer::new() {
+            Ok(t) => {
+                eprintln!("[tokenizer] lindera ko-dic ready");
+                Box::new(t) as Box<dyn Tokenizer>
+            }
+            Err(e) => {
+                eprintln!("[tokenizer] lindera unavailable ({e}), falling back to whitespace");
+                Box::new(SimpleTokenizer)
+            }
+        })
+        .as_ref()
+}
+
+/// Convenience — returns the tokenize-for-FTS string using the global tokenizer.
+/// Safe to call from anywhere; empty input yields empty output.
+pub fn tokenize_query_for_fts(text: &str) -> String {
+    if text.trim().is_empty() {
+        return text.to_string();
+    }
+    global_tokenizer().tokenize_for_fts(text)
+}
+
+/// Is morphological query tokenization enabled?
+///
+/// Default OFF (opt-in) because the index side is still whitespace-tokenized.
+/// Enabling this without rebuilding the FTS index hurts recall — the query
+/// turns into morphemes but the index still holds whole words.
+///
+/// Flip this only after `rebuild_messages_fts` (Phase C Part2) has re-indexed
+/// existing content with the same tokenizer.
+pub fn morphological_query_enabled() -> bool {
+    match std::env::var("TUNAFLOW_MORPH_QUERY") {
+        Ok(v) => matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "on" | "yes"),
+        Err(_) => false,
+    }
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn simple_tokenize_splits_on_whitespace_and_punctuation() {
+        let out = simple_tokenize("Hello, world! 플랜을 찾자.");
+        assert!(out.iter().any(|t| t == "hello"));
+        assert!(out.iter().any(|t| t == "world"));
+        // Korean stays intact (no morphological analysis in simple mode).
+        assert!(out.iter().any(|t| t.contains("플랜을") || t.contains("플랜")));
+    }
+
+    #[test]
+    fn simple_tokenize_drops_single_char() {
+        let out = simple_tokenize("a bb ccc");
+        assert_eq!(out, vec!["bb", "ccc"]);
+    }
+
+    #[test]
+    fn simple_tokenize_lowercases() {
+        let out = simple_tokenize("Hello HELLO hello");
+        assert_eq!(out, vec!["hello", "hello", "hello"]);
+    }
+
+    #[test]
+    fn simple_tokenizer_trait_works() {
+        let tok = SimpleTokenizer;
+        let joined = tok.tokenize_for_fts("Quick brown fox");
+        assert_eq!(joined, "quick brown fox");
+    }
+
+    #[test]
+    fn simple_empty_input() {
+        assert!(simple_tokenize("").is_empty());
+        assert!(simple_tokenize("   ").is_empty());
+    }
+
+    #[test]
+    fn tokenize_query_for_fts_passes_empty_through() {
+        assert_eq!(tokenize_query_for_fts(""), "");
+        assert_eq!(tokenize_query_for_fts("   "), "   ");
+    }
+
+    #[test]
+    fn lindera_korean_decomposition() {
+        // Lindera ko-dic splits particles off — "플랜을" should NOT remain as
+        // a single token when the morphological analyzer is available. If
+        // init fails, the fallback keeps the surface form as-is (covered
+        // separately above).
+        let tok = match LinderaKoTokenizer::new() {
+            Ok(t) => t,
+            Err(_) => return, // Dict unavailable in this environment; skip.
+        };
+        let tokens = tok.tokenize("아키텍처를 설계한다");
+        assert!(!tokens.is_empty(), "lindera returned empty");
+        let joined = tokens.join(" ");
+        // Either "아키텍처" as a standalone noun, or at minimum some
+        // normalized form — the exact tag coverage depends on ko-dic version.
+        assert!(
+            joined.contains("아키텍처") || joined.contains("설계"),
+            "expected noun to survive filtering, got: {joined}"
+        );
+    }
+
+    #[test]
+    fn lindera_english_passes_through_as_sl_or_falls_back() {
+        let tok = match LinderaKoTokenizer::new() {
+            Ok(t) => t,
+            Err(_) => return,
+        };
+        let tokens = tok.tokenize("Rust workspace");
+        // Either Lindera tags these as SL and keeps them, OR the result is
+        // empty and we fall through to simple_tokenize which would return
+        // lowercase whitespace splits.
+        let joined = tokens.join(" ");
+        assert!(
+            joined.contains("rust") || joined.contains("workspace"),
+            "english should be preserved in one form, got: {joined}"
+        );
+    }
+
+    #[test]
+    fn lindera_mixed_korean_english() {
+        let tok = match LinderaKoTokenizer::new() {
+            Ok(t) => t,
+            Err(_) => return,
+        };
+        let tokens = tok.tokenize("seCall의 BM25 검색");
+        assert!(!tokens.is_empty());
+    }
+
+    #[test]
+    fn lindera_empty_input_returns_empty() {
+        let tok = match LinderaKoTokenizer::new() {
+            Ok(t) => t,
+            Err(_) => return,
+        };
+        assert!(tok.tokenize("").is_empty());
+    }
+
+    #[test]
+    fn lindera_special_chars_only_falls_back_or_empty() {
+        let tok = match LinderaKoTokenizer::new() {
+            Ok(t) => t,
+            Err(_) => return,
+        };
+        let tokens = tok.tokenize("!@#$%^");
+        assert!(tokens.is_empty(), "special chars should yield no tokens");
+    }
+
+    #[test]
+    fn global_tokenizer_is_same_instance_on_repeat_calls() {
+        let a = global_tokenizer() as *const _ as *const u8;
+        let b = global_tokenizer() as *const _ as *const u8;
+        assert_eq!(a, b, "global_tokenizer must be a singleton");
+    }
+}

--- a/src-tauri/src/commands/search/unified.rs
+++ b/src-tauri/src/commands/search/unified.rs
@@ -17,6 +17,7 @@ use crate::errors::AppError;
 
 use super::hybrid::{reciprocal_rank_fusion, RankedCandidate, RRF_K};
 use super::query_expand::{expand_query, query_expansion_enabled};
+use super::tokenizer::{morphological_query_enabled, tokenize_query_for_fts};
 
 /// Default cap for per-conversation result diversity, matches secall.
 const DEFAULT_MAX_PER_CONVERSATION: usize = 2;
@@ -71,7 +72,16 @@ pub fn search_unified(
         query.clone()
     };
 
-    let fts_results = fts_conversation_search(&state, &effective_query, &project_key, per_source)?;
+    // Optional morphological tokenization for the FTS side. Only when the
+    // index has been rebuilt under the same tokenizer (Phase C Part2); until
+    // then, leaving the flag off is the correct default.
+    let fts_query = if morphological_query_enabled() {
+        tokenize_query_for_fts(&effective_query)
+    } else {
+        effective_query.clone()
+    };
+
+    let fts_results = fts_conversation_search(&state, &fts_query, &project_key, per_source)?;
     let vec_results = document_vector_search(&state, &effective_query, &project_key, per_source);
 
     let fused = reciprocal_rank_fusion(&[fts_results.as_slice(), vec_results.as_slice()], RRF_K);


### PR DESCRIPTION
## 배경

searchPipelineFromSecallPlan.md Phase C. 한국어 형태소 분해기 도입. secall 의 검증된 Lindera ko-dic 기반 구조를 이식.

## Part split 이유

Phase C 는 (a) tokenizer 구조 (b) 인덱스 재구축 (migration + trigger + re-index command) 둘로 나뉨:
- **Part1 (이 PR)**: tokenizer 모듈 + 쿼리 측 opt-in 통합. dev 앱에 0 영향.
- **Part2 (별도 PR)**: `messages_fts` trigger 변경 + `rebuild_messages_fts` command + migration v45. 실제 인덱스 재구축.

쿼리만 morphemize 하고 인덱스는 whitespace 로 남으면 recall 이 오히려 떨어짐 → Part2 전까진 쿼리 측 플래그도 OFF 권장.

## 변경

### Cargo 의존성
```toml
lindera = { version = "2.3", features = ["embed-ko-dic"] }  # secall 과 동일
```

### `src/commands/search/tokenizer.rs`
- `Tokenizer` trait (Send + Sync)
- `LinderaKoTokenizer` — ko-dic 임베디드, NNG/NNP/NNB/VV/VA/SL 태그 유지
- `SimpleTokenizer` — whitespace + punctuation fallback
- `global_tokenizer()` — OnceLock 싱글톤. Lindera 초기화 실패 시 자동 Simple fallback
- `tokenize_query_for_fts(text) -> String`
- `morphological_query_enabled()` — `TUNAFLOW_MORPH_QUERY` 플래그 (default **OFF**)

### `search_unified` opt-in 통합
```rust
let fts_query = if morphological_query_enabled() {
    tokenize_query_for_fts(&effective_query)
} else {
    effective_query.clone()
};
```
플래그 OFF 일 때 기존 동작 완전 동일. ON 은 Part2 의 인덱스 재구축 완료 후 활성화 권장.

## 테스트

12 신규:
- simple tokenizer: 공백/punct split, 소문자화, 1글자 drop, empty input
- lindera: 한국어 형태소 분해, 영한 혼합, 빈 입력, 특수문자
- singleton: `global_tokenizer()` 재호출 시 동일 인스턴스

Lindera 테스트는 런타임에 ko-dic 로드 불가 시 early return (플랫폼 호환).

**\`cargo test --lib\`: 383 passed / 0 failed** (baseline 371 → +12).

## 다음 단계 (Part2)

- migration v45: `messages` 에 `content_tokenized` 컬럼 추가
- `messages_fts` trigger 수정 (tokenized content 로 인덱싱)
- `rebuild_messages_fts` Tauri command — 기존 corpus 재처리
- Settings UI (tokenizer backend 선택) — 후순위

## Test plan
- [x] \`cargo test --lib\` — 383 passed
- [ ] 빌드 + 앱 재기동 후 `TUNAFLOW_MORPH_QUERY=on` 으로 쿼리 로그 확인 (임시)
- [ ] Part2 에서 재인덱싱 command 돌린 뒤 "플랜을" → "플랜" matching 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)