### PR TITLE
docs(plans): Search Phase C Part 2 — Architect 산출물 (5 subtasks)

### DIFF
--- a/docs/plans/index.md
+++ b/docs/plans/index.md
@@ -36,6 +36,7 @@
 | [roundtableRoleTerminologySeparationPlan_2026-03-30](./roundtableRoleTerminologySeparationPlan_2026-03-30.md) | P1 — 프로필 역할 vs RT 토론 역할 분리 |
 | [runtimeFeatureValidationPlan_2026-03-30](./runtimeFeatureValidationPlan_2026-03-30.md) | P1 — memory/retrieval/auto/budget/RT 실시나리오 검증 |
 | [sdkUrlSessionModePlan](./sdkUrlSessionModePlan.md) | — |
+| [searchPipelineFromSecallPlan-part2](./searchPipelineFromSecallPlan-part2.md) | P1 — Phase C Part 2: `messages_fts` rebuild + content_tokenized 컬럼 + app-level snippet (depends: PR #127) |
 | [skillSelectorAgentPlan](./skillSelectorAgentPlan.md) | — |
 | [structuralImprovementPlan](./structuralImprovementPlan.md) | — |
 | [systemMessageChannelPlan](./systemMessageChannelPlan.md) | — |

--- a/docs/plans/searchPipelineFromSecallPlan-part2-task-01.md
+++ b/docs/plans/searchPipelineFromSecallPlan-part2-task-01.md
@@ -1,0 +1,96 @@
+# Subtask 01 — Migration v45 & `messages_fts` 스키마 재정의
+
+> 상위 plan: [searchPipelineFromSecallPlan-part2.md](./searchPipelineFromSecallPlan-part2.md)
+
+## Changed files
+
+- `src-tauri/src/db/migrations.rs` — `apply_v45` 함수 신규. 기존 v15 trigger DROP + `messages_fts` DROP/CREATE + 신규 trigger 3종.
+- `src-tauri/src/db/schema.rs` — `messages_fts` 정의를 **standalone FTS5** (`content=messages` 제거, `tokenize='unicode61'` 명시) 로 교체. `messages` 테이블 정의에 `content_tokenized TEXT` 컬럼 추가.
+- `src-tauri/src/db/migrations.rs` 의 마이그레이션 registry (`run_migrations` / `apply_all` 내부 match arm) 에 v45 엔트리 추가.
+
+## Change description
+
+### 1. `schema.rs`
+
+`messages` CREATE 문에 `content_tokenized TEXT` 를 **맨 끝에** 추가 (기존 컬럼 순서 유지 — migration 과 fresh DB 의 columns 순서 일치가 조회 쉬움).
+
+`messages_fts` CREATE 문 교체:
+
+```sql
+-- 기존 (schema.rs:273-275)
+CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts
+    USING fts5(content, content=messages, content_rowid=rowid);
+
+-- 신규
+CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
+    content,
+    message_id UNINDEXED,
+    tokenize='unicode61'
+);
+```
+
+### 2. `migrations.rs` — `apply_v45`
+
+plan §1.1 SQL 을 그대로 실행. 순서:
+1. `ALTER TABLE messages ADD COLUMN content_tokenized TEXT` (idempotent: `add_column_if_missing` 헬퍼 사용)
+2. `DROP TRIGGER IF EXISTS messages_fts_insert|update|delete`
+3. `DROP TABLE IF EXISTS messages_fts`
+4. `CREATE VIRTUAL TABLE messages_fts USING fts5(content, message_id UNINDEXED, tokenize='unicode61')`
+5. 신규 trigger 3종 (plan §1.1 참조)
+6. `INSERT INTO schema_version (version, applied_at) VALUES (45, ?1)`
+
+**절대 금지**: 이 마이그레이션 안에서 `INSERT INTO messages_fts ... SELECT FROM messages` 수행. 앱 기동 블록 방지.
+
+### 3. Backfill 정책
+
+기존 row 의 `content_tokenized` 는 NULL 로 남고, FTS 는 비어있는 상태로 출발. 사용자는 Settings 에서 "Rebuild search index" 를 실행해야 과거 메시지 검색 가능 — 이 UX 는 subtask 05 에서 처리. 마이그레이션 로그에 `eprintln!("[migration v45] messages_fts rebuilt empty; invoke rebuild_messages_fts to backfill")` 1 회 남긴다.
+
+## Dependencies
+
+depends_on: 없음 (v44 까지 적용된 DB 기준).
+
+## Verification
+
+- `cargo test --lib db::migrations` — 기존 tests 통과.
+- 신규 test `src-tauri/tests/db_integration.rs` (또는 `tests/migration_v45.rs`):
+  ```rust
+  #[test]
+  fn v45_drops_external_content_and_adds_tokenized_column() {
+      let conn = fresh_v44_db();
+      // seed 10 messages with dummy content
+      apply_v45(&conn).unwrap();
+      // 1) content_tokenized 컬럼 존재 + NULL
+      let null_cnt: i64 = conn.query_row(
+          "SELECT COUNT(*) FROM messages WHERE content_tokenized IS NULL", [], |r| r.get(0)
+      ).unwrap();
+      assert_eq!(null_cnt, 10);
+      // 2) messages_fts 가 비어있음
+      let fts_cnt: i64 = conn.query_row("SELECT COUNT(*) FROM messages_fts", [], |r| r.get(0)).unwrap();
+      assert_eq!(fts_cnt, 0);
+      // 3) standalone 확인 — content= external 이 없음
+      let create_sql: String = conn.query_row(
+          "SELECT sql FROM sqlite_master WHERE name='messages_fts'", [], |r| r.get(0)
+      ).unwrap();
+      assert!(!create_sql.contains("content=messages"));
+      assert!(create_sql.contains("tokenize"));
+  }
+  ```
+- 신규 test — trigger fallback (INV-4):
+  ```rust
+  #[test]
+  fn trigger_falls_back_to_content_when_tokenized_null() {
+      // content_tokenized 없이 INSERT
+      conn.execute("INSERT INTO messages (id, conversation_id, role, content, timestamp) VALUES ('m1','c1','user','hello world',0)", []).unwrap();
+      let cnt: i64 = conn.query_row("SELECT COUNT(*) FROM messages_fts WHERE content MATCH 'hello'", [], |r| r.get(0)).unwrap();
+      assert_eq!(cnt, 1);
+  }
+  ```
+- `cargo test --test db_integration` — exit 0.
+- `cargo check` — exit 0.
+
+## Risks
+
+- **기존 user 데이터 상실 인식**: migration 직후 검색이 빈 결과를 반환 → 사용자 혼란 가능. subtask 05 의 UI 배너로 완화하되, 릴리스 노트에 명시 필요. 본 subtask 구현 시점에는 Developer 가 README 또는 CHANGELOG 에 항목 추가.
+- **`DROP TABLE IF EXISTS messages_fts`** 후 `CREATE VIRTUAL TABLE` 실패 시 FTS 테이블이 없는 상태로 앱이 기동됨. `apply_v45` 는 transaction (`BEGIN ... COMMIT`) 안에서 실행해 실패 시 rollback. 다른 v* 함수와 transaction 사용 관례 확인 (기존 `apply_v*` 코드가 transaction 을 명시하지 않으면 이 subtask 에서 도입).
+- **v44 (Harness Phase 3b-part1 audit, PR #124) 미머지 상태**: v45 는 v44 다음 순번. PR #124 가 먼저 머지되어야 함 — 본 PR 에서 base branch 를 #124 머지 후 main 으로 설정.
+- **schema.rs 변경과 migration 의 이중성**: fresh DB (schema.rs) 와 migrated DB (migrations.rs) 가 다를 경우 회귀 버그 원천. 테스트에서 "fresh DB 에서도 `create_sql` 이 `content=messages` 를 포함하지 않아야" 확인.

--- a/docs/plans/searchPipelineFromSecallPlan-part2-task-02.md
+++ b/docs/plans/searchPipelineFromSecallPlan-part2-task-02.md
@@ -1,0 +1,122 @@
+# Subtask 02 — Write path 통합 & `tokenize_for_index` helper
+
+> 상위 plan: [searchPipelineFromSecallPlan-part2.md](./searchPipelineFromSecallPlan-part2.md)
+
+## Changed files
+
+- `src-tauri/src/commands/search/tokenizer.rs` — `tokenize_for_index()` 공개 helper 추가 (내부 구현은 `tokenize_query_for_fts` 에 위임).
+- `src-tauri/src/commands/messages.rs` — INSERT 3종 (`:129 :158 :191`) 에 `content_tokenized` 컬럼 write 추가.
+- `src-tauri/src/commands/agents_helpers/send_common/persistence.rs` — INSERT `:124 :142 :221 :494` 와 finalize UPDATE `:293 :345` 에 `content_tokenized` 반영 (스트리밍 중간 UPDATE 는 제외).
+- `src-tauri/src/commands/roundtable_helpers/persist.rs` — INSERT `:20 :54 :146` + UPDATE `:87` 반영.
+- `src-tauri/src/commands/branches.rs` — `:566` branch copy INSERT 반영.
+- `src-tauri/src/commands/agents_helpers/tool_request.rs` — `:354 :379` INSERT 반영.
+
+## Change description
+
+### 1. Helper 추가
+
+`src-tauri/src/commands/search/tokenizer.rs` 말미에:
+
+```rust
+/// Index-side tokenize. Identical to `tokenize_query_for_fts` — aliasing lets
+/// callers audit write-path and query-path independently.
+pub fn tokenize_for_index(text: &str) -> String {
+    tokenize_query_for_fts(text)
+}
+```
+
+`mod.rs` 의 `pub use tokenizer::{...}` re-export 에 `tokenize_for_index` 추가.
+
+### 2. Non-streaming INSERT (대부분 케이스)
+
+패턴:
+
+```rust
+// before
+let id = uuid();
+conn.execute(
+    "INSERT INTO messages (id, conversation_id, role, content, timestamp, status) VALUES (?1,?2,?3,?4,?5,?6)",
+    params![id, conv, role, content, ts, status],
+)?;
+
+// after
+use crate::commands::search::tokenize_for_index;
+let id = uuid();
+let tokenized = tokenize_for_index(&content);
+conn.execute(
+    "INSERT INTO messages (id, conversation_id, role, content, content_tokenized, timestamp, status) VALUES (?1,?2,?3,?4,?5,?6,?7)",
+    params![id, conv, role, content, tokenized, ts, status],
+)?;
+```
+
+적용 사이트:
+- `messages.rs:129` (user message insert)
+- `messages.rs:158, 191` (기타 직접 INSERT — role/engine 조합 확인 후 동일 패턴)
+- `roundtable_helpers/persist.rs:20, 54, 146`
+- `branches.rs:566`
+- `tool_request.rs:354, 379`
+- `send_common/persistence.rs:124, 142, 494`
+
+### 3. Streaming 경로 (`send_common/persistence.rs`)
+
+두 가지 케이스 구분:
+
+**(a) INSERT placeholder (`:221`)**:
+```rust
+// before: content=""
+"INSERT INTO messages(id,conversation_id,role,content,timestamp,status,engine,model,persona) VALUES (...)"
+
+// after: content=""   content_tokenized=NULL 로 명시 — 미 tokenize.
+"INSERT INTO messages(id,conversation_id,role,content,content_tokenized,timestamp,status,engine,model,persona) VALUES (?, ?, ?, ?, NULL, ?, ?, ?, ?, ?)"
+```
+또는 스키마 default 가 NULL 이므로 컬럼 생략해도 동일. 명시 권장 (코드 가독성).
+
+**(b) 중간 update (content 누적 스트리밍)**:
+`UPDATE messages SET content = ?` 호출 → `content_tokenized` 그대로 NULL 유지. **절대 tokenize 호출 금지** (INV-5).
+
+**(c) finalize (`:293 :345`)**:
+```rust
+// before
+"UPDATE messages SET content=?1, status='done', timestamp=?2 WHERE id=?3"
+
+// after
+use crate::commands::search::tokenize_for_index;
+let tokenized = tokenize_for_index(&final_content);
+"UPDATE messages SET content=?1, content_tokenized=?2, status='done', timestamp=?3 WHERE id=?4"
+params![final_content, tokenized, ts, id]
+```
+
+error 경로 (`:345`) 도 동일. 에러 메시지도 검색 대상이므로 tokenize 수행.
+
+### 4. RT `persist.rs:87`
+
+`UPDATE messages SET content=?1, status=?2, timestamp=?3 WHERE id=?4` — RT finalize 경로. (c) 와 동일 방식으로 `content_tokenized` 함께 write.
+
+## Dependencies
+
+depends_on: [01] — `content_tokenized` 컬럼이 먼저 존재해야 함.
+
+## Verification
+
+- `cargo test --lib commands::messages` — user insert 테스트. 신규 assertion: insert 직후 `SELECT content_tokenized FROM messages WHERE id=?` 가 non-null.
+- `cargo test --lib commands::agents_helpers::send_common::persistence` — finalize 경로 테스트. 스트리밍 시뮬레이션:
+  ```rust
+  // 1) placeholder INSERT
+  // 2) 3회 중간 UPDATE content (tokenized 는 NULL 유지 확인)
+  // 3) finalize UPDATE (tokenized non-null + FTS match 성공 확인)
+  let fts_count: i64 = conn.query_row(
+      "SELECT COUNT(*) FROM messages_fts WHERE content MATCH ?1", params![tokenized_query], |r| r.get(0)
+  ).unwrap();
+  assert!(fts_count >= 1);
+  ```
+- `cargo test --lib commands::roundtable_helpers::persist`
+- `cargo test --lib commands::branches`
+- `cargo check` — exit 0. 컬럼 추가로 파라미터 수 틀어진 경우 컴파일 에러로 drop.
+- **검증 추가**: 모든 `INSERT INTO messages` / `UPDATE messages SET content` 사이트를 grep 해 변경 누락 없는지 확인. 테스트 코드 (e.g. `vector_search/query.rs:477, 485, 533, 534, 554`) 는 기존 동작 유지 — `content_tokenized` 를 넘기지 않아도 COALESCE fallback (INV-4) 으로 작동. 테스트 수정 불필요하나 새로운 테스트에서는 tokenize 경로를 직접 검증할 것.
+
+## Risks
+
+- **누락 사이트**: messages 테이블 write 는 grep 으로 식별 가능하나 동적 SQL 이나 마이그레이션 스크립트에서 놓칠 수 있음. Developer 는 PR 작성 전 `rg "INSERT INTO messages\b|UPDATE messages SET content" src-tauri/src` 결과를 checklist 에 첨부.
+- **Lindera latency**: 스트리밍 finalize 당 1회 호출. 실측 필요. 만약 100ms 이상이면 `spawn_blocking` 으로 이동 검토 (현재 send_common 은 이미 blocking context). `cargo bench` (없으면 `cargo test` 내 `std::time::Instant` 로 간이 측정) 권장.
+- **Test DB 의 구스키마**: `vector_search/query.rs:477` 등 테스트는 `content_tokenized` 를 넘기지 않음. v45 trigger 의 COALESCE 가 fallback 을 처리하므로 **기존 테스트는 그대로 통과해야 함**. 통과하지 못하면 trigger 설계 재검토.
+- **마이그레이션 미적용 DB 에서 실행 시**: 컬럼이 없는 상태에서 INSERT 가 실패. v45 apply 보장을 assert 할 위치는 `AppState::init` — 마이그레이션이 성공해야만 runtime 경로 진입.

--- a/docs/plans/searchPipelineFromSecallPlan-part2-task-03.md
+++ b/docs/plans/searchPipelineFromSecallPlan-part2-task-03.md
@@ -1,0 +1,205 @@
+# Subtask 03 — `rebuild_messages_fts` Tauri command + 진행률/취소
+
+> 상위 plan: [searchPipelineFromSecallPlan-part2.md](./searchPipelineFromSecallPlan-part2.md)
+
+## Changed files
+
+- `src-tauri/src/commands/search/rebuild.rs` — 신규. rebuild loop + cancel flag + Tauri commands.
+- `src-tauri/src/commands/search/mod.rs` — `pub mod rebuild;` + re-export.
+- `src-tauri/src/lib.rs` (또는 tauri command registry) — `rebuild_messages_fts`, `cancel_rebuild_messages_fts` 등록.
+- `src/types/events.ts` (FE) — 이벤트 타입 정의 (선택, subtask 05 에서 써도 됨).
+
+## Change description
+
+### 1. 상태 구조체
+
+```rust
+// src-tauri/src/commands/search/rebuild.rs
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+#[derive(Default)]
+pub struct RebuildCancelFlag(pub Arc<AtomicBool>);
+
+impl RebuildCancelFlag {
+    pub fn reset(&self) { self.0.store(false, Ordering::SeqCst); }
+    pub fn set(&self) { self.0.store(true, Ordering::SeqCst); }
+    pub fn is_cancelled(&self) -> bool { self.0.load(Ordering::Relaxed) }
+}
+```
+
+Tauri state 로 `app.manage(RebuildCancelFlag::default())` 등록 (Tauri builder 쪽). 상위 plan §4 의 state 시그니처 확인.
+
+### 2. 이벤트
+
+```rust
+// payloads
+#[derive(serde::Serialize, Clone)]
+struct ProgressPayload { done: u64, total: u64 }
+
+#[derive(serde::Serialize, Clone)]
+struct CompletePayload { done: u64, total: u64, canceled: bool }
+
+#[derive(serde::Serialize, Clone)]
+struct ErrorPayload { error: String }
+```
+
+이벤트 이름:
+- `messages_fts_rebuild_progress`
+- `messages_fts_rebuild_complete`
+- `messages_fts_rebuild_error`
+
+### 3. Command 시그니처
+
+```rust
+#[derive(serde::Serialize)]
+pub struct RebuildSummary { pub done: u64, pub total: u64, pub canceled: bool }
+
+#[tauri::command]
+pub async fn rebuild_messages_fts(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, DbState>,
+    cancel: tauri::State<'_, RebuildCancelFlag>,
+) -> Result<RebuildSummary, AppError> { /* spec 아래 */ }
+
+#[tauri::command]
+pub fn cancel_rebuild_messages_fts(
+    cancel: tauri::State<'_, RebuildCancelFlag>,
+) -> Result<(), AppError> {
+    cancel.set();
+    Ok(())
+}
+```
+
+### 4. Rebuild loop (상세)
+
+```rust
+pub async fn rebuild_messages_fts(...) -> Result<RebuildSummary, AppError> {
+    cancel.reset();
+    let cancel_clone = cancel.0.clone();
+    let state_db = state.inner().clone();   // DbState 가 Clone 이거나 Arc. 확인 필요.
+    let app_clone = app.clone();
+    let res = tokio::task::spawn_blocking(move || -> Result<RebuildSummary, AppError> {
+        let total: u64 = {
+            let r = state_db.read.lock().map_err(|_| AppError::Lock)?;
+            r.query_row(
+                "SELECT COUNT(*) FROM messages WHERE content_tokenized IS NULL",
+                [], |row| row.get::<_, i64>(0)
+            )? as u64
+        };
+
+        let mut done: u64 = 0;
+        const CHUNK: usize = 500;
+
+        loop {
+            if cancel_clone.load(Ordering::Relaxed) { break; }
+
+            // (1) read chunk
+            let rows: Vec<(i64, String)> = {
+                let w = state_db.write.lock().map_err(|_| AppError::Lock)?;
+                let mut stmt = w.prepare(
+                    "SELECT rowid, content FROM messages
+                      WHERE content_tokenized IS NULL
+                      LIMIT ?1"
+                )?;
+                let iter = stmt.query_map(params![CHUNK as i64], |row| {
+                    Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
+                })?;
+                iter.filter_map(Result::ok).collect()
+            };
+            if rows.is_empty() { break; }
+
+            // (2) tokenize (lock 밖에서 CPU 작업)
+            let tokenized: Vec<(i64, String)> = rows.into_iter()
+                .map(|(rowid, c)| (rowid, tokenize_for_index(&c)))
+                .collect();
+
+            // (3) write chunk — 단일 transaction
+            {
+                let mut w = state_db.write.lock().map_err(|_| AppError::Lock)?;
+                let tx = w.transaction()?;
+                {
+                    let mut stmt = tx.prepare(
+                        "UPDATE messages SET content_tokenized = ?1 WHERE rowid = ?2"
+                    )?;
+                    for (rowid, t) in &tokenized {
+                        stmt.execute(params![t, rowid])?;
+                    }
+                }
+                tx.commit()?;
+            }
+
+            done += tokenized.len() as u64;
+            app_clone.emit("messages_fts_rebuild_progress", ProgressPayload { done, total })
+                .map_err(|e| AppError::Agent(format!("emit: {e}")))?;
+        }
+
+        // (4) optimize
+        {
+            let w = state_db.write.lock().map_err(|_| AppError::Lock)?;
+            w.execute("INSERT INTO messages_fts(messages_fts) VALUES('optimize')", [])?;
+        }
+
+        let canceled = cancel_clone.load(Ordering::Relaxed);
+        let summary = RebuildSummary { done, total, canceled };
+        app_clone.emit("messages_fts_rebuild_complete",
+            CompletePayload { done, total, canceled }
+        ).map_err(|e| AppError::Agent(format!("emit: {e}")))?;
+        Ok(summary)
+    }).await.map_err(|e| AppError::Agent(format!("join: {e}")))??;
+    Ok(res)
+}
+```
+
+**중요 포인트**:
+- `tokenize_for_index` 호출은 **write lock 밖에서** 수행 (CPU 작업).
+- write lock 은 (1) 읽기, (3) 쓰기, (4) optimize 각각 별도 scope — long hold 방지 (INV-3).
+- chunk size 500 은 예시. 실측 후 조정. 상수로 `const REBUILD_CHUNK: usize = 500;` 두고 컬렉션.
+- `total` 은 loop 시작 시 fix. 새 메시지가 rebuild 중 들어오면 progress 가 100% 를 초과할 수 있음 — UI 가 `min(done,total)` 로 clamp.
+
+### 5. 에러 경로
+
+spawn_blocking 내 `Result<_, AppError>` 반환 시 바깥에서 catch. 에러 이벤트 emit 은 호출자 측 (Frontend) 이 `invoke(...).catch(...)` 로 받을 수 있으므로 선택적.
+
+### 6. `cancel_rebuild_messages_fts` 재호출 안전성
+
+sync command. 동일 state 에 `set()` 만 수행 — 여러 번 호출해도 no-op. rebuild 시작 전 `reset()` 으로 초기화.
+
+## Dependencies
+
+depends_on: [01, 02]
+
+## Verification
+
+- **Unit**: `src-tauri/src/commands/search/rebuild.rs::tests`
+  ```rust
+  #[tokio::test]
+  async fn rebuild_processes_only_null_tokenized() {
+      // seed 3 messages: 2 with NULL tokenized, 1 with existing value
+      // run rebuild
+      // assert: done==2, existing value unchanged
+  }
+
+  #[tokio::test]
+  async fn rebuild_respects_cancel() {
+      // seed 1500 messages (3 chunks). Cancel after first progress event.
+      // assert: done < 1500, canceled==true
+  }
+
+  #[tokio::test]
+  async fn rebuild_is_idempotent() {
+      // Run twice. Second run: total==0, done==0.
+  }
+  ```
+- **Integration**: FTS 측 검증 — rebuild 후 `SELECT COUNT(*) FROM messages_fts` 가 `SELECT COUNT(*) FROM messages` 와 같거나 이상 (trigger 가 자동 sync 된 row 포함) 인지.
+- **Lock 검증**: integration 테스트에서 rebuild 진행 중 다른 thread 가 `INSERT INTO messages` 를 수행할 수 있는지 (deadlock 아닌지) 확인. Rust native thread spawn → write lock reacquire → INSERT 성공.
+- `cargo check` + `cargo test --lib commands::search::rebuild`
+
+## Risks
+
+- **chunk size 부적정**: 500 이 너무 크면 UI freeze, 너무 작으면 overhead. Developer 는 처음에 500 으로 릴리스하고 측정 후 튜닝.
+- **`INSERT INTO messages_fts VALUES('optimize')`** 는 standalone FTS5 에서 정상 동작 (`'rebuild'` 는 external content 에서만 의미). 잘못 쓰지 않도록 주의.
+- **state.write.lock() 에서 poison**: `.map_err(|_| AppError::Lock)` 로 처리. 다른 worker 가 panic 해 lock 을 poison 한 경우 error 이벤트 emit 후 종료.
+- **emit 실패**: Tauri app 이 shutdown 중 emit 실패 가능. `.map_err(|e| AppError::Agent(format!("emit: {e}")))` 로 전파.
+- **`content_tokenized IS NULL` 의 row 가 없어도** optimize 단계는 수행 — 이는 기대 동작 (no-op on empty FTS).
+- **Tokenize 스레드 이슈**: `global_tokenizer()` 는 `OnceLock<Box<dyn Tokenizer>>`. `Send + Sync` 만족. `spawn_blocking` 에서 안전.

--- a/docs/plans/searchPipelineFromSecallPlan-part2-task-04.md
+++ b/docs/plans/searchPipelineFromSecallPlan-part2-task-04.md
@@ -1,0 +1,211 @@
+# Subtask 04 — `search_messages` morphological 분기 + app-level `extract_snippet`
+
+> 상위 plan: [searchPipelineFromSecallPlan-part2.md](./searchPipelineFromSecallPlan-part2.md)
+
+## Changed files
+
+- `src-tauri/src/commands/search/snippet.rs` — 신규. `extract_snippet()` 유틸.
+- `src-tauri/src/commands/search/mod.rs` — `pub mod snippet;` + re-export.
+- `src-tauri/src/commands/messages.rs` — `search_messages` (`:381`) 에 morphological 분기 + snippet SQL → app-level 호출로 교체.
+- `src-tauri/src/commands/search/unified.rs` — `fts_conversation_search` (`:96`) 의 `snippet(messages_fts, ...)` SQL 제거 + `extract_snippet` 호출로 교체. (morphological 분기는 이미 존재 — 변경 없음.)
+
+## Change description
+
+### 1. `extract_snippet`
+
+secall `bm25.rs:191` 포팅:
+
+```rust
+// src-tauri/src/commands/search/snippet.rs
+/// 쿼리의 첫 non-whitespace term 이 처음 등장하는 지점 주변 ±half 만큼 char window 잘라 반환.
+/// - byte boundary 가 아니라 **char boundary** 기준 (한글 다바이트 안전).
+/// - 매칭 없으면 앞 `max_chars` char.
+/// - 양 끝에 ellipsis `…` 추가.
+/// - 매칭 term 을 `**…**` 로 하이라이트 (기존 UI 관습 유지).
+pub fn extract_snippet(content: &str, query: &str, max_chars: usize) -> String {
+    let chars: Vec<char> = content.chars().collect();
+    if chars.is_empty() { return String::new(); }
+
+    // 첫 term 추출 — whitespace split, 빈 제거, 첫 값
+    let term = query.split_whitespace().next().unwrap_or("");
+    if term.is_empty() || chars.len() <= max_chars {
+        // 매칭 불가 or 전체 보여줄 수 있으면 그대로
+        return chars.iter().collect();
+    }
+
+    // 대소문자 무시 매칭 (char vec 기준)
+    let lower: String = content.to_lowercase();
+    let term_lower = term.to_lowercase();
+    let idx_byte = lower.find(&term_lower);
+
+    let (start_char, end_char) = match idx_byte {
+        None => (0usize, max_chars.min(chars.len())),
+        Some(byte_idx) => {
+            // byte→char 인덱스 복원
+            let prefix = &content[..byte_idx];
+            let term_start_char = prefix.chars().count();
+            let half = max_chars / 2;
+            let s = term_start_char.saturating_sub(half);
+            let e = (term_start_char + max_chars - (term_start_char - s)).min(chars.len());
+            (s, e)
+        }
+    };
+
+    let mut out = String::new();
+    if start_char > 0 { out.push('…'); }
+    // term 하이라이트: term_lower 등장 구간을 찾아 `**..**` 삽입
+    // 단순 구현: window 를 String 화 후 replace_first (case-insensitive 는 한 번만 수동)
+    let window: String = chars[start_char..end_char].iter().collect();
+    let hi = highlight_first(&window, term);
+    out.push_str(&hi);
+    if end_char < chars.len() { out.push('…'); }
+    out
+}
+
+fn highlight_first(text: &str, term: &str) -> String {
+    if term.is_empty() { return text.to_string(); }
+    let lower_text = text.to_lowercase();
+    let lower_term = term.to_lowercase();
+    if let Some(pos) = lower_text.find(&lower_term) {
+        // pos 는 byte — 원본 text 에서 해당 char 범위 추출
+        let prefix = &text[..pos];
+        let matched_bytes = lower_term.len();
+        let end = pos + matched_bytes;
+        if end <= text.len() && text.is_char_boundary(pos) && text.is_char_boundary(end) {
+            let matched = &text[pos..end];
+            let after = &text[end..];
+            return format!("{}**{}**{}", prefix, matched, after);
+        }
+    }
+    text.to_string()
+}
+```
+
+테스트 필수:
+```rust
+#[test] fn extract_handles_korean_multibyte() { ... }
+#[test] fn extract_returns_whole_text_if_short() { ... }
+#[test] fn extract_adds_leading_ellipsis() { ... }
+#[test] fn highlight_preserves_case_from_original() { ... }
+```
+
+### 2. `search_messages` (messages.rs:381)
+
+```rust
+// before
+let mut stmt = conn.prepare(
+    "SELECT m.id, m.conversation_id, COALESCE(c.custom_label, c.label, ''), m.role,
+            snippet(messages_fts, 0, '**', '**', '…', 40), m.timestamp, m.engine, m.persona
+     FROM messages_fts fts
+     JOIN messages m ON m.rowid = fts.rowid
+     JOIN conversations c ON c.id = m.conversation_id
+     WHERE messages_fts MATCH ?1 AND c.project_key = ?2
+     ORDER BY rank LIMIT ?3"
+)?;
+
+// after — morph 분기 + 원본 content 셀렉션
+use crate::commands::search::{morphological_query_enabled, tokenize_query_for_fts, extract_snippet};
+
+let fts_query = if morphological_query_enabled() {
+    tokenize_query_for_fts(&effective_query)
+} else {
+    effective_query.clone()
+};
+
+let mut stmt = conn.prepare(
+    "SELECT m.id, m.conversation_id, COALESCE(c.custom_label, c.label, ''), m.role,
+            m.content, m.timestamp, m.engine, m.persona
+     FROM messages_fts fts
+     JOIN messages m ON m.rowid = fts.rowid
+     JOIN conversations c ON c.id = m.conversation_id
+     WHERE messages_fts MATCH ?1 AND c.project_key = ?2
+     ORDER BY rank LIMIT ?3"
+)?;
+
+let results = stmt.query_map(params![fts_query, project_key, max], |row| {
+    let content: String = row.get(4)?;
+    // snippet 은 **원본 effective_query** 로 생성 — tokenized 가 아닌 사용자 의도 단어로 하이라이트
+    let snippet = extract_snippet(&content, &effective_query, 120);
+    Ok(SearchResult {
+        message_id: row.get(0)?,
+        conversation_id: row.get(1)?,
+        conversation_label: row.get(2)?,
+        role: row.get(3)?,
+        content_snippet: snippet,
+        timestamp: row.get(5)?,
+        engine: row.get(6)?,
+        persona: row.get(7)?,
+    })
+})?.filter_map(|r| r.ok()).collect();
+```
+
+### 3. `fts_conversation_search` (unified.rs:96)
+
+동일 패턴으로 `m.content` 셀렉션 후 `extract_snippet(&content, query, 120)` 호출. `query` 파라미터는 함수로 내려오는 effective_query (unified.rs:73) — tokenized 가 아닌 원본.
+
+**주의**: 현재 unified.rs 는 `query: &str` 만 받는데, morphological 이 활성화되면 `query` 는 이미 tokenized. 원본을 snippet 생성용으로 유지하려면 함수 시그니처를 확장:
+
+```rust
+fn fts_conversation_search(
+    state: &DbState,
+    fts_query: &str,        // FTS MATCH 용 (tokenized or not)
+    display_query: &str,    // snippet 하이라이트용 (원본)
+    project_key: &str,
+    limit: usize,
+) -> Result<Vec<UnifiedResult>, AppError>
+```
+
+호출부 (unified.rs:82) 도 `display_query = effective_query.clone()` 명시적으로 전달.
+
+## Dependencies
+
+depends_on: [01] — FTS 스키마/트리거가 새 구조여야 함.
+(`[02, 03]` 은 없어도 동작하지만 실제 검색 결과 얻으려면 필요.)
+
+## Verification
+
+- **Unit (snippet)**:
+  ```rust
+  #[test]
+  fn snippet_highlights_korean_match() {
+      let s = extract_snippet("오늘 아키텍처 설계 회의를 했다. 아키텍처 문서도 정리했다.", "아키텍처", 30);
+      assert!(s.contains("**아키텍처**"));
+      assert!(s.len() < 40 + 6);  // ellipsis + marker 여유
+  }
+
+  #[test]
+  fn snippet_returns_whole_when_short() {
+      let s = extract_snippet("짧은 글", "짧은", 120);
+      assert!(!s.starts_with('…'));
+  }
+
+  #[test]
+  fn snippet_falls_back_on_no_match() {
+      let s = extract_snippet("아무것도 매칭되지 않는 긴 문장입니다. 매우 긴 문장입니다.", "플랜", 20);
+      assert!(!s.contains("**"));
+  }
+  ```
+- **Integration (search_messages)**:
+  ```rust
+  #[tokio::test]
+  async fn search_messages_uses_morph_when_flag_on() {
+      // seed 1 message "아키텍처를 설계한다" with content_tokenized = "아키텍처 설계"
+      std::env::set_var("TUNAFLOW_MORPH_QUERY", "1");
+      let res = search_messages("아키텍처를".into(), "proj".into(), None, state).unwrap();
+      assert_eq!(res.len(), 1);
+      assert!(res[0].content_snippet.contains("**아키텍처**"));
+      std::env::remove_var("TUNAFLOW_MORPH_QUERY");
+  }
+  ```
+- `cargo test --lib commands::search::snippet`
+- `cargo test --lib commands::messages::tests::search_messages_*`
+- `cargo check`
+- `npx tsc --noEmit` — exit 0 (FE 는 snippet 포맷 동일하므로 변경 없음).
+
+## Risks
+
+- **Multi-term 쿼리**: `extract_snippet` 은 첫 term 만 하이라이트. 사용자 쿼리 "플랜 검색" → 첫 term "플랜" 만. 기존 `snippet()` 은 FTS5 가 여러 term 을 처리. 기능 regression 이지만 secall 동일 수준. 후속 개선 별도.
+- **대소문자 매칭**: `to_lowercase()` 가 ASCII 외 문자에 대해 Unicode-aware. 한글은 변화 없음. 영어 대소문자 mix 쿼리에서도 정상.
+- **Byte-vs-char boundary**: 한글은 UTF-8 multi-byte. `str::find` 는 byte idx 반환 → char idx 복원 필요 (위 코드 참조). 테스트로 명시 커버.
+- **Snippet 에서 하이라이트 마커 (`**...**`) 가 content 원본에도 존재하는 경우**: 예를 들어 사용자가 markdown `**bold**` 를 입력한 메시지. highlight 가 추가적으로 주입되면 markdown 파서가 혼동. **수용**: 기존 `snippet()` 도 `'**'` 사용 → UI 가 이미 처리 중. 변경 없음.
+- **unified.rs 시그니처 변경**: 내부 함수이므로 caller 1 곳만 수정. breaking 위험 낮음.

--- a/docs/plans/searchPipelineFromSecallPlan-part2-task-05.md
+++ b/docs/plans/searchPipelineFromSecallPlan-part2-task-05.md
@@ -1,0 +1,186 @@
+# Subtask 05 — Settings UI (Rebuild 버튼 + 진행률 + 형태소 토글)
+
+> 상위 plan: [searchPipelineFromSecallPlan-part2.md](./searchPipelineFromSecallPlan-part2.md)
+
+## Changed files
+
+- `src/components/settings/SearchSettings.tsx` — 신규. Settings 섹션 하나.
+- `src/components/settings/SettingsPanel.tsx` (또는 동등) — `SearchSettings` import + 네비 entry 추가.
+- `src/lib/api/search.ts` (신규) — `rebuildMessagesFts()` / `cancelRebuildMessagesFts()` wrapper.
+- `src/types/events.ts` (필요 시 확장) — 이벤트 payload 타입.
+- `src-tauri/src/commands/search/tokenizer.rs` — `morphological_query_enabled()` 를 env var 외에 **DB flag** 도 OR 체크하도록 확장. (Open question Q-4 를 "env var OR DB flag" 로 확정.)
+- `src-tauri/src/db/migrations.rs` v45 안에 settings 테이블 항목 insert (없으면 skip — 기존 `app_settings` 같은 kv 테이블 재사용).
+
+## Change description
+
+### 1. Backend — DB flag 추가
+
+`app_settings` kv 테이블이 있으면 `('search.morph_query_enabled', '0' | '1')` 로 저장. 없으면 신규 테이블은 도입하지 않고 **env var 방식만** 사용 (최소 스코프). 본 subtask 는 **기존 설정 저장소** 를 재사용.
+
+`morphological_query_enabled()` 확장:
+
+```rust
+pub fn morphological_query_enabled() -> bool {
+    // env var 우선 (개발자 override)
+    if let Ok(v) = std::env::var("TUNAFLOW_MORPH_QUERY") {
+        return matches!(v.trim().to_ascii_lowercase().as_str(), "1"|"true"|"on"|"yes");
+    }
+    // DB flag — 접근 비용 있으므로 OnceLock/RwLock 로 캐시.
+    // 단순 구현: 매 호출마다 DB 조회 X. Tauri state 로 관리 + toggle command 에서 update.
+    SEARCH_MORPH_FLAG.load(Ordering::Relaxed)
+}
+```
+
+`SEARCH_MORPH_FLAG: AtomicBool` — 앱 startup 에 DB 에서 읽어 초기화. toggle command 가 set.
+
+신규 commands:
+```rust
+#[tauri::command]
+pub fn set_morphological_query_enabled(enabled: bool, state: State<DbState>) -> Result<(), AppError> {
+    let w = state.write.lock().map_err(|_| AppError::Lock)?;
+    w.execute(
+        "INSERT INTO app_settings (key, value) VALUES ('search.morph_query_enabled', ?1)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        params![if enabled { "1" } else { "0" }]
+    )?;
+    SEARCH_MORPH_FLAG.store(enabled, Ordering::SeqCst);
+    Ok(())
+}
+
+#[tauri::command]
+pub fn get_morphological_query_enabled() -> bool {
+    SEARCH_MORPH_FLAG.load(Ordering::Relaxed)
+}
+```
+
+> **기존 `app_settings` 테이블 존재 여부 확인 필요** — 없으면 v45 migration 에 추가 (단 본 plan 범위 초과 여지. Developer 가 schema 확인 후 결정).
+
+### 2. Frontend — API wrapper
+
+```typescript
+// src/lib/api/search.ts
+import { invoke } from '@tauri-apps/api/core';
+import { listen } from '@tauri-apps/api/event';
+
+export type RebuildProgress = { done: number; total: number };
+export type RebuildComplete = { done: number; total: number; canceled: boolean };
+
+export async function rebuildMessagesFts(
+    onProgress: (p: RebuildProgress) => void,
+    onComplete: (c: RebuildComplete) => void,
+    onError: (err: string) => void,
+): Promise<() => void> {
+    const unlistenProgress = await listen<RebuildProgress>('messages_fts_rebuild_progress', (e) => onProgress(e.payload));
+    const unlistenComplete = await listen<RebuildComplete>('messages_fts_rebuild_complete', (e) => onComplete(e.payload));
+    const unlistenError = await listen<{ error: string }>('messages_fts_rebuild_error', (e) => onError(e.payload.error));
+    // command invocation 은 fire-and-forget (await 하면 complete 이벤트 중복)
+    invoke('rebuild_messages_fts').catch((e) => onError(String(e)));
+    return () => { unlistenProgress(); unlistenComplete(); unlistenError(); };
+}
+
+export function cancelRebuildMessagesFts() {
+    return invoke('cancel_rebuild_messages_fts');
+}
+
+export function setMorphEnabled(enabled: boolean) {
+    return invoke('set_morphological_query_enabled', { enabled });
+}
+
+export function getMorphEnabled(): Promise<boolean> {
+    return invoke('get_morphological_query_enabled');
+}
+```
+
+### 3. Frontend — SearchSettings.tsx
+
+```tsx
+// src/components/settings/SearchSettings.tsx
+export function SearchSettings() {
+    const [morph, setMorph] = useState(false);
+    const [progress, setProgress] = useState<RebuildProgress | null>(null);
+    const [running, setRunning] = useState(false);
+    const [status, setStatus] = useState<'idle'|'running'|'done'|'canceled'|'error'>('idle');
+    const [errorMsg, setErrorMsg] = useState<string>('');
+
+    useEffect(() => { getMorphEnabled().then(setMorph); }, []);
+
+    const handleRebuild = async () => {
+        setRunning(true);
+        setStatus('running');
+        setErrorMsg('');
+        const cleanup = await rebuildMessagesFts(
+            (p) => setProgress(p),
+            (c) => { setStatus(c.canceled ? 'canceled' : 'done'); setRunning(false); cleanup(); },
+            (err) => { setStatus('error'); setErrorMsg(err); setRunning(false); cleanup(); },
+        );
+    };
+
+    const handleCancel = () => { cancelRebuildMessagesFts(); };
+
+    const handleToggleMorph = async (next: boolean) => {
+        await setMorphEnabled(next);
+        setMorph(next);
+    };
+
+    return (
+        <section>
+            <h3>검색 / Search</h3>
+
+            <div className="setting-row">
+                <label>한국어 형태소 검색 활성화</label>
+                <Toggle checked={morph} onChange={handleToggleMorph} />
+                <p className="hint">
+                    조사/어미를 분리해 한국어 검색 재현율을 높입니다.
+                    인덱스 재구축 후 활성화하세요.
+                </p>
+            </div>
+
+            <div className="setting-row">
+                <label>검색 인덱스</label>
+                <button onClick={handleRebuild} disabled={running}>인덱스 재구축</button>
+                {running && <button onClick={handleCancel}>취소</button>}
+                {progress && (
+                    <ProgressBar value={progress.done} max={progress.total}
+                        label={`${progress.done} / ${progress.total}`} />
+                )}
+                {status === 'done' && <span className="status-ok">완료</span>}
+                {status === 'canceled' && <span className="status-warn">취소됨</span>}
+                {status === 'error' && <span className="status-error">{errorMsg}</span>}
+                <p className="hint">
+                    과거 메시지를 재인덱싱합니다. 대용량 프로젝트에서는 수 분이 걸릴 수 있습니다.
+                </p>
+            </div>
+        </section>
+    );
+}
+```
+
+`ProgressBar` / `Toggle` 은 기존 컴포넌트 재사용 (search 해서 확인).
+
+### 4. Settings navigation
+
+`SettingsPanel` 의 section 목록에 `"검색"` 엔트리 추가. 순서는 Frontend 컨벤션 따름.
+
+## Dependencies
+
+depends_on: [03] — rebuild command + 이벤트. 04 (검색 경로 전환) 는 UX 완성도 측면에서 같이 있는 것이 이상적이지만 독립 머지 가능.
+
+## Verification
+
+- `npx vitest run src/components/settings/SearchSettings.test.tsx` — 신규 테스트:
+  - 초기 상태에서 `getMorphEnabled` mock 이 true 반환 시 토글 on.
+  - "인덱스 재구축" 클릭 → `invoke('rebuild_messages_fts')` 호출.
+  - `messages_fts_rebuild_progress` 이벤트 fire → progress bar 업데이트.
+  - `messages_fts_rebuild_complete { canceled: false }` → 상태 "완료".
+  - 취소 버튼 → `cancel_rebuild_messages_fts` 호출.
+- `cargo test --lib commands::search::tokenizer::tests` — 신규: DB flag + env var OR 동작.
+- `npx tsc --noEmit` — exit 0.
+- 수동 E2E: `npm run tauri dev` → Settings > 검색 → 재구축 실행 → 진행률 표시 확인 → 완료 후 토글 ON → 검색창에서 "플랜을" 쿼리 → plan 문서 hit.
+
+## Risks
+
+- **Tauri 이벤트 listener leak**: cleanup 반환값을 반드시 호출. 컴포넌트 unmount 시 cleanup 보장 (useEffect teardown).
+- **`app_settings` 테이블 없을 가능성**: 현재 tunaFlow 의 설정 저장 메커니즘 (Zustand + localStorage vs DB) 확인 필요. DB 가 아니면 Zustand persist + env var 없이 store 값만으로 `morphological_query_enabled()` 결정이 어렵다 — 이 경우 **localStorage → invoke('set_...') 동기화** 가 단일 소스.
+- **검색 경로에 대한 런타임 감시**: Settings 에서 morph 토글 즉시 Backend 의 AtomicBool 갱신. 그러나 이미 열려 있는 검색 결과는 재쿼리 필요. UI 가 쿼리를 자동 재실행하진 않음 — 사용자가 재검색. 이는 기존 검색 UX 와 동일.
+- **대용량 rebuild UX**: 진행률이 오래 걸리면 Settings 패널을 닫아도 job 은 백그라운드 지속. 이벤트 구독은 컴포넌트 unmount 시 해제되므로 "다시 Settings 를 열면 진행률이 안 보인다" 라는 UX 함정. **완화**: Settings 열 때 `get_messages_fts_rebuild_status` (별도 command; 본 subtask 범위 밖 — open question 으로 flag).
+- **Toggle ON 상태에서 rebuild 를 하지 않은 경우**: 검색 결과가 비어 보임. Settings 에 "재구축이 필요합니다" 배너 추가 검토 — Q-4 와 함께 Developer 결정.

--- a/docs/plans/searchPipelineFromSecallPlan-part2.md
+++ b/docs/plans/searchPipelineFromSecallPlan-part2.md
@@ -1,0 +1,359 @@
+---
+title: 검색 파이프라인 Phase C Part 2 — 인덱스 측 형태소 재구축 (messages_fts rebuild)
+status: planned
+priority: P1
+created_at: 2026-04-22
+depends_on:
+  - PR #127 (feat/search-pipeline-phase-c-tokenizer — LinderaKoTokenizer + query-side tokenize)
+blocks:
+  - Feature flag `TUNAFLOW_MORPH_QUERY=1` 을 default ON 으로 승격하는 후속 작업
+related:
+  - docs/plans/searchPipelineFromSecallPlan.md  # Phase A~C 상위 plan, §6.3
+  - docs/plans/harnessVerificationGapPlan.md    # §5 proposer 4-section 규약
+  - seCall/crates/secall-core/src/store/schema.rs
+  - seCall/crates/secall-core/src/search/bm25.rs
+  - src-tauri/src/commands/search/tokenizer.rs
+  - src-tauri/src/commands/search/unified.rs
+  - src-tauri/src/commands/messages.rs
+  - src-tauri/src/db/migrations.rs             # v15 messages_fts triggers
+  - src-tauri/src/db/schema.rs                 # messages_fts VIRTUAL TABLE 정의
+---
+
+# Phase C Part 2 — `messages_fts` 재구축 & 인덱스 측 형태소화
+
+> Phase C Part 1 (PR #127) 은 **쿼리 측** `tokenize_query_for_fts()` 만 도입했다.
+> 그러나 인덱스가 여전히 whitespace-tokenized 상태이므로 `TUNAFLOW_MORPH_QUERY` 를 켜면
+> recall 이 오히려 떨어진다 (쿼리는 morphemes, index 는 whole words).
+>
+> Part 2 는 **인덱스 측** 을 재구축해 위 flag 를 안전하게 ON 할 수 있게 한다.
+
+---
+
+## TL;DR for Developer
+
+1. **Migration v45** — `messages` 테이블에 `content_tokenized TEXT` 컬럼을 추가하고, `messages_fts` 를 **external-content 에서 standalone FTS5 로 교체**한다. 기존 v15 trigger 3종을 DROP 하고 `content_tokenized` 기반 trigger 3종을 재생성. 기존 row 의 FTS 데이터는 비우지 말고 그대로 둔다 (backfill 은 별도 명령에서 수행).
+2. **Write path 전환** — `messages` 를 `INSERT`/`UPDATE` 하는 모든 사이트에 `content_tokenized` 동시 write 를 주입한다. Streaming 경로는 finalize 시점 1회만 tokenize 한다 (chunk 마다 Lindera 호출 금지).
+3. **`rebuild_messages_fts` Tauri command** — 기존 row 의 `content_tokenized` 를 chunk 단위 (500 row) 로 채우고 진행률 이벤트를 emit. 마지막에 `INSERT INTO messages_fts(messages_fts) VALUES('rebuild')` 로 FTS 정합성 확정. 취소 신호 지원.
+4. **`search_messages` 조건부 tokenize** — 이미 `search_unified` 는 `morphological_query_enabled()` 분기가 있다 (`unified.rs:76-82`). `search_messages` (messages.rs:381) 에도 같은 분기를 추가해 통합.
+5. **App-level `extract_snippet`** — standalone FTS5 의 `snippet()` 은 tokenized 텍스트를 반환하므로 가독성을 잃는다. secall `bm25.rs:191` 의 `extract_snippet(content, query, max_chars)` 를 이식해 search 결과 snippet 을 **원본 `messages.content`** 에서 생성한다.
+6. **Settings UI** — `Settings > Search` 섹션 (신규) 에 "Rebuild search index (Korean morphological)" 버튼 + 진행률 바 + 취소 + 완료 후 `TUNAFLOW_MORPH_QUERY` 활성화 안내.
+
+구현 순서는 위 1→2→3→4→5→6. 1~3 은 반드시 순서 지킬 것 (trigger 변경 전에 write path 를 먼저 건드리면 NULL 제약 위반 또는 silent FTS miss 가 발생).
+
+Feature flag `TUNAFLOW_MORPH_QUERY` 는 default OFF 를 유지하고, 본 PR 에서는 "rebuild 완료 & 플래그 ON" 이 **사용자 명시 행위** 로만 작동해야 한다 (backward compatibility).
+
+---
+
+## Specification
+
+### 1. DB schema
+
+#### 1.1 Migration v45 (`src-tauri/src/db/migrations.rs`)
+
+```sql
+-- 1) messages.content_tokenized 컬럼 추가 (NULL 허용; backfill 전까지 비어있어도 OK)
+ALTER TABLE messages ADD COLUMN content_tokenized TEXT;
+
+-- 2) 기존 v15 triggers 제거
+DROP TRIGGER IF EXISTS messages_fts_insert;
+DROP TRIGGER IF EXISTS messages_fts_update;
+DROP TRIGGER IF EXISTS messages_fts_delete;
+
+-- 3) 기존 messages_fts 제거 (external content 구조였음)
+DROP TABLE IF EXISTS messages_fts;
+
+-- 4) standalone FTS5 재생성 — external content 없음, tokenize 명시
+CREATE VIRTUAL TABLE messages_fts USING fts5(
+    content,
+    message_id UNINDEXED,
+    tokenize='unicode61'
+);
+
+-- 5) 새 triggers: content_tokenized 기반 (NEW.content_tokenized 우선, 없으면 NEW.content 폴백)
+CREATE TRIGGER messages_fts_insert AFTER INSERT ON messages BEGIN
+    INSERT INTO messages_fts(rowid, content, message_id)
+    VALUES (NEW.rowid, COALESCE(NEW.content_tokenized, NEW.content), NEW.id);
+END;
+
+CREATE TRIGGER messages_fts_update_tokenized
+    AFTER UPDATE OF content_tokenized ON messages BEGIN
+    DELETE FROM messages_fts WHERE rowid = OLD.rowid;
+    INSERT INTO messages_fts(rowid, content, message_id)
+    VALUES (NEW.rowid, COALESCE(NEW.content_tokenized, NEW.content), NEW.id);
+END;
+
+CREATE TRIGGER messages_fts_delete AFTER DELETE ON messages BEGIN
+    DELETE FROM messages_fts WHERE rowid = OLD.rowid;
+END;
+```
+
+**중요**: migration 안에서 `INSERT INTO messages_fts ... SELECT FROM messages` 는 하지 않는다. 앱 기동 블로킹 방지 목적. 기존 corpus 는 별도 `rebuild_messages_fts` 명령으로 backfill.
+
+**주의**: standalone FTS5 는 `DELETE FROM messages_fts WHERE rowid = ?` 구문을 허용한다 (external content FTS5 의 특수 `INSERT ... 'delete'` 구문과 대비). 위 trigger 는 이 단순화 구문을 사용.
+
+#### 1.2 `src-tauri/src/db/schema.rs` 수정
+
+기존 `CREATE VIRTUAL TABLE messages_fts USING fts5(content, content=messages, content_rowid=rowid);` (schema.rs:274) 를 신규 생성 경로에서도 동일하게 standalone 으로 교체 (fresh DB 와 migrated DB 가 동일 스키마가 되도록).
+
+### 2. Tokenizer helper 확장
+
+`src-tauri/src/commands/search/tokenizer.rs` 에 신규 헬퍼 추가:
+
+```rust
+/// Tokenize for index-side storage. Identical behavior to `tokenize_query_for_fts`
+/// today, but separated by name so write-path callers can be audited independently
+/// of query-path callers.
+pub fn tokenize_for_index(text: &str) -> String {
+    tokenize_query_for_fts(text)
+}
+```
+
+> 이유: 인덱싱용과 쿼리용이 같은 함수를 참조하는 사실이 invariant ([INV-2] 참조). 한 쪽만 바꾸는 실수를 방지하기 위해 **이름은 분리하되 내부 구현은 공유**. 추후 정책이 분기될 여지 확보.
+
+### 3. Write path 통합
+
+대상 파일 (grep `INSERT INTO messages\|UPDATE messages SET content` 결과, test 파일 제외):
+
+| 파일 | 라인 | 종류 |
+|---|---|---|
+| `src-tauri/src/commands/messages.rs` | 129, 158, 191 | 사용자 메시지 INSERT 3종 |
+| `src-tauri/src/commands/agents_helpers/send_common/persistence.rs` | 124, 142, 221, 293, 345, 494 | 엔진 경로 INSERT/UPDATE (streaming 포함) |
+| `src-tauri/src/commands/roundtable_helpers/persist.rs` | 20, 54, 87, 146 | RT 경로 INSERT/UPDATE |
+| `src-tauri/src/commands/branches.rs` | 566 | branch copy INSERT |
+| `src-tauri/src/commands/agents_helpers/tool_request.rs` | 354, 379 | tool-request 경로 INSERT |
+
+#### 3.1 비-스트리밍 INSERT
+
+최종 content 가 이미 확정된 경우 (user message, tool-request 응답, branch 복사 등):
+
+```rust
+// before
+"INSERT INTO messages (id, conversation_id, role, content, timestamp, ...) VALUES (?, ?, ?, ?, ?, ...)"
+
+// after
+let content_tokenized = tokenize_for_index(&content);
+"INSERT INTO messages (id, conversation_id, role, content, content_tokenized, timestamp, ...) VALUES (?, ?, ?, ?, ?, ?, ...)"
+```
+
+#### 3.2 스트리밍 INSERT + 중간 UPDATE
+
+`persistence.rs:221` INSERT (placeholder content=`""`) → `:293` 또는 `:345` 최종 UPDATE 패턴:
+- **중간 update 에서는 `content_tokenized` 를 건드리지 않는다** (Lindera 비용 회피).
+- **finalize (`status='done' | 'error'`) 시점에만** `content_tokenized = tokenize_for_index(final_content)` 를 함께 UPDATE.
+
+```rust
+// finalize
+let tokenized = tokenize_for_index(&final_content);
+conn.execute(
+    "UPDATE messages SET content = ?1, content_tokenized = ?2, status = 'done', timestamp = ?3 WHERE id = ?4",
+    params![final_content, tokenized, ts, id],
+)?;
+```
+
+위 UPDATE 는 **두 컬럼 동시 갱신** 이지만 `AFTER UPDATE OF content_tokenized` trigger 하나만 발화 (SQLite 는 같은 UPDATE 에서 여러 컬럼 바뀌어도 각 trigger 발화 조건은 독립 평가, 그러나 `update_content` trigger 는 존재하지 않으므로 `update_tokenized` 만 발화). 결과적으로 FTS 는 1회 sync.
+
+#### 3.3 배치성 INSERT
+
+`persistence.rs:494` 와 같은 다건 INSERT 는 loop 내부에서 tokenize 호출. chunk 가 크지 않다면 성능 impact 미미 (Lindera 건당 마이크로초 수준).
+
+### 4. Rebuild command
+
+`src-tauri/src/commands/search/rebuild.rs` (신규) + `mod.rs` re-export.
+
+```rust
+#[tauri::command]
+pub async fn rebuild_messages_fts(
+    app: AppHandle,
+    state: State<'_, DbState>,
+    cancel: State<'_, RebuildCancelFlag>,
+) -> Result<RebuildSummary, AppError> {
+    cancel.reset();
+    tokio::task::spawn_blocking(move || { /* 아래 loop */ })
+        .await
+        .map_err(|e| AppError::Agent(format!("join: {e}")))?
+}
+```
+
+루프 의사코드:
+
+```
+let total = SELECT COUNT(*) FROM messages WHERE content_tokenized IS NULL;
+let mut done = 0;
+loop {
+    if cancel.load() { break; }
+    // 매 chunk 마다 write lock 재획득/해제 — streaming 과의 경합 최소화
+    let rows = { let w = state.write.lock()?;
+                 w.prepare("SELECT rowid, content FROM messages WHERE content_tokenized IS NULL LIMIT 500")?
+                  .query_map(...)?.collect::<Vec<_>>() };
+    if rows.is_empty() { break; }
+    let tokenized: Vec<(i64, String)> = rows.into_iter()
+        .map(|(rowid, c)| (rowid, tokenize_for_index(&c))).collect();
+    {
+        let w = state.write.lock()?;
+        let tx = w.transaction()?;
+        for (rowid, t) in &tokenized {
+            tx.execute("UPDATE messages SET content_tokenized = ?1 WHERE rowid = ?2", params![t, rowid])?;
+        }
+        tx.commit()?;
+    }
+    done += tokenized.len();
+    app.emit("messages_fts_rebuild_progress", json!({ "done": done, "total": total }))?;
+}
+// FTS 일관성 확정 — external content 가 아니므로 'rebuild' 커맨드 의미가 제한적이지만,
+// optimize + integrity_check 를 수행해 orphan rowid 제거.
+{
+    let w = state.write.lock()?;
+    w.execute("INSERT INTO messages_fts(messages_fts) VALUES('optimize')", [])?;
+    // integrity_check 는 corpus 가 클 때 O(N) — 단 에러 없음을 확인
+    let _: i64 = w.query_row("SELECT COUNT(*) FROM messages_fts", [], |r| r.get(0))?;
+}
+app.emit("messages_fts_rebuild_complete", json!({ "done": done, "total": total, "canceled": cancel.load() }))?;
+```
+
+`RebuildCancelFlag` 은 `Arc<AtomicBool>` wrapper. 별도 command `cancel_rebuild_messages_fts` 가 set.
+
+**이벤트 스펙**:
+- `messages_fts_rebuild_progress` → `{ done: u64, total: u64 }`
+- `messages_fts_rebuild_complete` → `{ done: u64, total: u64, canceled: bool }`
+- `messages_fts_rebuild_error` → `{ error: string }` (Rust 측 panic/error 를 UI 가 catch)
+
+### 5. Search path 전환
+
+#### 5.1 `search_messages` (`messages.rs:381`)
+
+현재 `effective_query` 를 곧바로 FTS MATCH 에 넘긴다. Part 1 의 morphological 분기를 동일하게 주입:
+
+```rust
+let fts_query = if crate::commands::search::morphological_query_enabled() {
+    crate::commands::search::tokenize_query_for_fts(&effective_query)
+} else {
+    effective_query.clone()
+};
+// 기존 MATCH ?1 자리에 fts_query 사용
+```
+
+#### 5.2 `search_unified` (`unified.rs`)
+
+이미 분기 있음 (Part 1). 변경 불필요. 단 주석에서 "until Phase C Part 2 rebuild" 언급을 제거한다.
+
+### 6. App-level snippet
+
+`src-tauri/src/commands/search/snippet.rs` (신규):
+
+```rust
+/// secall bm25.rs:191 패턴을 tunaFlow 에 맞춰 이식.
+/// FTS5 snippet() 이 tokenized 텍스트를 반환하는 문제를 우회.
+pub fn extract_snippet(content: &str, query: &str, max_chars: usize) -> String {
+    // 1) query 를 whitespace split → 첫 매칭 term
+    // 2) content 안에서 해당 term 의 byte offset 찾기 (대소문자 무시)
+    // 3) offset 중심으로 ±max_chars/2 char window, char boundary 보존
+    // 4) 앞뒤 ellipsis 추가
+    // 매칭 없으면 content 의 앞 max_chars char 반환
+}
+```
+
+`search_messages` / `fts_conversation_search` (unified.rs:96) 의 `snippet(messages_fts, 0, '**', '**', '…', 40)` SQL 호출을 제거하고, `SELECT m.content` 로 바꾼 뒤 Rust 측에서 `extract_snippet(content, query, 120)` 호출. 하이라이트 마커 (`**..**`) 를 중심 term 에 주입.
+
+> **비고**: secall 은 snippet 을 200 char 로 자른다. tunaFlow 기존 `…` + 40 char 는 화면 폭과 어긋나지 않게 `120` 권장 (subtask 05 에서 UI 와 조율).
+
+### 7. Settings UI
+
+`src/components/settings/SearchSettings.tsx` (신규) 또는 기존 `SettingsPanel` 확장.
+
+- 섹션 타이틀: "검색 / Search"
+- 토글: "한국어 형태소 검색 활성화" — 내부적으로 localStorage `tunaflow.search.morphEnabled` + 런타임 env injection.
+  - 이 토글만으로는 env 가 프로세스에 주입되지 않으므로, **`morphological_query_enabled()` 판단 로직을 env var 외에 DB flag 도 OR 체크하도록 확장** (subtask 05 스펙 참조).
+- 버튼: "인덱스 재구축 (Rebuild search index)" → `invoke('rebuild_messages_fts')`
+- 진행률 바: `messages_fts_rebuild_progress` 이벤트 구독, `done/total * 100%`
+- 취소 버튼: `invoke('cancel_rebuild_messages_fts')`
+- 완료 시 토스트 + "이제 한국어 형태소 검색을 활성화할 수 있습니다"
+
+진행률 바 구현은 `src/components/settings/DocumentIndexSettings.tsx` 등에 이미 사용 중인 패턴을 재사용. 별도 dep 도입 금지.
+
+---
+
+## Invariants
+
+- **[INV-1]** Migration v45 는 `messages_fts` 를 DROP/CREATE 하지만 기존 `messages` row 는 건드리지 않는다. 앱 첫 기동 후 `rebuild_messages_fts` 실행 전까지 기존 corpus 는 검색 결과에서 사라진다 — 이 기대치를 UI 에 명시해야 한다. **이유**: migration 안에서 N 백만 row tokenize 시 기동 블록. **검증**: migration 테스트에서 v44→v45 적용 직후 `SELECT COUNT(*) FROM messages_fts` 가 0 이고 `SELECT COUNT(*) FROM messages` 는 불변인지 assert.
+
+- **[INV-2]** `tokenize_for_index` 와 `tokenize_query_for_fts` 는 **동일 함수 본체를 공유**해야 한다 (alias 또는 동일 helper 위임). 검색 recall 은 index 와 query 가 같은 토큰 분해를 적용해야만 성립. **이유**: 둘이 분기하면 silent recall 0. **검증**: Rust unit test — 동일 입력에 대해 두 함수 출력 동치 확인.
+
+- **[INV-3]** `rebuild_messages_fts` 는 write lock 을 **chunk 경계마다 release** 한다 (단일 long-hold 금지). **이유**: `finalize_engine_run` deadlock 사례 (work-safety.md 2026-04-22) 및 streaming 메시지 write 와의 경합. **검증**: code review — `state.write.lock()` scope 가 chunk loop body 안에 국한됨을 확인.
+
+- **[INV-4]** 신규 `messages` INSERT 사이트에서 `content_tokenized` 를 누락한 경우, `COALESCE(NEW.content_tokenized, NEW.content)` trigger 덕분에 기존 whitespace 동작으로 **graceful fallback** 한다 (검색 miss 아님). **이유**: 점진적 write-path 마이그레이션 허용. **검증**: `cargo test` — content_tokenized 를 주지 않고 INSERT 한 뒤 `SELECT * FROM messages_fts WHERE content MATCH ?` 로 원본 content 기반 매칭 성공 확인.
+
+- **[INV-5]** 스트리밍 중간 UPDATE (`content` 만 바뀌고 `content_tokenized` 는 NULL/고정) 는 FTS 를 재인덱싱하지 않는다. **이유**: chunk 당 Lindera 호출 시 CPU 폭증. **검증**: trigger 문법 (`AFTER UPDATE OF content_tokenized` 만 존재, `OF content` 는 없음) 확인 + finalize 경로에서만 re-index 되는지 integration 테스트.
+
+- **[INV-6]** `rebuild_messages_fts` 취소 시 이미 tokenized 된 row 는 원복하지 않는다 (idempotent). 재실행 시 `WHERE content_tokenized IS NULL` 로 skip. **이유**: 대규모 corpus 에서 재시도 비용 최소화. **검증**: 테스트 — 100건 중 50건 처리 후 취소 → 재실행 → 나머지 50건만 처리 확인.
+
+- **[INV-7]** Feature flag `TUNAFLOW_MORPH_QUERY` 를 OFF 로 되돌리면 `search_messages` / `search_unified` 둘 다 원본 쿼리로 FTS MATCH 수행. Rebuild 결과는 whitespace 쿼리로도 유효하다 (tokenized content 안에 원본 단어도 보존되는 경우가 많음). **이유**: 비상 롤백 경로. **검증**: 동일 corpus 에서 flag ON/OFF 쿼리 결과가 최소한 빈 배열은 아닌지 smoke test.
+
+---
+
+## Rationale (reviewer-only)
+
+### 설계 결정 — external content 포기 이유
+
+원래 `messages_fts USING fts5(content, content=messages, content_rowid=rowid)` 구조는 FTS5 external-content 모드로, `snippet()` / `highlight()` 호출 시 **외부 테이블 (`messages.content`) 에서 원문을 읽어온다**. 이 모드에서 "tokenized 저장 + 원문 snippet" 을 동시에 노리기는 불가능한데, FTS5 가 snippet 복원 시 **token offset 을 external content 의 byte offset 에 매핑** 하기 때문. tokenized 스트림 ("아키텍처 설계") 과 원문 ("아키텍처를 설계한다") 의 offset 이 다르면 snippet 결과는 garbage 가 된다 (SQLite FTS5 docs §4.4 참조).
+
+secall 이 `CREATE VIRTUAL TABLE turns_fts USING fts5(content, session_id UNINDEXED, turn_id UNINDEXED, tokenize='unicode61')` 처럼 standalone FTS5 + app-level `extract_snippet` 을 쓰는 이유가 정확히 이것. 본 plan 은 secall 의 입증된 경로를 따른다.
+
+### 대안 비교
+
+| Option | 구조 | 장점 | 단점 | 결정 |
+|---|---|---|---|---|
+| A | external content 유지 + `snippet()` 그대로 | 최소 변경 | snippet offset mismatch → 깨진 snippet | 기각 |
+| B | external content 유지 + tokenized 컬럼 mapping | storage 1x | snippet 은 여전히 깨짐 | 기각 |
+| **C (채택)** | standalone FTS5 + content_tokenized + app-level snippet | secall 검증 패턴, snippet 원문 보존 | storage ~1.5x (tokenized 별도 저장) | ✅ |
+| D | Dual-index (whitespace + morph 두 벌) | flag 전환 무비용 | storage 2x, trigger 복잡 | 기각 |
+| E | FTS5 custom tokenizer C extension | 순수 DB 레이어 | fts5_api 등록 + Rust FFI 복잡 | 기각 |
+
+### 비용/위험
+
+- **Storage overhead**: 한국어 corpus 기준 tokenized 텍스트는 원문의 60~80% (조사/어미 제거 + 단일글자 드롭). 전체 overhead ~1.6x. SSD 환경 허용 범위.
+- **Tokenize CPU**: Lindera ko-dic 은 건당 마이크로초 단위. 스트리밍 finalize 시 1회만 호출하므로 hot-path 영향 미미. Rebuild 시 500 row/chunk 기준 chunk 당 <1 초 예상 (로컬 benchmark 필요).
+- **Write lock 경합**: INV-3 으로 완화. 실측 후 chunk size 조정 여지.
+- **점진적 마이그레이션 실수**: INV-4 (COALESCE fallback) 로 silent miss 대신 legacy 동작 유지.
+- **UI 혼선**: rebuild 전까지 검색 결과가 empty — Settings UI 에서 명시적으로 "재구축이 필요합니다" 안내 필수 (subtask 05 스펙).
+
+### Scope 밖 (별도 plan 권장)
+
+- **영문 stemmer** (Porter/Snowball) — 한국어 해결 후 논의.
+- **rawq 결과 hybrid 합류** — `hybrid.rs` extensibility 는 있으나 별도 plan.
+- **FTS index 를 per-project DB 로 sharding** — `perProjectDatabaseSplitPlan.md` 와 합산 설계 필요.
+- **Snippet 하이라이트 멀티-term 지원** — secall extract_snippet 은 first term 기준. 후속 UX 작업.
+
+### Open questions (Developer 확정 필요)
+
+1. **Tokenized 저장 시점 (Q-1)**: `messages.content_tokenized` 를 `INSERT` 시 계산 vs `AFTER INSERT` Rust callback 으로 계산 후 `UPDATE` — 전자가 1 write, 후자가 2 write. spec §3.1 은 전자 권장. Developer 가 persistence.rs hot-path 에서 Lindera latency 측정 후 확정.
+
+2. **Rebuild 실패 시 content_tokenized 정합성 (Q-2)**: 중간 실패 row 가 부분적으로 tokenized 된 상태에서 다음 rebuild 시 재처리 필요 여부. 현재 설계는 `IS NULL` 체크만 하므로 "partial tokenized" 는 건너뜀. 재처리 강제는 별도 "force" 플래그로.
+
+3. **Search index 크기 한계 (Q-3)**: 현재 tunaFlow 는 단일 SQLite. 대용량 프로젝트에서 messages 가 100만건 이상이 될 때 rebuild 시간 (~수 분) 이 허용 가능한지. 허용 불가능하면 per-project DB 분리가 선결 조건.
+
+4. **Flag 활성화 UX (Q-4)**: env var (`TUNAFLOW_MORPH_QUERY=1`) 강제 vs Settings DB flag. 후자가 편하지만 `morphological_query_enabled()` 를 DB state 의존으로 바꾸는 건 Part 1 계약 변경. subtask 05 에서 "env var 우선 + DB flag 보조" 로 제안하나 Developer 합의 필요.
+
+5. **Snippet max_chars 기본값 (Q-5)**: secall=200, 기존 tunaFlow snippet()=40 (의미적 토큰 개수). UI 에서 `line-clamp-2` 와 정합하려면 120 권장 — 최종값은 Frontend 검증.
+
+---
+
+## Subtask 구조
+
+| # | 파일 | 범위 | 의존 |
+|---|---|---|---|
+| 01 | [-task-01.md](./searchPipelineFromSecallPlan-part2-task-01.md) | Migration v45 + schema.rs + trigger 재작성 | — |
+| 02 | [-task-02.md](./searchPipelineFromSecallPlan-part2-task-02.md) | Write path 통합 (10+ sites) + tokenize_for_index helper | 01 |
+| 03 | [-task-03.md](./searchPipelineFromSecallPlan-part2-task-03.md) | `rebuild_messages_fts` + 취소 + 진행률 이벤트 | 01, 02 |
+| 04 | [-task-04.md](./searchPipelineFromSecallPlan-part2-task-04.md) | `search_messages` morph 분기 + app-level extract_snippet | 01 |
+| 05 | [-task-05.md](./searchPipelineFromSecallPlan-part2-task-05.md) | Settings UI (rebuild 버튼 + 진행률) | 03 |
+
+총 5 subtask. 06 (snippet 단독) 를 분리하지 않은 이유: search_messages 전환과 한 PR 에 묶는 편이 자연스럽다 (같은 호출부).
+
+---
+
+## 관련 문서
+
+- 상위 plan: `docs/plans/searchPipelineFromSecallPlan.md` §6 Phase C
+- 선행 PR: #127 `feat/search-pipeline-phase-c-tokenizer`
+- RT 규약: `docs/plans/harnessVerificationGapPlan.md` §5 proposer 2-track output
+- secall 참조: `seCall/crates/secall-core/src/store/schema.rs:44-51`, `seCall/crates/secall-core/src/search/bm25.rs:191`

--- a/docs/prompts/architectHandoff_2026-04-22.md
+++ b/docs/prompts/architectHandoff_2026-04-22.md
@@ -1,0 +1,244 @@
+# Architect 핸드오프 — 새 Opus 세션용
+
+> 용도: 새 Opus 세션을 **tunaFlow Architect 역할** 로 부트스트랩. 현재 Developer 세션(지금 내가 있는 곳) 의 요청으로 생성.
+> 전달 방식: 이 문서 전문을 새 세션의 첫 메시지로 붙여넣기.
+> 작성일: 2026-04-22
+
+---
+
+## 당신의 역할
+
+당신은 **tunaFlow 프로젝트의 Architect** 입니다. 이 세션에서 당신의 책임은:
+
+1. **Plan 설계** — "무엇을" 와 "어떻게" 의 첫 정의
+2. **Subtask 분해** — 각 subtask 의 구현 범위, 대상 파일, 검증 방법
+3. **Invariants 명시** — 구현이 절대 위반해선 안 되는 제약
+4. **설계 근거** — 왜 이 방식인지, 대안 대비 장단
+
+당신은 **코드를 작성하지 않습니다**. 당신의 출력은 **별도 Developer Opus 세션** 이 받아 구현합니다. 따라서:
+
+- "여기는 내가 고칠 수 있다" 류의 자기 완결적 착수 금지
+- Plan document 와 per-subtask 작업 지시서만 작성
+- 구현 결과에 대한 검증은 Reviewer Codex 세션 이 담당 (별도)
+
+---
+
+## tunaFlow 제품 정체성
+
+**"다중 에이전트 오케스트레이션 클라이언트 (AOC)"** — Claude/Codex/Gemini/OpenCode CLI 를 프로젝트 단위로 조율하는 Tauri 2 데스크톱 앱.
+
+핵심 철학 (모두 memory 에 정착):
+
+- **"Of the agent, By the agent, For the agent"** — 인간지능 주도형. 사용자는 방향만 결정, 실행은 agent.
+- **상용 CLI 오케스트레이션** 이 범위. 소형 LLM 내장 (LiteRT-LM / Gemma) 은 다른 프로덕트 (tunaMicro) 로 분리. 품질·성능 경계가 측정 가능한 foundation 에만 의존.
+- **100% AI 작성 코드베이스** — 사용자는 코드 레벨 리뷰 하지 않음. AI 가 스스로 엄격해야 함. 잦은 리팩토링은 자연스러운 귀결.
+- **CLI-first** — SDK 는 fallback. API 키 과금 경로 비권장 (구독 사용자 중심).
+- **PTY → WS (sdk-url) 전환 중** — 인터랙티브 세션은 능력 확장의 핵심. claude `--sdk-url` WS 세션이 기본 경로로 이동 중. PTY 는 legacy fallback.
+
+---
+
+## 기술 스택
+
+| 계층 | 기술 |
+|---|---|
+| Desktop shell | Tauri 2 |
+| Frontend | React 18 + TS + Zustand 5 + Tailwind 4 |
+| Backend | Rust |
+| DB | SQLite WAL (dual read/write connections) |
+| Agent CLI | claude / codex (OpenAI) / gemini / opencode / Ollama / LMStudio |
+| Markdown | react-markdown + remark-gfm + Prism |
+| Code search | rawq sidecar (snowflake-arctic-embed-s) |
+| Document RAG | bge-m3 ONNX, in-process (sqlite-vec) |
+
+상세 아키텍처: `docs/reference/architecture-detail.md` (필요 시에만).
+
+---
+
+## 필수 참고 문서 (읽는 순서)
+
+1. **CLAUDE.md** (프로젝트 루트) — 현재 세션 번호, 우선순위, 알려진 이슈, 도구 사용 규칙
+2. **docs/reference/sessionHistory.md** — 세션 이력. 과거 결정 맥락 필요할 때.
+3. **docs/plans/index.md** — 현재 진행중 plans (active + partial) 목록
+4. **docs/plans/harnessVerificationGapPlan.md** — Reviewer RT 확장 + invariants 체계 (당신이 지금부터 따라야 할 규약)
+5. **docs/plans/searchPipelineFromSecallPlan.md** — 방금 Phase A/B/C Part1 구현 완료. Part2 남음.
+6. **docs/reference/coding-convention.md** + **docs/reference/work-safety.md** — 코드/UI 변경 전 필수 규칙
+
+---
+
+## 현재 진행 중인 작업 (2026-04-22 기준)
+
+### 막 완성 (Developer 세션에서)
+- **PR #125 (merged)**: Search Phase A — Query expansion (claude-p haiku + 7d cache). Feature flag `TUNAFLOW_QUERY_EXPANSION` default OFF.
+- **PR #126 (merged)**: Search Phase B — Hybrid RRF + `search_unified` Tauri command. Conversation FTS + document vector 통합.
+- **PR #127 (open)**: Search Phase C Part1 — Lindera 한국어 tokenizer 모듈 + opt-in 쿼리 통합.
+- **PR #124 (open)**: Harness Phase 3b-part1 — agent session audit lifecycle (SAVEPOINT 없는 audit 로그만).
+- **PR #122 (open)**: Golden dataset seed (20 시나리오, secall 실 데이터 기반).
+- **PR #123 (open)**: Search idea 문서화.
+- **PR #116 / #119 / #120 (merged)**: Harness Phase 1 (invariants checklist) / Phase 2 (regression + divergence) / Phase 4 (proposer 2-track output). RT role prompt 전면 확장.
+
+### 즉시 후속 가능 (당신이 plan 작성 대상)
+
+선택지:
+
+**A. Search Phase C Part2** — messages_fts 의 **인덱스 측 재구축** + migration v45 + `rebuild_messages_fts` Tauri command.
+   - 목표: 한국어 쿼리 "플랜을" 이 "플랜" 으로 인덱싱된 문서와 매칭
+   - 의존성: PR #127 머지 후
+   - 범위: migration (new column `content_tokenized` + trigger 재작성) + rebuild command + Settings UI 최소
+
+**B. Frontend 검색 UI 전환** — 헤더 검색창을 `search_messages` 에서 `search_unified` 로 교체.
+   - 목표: 사용자가 실제로 통합 검색 결과를 볼 수 있게
+   - 범위: kind 배지 (💬/📄) + source label 링크 + 클릭 네비게이션
+
+**C. Harness Phase 3b-part2** — `AgentSessionTx` SAVEPOINT 를 persistence 경로에 실제 연결.
+   - 목표: 중간 실패 시 half-formed row 자동 rollback
+   - 위험: write lock contention. feature flag 필수. audit 데이터 수집 선행 권장.
+
+**D. Phase C/Part1 머지 후 Harness Phase 3c** — startup sweeper (in_progress → panic 재조정).
+
+**E. 다른 주제** — ideas/ 에서 선정 (e.g. `mobileConnectivityAndFormIdea`, `reviewerWorkflowEnhancementsIdea`). 당신이 판단.
+
+**기본 추천**: A (Search Phase C Part2) — 자연스러운 연속. 사용자 요청 ("플랜" 검색 문제) 의 진짜 최종 해결.
+
+---
+
+## 출력 형식 (RT Proposer role 규약 준수)
+
+당신의 plan 산출물은 **4 섹션 구조** 를 반드시 지킵니다 (`harnessVerificationGapPlan.md` §5 = RT Proposer role guidelines):
+
+```markdown
+## TL;DR for Developer
+
+5~20 줄. 실행 지침만. 무엇을, 어디에, 어떤 순서로. 근거·대안은 여기에 쓰지 않음.
+
+## Specification
+
+구체 contract: 함수 시그니처, 파일 경로, 기대 동작, edge case. Developer 가
+추가 질문 없이 구현 가능할 정도.
+
+## Invariants
+
+[INV-N] <짧은 문장> — <이유>
+
+예시:
+- [INV-1] Do not call db.write.lock() inside broadcast_event — same-thread re-entrant deadlock
+- [INV-2] New messages_fts trigger 는 기존 unicode61 인덱스와 동시 공존 금지 — 중복 인덱싱
+
+0~7개. 없으면 `None` + 간단한 이유. 각 invariant 는 코드 읽기 또는 테스트로
+검증 가능해야 함 (주관적 품질 판단 X).
+
+## Rationale (reviewer-only)
+
+설계 근거, 고려한 대안, tradeoff, 위험. 이 섹션은 Developer ContextPack 에서
+제외되고 Reviewer/Verifier audit 에서만 사용됨. 중복 서술 금지 — TL;DR 에
+나온 내용을 여기 다시 쓰지 말 것.
+```
+
+### Subtask 파일
+
+Plan 이 여러 단계로 나뉘면 `{slug}-task-NN.md` 형식으로 per-subtask 작업 지시서:
+
+```markdown
+# Subtask N: <title>
+
+## Changed files
+- path/to/file1.rs — <무엇을 수정>
+- path/to/file2.ts — <신규>
+
+## Change description
+<추가/수정/삭제 항목과 근거>
+
+## Dependencies
+depends_on: [N-1]  (또는 없음)
+
+## Verification
+- `cargo test --lib <module>` — <expected output>
+- `npx tsc --noEmit` — exit 0
+(실행 가능한 구체 명령. "works" / "compiles" 같은 모호한 기준 금지)
+
+## Risks
+<예상 side effect, 주의할 mutex/lock 지점 등>
+```
+
+`{slug}` 는 `plans/<your-title>.md` 의 파일명. 임의 slug 금지 — 위 예시처럼 kebab-case.
+
+---
+
+## 도구 사용
+
+당신은 코드를 직접 읽거나 편집할 수 없는 환경일 수 있습니다. 필요 시 **tool-request 마커** 로 정보를 요청하세요. Developer 세션이 결과를 제공합니다:
+
+- `<!-- tunaflow:tool-request:docs:QUERY -->` — 라이브러리/프레임워크 문서 조회
+- `<!-- tunaflow:tool-request:rawq:QUERY -->` — 프로젝트 코드베이스 검색
+- `<!-- tunaflow:tool-request:graph:PATTERN TARGET -->` — 코드 그래프 (callers_of, tests_for 등)
+- `<!-- tunaflow:tool-request:probe_message:MESSAGE_ID -->` — 메시지 메타+head/tail preview
+- `<!-- tunaflow:tool-request:fetch_slice:MESSAGE_ID:OFFSET:LEN -->` — 메시지 일부 slice
+- `<!-- tunaflow:tool-request:full_message:MESSAGE_ID -->` — 메시지 전문 (무거움)
+
+응답 말미에 마커 배치. 추측 금지 — 확실하지 않으면 tool-request 먼저, 그 다음 설계.
+
+---
+
+## 협업 흐름 (당신의 출력이 어떻게 흐르는가)
+
+```
+(당신: Architect Opus 신세션)
+  ↓  plan + subtask 문서 작성
+(Developer Opus 현세션 — 지금 내가 있는 곳)
+  ↓  1차 검토 (invariants 체크, 범위 적정성, 구현 가능성)
+  ↓  필요 시 질문 roundtrip
+(Codex Reviewer — 선택적 RT)
+  ↓  2차 검토 (blind verifier)
+  ↓  합의 또는 이견 문서화
+(Developer Opus)
+  ↓  최종 구현 + 테스트 + PR
+(Codex Reviewer)
+  ↓  코드 리뷰 (invariant_checks + regression_check)
+```
+
+즉 당신 출력이 바로 코드가 되지 않음. 중간 Developer/Reviewer 의 검토 및 재요청이 들어옴. 이 roundtrip 을 예상하고:
+- 첫 번째 plan 은 "완벽한 최종판" 을 목표하지 말 것
+- 불확실 지점은 **명시적으로** flag (e.g. "이 부분은 Developer 가 기존 구현 읽고 구체화 필요")
+- 대안 몇 개 제시 + tradeoff 명확화 → Developer/Reviewer 가 선택할 여지
+
+---
+
+## 하지 말아야 할 것
+
+- 코드 직접 작성 (Developer 역할)
+- CLAUDE.md, docs/reference, 기존 plans 수정 (그건 별도 작업)
+- 확실하지 않은 파일 경로 / 함수명을 단정적으로 사용 (먼저 tool-request)
+- 한 plan 에 3개 이상의 독립 기능 묶기 (단일 목적 원칙 — `docs/reference/coding-convention.md` 참조)
+- 과거 작업을 재구성하려 시도 (이미 완료된 건 archive 로 이동됨 — `docs/archive/plans/completed/`)
+
+---
+
+## 첫 과제 (즉시 착수 권장)
+
+**Search Phase C Part2 Plan 작성**.
+
+배경:
+- Phase C Part1 (PR #127) 에서 `LinderaKoTokenizer` + `tokenize_query_for_fts()` + `morphological_query_enabled()` 플래그 도입 완료
+- 현재 `messages_fts` 는 SQLite FTS5 + `unicode61` tokenizer + trigger 기반 자동 유지 (INSERT/UPDATE/DELETE)
+- **문제**: 쿼리를 morphemize 해도 인덱스가 whitespace 기반이라 매칭 실패. Part2 가 인덱스 측 재구축.
+
+당신이 작성할 것:
+
+1. **`docs/plans/searchPipelineFromSecallPlan-part2.md`** (또는 파생 slug)
+2. Migration v45 설계 — `messages.content_tokenized` 컬럼 vs 기존 `messages_fts` trigger 수정
+3. `rebuild_messages_fts` Tauri command 설계 — 기존 corpus 재인덱싱 진행률 + 취소
+4. 기존 쿼리 경로 전환 시점 (feature flag 관리)
+5. Settings UI 최소 범위 (토글 버튼 + 진행률)
+6. 롤백 경로 — 재인덱싱 실패 시 기존 인덱스 보존
+7. Invariants 최소 3개 (예: "재인덱싱 중 search_messages 는 기존 결과 유지해야 함")
+
+결과물 형식은 위 "출력 형식" 섹션 규약.
+
+---
+
+## 마지막 당부
+
+사용자는 tunaFlow 코드를 직접 읽지 않습니다. 문서는 **미래의 당신 자신 / 다른 AI** 가 읽는 메모로 작성하세요. 사용자 가독성은 2차입니다.
+
+질문은 마커로 하고, 추측은 하지 않습니다. Invariants 는 구체적이고 검증 가능해야 합니다.
+
+시작하세요.


### PR DESCRIPTION
## 배경

별도 Opus Architect 세션 (\`docs/prompts/architectHandoff_2026-04-22.md\` 로 부트스트랩) 이 산출한 plan + subtask 문서. Developer 세션(이 PR 작성 중인 세션) 에서 1차 검토 통과.

## 내용

- \`searchPipelineFromSecallPlan-part2.md\` (22KB) — 4-섹션 proposer 규약 준수 (TL;DR / Spec / Invariants 7개 / Rationale-reviewer-only)
- Subtask 5개 (각각 독립 PR 가능)
- plans/index.md 에 진행 예정 섹션 등록

## 핵심 설계 결정

- External content FTS5 → **standalone FTS5** (snippet offset mismatch 우회, secall 입증 패턴)
- messages.content_tokenized TEXT + **trigger 기반 sync** (app-level sync 기각 근거 명시)
- 스트리밍 chunk 마다 tokenize 금지 — finalize 1회 (INV-5)

## Developer 검토 의견

### ✅ Approve 항목
- 4-섹션 규약 완벽 준수
- INV 7개 모두 검증 가능한 기준 포함
- Subtask 분할 독립 PR 가능

### 🔎 구현 시 반영
- **Q-1 (tokenize 시점)**: INSERT-time 확정 (Lindera 호출 마이크로초)
- **INV-2 검증 강화**: \`tokenize_for_index ≡ tokenize_query_for_fts\` 동치성 unit test 명시 (Subtask 02)
- **Storage overhead 재계산**: ~1.6x 낙관적, 실제 ~2.5~3x. Settings UI 에 "예상 용량" 표시 권고 (Subtask 05)
- **검색 공백 안내**: Migration v45 적용 직후 FTS = empty. Rebuild 전 헤더 검색창에 "재구축 필요" 배너 필요 (Subtask 05)
- **FTS5 \`'rebuild'\` 명령**: standalone 에선 의미 제한적 — \`optimize\` 만 사용 권고 (Subtask 03)

### ❓ 신규 Open Question (Architect 재확인 여지)
- **Q-6**: Migration v45 의 \`DROP TRIGGER; DROP TABLE; CREATE ...\` 시퀀스를 SQLite transaction 으로 감쌀 수 있는지. FTS5 virtual table DDL 의 transactional 지원 확인 필요.

## 다음 단계 (선택)

1. **Codex RT 검토** — 사용자가 Codex 세션에 plan 전달 → Reviewer 역할로 2차 검토 후 합의/이견 반영
2. **바로 구현 시작** — Subtask 01 부터 순차. Developer 세션 (이 세션) 이 담당.

Architect 프롬프트는 PR #128, 상위 plan 은 \`docs/plans/searchPipelineFromSecallPlan.md\` §6 Phase C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)