### PR TITLE
docs(plans): Session Continuity Fix Plan — Architect 산출 (3 subtasks)

### DIFF
--- a/docs/plans/index.md
+++ b/docs/plans/index.md
@@ -34,6 +34,7 @@
 | [refactorRoadmap_first_prompt](./refactorRoadmap_first_prompt.md) | 새 세션에 붙여넣을 첫 프롬프트 텍스트 |
 | [refactorRoadmap_handoff_2026-04-20](./refactorRoadmap_handoff_2026-04-20.md) | 새 세션용 핸드오프 — 프로젝트 철학 / 피할 함정 / Phase 1 Finding 6 진입점 |
 | [roundtableRoleTerminologySeparationPlan_2026-03-30](./roundtableRoleTerminologySeparationPlan_2026-03-30.md) | P1 — 프로필 역할 vs RT 토론 역할 분리 |
+| [sessionContinuityFixPlan](./sessionContinuityFixPlan.md) | **P0** — claude WS session identity 를 claude session_id 기반으로 재정의. `is_session_continuation` false positive 해결. |
 | [runtimeFeatureValidationPlan_2026-03-30](./runtimeFeatureValidationPlan_2026-03-30.md) | P1 — memory/retrieval/auto/budget/RT 실시나리오 검증 |
 | [sdkUrlSessionModePlan](./sdkUrlSessionModePlan.md) | — |
 | [searchPipelineFromSecallPlan-part2](./searchPipelineFromSecallPlan-part2.md) | P1 — Phase C Part 2: `messages_fts` rebuild + content_tokenized 컬럼 + app-level snippet (depends: PR #127) |

--- a/docs/plans/sessionContinuityFixPlan-task-01.md
+++ b/docs/plans/sessionContinuityFixPlan-task-01.md
@@ -1,0 +1,125 @@
+# Subtask 01 — `current_session_key` 재정의 + `promote_pending_to_delivered` 수정
+
+> 상위 plan: [sessionContinuityFixPlan.md](./sessionContinuityFixPlan.md)
+
+## Changed files
+
+- `src-tauri/src/agents/claude_sdk_session.rs` — `current_session_key()` (L229-233) 수정.
+- `src-tauri/src/commands/agents_helpers/send_common/session_freshness.rs` — `promote_pending_to_delivered()` (L42-48) 수정. 기존 `test promote_uses_pending_value_not_live_lookup` 의 기대값 역전 (live 우선).
+
+## Change description
+
+### 1. `current_session_key` — RESUME_IDS 우선, SESSIONS fallback
+
+```rust
+// src-tauri/src/agents/claude_sdk_session.rs
+pub fn current_session_key(conv_id: &str) -> Option<String> {
+    // (a) Claude 자체 session identity 우선. WS respawn 후에도 유지되므로 안정적.
+    if let Some(sid) = RESUME_IDS.lock().get(conv_id).cloned() {
+        return Some(format!("claude-ws:{}", sid));
+    }
+    // (b) Fallback: SESSIONS 의 router UUID. 첫 send (RESUME_IDS 아직 없음) 전용.
+    //     이 값은 LAST_DELIVERED 와 매칭되지 않는 것이 정상 (첫 send 는 fresh).
+    //     process_alive=false 면 None — is_session_continuation=false 강제.
+    let sessions = SESSIONS.lock();
+    let s = sessions.get(conv_id)?;
+    if !s.process_alive.load(std::sync::atomic::Ordering::Relaxed) {
+        return None;
+    }
+    Some(format!("claude-ws:router:{}", s.session_id))
+}
+```
+
+### 2. `promote_pending_to_delivered` — live 우선
+
+```rust
+// src-tauri/src/commands/agents_helpers/send_common/session_freshness.rs
+pub fn promote_pending_to_delivered(msg_id: &str, conv_id: &str, engine: &str) {
+    let live = current_session_key(conv_id, engine);  // finalize 시점의 진짜 session identity
+    let stashed = PENDING_DELIVERY.lock().remove(msg_id);
+    let key = live.or(stashed);   // ← 순서 반전이 핵심 (before: stashed.or(live))
+    if let Some(k) = key {
+        LAST_DELIVERED_KEY.lock().insert(conv_id.to_string(), k);
+    }
+}
+```
+
+### 3. 기존 테스트 조정
+
+`promote_uses_pending_value_not_live_lookup` (session_freshness.rs:128-141) 의 기대값을 뒤집는다. 새 의미:
+
+```rust
+#[test]
+fn promote_uses_live_when_available_stashed_is_fallback() {
+    let conv = unique_conv("promote-live-priority");
+    let msg = "msg-promote-1";
+
+    // Arrange: stash router UUID 를 두고, live 조회도 None (engine=nonexistent) 이 반환되도록
+    stash_pending(msg, "claude-ws:router:stashed-at-prepare");
+
+    // Act: live=None → stashed 사용 (fallback 동작)
+    promote_pending_to_delivered(msg, &conv, "nonexistent");
+
+    // Assert: fallback 으로 stashed 가 기록됨
+    assert_eq!(
+        last_delivered_key(&conv).as_deref(),
+        Some("claude-ws:router:stashed-at-prepare"),
+        "live 가 None 이면 stashed 가 fallback 으로 사용되어야 함"
+    );
+}
+```
+
+또한 신규 테스트 — live 가 있을 때 stashed 가 무시되는지:
+```rust
+// 이 테스트는 claude_sdk_session 을 mock 할 수 있어야 함 — 또는 engine 별 분기 우회.
+// 실구현에서는 current_session_key(conv, engine) 의 engine 이 claude/claude-code 일 때만
+// RESUME_IDS 를 본다. engine="claude" 로 호출하되 RESUME_IDS 에 직접 insert 해 live 가
+// Some 을 반환하게 만든다. 이는 integration 성격 — 별도 test 모듈 또는 pub(crate) helper.
+```
+
+### 4. 신규 회귀 테스트
+
+`src-tauri/src/agents/claude_sdk_session.rs::tests` (또는 신설 `tests/session_identity.rs` integration test):
+
+```rust
+#[test]
+fn router_uuid_change_does_not_change_identity_when_resume_id_preserved() {
+    // RESUME_IDS 에 claude session_id 고정
+    RESUME_IDS.lock().insert("conv-A".into(), "claude-sess-AAA".into());
+    let k1 = current_session_key("conv-A").unwrap();
+
+    // SESSIONS 에 두 번 다른 router UUID 로 삽입/제거 (respawn 시뮬레이션)
+    // — 구체적으로는 SdkSession 구조를 직접 만들기 어려우므로 SESSIONS 를 건드리지 않고
+    //   RESUME_IDS 의 우선순위만 검증.
+    let k2 = current_session_key("conv-A").unwrap();
+    assert_eq!(k1, k2, "RESUME_IDS 가 있는 한 key 는 router UUID 와 무관");
+    assert!(k1.starts_with("claude-ws:") && !k1.contains("router:"), "router fallback prefix 가 아니어야");
+
+    RESUME_IDS.lock().remove("conv-A");  // cleanup (전역 lazy_static 격리)
+}
+
+#[test]
+fn dead_session_without_resume_id_returns_none() {
+    // RESUME_IDS 없고 SESSIONS 에 dead entry 가 있는 경우 None 반환 — is_session_continuation=false 강제.
+    // SESSIONS 에 직접 entry 주입은 어렵다 (Arc<SdkSession> 필요). 이 테스트는 구현 시점에
+    // test hook 을 추가하거나 skip. 대체: integration — 실제 spawn 후 kill.
+}
+```
+
+## Dependencies
+
+depends_on: 없음.
+
+## Verification
+
+- `cargo test --lib agents::claude_sdk_session` — 기존 + 신규 tests 통과.
+- `cargo test --lib commands::agents_helpers::send_common::session_freshness` — 기존 5 tests 중 `promote_uses_pending_value_not_live_lookup` 는 새 이름/의도로 교체. 나머지 4 tests 유지.
+- `cargo check` — exit 0.
+- **수동 검증**: 로컬 `npm run tauri dev` 기동 후 claude-code 대화 2턴 이상 — `eprintln!("[session_freshness] continuation conv=…")` 로그가 2턴째에 찍히는지. 찍히지 않고 계속 "new session" 로그가 나오면 버그 미해결.
+
+## Risks
+
+- **기존 behavior 신뢰도 의존**: `LAST_DELIVERED_KEY` 에 router UUID 가 기록되던 경우 (현재 동작) 를 가정하는 다른 코드 경로가 있을 수 있다. 본 PR 로 key 포맷이 `claude-ws:<claude_sid>` 또는 `claude-ws:router:<uuid>` 로 변경됨. grep 으로 `claude-ws:` prefix 를 검색해 hardcoded 비교가 없는지 확인 필요 (예상: `session_freshness.rs` 외에는 없음).
+- **테스트 전역 격리**: `RESUME_IDS` 는 `lazy_static` 이라 테스트 간 공유. 신규 테스트는 고유 conv_id + 테스트 종료 시 `RESUME_IDS.lock().remove(conv)` 로 cleanup.
+- **Race**: `current_session_key` 가 RESUME_IDS lock → SESSIONS lock 순차 획득. 두 lock 모두 `parking_lot::Mutex` 이므로 deadlock 위험 낮음. 그러나 다른 경로가 SESSIONS → RESUME_IDS 순으로 잡는 케이스가 있는지 검토 (grep). 현재 `monitor_task` 는 SESSIONS 만 건드리고, `get_or_create_session` 는 SESSIONS → RESUME_IDS 순. **동일 순서 유지** 위해 `current_session_key` 도 SESSIONS 먼저 잡고 RESUME_IDS 로 확인할지 검토. 하지만 우선순위 역전은 deadlock 요건인 "순환 대기" 가 필요 — 읽기 전용 lock scope 라면 실질 위험 낮음.
+- **process_alive 체크의 정당성**: monitor_task 가 SESSIONS.remove 까지 하므로 dead entry 가 남는 window 는 아주 짧다. double-check 는 방어적이지만 중복일 수 있음. Q-4 가 이 판단을 요청.

--- a/docs/plans/sessionContinuityFixPlan-task-02.md
+++ b/docs/plans/sessionContinuityFixPlan-task-02.md
@@ -1,0 +1,144 @@
+# Subtask 02 — `RESUME_IDS` bootstrap from DB `resume_token`
+
+> 상위 plan: [sessionContinuityFixPlan.md](./sessionContinuityFixPlan.md)
+
+## Changed files
+
+- `src-tauri/src/agents/claude_sdk_session.rs` — `bootstrap_resume_id_from_db()` 신설. `get_or_create_session()` 진입부에서 호출.
+- `src-tauri/src/agents/claude.rs` (또는 sdk-url 진입점) — `get_or_create_session` 호출 시 AppState / DB 참조 전달.
+- `src-tauri/src/lib.rs` — 필요 시 시그니처 변경에 따른 builder 조정.
+
+## Change description
+
+### 1. bootstrap helper
+
+```rust
+// src-tauri/src/agents/claude_sdk_session.rs
+/// DB 의 conversations.resume_token 을 RESUME_IDS 로 끌어올린다.
+/// 앱 재시작 후 첫 접근 시 1회 실행. 이미 메모리에 있으면 no-op.
+///
+/// 호출부 시점에 DB 읽기 가능해야 한다 (Tauri State<AppState> 주입).
+fn bootstrap_resume_id_from_db<DB>(conv_id: &str, db: &DB) -> Option<String>
+where DB: crate::db::ReadConnProvider  // trait 또는 concrete AppState.db
+{
+    if RESUME_IDS.lock().contains_key(conv_id) {
+        return RESUME_IDS.lock().get(conv_id).cloned();
+    }
+    let conn = db.read_conn().ok()?;
+    let token: Option<String> = conn.query_row(
+        "SELECT resume_token FROM conversations
+          WHERE id = ?1
+            AND resume_token IS NOT NULL
+            AND resume_token_engine IN ('claude','claude-code')",
+        [conv_id],
+        |row| row.get(0),
+    ).ok();
+    if let Some(ref t) = token {
+        RESUME_IDS.lock().insert(conv_id.to_string(), t.clone());
+        eprintln!("[sdk-session] bootstrapped RESUME_IDS conv={} from DB resume_token", conv_id);
+    }
+    token
+}
+```
+
+### 2. `get_or_create_session` 시그니처 변경
+
+```rust
+// before
+pub async fn get_or_create_session(
+    conv_id: &str, project_path: Option<&str>, model: Option<&str>,
+) -> Result<Arc<SdkSession>, AppError>
+
+// after — AppState (또는 DbState) 를 받아 bootstrap 수행
+pub async fn get_or_create_session(
+    conv_id: &str,
+    project_path: Option<&str>,
+    model: Option<&str>,
+    db: &crate::state::DbHandle,   // 최소한 read lock 만 필요
+) -> Result<Arc<SdkSession>, AppError> {
+    // ... 기존 SESSIONS 조회 로직 ...
+
+    if !SESSIONS.lock().contains_key(conv_id) {
+        // 신규 spawn 전 bootstrap 시도
+        bootstrap_resume_id_from_db(conv_id, db);
+    }
+
+    let resume_id = RESUME_IDS.lock().get(conv_id).cloned();
+    let session = spawn_session(conv_id, project_path, effective_model, resume_id.as_deref()).await?;
+    SESSIONS.lock().insert(conv_id.to_string(), Arc::clone(&session));
+    Ok(session)
+}
+```
+
+### 3. 호출부 업데이트
+
+`get_or_create_session` 호출 지점을 grep 으로 확인:
+```
+rg "get_or_create_session\(" src-tauri/src/
+```
+각 site 에서 `AppState` / `DbState` 를 전달. 현재 호출 site 는 (예상):
+- `src-tauri/src/agents/claude.rs` — sdk-url 경로의 run 함수
+- `src-tauri/src/agents/claude_sdk_session.rs::prewarm_session`
+- 테스트 코드
+
+`prewarm_session` 도 bootstrap 해야 "프로젝트 오픈 직후 첫 send" 에서 --resume 이 작동한다.
+
+## Dependencies
+
+depends_on: [01]
+
+## Verification
+
+- Unit test (mock DB):
+  ```rust
+  #[test]
+  fn bootstrap_loads_resume_token_when_memory_empty() {
+      // Arrange: 메모리 비어있음, DB 에 resume_token='sess-XYZ', engine='claude'
+      RESUME_IDS.lock().remove("conv-boot");
+      let db = test_db_with_conversation("conv-boot", Some("sess-XYZ"), Some("claude"));
+
+      // Act
+      let got = bootstrap_resume_id_from_db("conv-boot", &db);
+
+      // Assert
+      assert_eq!(got.as_deref(), Some("sess-XYZ"));
+      assert_eq!(RESUME_IDS.lock().get("conv-boot").cloned().as_deref(), Some("sess-XYZ"));
+  }
+
+  #[test]
+  fn bootstrap_is_noop_when_memory_has_value() {
+      RESUME_IDS.lock().insert("conv-boot-2".into(), "sess-MEM".into());
+      let db = test_db_with_conversation("conv-boot-2", Some("sess-DB"), Some("claude"));
+      let got = bootstrap_resume_id_from_db("conv-boot-2", &db);
+      // 메모리 값 유지, DB 값 미사용
+      assert_eq!(got.as_deref(), Some("sess-MEM"));
+  }
+
+  #[test]
+  fn bootstrap_skips_non_claude_engine() {
+      let db = test_db_with_conversation("conv-boot-3", Some("sess-WRONG"), Some("codex"));
+      RESUME_IDS.lock().remove("conv-boot-3");
+      let got = bootstrap_resume_id_from_db("conv-boot-3", &db);
+      assert!(got.is_none());
+  }
+  ```
+- Integration E2E (manual):
+  1. claude-code 대화 2턴 송수신
+  2. `SELECT resume_token FROM conversations WHERE id = '<conv>'` 으로 토큰 확인
+  3. 앱 완전 종료 후 재기동
+  4. 같은 conversation 에서 세 번째 메시지 송신
+  5. 확인:
+     - `[sdk-session] bootstrapped RESUME_IDS conv=...` 로그
+     - claude spawn 인자에 `--resume <sess-id>` 포함
+     - claude 응답이 2턴 전 맥락을 기억
+     - (INV-7 수용) 이 첫 send 자체는 `context` 섹션 포함 (fresh LAST_DELIVERED)
+     - (핵심) 네 번째 메시지는 continuation → `context` 섹션 미포함
+- `cargo check` — exit 0.
+
+## Risks
+
+- **시그니처 변경 범위**: `get_or_create_session` 호출 site 가 예상보다 많으면 리팩토링 범위 확대. 미리 grep 으로 count. 3 이하면 단순, 10+ 면 adapter 함수 도입 고려.
+- **DB access 순환**: `claude_sdk_session` 은 `agents/` 레이어, DB 접근은 `AppState` 레이어. 레이어 crossing 이 관례와 충돌하는지 — 기존 `persistence.rs:338` 이 이미 conversations.resume_token 을 쓰므로 crossing 자체는 허용. 다만 `agents/` 가 직접 DB 접근하면 circular 위험 — trait (예: `ReadConnProvider`) 추상화 권장.
+- **Lock order**: bootstrap 은 DB read lock → RESUME_IDS lock 순. persistence.rs finalize 는 DB write → (다른 코드경로 RESUME_IDS 갱신). 순환 여부 grep 으로 확인. 현재까지는 위험 없음.
+- **DB resume_token 이 stale**: claude CLI 가 수동으로 `--session-id` 바꿔 실행한 이력이 있으면 DB 값과 실제 claude session 불일치. 본 fix 는 claude 가 응답 시 parsed.session_id 로 덮어쓰므로 첫 응답 이후 자연스럽게 정합. 그 전까지 `--resume` 시도가 claude 측 "no such session" 에러로 실패 가능 → Subtask 03 의 INV-6 경로가 이 edge 를 커버.
+- **AppState clone 부담**: DB handle 만 전달하면 되므로 Arc 기반 trait object 로 충분. 전체 AppState 전달 금지 (과도한 결합).

--- a/docs/plans/sessionContinuityFixPlan-task-03.md
+++ b/docs/plans/sessionContinuityFixPlan-task-03.md
@@ -1,0 +1,129 @@
+# Subtask 03 — 신규 session_id 감지 시 auto-invalidate + 측정 지표
+
+> 상위 plan: [sessionContinuityFixPlan.md](./sessionContinuityFixPlan.md)
+
+## Changed files
+
+- `src-tauri/src/agents/claude_sdk_session.rs` — L714-717 부근 `parsed.session_id` 갱신 로직에 prior-vs-new 비교 + `clear_delivered_key` 호출 추가.
+- `tests/session_continuity_integration.rs` (신규) — 통합 테스트: 5턴 시나리오에서 trace_log.ctx_sections 기대값 검증.
+- `docs/how-to/` — 없음 (내부 로직 변경만, 외부 API 불변).
+
+## Change description
+
+### 1. Auto-invalidate on new session_id
+
+```rust
+// src-tauri/src/agents/claude_sdk_session.rs L714-717
+// before
+if let Some(sid) = &parsed.session_id {
+    RESUME_IDS.lock().insert(conv_id_owned.clone(), sid.clone());
+}
+
+// after
+if let Some(sid) = &parsed.session_id {
+    let prior = RESUME_IDS.lock().insert(conv_id_owned.clone(), sid.clone());
+    if let Some(p) = prior {
+        if p != *sid {
+            eprintln!(
+                "[sdk-session] claude returned new session_id (prior={} new={}) — \
+                 --resume likely rejected; invalidating LAST_DELIVERED for conv={}",
+                p, sid, conv_id_owned
+            );
+            crate::commands::agents_helpers::send_common::session_freshness::clear_delivered_key(
+                &conv_id_owned,
+            );
+        }
+    }
+}
+```
+
+### 2. Integration test (신규 파일)
+
+```rust
+// src-tauri/tests/session_continuity_integration.rs
+//! Plan: docs/plans/sessionContinuityFixPlan.md
+//! Verifies is_session_continuation remains true across WS respawn
+//! and flips to false when claude returns a new session_id.
+
+#[test]
+fn continuation_survives_router_uuid_change() {
+    // Setup: 동일 conv_id 에 대해 RESUME_IDS = claude_sid_1, LAST_DELIVERED = claude-ws:claude_sid_1
+    //        SESSIONS entry 를 두 번 (서로 다른 router UUID) 로 교체해도 current_session_key 불변.
+    // Assert: is_session_continuation == true 유지.
+    // (SESSIONS 조작은 test hook 또는 pub(crate) 접근 필요 — 구현 시점 결정)
+}
+
+#[test]
+fn continuation_breaks_when_claude_starts_new_session() {
+    // Setup: RESUME_IDS = sid1, LAST_DELIVERED = claude-ws:sid1
+    // Act: parsed.session_id = sid2 (sid1 ≠ sid2) 로 갱신 시나리오 (unit-level mock of event_loop).
+    //      해당 코드 경로에서 clear_delivered_key 호출되면 LAST_DELIVERED 비어야.
+    // Assert:
+    //   - RESUME_IDS = sid2
+    //   - LAST_DELIVERED_KEY = None
+    //   - 다음 is_session_continuation 호출 = false
+}
+
+#[test]
+fn trace_log_continuation_drops_context_section() {
+    // End-to-end 수준 (가벼운 DB + mock engine):
+    //   1. prepare + finalize turn 1 → LAST_DELIVERED 기록
+    //   2. prepare turn 2 (동일 RESUME_IDS) → data.is_session_continuation = true
+    //   3. assemble_prompt 의 ctx_sections 에서 "context" 섹션 없음
+    //   4. trace_log INSERT 직전의 ContextPackMeta 에 section 목록 확인
+}
+```
+
+### 3. 측정 지표 자동화
+
+Golden scenario 실행 스크립트 또는 기존 `evals/` 인프라 재사용:
+
+```bash
+# 예시 (실제 명령은 프로젝트의 evals/ 구조에 맞춤)
+cargo run --bin eval -- session-continuity \
+    --conv <new-uuid> --turns 5 --kill-at turn=3
+```
+
+기대 출력:
+```
+turn=1 mode=Standard ctx_sections=[identity, context, memory, user_prompt]   [fresh: ✅]
+turn=2 mode=Standard ctx_sections=[identity, user_prompt]                    [cont: ✅]
+turn=3 mode=Standard ctx_sections=[identity, context, memory, user_prompt]   [post-kill fresh: ✅]
+turn=4 mode=Standard ctx_sections=[identity, user_prompt]                    [cont: ✅]
+turn=5 mode=Standard ctx_sections=[identity, user_prompt]                    [cont: ✅]
+
+continuation_rate = 4/5 = 80%  (fresh turns 제외)
+context_section_unnecessary_reinjection = 0/3 (cont turns) ✅
+```
+
+현재 증상 baseline: `context_section_unnecessary_reinjection = 3/3` (100%).
+
+## Dependencies
+
+depends_on: [01]. [02] 없이도 동작하지만, [02] 없으면 앱 재시작 후 시나리오가 재현 안 됨 — 측정의 완전성을 위해 [02] 머지 후 실행 권장.
+
+## Verification
+
+- `cargo test --test session_continuity_integration` — 3 tests 모두 pass.
+- `cargo check` — exit 0.
+- **수동 acceptance**:
+  1. 새 conversation 생성, claude-code 엔진.
+  2. 5턴 송수신 (각 3~10분 간격). 중간 (turn 3 직전) 에 `pkill -9 claude` 로 claude 프로세스 강제 종료.
+  3. DB 확인:
+     ```sql
+     SELECT turn_index, ctx_sections FROM trace_log
+       WHERE conversation_id = '<conv>' ORDER BY recorded_at;
+     ```
+  4. 기대:
+     - turn 1, 3 (post-kill) 에만 `"context"` 포함
+     - turn 2, 4, 5 에는 `"context"` 미포함
+  5. Architect 재현 (이 버그 발견 시나리오):
+     - tunaReader 유사 conversation 에서 ~5분 간격 5 턴 후 마지막 Architect 가 1턴 전 응답의 뒷부분을 **tool-request 없이** 언급할 수 있어야 함 (Claude 내부 buffer 의존).
+
+## Risks
+
+- **`parsed.session_id` 이 `None` 인 응답**: 일부 event 에선 session_id 가 없을 수 있다. 현 코드는 `Some` 일 때만 insert. invalidate 로직도 `Some` 분기 안에서만 실행 — 안전.
+- **RESUME_IDS 와 LAST_DELIVERED_KEY 동시 갱신 ordering**: invalidate 가 RESUME_IDS insert 이후 실행됨. race 는 없으나 다른 thread 가 중간에 `current_session_key` 를 호출하면 새 RESUME_IDS 값 (sid2) 를 보고 LAST_DELIVERED 는 sid1. → `is_session_continuation = false`. 정확한 동작 (sid1 세션은 이미 끝남). ✅
+- **수동 테스트의 자동화 부담**: 측정 지표 §3 는 수동이어도 blocker 아님. 자동화는 후속 `promptRegressionEvalPlan.md` 연동. 본 PR 은 trace_log 로그 해석 가이드만 문서화하면 충분.
+- **`clear_delivered_key` 는 LAST_DELIVERED 만 삭제**. PENDING_DELIVERY 의 현재 in-flight 키는 건드리지 않음. 해당 send 는 이미 prepare 시 결정된 mode 로 진행. 이는 의도 — 진행 중인 응답을 invalidate 하면 사용자 혼란.
+- **Integration test 의 SESSIONS 조작**: SdkSession 구조체 직접 생성이 어렵다 (child Child + 여러 channel). test hook (pub(crate) 생성자 또는 builder) 이 필요. 구현 난이도 있음 — 필요 시 이 test 는 unit 대신 수동 manual test 로 대체하고 issue 로 남김.

--- a/docs/plans/sessionContinuityFixPlan.md
+++ b/docs/plans/sessionContinuityFixPlan.md
@@ -1,0 +1,241 @@
+---
+title: Session Continuity Fix — ContextPack 재주입 방지 (claude WS session identity 재정의)
+status: planned
+priority: P0
+created_at: 2026-04-22
+related:
+  - src-tauri/src/agents/claude_sdk_session.rs
+  - src-tauri/src/commands/agents_helpers/send_common/session_freshness.rs
+  - src-tauri/src/commands/agents_helpers/send_common/persistence.rs
+  - docs/plans/harnessVerificationGapPlan.md           # §5 proposer 4-section
+  - docs/prompts/architectFollowup_sessionPersistence_2026-04-22.md  # Developer 진단 + 사용자 방침
+supersedes:
+  - (was-deferred) fix/contextpack-handoff-recall       # 브랜치는 존재하지 않음, 본 plan 이 대체
+---
+
+# Session Continuity Fix Plan
+
+> **사용자 방침 (강제 범위)**: preview → full content 주입 / recent_turns cap 확대 / anchor N 턴 확대 — **전부 금지**.
+> 근본 수정은 `is_session_continuation` 판정 정확화 + `--resume` 신뢰도 개선. 판정이 맞으면 tunaFlow 는 아무 context 도 주입하지 않는다.
+
+---
+
+## TL;DR for Developer
+
+1. **`claude_sdk_session::current_session_key` 를 "claude 의 실제 session_id" 기반으로 재정의** — 현재는 `s.session_id` (= `spawn_session` 에서 `Uuid::new_v4()` 로 생성되는 router UUID, L272) 를 반환하는데, 이 값은 WS respawn 마다 바뀐다. 올바른 identity 는 `RESUME_IDS[conv_id]` (= claude `--resume` 타깃, L133, parsed `result.session_id` 로 갱신 L715). 이 변경 하나가 증상의 대부분을 해결한다.
+2. **`promote_pending_to_delivered` 를 finalize-time current_session_key 우선으로 수정** — 지금은 prepare 시점 stashed 값을 우선 사용 (`session_freshness.rs:44`). 첫 send 에서 pending 에 router UUID 가 들어가면 LAST_DELIVERED 에 router UUID 가 기록되어 다음 send 와 불일치. finalize 시점에 RESUME_IDS 가 이미 채워져 있으므로 그 값으로 **덮어쓰기** 해야 연속성 유지.
+3. **`RESUME_IDS` 를 `conversations.resume_token` 에서 bootstrap** — 현재 앱 재시작 시 RESUME_IDS 는 빈 상태로 시작하고, `get_or_create_session` 이 빈 RESUME_IDS 로 spawn 하므로 `--resume` 자체가 동작하지 않는다. DB 의 `resume_token` 값을 최초 세션 요청 시 주입해 앱 재시작 ↔ claude process 연속성을 회복.
+4. **Claude 가 새 `session_id` 를 반환하면 (= `--resume` 실패로 fresh claude 세션 시작) LAST_DELIVERED_KEY 를 자동 invalidate** — 현재는 RESUME_IDS 만 새 값으로 덮어써서 다음 send 가 "claude 가 기억 없는 세션" 인데도 tunaFlow 는 continuation=true 로 판단. parsed.session_id 가 RESUME_IDS 의 기존 값과 다르면 `clear_delivered_key` 호출.
+5. **측정 지표** — `trace_log.ctx_sections` 의 `context` 섹션이 **연속 송수신 시 0%** 출현해야 한다. 현재 증상은 100%. Fix 후 golden scenario (같은 conv, 5-8 분 간격 5 턴) 에서 turn 2+ 는 전부 미포함.
+
+구현 순서: 1 → 2 → 3 → 4 → 5 (측정). subtask 01 (§1+2 합침), subtask 02 (§3), subtask 03 (§4+5 합침) 로 3 PR 로 분해.
+
+**하지 말 것**: ContextPack `context` 섹션 preview→full 확대, recent_turns cap 상향, anchor N 턴 확대. 이는 재주입 **경로의 규모** 만 키우며 사용자 방침에 위배.
+
+---
+
+## Specification
+
+### 1. `current_session_key` 재정의
+
+파일: `src-tauri/src/agents/claude_sdk_session.rs` L229-233
+
+```rust
+// before
+pub fn current_session_key(conv_id: &str) -> Option<String> {
+    SESSIONS.lock().get(conv_id).map(|s| format!("claude-ws:{}", s.session_id))
+}
+
+// after
+pub fn current_session_key(conv_id: &str) -> Option<String> {
+    // 1) Claude 자체 session identity (--resume 타깃) 우선.
+    //    이 값은 respawn 이후에도 유지되므로 LAST_DELIVERED_KEY 와 안정적으로 비교 가능.
+    if let Some(sid) = RESUME_IDS.lock().get(conv_id).cloned() {
+        return Some(format!("claude-ws:{}", sid));
+    }
+    // 2) RESUME_IDS 가 아직 없는 케이스 (첫 send, finalize 전) — SESSIONS 의 router UUID 로 fallback.
+    //    첫 send 는 어차피 LAST_DELIVERED 가 비어있어 is_session_continuation=false 로 흐르므로
+    //    fallback 키가 다음 send 와 매칭되지 않는 문제는 발생하지 않는다.
+    let sessions = SESSIONS.lock();
+    let s = sessions.get(conv_id)?;
+    // process_alive 가 false 이면 세션은 dead → None 반환하여 is_session_continuation=false 강제
+    if !s.process_alive.load(std::sync::atomic::Ordering::Relaxed) {
+        return None;
+    }
+    Some(format!("claude-ws:router:{}", s.session_id))  // prefix 로 구분 — LAST_DELIVERED 에는 보통 매치 안 됨
+}
+```
+
+**핵심**: `claude-ws:<sid>` 포맷의 `sid` 는 **claude 가 결정하는 UUID** 여야 한다. router UUID 는 안전장치 fallback 으로만 사용하고, prefix 를 `claude-ws:router:` 로 분리해 누수 시 쉽게 식별 가능하게 한다.
+
+### 2. `promote_pending_to_delivered` 수정
+
+파일: `src-tauri/src/commands/agents_helpers/send_common/session_freshness.rs` L42-48
+
+```rust
+// before
+pub fn promote_pending_to_delivered(msg_id: &str, conv_id: &str, engine: &str) {
+    let from_pending = PENDING_DELIVERY.lock().remove(msg_id);
+    let key = from_pending.or_else(|| current_session_key(conv_id, engine));
+    if let Some(k) = key {
+        LAST_DELIVERED_KEY.lock().insert(conv_id.to_string(), k);
+    }
+}
+
+// after
+pub fn promote_pending_to_delivered(msg_id: &str, conv_id: &str, engine: &str) {
+    // prepare 시점의 stashed 키는 "이 send 가 시작될 때 어떤 세션에 바인딩되었는가" 를
+    // 기록하기 위한 것 (A2 race 보호). 그러나 **LAST_DELIVERED 의 의미** 는
+    // "이번 send 가 끝난 시점에 claude 가 어떤 세션을 유지 중인가" 이다.
+    // finalize 시점에 RESUME_IDS 가 갱신되어 있으므로 current_session_key 를 우선 사용.
+    let live = current_session_key(conv_id, engine);
+    let stashed = PENDING_DELIVERY.lock().remove(msg_id);
+    let key = live.or(stashed);  // live 가 있으면 우선, 없으면 stashed fallback
+    if let Some(k) = key {
+        LAST_DELIVERED_KEY.lock().insert(conv_id.to_string(), k);
+    }
+}
+```
+
+**검증 포인트**: `live.or(stashed)` 의 순서 반전이 이 패치의 핵심. 기존 `stashed.or(live)` 는 prepare 시점 router UUID 가 승급되는 반면, 변경 후는 finalize 시점 claude session_id 가 승급된다.
+
+### 3. `RESUME_IDS` bootstrap from DB
+
+파일: `src-tauri/src/agents/claude_sdk_session.rs` — `get_or_create_session` 진입부 (L140-177)
+
+```rust
+// 추가: RESUME_IDS 가 비어있다면 DB 에서 1회 로드 시도
+fn bootstrap_resume_id_from_db(conv_id: &str, state: &crate::AppState) -> Option<String> {
+    // 이미 메모리에 있으면 skip
+    if RESUME_IDS.lock().contains_key(conv_id) { return None; }
+
+    let r = state.db.read.lock().ok()?;
+    let token: Option<String> = r.query_row(
+        "SELECT resume_token FROM conversations WHERE id=?1 AND resume_token_engine IN ('claude','claude-code')",
+        [conv_id], |row| row.get(0),
+    ).ok().flatten();
+    if let Some(t) = token.clone() {
+        RESUME_IDS.lock().insert(conv_id.to_string(), t);
+    }
+    token
+}
+```
+
+`get_or_create_session` 에서 `SESSIONS` 가 비어있는 branch 로 진입하기 전에 이 함수 호출. `AppState` 접근 시그니처 변경 필요 — `get_or_create_session` 호출부 (claude.rs / sdk-url 경로) 에서 AppState 를 전달하거나, 별도 `tauri::State` 파라미터로 받아 Arc clone.
+
+**주의**: DB 쓰기 lock 대신 **read lock** 만 사용 (bootstrap 은 read-only). Session persistence 가 finalize_engine_run 에서 DB 를 갱신하므로 write race 없음.
+
+### 4. Claude 가 새 session_id 반환 시 자동 invalidate
+
+파일: `src-tauri/src/agents/claude_sdk_session.rs` L714-717 부근
+
+```rust
+// before
+if let Some(sid) = &parsed.session_id {
+    RESUME_IDS.lock().insert(conv_id_owned.clone(), sid.clone());
+}
+
+// after
+if let Some(sid) = &parsed.session_id {
+    let prior = RESUME_IDS.lock().insert(conv_id_owned.clone(), sid.clone());
+    // prior 가 있고 sid 와 다르면: --resume 이 실패 또는 불인정되어 claude 가 새 세션을 시작한 것.
+    // LAST_DELIVERED_KEY 를 invalidate 해 다음 send 가 full 로 흐르게 한다.
+    if let Some(p) = prior {
+        if p != *sid {
+            eprintln!("[sdk-session] claude returned new session_id (prior={} new={}) — invalidating delivery cache", p, sid);
+            crate::commands::agents_helpers::send_common::session_freshness::clear_delivered_key(&conv_id_owned);
+            // 이번 send 는 이미 prepare 시 Continuation/Fresh 결정이 끝났으므로 다음 send 부터 effect.
+        }
+    }
+}
+```
+
+### 5. 측정 지표
+
+`trace_log` 는 각 턴의 `ctx_sections` 를 기록한다 (persistence.rs:343 `insert_trace_log_with_context`). Fix 전후 비교를 위해:
+
+**수동 E2E (acceptance)**:
+- 새 conversation 생성, claude-code 엔진
+- 5 턴 송수신 (각 간격 1~8 분, 중간에 claude 프로세스 강제 kill 1회 포함)
+- `SELECT ctx_sections FROM trace_log WHERE conversation_id=? ORDER BY recorded_at` 결과에서:
+  - turn 1: `context` 섹션 포함 (fresh) ✅
+  - turn 2~5: `context` 섹션 **미포함** ✅ (continuation)
+  - 강제 kill 직후 turn: `context` 섹션 포함 ✅ (정당한 fresh)
+
+**자동 unit/integration**:
+- `session_freshness.rs::tests` 에 "router UUID 변경 with same claude_session_id → continuation=true" 케이스 추가.
+- `claude_sdk_session.rs::tests` (또는 별도) 에 RESUME_IDS bootstrap 테스트.
+
+---
+
+## Invariants
+
+- **[INV-1]** `ContextPack` 의 `recent_context` / `compressed_memory` 섹션은 `is_session_continuation == true` 일 때 **절대 주입되지 않는다**. Claude 자체 세션 히스토리가 source of truth. **이유**: 사용자 방침 명시. **검증**: `prepare_engine_run` 분기 (persistence.rs:258-266) 가 `data.is_session_continuation = true` 시 assemble_prompt 의 context 섹션을 drop. 기존 구현이 이 경로를 이미 보장함 — INV 는 이 경로가 **실제로 타는 빈도** 를 높여야 함을 의미.
+
+- **[INV-2]** `is_session_continuation` 판정의 key 는 **claude 자체 `session_id`** (= `--resume` 타깃, `parsed.session_id` 로 갱신되는 값) 이다. tunaFlow 측 프로세스 식별자 (spawn 마다 새로 생성되는 router UUID) 는 continuation 판정 key 로 쓰지 않는다. **이유**: router UUID 는 WS respawn 마다 변해 false negative 양산. **검증**: `current_session_key` 유닛 테스트 — 같은 claude session_id 에 대해 router UUID 가 변경되어도 동일 key 반환.
+
+- **[INV-3]** WS 세션 respawn 은 (a) `kill_session*` 명시 호출, (b) `monitor_task` 의 child process exit 감지, (c) `get_or_create_session` 에서 `SESSIONS` 에 없을 때 중 하나의 경로로만 발생한다. send 경로가 "활성 세션이 있는데 임의로 재생성" 하지 않는다. **이유**: 불필요 respawn 은 claude session buffer 를 잃게 만들어 `--resume` 성공률을 낮춘다. **검증**: `spawn_session` 호출지점 grep — `get_or_create_session` 내 단일 호출만 존재.
+
+- **[INV-4]** `RESUME_IDS[conv_id]` 는 **앱 생애주기 전반에서 claude 가 최종적으로 알려준 session_id 와 동기** 상태를 유지한다. (a) 앱 시작 시 `conversations.resume_token` 에서 lazy bootstrap, (b) 매 응답 `parsed.session_id` 로 갱신, (c) `kill_session_clear_resume` 으로만 제거. **이유**: claude `--resume` 성공률 = RESUME_IDS 정확도. 부정확하면 "내가 기억하는 세션" 오해로 토큰 낭비. **검증**: bootstrap 단위 테스트 + parsed.session_id 갱신 unit test.
+
+- **[INV-5]** `LAST_DELIVERED_KEY[conv_id]` 는 **마지막으로 claude 가 실제 응답을 완성한 send 종료 시점의 `current_session_key`** 를 기록한다. prepare 시점 stashed 값은 `current_session_key` 가 None 인 경우에만 fallback. **이유**: prepare 시점 router UUID 가 승급되면 다음 send 와 불일치. 현 버그의 직접 원인. **검증**: `promote_pending_to_delivered` 테스트 — live current key 우선 사용되는지.
+
+- **[INV-6]** Claude 응답의 `parsed.session_id` 가 `RESUME_IDS` 에 이미 있는 기존 값과 **다른 경우** (= `--resume` 실패 후 claude 가 fresh 세션 시작), `clear_delivered_key` 를 호출해 LAST_DELIVERED_KEY 를 즉시 invalidate 한다. **이유**: 이 상황에서 다음 send 가 continuation=true 로 가면 "claude 는 기억 없는데 tunaFlow 는 있다고 착각" — 사용자 맥락 유실의 다른 경로. **검증**: "새 session_id 반환" 시뮬레이션 테스트 (변조된 JSONL fixture).
+
+- **[INV-7]** 앱 재시작 후 첫 send 는 `LAST_DELIVERED_KEY` 가 in-memory 이므로 `is_session_continuation=false` 로 흘러 full ContextPack 을 생성한다. 이는 수용된 behavior — claude 프로세스도 앱과 함께 죽었다가 `--resume` 으로 복원되므로 tunaFlow 가 "첫 send 에 한 번 전체 맥락을 건네는 것" 은 버퍼 warm-up 비용으로 정당하다. **이유**: 이 경우까지 재주입을 skip 하려면 LAST_DELIVERED 를 DB persist 해야 하고, 복잡도 증가 대비 이득 작음. **검증**: 스펙 문서화 + trace_log 첫 턴에 `context` 섹션 기대값 포함.
+
+---
+
+## Rationale (reviewer-only)
+
+### 왜 preview → full injection 이 아닌가
+
+증상 (2-3 턴 전 assistant 응답의 뒷부분 유실) 을 해결하는 가장 쉬운 경로는 ContextPack `context` 섹션에 preview 대신 full content 를 넣거나 recent_turns 의 2000자 cap 을 제거하는 것이다. 그러나:
+
+1. **같은 정보를 두 곳에서 보관** — claude WS session buffer + tunaFlow context 섹션. 매 턴마다 ~3000자 × N 턴이 재전송되어 입력 토큰이 턴당 수만 토큰 폭증.
+2. **claude 가 이미 기억하는 내용을 다시 보내면** 혼동 (같은 turn 이 두 번 보이는 것처럼 대화 흐름이 꼬임).
+3. **근본 문제는 "기억이 없는 것" 이 아니라 "기억이 있는데 tunaFlow 가 false negative 로 판단하는 것"** — 판정 로직 자체를 고치는 것이 옳은 계층.
+
+사용자 방침 ("체감 개선으로 토큰 낭비 금지") 은 이를 명시적으로 배제.
+
+### 대안 고려
+
+| 대안 | 판정 | 사유 |
+|---|---|---|
+| preview → full 주입 확대 | 기각 | 사용자 방침 명시 + 토큰 폭증 |
+| `recent_turns` cap 확대 (2000 → 8000) | 기각 | 재주입의 규모만 키움. 원인 치료 아님 |
+| anchor N turn 확대 (2 → 5) | 기각 | 동일. 재주입 자체가 본질적 낭비 |
+| `current_session_key` 정의 수정 (채택) | ✅ | 근본 수정. 판정 정확화 → 재주입 자연 감소 |
+| 매 send 마다 `--resume` 성공 여부 확인 응답 대기 | 고려함 → 기각 | latency 추가. `parsed.session_id` 대조로 비동기 감지 가능 (INV-6) |
+| `LAST_DELIVERED_KEY` 를 DB persist | 기각 (현 단계) | INV-7 수용. 복잡도 대비 이득 작음 |
+
+### Open questions (Developer 결정 필요)
+
+1. **Q-1**: `bootstrap_resume_id_from_db` 는 `get_or_create_session` 이 `AppState` 접근권을 갖도록 시그니처를 바꿔야 한다. 현재 `claude_sdk_session::get_or_create_session(conv_id, project_path, model)` 는 DB 접근이 없는 순수 함수. Tauri `State<'_, AppState>` 를 파라미터로 추가할지, 또는 `lazy_static` 전역 DB handle 에서 읽을지 — 호출 site (claude.rs 의 run) 가 이미 AppState 를 받고 있으면 전자 권장.
+
+2. **Q-2**: codex app-server (`codex_app_server::current_thread_key`) 에도 동일 문제가 있을 수 있다. 본 plan 은 claude 에 한정. codex 경로는 별도 plan 으로 분리 (Subtask 에 포함하지 않음 — scope creep 방지).
+
+3. **Q-3**: Roundtable 경로는 `LAST_DELIVERED_KEY` 를 공유할지 각 참여자별로 분리할지. 현재 코드는 conv_id 기준이므로 RT 내 여러 참여자가 같은 conv 의 key 를 덮어쓸 수 있음. 검증 시 RT 시나리오도 테스트에 포함할지 판단.
+
+4. **Q-4**: `process_alive=false` 상태의 session 에 대해 `current_session_key` 가 `None` 을 반환 (위 §1). 그러나 monitor_task 는 `SESSIONS.lock().remove` 도 하므로 대개 entry 자체가 사라진다. 이 double-check 가 필요한지 (방어적) vs 중복인지 판단.
+
+---
+
+## Subtask 구조
+
+| # | 파일 | 범위 | 의존 |
+|---|---|---|---|
+| 01 | [-task-01.md](./sessionContinuityFixPlan-task-01.md) | `current_session_key` 재정의 + `promote_pending_to_delivered` 수정 + unit tests (§1+§2) | — |
+| 02 | [-task-02.md](./sessionContinuityFixPlan-task-02.md) | `RESUME_IDS` bootstrap from DB `resume_token` (§3) + 시그니처 조정 | 01 |
+| 03 | [-task-03.md](./sessionContinuityFixPlan-task-03.md) | 신규 session_id 반환 시 auto-invalidate (§4) + 측정 지표 E2E (§5) | 01 |
+
+3 subtask 로 구성. 02 는 앱 재시작 후 `--resume` 연속성 회복 (가장 큰 scope 변경) 이지만 01 과 독립 동작 가능.
+
+---
+
+## 관련 문서
+
+- Developer 진단: `docs/prompts/architectFollowup_sessionPersistence_2026-04-22.md` (PR #130)
+- 이전 Architect 핸드오프: `docs/prompts/architectHandoff_2026-04-22.md`
+- RT 규약: `docs/plans/harnessVerificationGapPlan.md` §5 proposer 2-track output
+- Phase 4 `is_session_continuation` 최초 도입 세션: `project_session_2026-04-19_s38.md` (anchor 2turn / recent_turns tool-request 도입 맥락)


### PR DESCRIPTION
## 배경

tunaReader 증상에 대한 Architect Opus 세션 (architectFollowup_sessionPersistence_2026-04-22.md 로 이어서 받은 세션) 의 plan + 3 subtask 산출. 앱 사용 중이라 **구현은 보류**, Developer 1차 review 만 commit.

## Developer 리뷰 결과

### ✅ Approve 항목

**Root cause 진단 정확도**:
- Developer 가설(WS respawn) 은 surface-level 이었고, Architect 가 더 정확히 짚음: `current_session_key` 가 `s.session_id` (= spawn 마다 `Uuid::new_v4()` 로 새로 생성되는 **router UUID**) 를 반환하는 것이 근본. WS respawn 여부와 무관하게 identity 가 불안정.
- `promote_pending_to_delivered` 의 `stashed.or(live)` 순서가 첫 send 부터 mismatch 를 심는다는 지적도 정확.

**사용자 방침 준수**:
- preview→full / recent_turns cap / anchor N 확대 모두 Rationale §대안 table 에서 **명시적으로 기각**
- INV-1 이 "재주입 금지 조건" 을 구조적으로 못박음

**INV 품질 7개 모두 검증 가능**:
- INV-2 (router UUID 금지), INV-4 (RESUME_IDS ↔ DB 동기), INV-5 (live 우선), INV-6 (auto-invalidate) 가 서로 맞물려 재주입 최소화 전략을 완성
- INV-7 (앱 재시작 첫 send 는 full 수용) 은 합리적 trade-off — DB persist 복잡도 회피

### 🔎 Developer 판단 사항 (Open questions 응답 제안)

- **Q-1 (AppState 전달 방식)**: **`ReadConnProvider` trait 추상화 채택 권고**. `agents/` 레이어가 `DbState` 전체 의존하지 않고 read 만 필요 → 테스트 가능성 ↑
- **Q-2 (codex 동일 병증)**: **별도 plan 분리 동의**. Scope creep 방지.
- **Q-3 (RT 공유)**: 같은 conv_id 기준 공유가 정상. RT 내 여러 참여자 동시 writer race 는 각자 finalize 시점에 갱신하는 기존 구조로 OK. 구현 시 재확인.
- **Q-4 (process_alive double-check)**: **유지 권고**. monitor_task 의 `SESSIONS.remove` 와 무관하게 drop order / panic 경로 안전상 남는 window 가능. 방어적.

### ⚠️ 구현 시 주의

- **Task 02 시그니처 변경 영향 범위**: `get_or_create_session` 호출 site 수 `rg "get_or_create_session\("` 로 사전 확인 필요. 3 이하면 단순, 10+ 면 adapter 함수 도입
- **Task 03 Integration test**: `SdkSession` 직접 생성 어려움. `pub(crate)` test hook 또는 builder 추가 필요. Architect 도 인정한 부분
- **promote_pending_to_delivered live.or(stashed) 순서 반전**의 전제 — "finalize 시점에 RESUME_IDS 가 이미 갱신" — claude_sdk_session event_loop 에서 parsed.session_id 갱신이 run() 반환보다 먼저임을 코드로 재확인 필요

## 다음 단계

**Architect 권고**: Subtask 01 부터 구현 (30-50 LOC, 로컬 로그로 즉시 검증 가능)

**Developer 입장**: 동의. 단 **현재 tunaFlow 앱 사용 중이라 구현 보류**. 사용자가 앱 작업 끝나면 구현 시작.

옵션:
1. 앱 사용 종료 후 subtask-01 → 02 → 03 순차 구현 (Developer = 이 세션)
2. Codex Reviewer RT 로 blind 검증 후 구현 (특히 INV-2 / INV-5 정당성 + SESSIONS vs RESUME_IDS lock 순서 안전성)
3. 현재 상태로 merge 대기 — 구현 착수 시점 사용자 결정

🤖 Generated with [Claude Code](https://claude.com/claude-code)