### PR TITLE
diag(sdk-session): stderr capture + resume bootstrap escape hatch (TEMP)

### DIFF
--- a/docs/plans/designReviewGatePlan-task-01.md
+++ b/docs/plans/designReviewGatePlan-task-01.md
@@ -1,0 +1,143 @@
+# Subtask 01 — PlanProposalCard 2버튼 + 힌트 pill + RT 드로어 mode 구분
+
+> 상위 plan: [designReviewGatePlan.md](./designReviewGatePlan.md)
+
+## Changed files
+
+- `src/components/tunaflow/chat/PlanProposalCard.tsx` — 승인 action 을 2개 버튼으로 분기 + 카드 상단 hint row.
+- `src/components/tunaflow/RoundtableDrawer.tsx` (또는 동등) — `branch.mode === 'design_review'` 시 드로어 헤더에 구분 배지.
+- `src/store/*.ts` — plan proposal 상태 슬라이스에 `approvalPath: 'direct' | 'rt' | null` 필드 추가 (이미 있으면 재사용).
+- `src/types/plans.ts` (또는 동등) — `PlanProposal` 인터페이스에 `touchedPaths?: string[]`, `planDocumentPath?: string` 추가.
+
+## Change description
+
+### 1. Hint heuristic
+
+`PlanProposalCard.tsx` 내부 또는 util 파일:
+
+```ts
+function shouldSuggestRT(plan: PlanProposal): boolean {
+  if (plan.invariants && plan.invariants.length >= 3) return true;
+  if (plan.subtasks && plan.subtasks.length >= 2) return true;
+  const sensitive = ['src-tauri/src/db/migrations', 'src-tauri/src/agents/',
+                     'src-tauri/src/commands/agents_helpers/send_common/'];
+  return (plan.touchedPaths ?? []).some(p => sensitive.some(s => p.startsWith(s)));
+}
+```
+
+이 함수는 **힌트 pill 표시 여부만** 결정. 버튼 활성화 / 비활성화에는 영향 없음 (INV-1).
+
+### 2. 2-button 렌더
+
+기존 단일 "승인" 버튼 자리에:
+
+```tsx
+<ActionRow>
+  <Button
+    variant="ghost"
+    onClick={() => onApproveDirect(plan)}
+    data-testid="plan-approve-direct"
+  >
+    바로 승인 → 구현
+  </Button>
+  <Button
+    variant="primary"
+    onClick={() => onApproveViaRT(plan)}
+    data-testid="plan-approve-via-rt"
+  >
+    RT 검토 먼저 (Architect ↔ Codex)
+  </Button>
+</ActionRow>
+```
+
+`onApproveDirect` 는 기존 승인 경로 호출. `onApproveViaRT` 는 Subtask 02 의 신규 Tauri command `open_design_review_branch({ planId, planDocumentPath })` 호출.
+
+### 3. Hint row
+
+카드 헤더 하단:
+
+```tsx
+<div className="flex items-center gap-2 text-xs text-gray-500">
+  <span>INV {plan.invariants?.length ?? 0}</span>
+  <span>·</span>
+  <span>Subtask {plan.subtasks?.length ?? 0}</span>
+  <span>·</span>
+  <span>{plan.touchedPaths?.length ?? 0} paths</span>
+  {shouldSuggestRT(plan) && (
+    <span className="ml-2 px-2 py-0.5 rounded-full bg-yellow-100 text-yellow-800 text-[10px] font-medium">
+      RT 검토 권장
+    </span>
+  )}
+</div>
+```
+
+pill 은 권장 문구일 뿐 — 버튼 disabled 로 연결하지 않음.
+
+### 4. RT 드로어 mode 구분 배지
+
+`RoundtableDrawer` 헤더에:
+
+```tsx
+{branch.mode === 'design_review' && (
+  <Badge variant="accent">Design Review (Round {round}/3)</Badge>
+)}
+{branch.mode === 'roundtable' && (
+  <Badge variant="default">Roundtable</Badge>
+)}
+```
+
+`round` 는 branch state 또는 별도 Tauri command (`get_design_review_round(branchId)`) 로 읽음 — Subtask 02 범위.
+
+### 5. Zustand 상태 확장
+
+기존 `planProposalSlice` 에 `approvalPath` 필드:
+
+```ts
+interface PlanProposalState {
+  // ... 기존 필드 ...
+  approvalPath: 'direct' | 'rt' | null;
+  rtRound: number;           // 0 = not started
+  rtVerdict: 'pass' | 'fail' | 'escalate_to_human' | null;
+  rtBlockerCount: number;    // INV-2 용 disabled 판정
+}
+```
+
+`onApproveDirect` 는 `approvalPath='direct'`, `onApproveViaRT` 는 `'rt'` set.
+
+### 6. INV-2 반영 — 강제 승인 전 BLOCKER 잔존 시 disabled
+
+```tsx
+const blocksDirect = approvalPath === 'rt' && rtVerdict === 'fail' && rtBlockerCount > 0;
+
+<Button
+  disabled={blocksDirect}
+  onClick={blocksDirect ? openForceApprovalModal : onApproveDirect}
+>
+  {blocksDirect ? '강제 승인 (BLOCKER 있음)' : '바로 승인 → 구현'}
+</Button>
+```
+
+강제 승인 모달은 Subtask 02 의 backend command (`force_approve_design_review`) 호출.
+
+## Dependencies
+
+depends_on: 없음 (Backend Subtask 02 의 신규 Tauri command 들은 mock 으로 대체 가능하나 실제 동작은 02 구현 후).
+
+## Verification
+
+- `npx vitest run src/components/tunaflow/chat/PlanProposalCard.test.tsx`:
+  - 기본 rendering — 2 버튼 모두 표시
+  - `plan.invariants.length === 4` → hint pill `RT 검토 권장` 표시
+  - `plan.invariants.length === 1` + subtasks 0 + touchedPaths=['src/foo.ts'] → pill 미표시
+  - "바로 승인" 클릭 → `onApproveDirect` 호출
+  - "RT 검토 먼저" 클릭 → `onApproveViaRT` 호출
+  - `rtVerdict='fail'` + `rtBlockerCount=1` → "바로 승인" disabled
+- `npx tsc --noEmit` — exit 0.
+- 수동: PlanProposalCard 가 표시되는 실제 플로우에서 두 버튼 클릭 시 Zustand state 변경 확인.
+
+## Risks
+
+- **PlanProposalCard prop 구조 변경 여지**: `touchedPaths`, `planDocumentPath`, `invariants`, `subtasks` 필드가 현재 prop 에 없을 수 있음. Architect 가 plan 산출 시 이 필드들을 응답에 포함하도록 Architect prompt 수정이 필요할 수 있음 — 이는 **Q-1 (plan 본문 §Open questions)** 로 flagged. Developer 는 구현 시 현재 PlanProposalCard prop 을 grep 하고 누락된 필드를 Architect 응답 파싱 쪽에 추가해야 할 수 있음.
+- **Zustand slice 충돌**: `planProposalSlice` 가 이미 있는지 확인. 없으면 신설. 있으면 필드 추가만.
+- **hint heuristic 의 sensitive paths 하드코딩**: 초기 릴리스는 하드코딩. 후속 Settings 에서 사용자 정의 경로 허용 가능 — 본 subtask 범위 밖.
+- **버튼 배치 우선순위**: "RT 검토" 를 primary 로 둘지 "바로 승인" 을 primary 로 둘지 UX 판단. 본 subtask 는 RT 를 primary (눈에 더 잘 띔) 로 제안 — shouldSuggestRT=false 일 때는 "바로 승인" 을 primary 로 flip 하는 동적 변형도 고려 가능.

--- a/docs/plans/designReviewGatePlan-task-02.md
+++ b/docs/plans/designReviewGatePlan-task-02.md
@@ -1,0 +1,208 @@
+# Subtask 02 — Backend: `branch.mode='design_review'` + Reviewer role + 라운드 상한
+
+> 상위 plan: [designReviewGatePlan.md](./designReviewGatePlan.md)
+
+## Changed files
+
+- `src-tauri/src/commands/branches.rs` — `branch_mode` 분기에 `"design_review"` 추가 + 신규 Tauri command `open_design_review_branch`.
+- `src-tauri/src/commands/roundtable_helpers/types.rs` — `role_guidance()` 에 `mode` 파라미터 추가 + design_review reviewer guidance 신설.
+- `src-tauri/src/commands/roundtable_helpers/deliberative.rs` (또는 RT 실행 루프) — design_review 모드 전용 라운드 카운터 + escalate 분기.
+- `src-tauri/src/commands/roundtable_helpers/prompt.rs` — plan 본문 + subtask 파일 payload 주입 + focus areas.
+- `src-tauri/src/commands/design_review.rs` (신규) — `advance_design_review_round`, `force_approve_design_review`, `cancel_design_review` Tauri commands.
+- `src-tauri/src/lib.rs` — 신규 command 등록.
+
+## Change description
+
+### 1. `branch.mode='design_review'` 수용
+
+`src-tauri/src/commands/branches.rs` 의 기존:
+```rust
+let branch_mode = input.mode.as_deref().unwrap_or("chat");
+let is_rt = branch_mode == "roundtable";
+```
+→
+```rust
+let branch_mode = input.mode.as_deref().unwrap_or("chat");
+let is_rt = matches!(branch_mode, "roundtable" | "design_review");
+let is_design_review = branch_mode == "design_review";
+```
+
+이후 `is_design_review` 분기에서:
+- 시스템 메시지 자동 삽입: `"Design review started · plan=<slug> · reviewer=<engine> · round=1"`
+- RT payload 에 plan 문서 본문 + subtask 파일들 + frontmatter `related` 파일 경로 자동 주입
+
+### 2. Reviewer role guidance 확장
+
+`src-tauri/src/commands/roundtable_helpers/types.rs`:
+
+```rust
+pub fn role_guidance(role: &str, mode: Option<&str>) -> &'static str {
+    match (role, mode) {
+        ("reviewer" | "critic", Some("design_review")) => DESIGN_REVIEW_REVIEWER_GUIDANCE,
+        ("reviewer" | "critic", _) => REVIEWER_GUIDANCE,
+        ("proposer", Some("design_review")) => DESIGN_REVIEW_PROPOSER_GUIDANCE,
+        ("proposer", _) => PROPOSER_GUIDANCE,
+        // ... 기존 verifier/synthesizer ...
+        _ => "",
+    }
+}
+
+const DESIGN_REVIEW_REVIEWER_GUIDANCE: &str = r#"
+You are a blind verifier of a design plan produced by an Architect agent.
+
+Produce the following sections in order (markdown):
+
+## Invariant checks
+JSON array of `{ "id": "INV-N", "status": "pass|fail|cannot_verify", "evidence": "<file:line or reasoning>" }`.
+Verdict MUST be `fail` if any status == "fail".
+
+## Scores (1-5)
+- plan_coverage: N/5 — one-line reason
+- code_quality: N/5 — one-line reason
+- test_coverage: N/5 — one-line reason
+- convention: N/5 — one-line reason
+
+## Findings
+- [BLOCKER] file:line — concrete defect
+- [MAJOR] ...
+- [MINOR] ...
+No subjective "clean/nice/better" language.
+
+## Recommendations
+Per finding, minimal actionable fix.
+
+## failed_subtask_ids
+JSON array of subtask numbers that should be blocked.
+
+## Verdict
+`pass` | `fail` | `escalate_to_human` — one-line reason.
+
+## regression_check
+{"prev_findings_resolved": [...], "newly_broken": [...]}
+"#;
+
+const DESIGN_REVIEW_PROPOSER_GUIDANCE: &str = r#"
+You are the Architect presenting a plan for blind review. The reviewer has full
+codebase access via tool-request markers. Your job is NOT to implement — your
+job is to respond to reviewer findings by updating the plan document.
+
+- Acknowledge each BLOCKER / MAJOR with either "resolved via X" or "out of scope — <reason>"
+- Do not inflate scope to include MINOR unless it blocks later subtasks
+- Keep the 4-section structure (TL;DR / Specification / Invariants / Rationale)
+- Record review history at the bottom of the plan as `## Codex Review (Round N — YYYY-MM-DD)`
+"#;
+```
+
+### 3. 라운드 카운터 + escalate
+
+`src-tauri/src/commands/design_review.rs`:
+
+```rust
+const MAX_ROUNDS: u8 = 3;
+
+#[derive(serde::Serialize, Clone)]
+pub struct ReviewRoundResult {
+    pub round: u8,
+    pub verdict: String,  // "pass" | "fail" | "escalate_to_human"
+    pub blocker_count: u32,
+    pub major_count: u32,
+    pub minor_count: u32,
+    pub failed_subtask_ids: Vec<u32>,
+    pub transcript_markdown: String,  // auto-append 용
+}
+
+#[tauri::command]
+pub async fn advance_design_review_round(
+    branch_id: String,
+    app: AppHandle,
+    state: State<'_, DbState>,
+) -> Result<ReviewRoundResult, AppError> {
+    let current_round: u8 = { /* SELECT design_review_round FROM branches WHERE id=?1 */ };
+    if current_round >= MAX_ROUNDS {
+        return Err(AppError::Agent(format!(
+            "design_review: max rounds ({}) reached — use force_approve or cancel",
+            MAX_ROUNDS
+        )));
+    }
+    // 1) RT deliberative 실행 (reviewer 호출)
+    // 2) reviewer 응답 파싱 (JSON + markdown sections)
+    // 3) divergence detector — 이전 라운드와 같은 finding category 2회 연속 시 verdict 강제 escalate
+    // 4) round += 1, UPDATE branches SET design_review_round = ?
+    // 5) emit "design_review_round_complete" event
+    // 6) 반환
+}
+
+#[tauri::command]
+pub fn force_approve_design_review(
+    branch_id: String,
+    plan_document_path: String,
+    state: State<DbState>,
+) -> Result<(), AppError> {
+    // plan frontmatter 에 force_approved_at_round + blocker_findings 기록
+    // branch archived=1
+    // main conversation 에 "plan force-approved (N blockers pending)" 시스템 메시지
+}
+
+#[tauri::command]
+pub fn cancel_design_review(branch_id: String, state: State<DbState>) -> Result<(), AppError> {
+    // INV-5: plan 문서 건드리지 않음. branch archived=1.
+    // 중간 reviewer 응답은 branch shadow conversation 메시지로만 남음.
+}
+```
+
+### 4. `open_design_review_branch` Tauri command
+
+Subtask 01 의 "RT 검토 먼저" 버튼이 호출:
+
+```rust
+#[tauri::command]
+pub async fn open_design_review_branch(
+    plan_id: String,
+    plan_document_path: String,
+    main_conversation_id: String,
+    reviewer_engine: Option<String>,  // default = "codex"
+    state: State<'_, DbState>,
+    app: AppHandle,
+) -> Result<String, AppError> {  // returns branch_id
+    // 1) 기존 create_branch 호출 with mode="design_review"
+    // 2) branch frontmatter / meta 에 plan_id, plan_document_path, reviewer_engine 기록
+    // 3) 첫 라운드 자동 시작 (advance_design_review_round 호출)
+    // 4) RT 드로어 open 이벤트 emit
+}
+```
+
+### 5. Divergence detector 재활용
+
+`roundtable_helpers/deliberative.rs` (또는 관련) 에 이미 Phase 2 구현된 divergence detector 를 `mode="design_review"` 에서도 활용:
+
+```rust
+if mode == Some("design_review") {
+    let same_category_count = count_consecutive_findings_category(&reviewer_outputs);
+    if same_category_count >= 2 && round >= 2 {
+        verdict = "escalate_to_human";
+    }
+}
+```
+
+## Dependencies
+
+depends_on: [01] — UI 버튼이 없으면 이 command 들을 호출할 경로가 없음.
+
+## Verification
+
+- `cargo test --lib commands::design_review`:
+  - `advance_design_review_round` — round < 3 이면 성공, round == 3 에서 호출 시 에러
+  - `cancel_design_review` — plan 문서 md5 변경 없음, branch archived=1
+  - `force_approve_design_review` — plan frontmatter 에 `force_approved_at_round` 기록 확인
+- `cargo test --lib commands::roundtable_helpers::types` — design_review reviewer guidance 가 `invariant_checks`, `Scores`, `Findings`, `Verdict`, `regression_check` 6 키워드를 모두 포함하는지 contains assert.
+- Integration: mock Codex 가 fail 3회 연속 → 4번째 호출 에러 확인.
+- Divergence: mock 이 라운드 1~2 에서 같은 `"defect_type": "deadlock"` 반환 → round 3 기다리지 않고 escalate_to_human 반환.
+- `cargo check` — exit 0.
+
+## Risks
+
+- **Codex CLI 호출 경로 유무**: 현재 tunaFlow 의 Codex 호출이 `agents/codex.rs` (CLI) + `agents/codex_app_server.rs` (app-server) 로 이원화. 어느 경로로 design review reviewer 를 호출할지 Developer 결정 — app-server 가 stateful 해서 thread_key 유지 가능하고 latency 낮음 (권장).
+- **Reviewer 응답 파싱**: reviewer 가 guidance 를 따르지 않고 자유 markdown 을 반환하면 `verdict` 추출 실패. 방어책: parsing fallback (verdict 섹션 못 찾으면 "escalate_to_human" 으로 안전 처리). Guidance 에 "반드시 위 섹션 순서" 를 강조.
+- **Lock contention**: `advance_design_review_round` 가 DB write lock 을 오래 잡으면 streaming 충돌. RT 실행 부분은 기존 deliberative 모드 경로를 통과하므로 이미 적절히 분리됨. 추가 주의 없음.
+- **라운드 카운터 persist**: `branches` 테이블에 `design_review_round INTEGER DEFAULT 0` 컬럼 필요. 본 subtask 에서 migration v46 으로 add_column_if_missing 추가. Schema 변경 주의.
+- **Reviewer engine 미설치**: `codex` CLI 가 시스템에 없으면 첫 라운드 spawn 실패. error 경로에서 UI 에 "codex 미설치 — Settings 에서 reviewer 변경 or 설치" 안내. Gemini fallback 자동화 여부는 Q-2 로 flag.

--- a/docs/plans/designReviewGatePlan-task-03.md
+++ b/docs/plans/designReviewGatePlan-task-03.md
@@ -1,0 +1,212 @@
+# Subtask 03 — Plan adopt (문서 머지) + Transcript auto-append + Settings UI
+
+> 상위 plan: [designReviewGatePlan.md](./designReviewGatePlan.md)
+
+## Changed files
+
+- `src-tauri/src/commands/design_review.rs` — `adopt_design_review` Tauri command 신규. transcript append 유틸 포함.
+- `src-tauri/src/commands/branches.rs` — 기존 `adopt_branch` 는 유지. design_review 는 별도 경로.
+- `src/components/tunaflow/chat/PlanProposalCard.tsx` — verdict=pass 또는 force-approved 시 "승인 완료" 상태 + "구현 시작" 버튼 노출.
+- `src/components/settings/DesignReviewSettings.tsx` (신규) — reviewer engine 선택 (codex | gemini) + 기본 engine 기록.
+- `src/lib/api/design_review.ts` (신규) — Tauri command wrapper + event listener helpers.
+
+## Change description
+
+### 1. Plan document adopt
+
+```rust
+// src-tauri/src/commands/design_review.rs
+#[tauri::command]
+pub async fn adopt_design_review(
+    branch_id: String,
+    plan_document_path: String,
+    main_conversation_id: String,
+    state: State<'_, DbState>,
+    app: AppHandle,
+) -> Result<(), AppError> {
+    // 1) transcript auto-append (§2)
+    append_review_transcript(&plan_document_path, &branch_id, &state)?;
+
+    // 2) frontmatter 에 review 메타 주입 (idempotent)
+    inject_review_frontmatter(&plan_document_path, &branch_id, &state)?;
+
+    // 3) main conversation 에 시스템 메시지
+    let (plan_title, rounds, engine) = read_review_meta(&branch_id, &state)?;
+    let sys_msg = format!(
+        "Plan [{}]({}) approved after {} review round(s) · reviewer={}",
+        plan_title, plan_document_path, rounds, engine
+    );
+    insert_system_message(&state, &main_conversation_id, &sys_msg)?;
+
+    // 4) branch archived=1
+    {
+        let w = state.write.lock().map_err(|_| AppError::Lock)?;
+        w.execute("UPDATE branches SET archived=1 WHERE id=?1", [&branch_id])?;
+    }
+
+    app.emit("design_review_adopted", serde_json::json!({
+        "branchId": branch_id,
+        "planDocumentPath": plan_document_path,
+        "rounds": rounds,
+    }))?;
+    Ok(())
+}
+```
+
+### 2. Transcript auto-append
+
+```rust
+fn append_review_transcript(
+    plan_path: &str,
+    branch_id: &str,
+    state: &DbState,
+) -> Result<(), AppError> {
+    let rounds = collect_review_rounds(branch_id, state)?;  // shadow conv 의 reviewer 메시지들
+    let today = chrono::Local::now().format("%Y-%m-%d");
+
+    let mut appended = String::from("\n\n---\n");
+    for (round_idx, round_data) in rounds.iter().enumerate() {
+        appended.push_str(&format!(
+            "\n## Codex Review (Round {} — {})\n\n<details>\n<summary>verdict={} · BLOCKER {} · MAJOR {} · MINOR {}</summary>\n\n{}\n\n</details>\n",
+            round_idx + 1,
+            today,
+            round_data.verdict,
+            round_data.blocker_count,
+            round_data.major_count,
+            round_data.minor_count,
+            round_data.full_markdown.trim(),
+        ));
+    }
+
+    let existing = std::fs::read_to_string(plan_path)
+        .map_err(|e| AppError::Agent(format!("read plan: {e}")))?;
+    let merged = format!("{}\n{}\n", existing.trim_end(), appended.trim());
+    std::fs::write(plan_path, merged)
+        .map_err(|e| AppError::Agent(format!("write plan: {e}")))?;
+    Ok(())
+}
+```
+
+`<details>` collapsible 로 plan 본문 가독성 유지.
+
+### 3. Frontmatter 주입
+
+```rust
+fn inject_review_frontmatter(
+    plan_path: &str,
+    branch_id: &str,
+    state: &DbState,
+) -> Result<(), AppError> {
+    // YAML frontmatter 파싱 → design_reviewed_at / review_rounds / reviewer_engine 필드 삽입 또는 갱신
+    // 주의: 기존 frontmatter 보존 (title, status, priority 등 변경 금지)
+    // 라이브러리: serde_yaml 또는 간단한 regex 기반 (frontmatter 는 문서 상단 `---` 블록)
+}
+```
+
+frontmatter 스키마 추가:
+```yaml
+design_reviewed_at: 2026-04-22T19:34:00+09:00
+review_rounds: 3
+reviewer_engine: codex
+force_approved_at_round: null   # or 3 if force approve
+blocker_findings: []            # force approve 시에만 채워짐
+```
+
+### 4. Settings UI — reviewer engine
+
+`src/components/settings/DesignReviewSettings.tsx`:
+
+```tsx
+export function DesignReviewSettings() {
+  const [engine, setEngine] = useState<'codex' | 'gemini'>('codex');
+
+  useEffect(() => {
+    const stored = localStorage.getItem('tunaflow.designReview.engine') ?? 'codex';
+    setEngine(stored as any);
+  }, []);
+
+  const handleChange = (next: 'codex' | 'gemini') => {
+    localStorage.setItem('tunaflow.designReview.engine', next);
+    setEngine(next);
+  };
+
+  return (
+    <section>
+      <h3>Design Review</h3>
+      <div className="setting-row">
+        <label>Reviewer 엔진</label>
+        <Select value={engine} onChange={handleChange}>
+          <option value="codex">Codex (기본, Architect=Opus 와 blind)</option>
+          <option value="gemini">Gemini</option>
+        </Select>
+        <p className="hint">
+          Architect 가 제안한 plan 을 다른 vendor 모델이 독립 검증합니다.
+          Codex CLI 가 설치돼 있어야 합니다.
+        </p>
+      </div>
+    </section>
+  );
+}
+```
+
+engine 값은 `open_design_review_branch` 호출 시 argument 로 전달.
+
+### 5. PlanProposalCard 상태 전이
+
+```tsx
+// Zustand 에서 rtVerdict, rtRound 읽어옴
+if (approvalPath === 'rt' && rtVerdict === 'pass') {
+  return (
+    <div>
+      <SuccessBadge>RT 검토 완료 ({rtRound}라운드) · verdict=pass</SuccessBadge>
+      <Button onClick={onStartImplementation}>구현 시작</Button>
+    </div>
+  );
+}
+if (rtVerdict === 'escalate_to_human' || (rtRound >= 3 && rtVerdict === 'fail')) {
+  return (
+    <div>
+      <WarningBadge>3라운드 후에도 blocker 있음 — 사용자 확인 필요</WarningBadge>
+      <Button variant="ghost" onClick={openForceApprovalModal}>강제 승인</Button>
+      <Button variant="ghost" onClick={onReworkPlan}>plan 재작성 요청</Button>
+      <Button variant="ghost" onClick={onDiscardPlan}>plan 폐기</Button>
+    </div>
+  );
+}
+```
+
+"구현 시작" 은 `adopt_design_review` invoke → 성공 시 Dev 단계 (기존 subtask 생성 flow) 진입.
+
+## Dependencies
+
+depends_on: [02]
+
+## Verification
+
+- `cargo test --lib commands::design_review::adopt_design_review`:
+  - 정상 adopt 후 plan 문서에 `## Codex Review (Round N)` append 확인
+  - frontmatter 에 `design_reviewed_at`, `review_rounds`, `reviewer_engine` 주입 확인
+  - main conversation 에 시스템 메시지 1건 추가 확인
+  - branch archived=1 확인
+- `cargo test --lib commands::design_review::append_review_transcript`:
+  - 여러 라운드 append 시 순서 보존
+  - 기존 plan 본문 변경 없음 (말미 append 만)
+  - `<details>` 블록 문법 정합
+- `npx vitest run src/components/settings/DesignReviewSettings.test.tsx`:
+  - 기본 engine=codex
+  - Select 변경 시 localStorage 저장
+- 수동 E2E:
+  1. plan proposal → "RT 검토 먼저" 클릭
+  2. 1~3 라운드 진행 (mock 또는 실제 Codex)
+  3. "구현 시작" 클릭 → plan 문서 말미에 reviewer transcript 추가됨 확인
+  4. frontmatter 에 메타 주입 확인
+  5. main 대화에 "Plan approved" 시스템 메시지 추가 확인
+
+## Risks
+
+- **Plan 파일 쓰기 권한**: tunaFlow 프로세스가 `docs/plans/` 에 쓰기 가능해야 함. macOS/Linux 는 대개 OK, Windows 일부 환경 (OneDrive 동기화 등) 에서 제약 가능. 실패 시 에러 toast + adopt 롤백 (branch archived 취소).
+- **Git 영향**: plan 파일이 git-tracked 라 transcript append 가 working tree 더러움. 사용자가 의도 못 한 커밋에 포함될 위험. 대응: adopt 후 "plan 문서 업데이트됨 — git diff 확인" toast. 또는 설정으로 "transcript append OFF" 옵션.
+- **Frontmatter 파싱 깨짐**: 일부 plan 은 frontmatter 없이 작성됐을 수 있음. adopt 시 frontmatter 없으면 상단에 신규 생성 (`---` block 추가). regex 기반 단순 파싱 권장 — serde_yaml 은 heavy.
+- **transcript 길이**: 3 라운드 × 수 KB reviewer 응답 → plan 문서가 2~3배 커짐. `<details>` collapsible 로 가독성 유지. 매우 큰 plan (10+ 라운드는 INV-3 으로 막힘) 은 애초 발생 안 함.
+- **Race condition**: 사용자가 adopt 클릭 직후 RT 가 백그라운드에서 추가 라운드 실행 가능. adopt 시점에 `UPDATE branches SET archived=1` 후에는 신규 라운드 command 가 "branch archived" 에러로 차단되어야 함. INV-3 과 함께 방어.
+- **engine=gemini 실제 검증**: Codex 외 Gemini 로 돌려본 적 없음. guidance 수용성 검증 필요. 초기 릴리스는 Codex 만, Gemini 는 후속 PR 에서 enable — 본 subtask 는 UI 드롭다운만 준비.

--- a/docs/plans/designReviewGatePlan.md
+++ b/docs/plans/designReviewGatePlan.md
@@ -1,0 +1,335 @@
+---
+title: Design Review Gate — Plan 승인 전 Architect↔Reviewer RT 선택 경로
+status: planned
+priority: P1
+created_at: 2026-04-22
+related:
+  - src/components/tunaflow/chat/PlanProposalCard.tsx
+  - src-tauri/src/commands/branches.rs                     # branch_mode 분기
+  - src-tauri/src/commands/roundtable_helpers/              # RT deliberative 모드 + role guidance
+  - docs/plans/harnessVerificationGapPlan.md                # §5 reviewer 규약 (본 plan 은 Phase 7 성격)
+  - docs/plans/searchPipelineFromSecallPlan-part2.md        # 본 gate 를 거친 실제 사례 (Codex 3 라운드)
+  - docs/plans/threadModelRoundtableRedesign.md             # Branch/RT 통합 모델
+triggered_by:
+  - 2026-04-22 세션 — Architect↔Codex 3 라운드로 Search Phase C Part 2 설계 blocker 4건 사전 해소.
+    Dev→Review RT 만으로는 설계 단계 결함을 못 잡는다는 사실을 사용자 지적으로 확인.
+---
+
+# Design Review Gate — Plan 승인 시 RT 선택 경로
+
+> 현재 RT 는 **구현 산출물 gate** (dev→review) 만 존재. 설계 단계에서 reviewer 가 invariant·대안·scope 를 검증하는 경로는 부재. 본 plan 은 PlanProposalCard 에 **사용자 1-click 선택 (RT 검토 vs 바로 승인)** 을 추가하고, RT 경로는 기존 Branch/RT 인프라를 재활용한다.
+
+---
+
+## TL;DR for Developer
+
+1. **PlanProposalCard 에 승인 액션을 2분기** — 기존 단일 "승인" 버튼을 `[바로 승인]` / `[RT 검토 먼저]` 2 버튼으로 교체. 카드 상단에 판단 힌트 표시 (INV 수, subtask 수, 영향 경로). 힌트는 **가이드일 뿐 강제 규칙 없음**. 사용자 주권 유지.
+2. **`branch.mode = 'design_review'` 신설** — 기존 `chat` / `roundtable` 2종에 3번째 mode 추가. `src-tauri/src/commands/branches.rs:178, 465` 의 `branch_mode` 분기에 반영. DB migration 불필요 (mode 는 TEXT 컬럼).
+3. **Reviewer role guidance 를 이번 Codex 응답 포맷으로 고정** — `roundtable_helpers/types.rs::role_guidance("reviewer")` 에 `invariant_checks` / `scores(4-dim)` / `findings(BLOCKER|MAJOR|MINOR)` / `recommendations` / `failed_subtask_ids` / `verdict(pass|fail|escalate_to_human)` / `regression_check` 스키마 포함. harness Phase 1·2 의 기존 invariant_checks / regression_check 위에 scores·findings·verdict 를 얹는 구조.
+4. **Reviewer 엔진은 Codex (또는 Gemini) 고정** — Architect 가 Opus 이므로 blind 확보. 사용자가 필요시 Settings 에서 변경 가능 (Q-2 참조).
+5. **라운드 상한 3 + escalate 배지** — 3라운드 후에도 verdict=fail+BLOCKER 잔존 → UI 에 "human 확인 필요" + "강제 승인" 모달. harness Phase 2 divergence detector 와 연동 (동일 finding category N 회 반복 시 조기 escalate).
+6. **Plan adopt = 문서 기반 머지** (기존 adopt 는 메시지 기반). `plan_document_id` + 본문 + RT transcript 를 main conversation 에 "plan 승인 완료" 시스템 메시지 + 문서 링크로 주입. 가장 큰 신규 작업 — Subtask 03 의 핵심 scope.
+7. **Transcript auto-append** — RT 라운드 종료 시 reviewer 산출을 plan 문서 말미에 `## Codex Review (Round N — YYYY-MM-DD)` 섹션으로 auto-append. Developer 가 "왜 이렇게 결정됐지" 되짚을 때 source of truth.
+
+구현 순서: 1 → 2 → 3 → 4 (평가·측정은 Developer 구현 후 수동 acceptance).
+
+**하지 말 것**: (a) RT 자동 트리거 규칙 엔진, (b) plan proposal 외 다른 UI 에 design review 확산, (c) Codex 호출을 main thread 블로킹으로.
+
+---
+
+## Specification
+
+### 1. UI — PlanProposalCard 승인 2분기
+
+현재 `src/components/tunaflow/chat/PlanProposalCard.tsx` 에 "승인" 단일 버튼이 있다고 가정 (실제 prop 구조는 Developer 가 확인).
+
+변경:
+
+```tsx
+<PlanProposalCard>
+  <CardHeader>
+    <Title>{plan.title}</Title>
+    <HintRow>
+      INV {plan.invariants.length} · Subtask {plan.subtasks.length} · {plan.touchedPaths.length} paths
+      {shouldSuggestRT && <HintPill>RT 검토 권장</HintPill>}
+    </HintRow>
+  </CardHeader>
+  <ActionRow>
+    <Button variant="primary-subtle" onClick={onApproveDirect}>
+      바로 승인 → 구현
+    </Button>
+    <Button variant="primary" onClick={onApproveViaRT}>
+      RT 검토 먼저 (Architect ↔ Codex)
+    </Button>
+  </ActionRow>
+</PlanProposalCard>
+```
+
+`shouldSuggestRT` heuristic (힌트용, 강제 아님):
+```ts
+const shouldSuggestRT =
+  plan.invariants.length >= 3 ||
+  plan.subtasks.length >= 2 ||
+  plan.touchedPaths.some(p =>
+    p.startsWith('src-tauri/src/db/migrations') ||
+    p.startsWith('src-tauri/src/agents/') ||
+    p.startsWith('src-tauri/src/commands/agents_helpers/send_common/')
+  );
+```
+
+힌트 텍스트는 회색 14px, pill 은 노란색 accent. 버튼 클릭은 둘 다 즉시 동작.
+
+### 2. Backend — `branch.mode = 'design_review'`
+
+`src-tauri/src/commands/branches.rs:178`:
+```rust
+let branch_mode = input.mode.as_deref().unwrap_or("chat");
+// before
+let is_rt = branch_mode == "roundtable";
+// after
+let is_rt = matches!(branch_mode, "roundtable" | "design_review");
+let is_design_review = branch_mode == "design_review";
+```
+
+`open_branch_stream` 또는 동등 경로가 `design_review` mode 진입 시:
+1. 시스템 메시지 1건 자동 삽입: `"Design review started: plan=<plan_id>, reviewer=codex, round=1"`
+2. RT payload 에 plan 본문 + subtask 파일들 + frontmatter `related` 경로 자동 주입
+3. Reviewer role guidance (§3) 로드
+
+DB migration 불필요 — `branches.mode` 가 TEXT 라 새 값 허용.
+
+### 3. Reviewer role guidance 확장
+
+`src-tauri/src/commands/roundtable_helpers/types.rs::role_guidance("reviewer")` (또는 `"critic"`) 에 design_review 모드 전용 스키마 고정:
+
+```
+**Reviewer guidelines (design_review mode):**
+- You are a blind verifier of the Architect's plan.
+- Produce the following sections in order:
+
+## Invariant checks
+```json
+[{"id": "INV-N", "status": "pass|fail|cannot_verify", "evidence": "<file:line or reasoning>"}]
+```
+
+## Scores (1-5)
+- plan_coverage: N/5 — reason
+- code_quality: N/5 — reason
+- test_coverage: N/5 — reason
+- convention: N/5 — reason
+
+## Findings
+- [BLOCKER] <file:line> — <defect>
+- [MAJOR] ...
+- [MINOR] ...
+
+## Recommendations
+- [BLOCKER] <minimal fix>
+...
+
+## failed_subtask_ids
+[NN, NN]  (or empty [])
+
+## Verdict
+pass | fail | escalate_to_human — <one-line reason>
+
+## regression_check
+{"prev_findings_resolved": [...], "newly_broken": [...]}
+```
+
+- Verdict MUST be `fail` if any `invariant_checks.status == "fail"`.
+- Verdict MUST be `escalate_to_human` if round >= 3 and BLOCKER still present.
+- No subjective "clean/nice/better" language — require file:line or concrete counter-example.
+- Focus areas 는 Architect 가 prompt 에 추가 지정 가능.
+```
+
+이 guidance 는 harness Phase 1 (invariant_checks 필수) + Phase 2 (regression_check) 위에 design-review 전용 필드를 얹은 superset. `_mode` 파라미터로 분기:
+
+```rust
+pub fn role_guidance(role: &str, mode: Option<&str>) -> &'static str {
+    match (role, mode) {
+        ("reviewer" | "critic", Some("design_review")) => DESIGN_REVIEW_REVIEWER_GUIDANCE,
+        ("reviewer" | "critic", _) => REVIEWER_GUIDANCE,  // 기존 Phase 1 guidance
+        ...
+    }
+}
+```
+
+### 4. Reviewer 엔진
+
+- **기본**: Codex CLI (`codex -p`) 또는 Codex app-server. Architect 가 Opus 이므로 blind 확보.
+- **fallback**: Gemini CLI — Codex 미설치 시 자동 fallback (기존 engine resolve 경로 재활용).
+- **Settings**: `Settings > 검색` 옆 새 섹션 `Settings > Design Review` 에 reviewer engine 드롭다운 (`codex` | `gemini`). 기본 `codex`.
+- 호출 패턴은 기존 `start_codex_stream` 과 동일 — 별도 인프라 신설 없음.
+
+### 5. 라운드 상한 + escalate
+
+Plan frontmatter 또는 RT branch 에 `design_review_round: u8` (기본 1). 종료 조건:
+
+| 조건 | 액션 |
+|---|---|
+| verdict=`pass` | RT 드로어에 "승인 가능" 배지, PlanProposalCard 의 "바로 승인 → 구현" 버튼 재활성화 + "RT 검토 완료 (N라운드)" 라벨 |
+| verdict=`fail` + round < 3 | Architect 에게 reviewer 피드백 자동 전달 → Architect 가 plan 수정 → 자동 다음 라운드 트리거 |
+| verdict=`fail` + round == 3 | `escalate_to_human` 배지. 사용자에게 "3라운드 후에도 blocker 있음. 강제 승인 하시겠습니까?" 모달. 선택지: (a) 강제 승인 → 구현, (b) Architect 에게 plan 전면 재작성 요청, (c) plan 폐기. |
+| verdict=`escalate_to_human` (reviewer 자발적) | 동일 모달 |
+
+강제 승인 시 plan 문서에 `force_approved_at_round: 3` + `blocker_findings: [...]` 메타 기록. Developer 는 구현 시 이 blocker 를 직접 판단.
+
+**Divergence detector 연동**: reviewer 가 같은 finding category 를 N=2 라운드 연속 지적 시 round 3 기다리지 않고 즉시 escalate (harness Phase 2 §3.1 재사용).
+
+### 6. Plan adopt — 문서 기반 머지
+
+기존 `adopt_branch` (branches.rs) 는 **메시지 요약 삽입** 모델. Design review 는 **plan 문서 확정** 이 목적이라 경로가 다름:
+
+```rust
+pub fn adopt_design_review(
+    conn: &Connection,
+    branch_id: &str,
+    plan_document_path: &str,
+    transcript_section: &str,   // "## Codex Review (Round 3 — ...)" 블록
+    app: &AppHandle,
+) -> Result<(), AppError> {
+    // 1) plan 문서 말미에 transcript_section append (문서 hygiene)
+    let existing = std::fs::read_to_string(plan_document_path)?;
+    let merged = format!("{}\n\n{}\n", existing.trim_end(), transcript_section);
+    std::fs::write(plan_document_path, merged)?;
+
+    // 2) main conversation 에 "design review 완료" 시스템 메시지 + 문서 링크
+    insert_system_message(conn, &main_conv_id,
+        format!("Plan [{}]({}) approved after {} review rounds — verdict=pass",
+                plan_title, plan_document_path, rounds))?;
+
+    // 3) branch.mode='design_review' 를 closed 로 mark (소프트 hide)
+    conn.execute("UPDATE branches SET archived=1 WHERE id=?1", [branch_id])?;
+
+    // 4) plan frontmatter 에 review 메타 주입 (선택)
+    // design_reviewed_at: <timestamp>, review_rounds: <n>, reviewer_engine: codex
+    app.emit("design_review_adopted", ...)?;
+    Ok(())
+}
+```
+
+**문서 경로 결정**: Architect 가 plan 산출 시 이미 `docs/plans/<slug>.md` 로 저장. PlanProposalCard payload 에 `plan_document_path` 필드 포함해야 함 — 이 필드가 현재 PlanProposalCard 에 있는지 여부가 **Open Question Q-1**.
+
+### 7. Transcript auto-append
+
+각 라운드 종료 시 reviewer JSON 응답을 markdown 으로 렌더 후 plan 문서 말미에 append:
+
+```markdown
+---
+## Codex Review (Round 3 — 2026-04-22)
+
+### Invariant checks
+| INV | status | evidence |
+|---|---|---|
+| INV-1 | pass | … |
+
+### Scores
+plan_coverage: 4/5 · code_quality: 4/5 · test_coverage: 3/5 · convention: 4/5
+
+### Findings
+- [MINOR] …
+
+### Verdict
+pass — MINOR only
+```
+
+Collapsible 포맷은 markdown `<details>` 권장 (긴 transcript 가 plan 본문 가독성 해치지 않게).
+
+---
+
+## Invariants
+
+- **[INV-1]** Design review RT 는 사용자 명시 클릭 (`[RT 검토 먼저]` 버튼) 으로만 발동한다. plan proposal 을 DB 에 기록하는 경로 / plan 자동 생성 경로 / 다른 RT 세션 / 임의 자동화 규칙 engine 등 **어떤 대체 경로로도 design_review 모드가 자동 시작되지 않는다**. **이유**: 사용자 주권 유지 + 토큰 비용 통제 + "모든 plan 이 RT 를 요구하진 않음" 사용자 명시 방침. **검증**: `grep "design_review" src-tauri/src -r` 결과가 UI 클릭 경로 (new_branch + mode=design_review) 1 곳만 트리거 진입점을 형성함을 확인. 테스트 — 자동 생성된 plan (예: metaAgent 등) 이 design_review 로 흐르는지 negative test.
+
+- **[INV-2]** verdict=`fail` + BLOCKER finding 이 1건 이상 존재하는 상태에서는 PlanProposalCard 의 "바로 승인 → 구현" 버튼이 **비활성화** 된다. 강제 승인은 별도 모달 (사용자 2-step confirm) 을 거쳐야만 가능하며, 강제 승인 이력은 plan frontmatter `force_approved_at_round` 메타에 기록된다. **이유**: BLOCKER 가 잡힌 설계를 한 번의 클릭으로 지나갈 수 없게 하는 안전망. **검증**: Frontend unit test — reviewer verdict=fail + findings.some(f => f.severity === 'BLOCKER') 시 disabled=true assertion.
+
+- **[INV-3]** RT 라운드는 **최대 3회**. 3회 도달 시 자동으로 `escalate_to_human` 상태로 전환되고, Codex 추가 호출은 차단된다. Divergence detector (harness Phase 2) 가 동일 finding category 를 2 라운드 연속 감지하면 round 3 도달 전이라도 즉시 escalate. **이유**: 무한 loop 방지 + doom-loop 비용 차단. **검증**: Integration test — reviewer 가 항상 fail 반환하는 mock 으로 4번째 호출 시도 시 차단 에러.
+
+- **[INV-4]** `branch.mode='design_review'` 브랜치는 **shadow conversation** 이며, main conversation 에 reviewer transcript 를 직접 주입하지 않는다. main 에 주입되는 것은 adopt 시점의 "plan 승인 완료 + 문서 링크" 시스템 메시지 1건뿐. reviewer 의 상세 출력은 plan 문서 말미에만 append. **이유**: main 대화가 reviewer 의 세부 문장으로 오염되지 않음 — 사용자가 원할 때만 plan 문서를 펼쳐서 봄 (이번 세션 Part 2 patterns 과 동일). **검증**: Integration test — RT 세션 종료 후 main conversation 의 메시지 diff 가 1건 (시스템 메시지) 만 증가했는지.
+
+- **[INV-5]** 사용자가 RT 진행 중 "취소" 를 클릭하면 design_review branch 는 archived 상태가 되고, **원본 plan 문서는 변경되지 않는다** (transcript append 없음). 중간 reviewer 응답은 branch 의 shadow conversation 메시지로만 남음 — 기존 branch drop 규칙과 동일 (stash 보존, 원본 보호). **이유**: 취소는 결정 권한을 사용자에게 돌려주는 경로이므로 irreversible 부작용 금지. **검증**: UI test — 취소 버튼 클릭 후 plan 문서의 md5 해시가 변경되지 않음을 확인.
+
+---
+
+## Rationale (reviewer-only)
+
+### 왜 자동 트리거 엔진 대신 사용자 버튼인가
+
+초기 구상은 heuristic 기반 자동 트리거 (INV 수 / subtask 수 / 영향 경로 grep) 였으나, 사용자 지적으로 방향 전환:
+- 자동 규칙은 "모든 plan 을 검증" 쪽으로 drift 하기 쉽고, 이는 사용자 방침 "체감 개선으로 토큰 낭비 금지" 와 충돌.
+- 간단한 UI fix / 문서 교정에 Codex 호출이 붙으면 marginal cost 커짐.
+- 사용자가 상황 (긴급도, plan 규모, 자신감 수준) 에 맞게 1-click 결정하는 편이 **정보가 가장 많은 주체가 결정권을 갖는** 패턴.
+- heuristic 은 **힌트 pill** 로 남겨 "참고" 수준 제공 → 사용자 판단 보조.
+
+### 왜 기존 Branch/RT 를 재활용하는가
+
+tunaFlow 는 이미 정교한 Branch/RT 인프라를 보유:
+- shadow conversation 분기 (branches.rs)
+- deliberative 모드 (roundtable_helpers/)
+- RT 드로어 UI
+- role_guidance + invariant_checks + regression_check (harness Phase 1·2 구현됨)
+- tool-request 마커 체계 (reviewer 가 코드 조회)
+
+design_review 를 별도 시스템으로 만들면 **동일 개념의 두 번째 구현** 이 생기고, 유지보수 부채가 2배. `branch.mode` 에 값 하나 추가 + reviewer guidance 1 variant 추가 = 최소 침습 경로.
+
+### 왜 reviewer 엔진이 Codex 고정 (기본) 인가
+
+- Architect 가 Opus → blind 확보를 위해 **다른 vendor** 필요.
+- Gemini 도 사용 가능하나 tunaFlow 의 기존 사용 비중 (Codex > Gemini) 에 맞춤.
+- Settings 에서 변경 가능하도록 유연성만 남김.
+- Anthropic 간 Sonnet/Haiku reviewer 는 "vendor 1개 의존성 증가" → 기각.
+
+### 대안 비교
+
+| 대안 | 판정 | 사유 |
+|---|---|---|
+| 자동 heuristic 트리거 규칙 엔진 | 기각 | 사용자 주권 침해 + 룰 drift 리스크 |
+| 별도 design-review 시스템 (branch/RT 미사용) | 기각 | 중복 구현, 유지보수 2배 |
+| reviewer 엔진을 Opus 로 — Architect 와 동일 | 기각 | blind 확보 불가능 |
+| 라운드 상한 없음 | 기각 | doom loop |
+| Plan adopt = 기존 메시지 adopt 재활용 | 기각 | plan 은 문서, 메시지 아님. 정보 loss |
+| **채택** (UI 2버튼 + branch.mode=design_review + Codex reviewer + 문서 adopt) | ✅ | 최소 침습, 사용자 주권, 기존 인프라 재활용 |
+
+### Open questions
+
+1. **Q-1 (PlanProposalCard payload 의 `plan_document_path`)**: 현재 PlanProposalCard 가 plan 문서 파일 경로를 prop 으로 받는지 확인 필요. 받지 않는다면 plan 생성 단계 (Architect 응답 파싱) 에서 path 추출 + payload 주입 로직 추가 필요 — 이는 Subtask 01 scope 초과 여지. Developer 가 기존 prop 구조 확인 후 결정.
+
+2. **Q-2 (reviewer 엔진 기본값)**: 초기 릴리스는 Codex 고정. Gemini fallback 은 codex 미설치 환경에서만. 사용자 Settings 에 engine 선택 UI 를 즉시 추가할지 후속 PR 로 미룰지 — 본 plan 은 "Codex 기본 + Settings UI 는 옵션" 으로 두고 Developer 판단에 맡김.
+
+3. **Q-3 (divergence detector 재활용)**: harness Phase 2 의 `regression_check` + divergence detector 가 design_review RT 에도 동일하게 동작하는지. 현재 dev_review RT 용으로 구현됐을 가능성 — mode 분기 또는 공통 helper 확인 필요.
+
+4. **Q-4 (라운드 간 plan 문서 업데이트 정책)**: Architect 가 round N 에서 plan 을 수정하면 그 수정본은 round N+1 의 reviewer 입력이 됨. 수정본을 plan 문서에 즉시 write 할지, round 내 임시 버퍼에 둘지. 본 plan 은 "즉시 write + `## Codex Review (Round N)` append 는 round 종료 시" 를 권장하나 Developer 판단 가능.
+
+5. **Q-5 (metaAgent 자동 plan 생성과의 충돌)**: 향후 metaAgent 가 plan 을 자동 생성하는 경로 (P0 metaAgentPlan) 와 본 design review gate 가 상호작용. 자동 생성 plan 은 사용자가 RT 를 선택할 기회가 있어야 하므로 PlanProposalCard UI 를 반드시 경유 — 이는 INV-1 로 강제.
+
+### 측정 지표 (Developer 구현 후 수집)
+
+- design_review RT 발동률 (사용자가 버튼 누른 비율)
+- 평균 라운드 수 (1~3)
+- 라운드당 잡힌 BLOCKER / MAJOR / MINOR 수
+- `force_approved_at_round=3` 사례 수 (이건 적을수록 좋음)
+- dev review 단계에서 design review 가 놓친 blocker 발견 수 (design review false negative)
+
+이번 세션의 Search Phase C Part 2 (3 라운드, BLOCKER 4 + MAJOR 1 + MINOR 3) 를 baseline reference 로 사용.
+
+---
+
+## Subtask 구조
+
+| # | 파일 | 범위 | 의존 |
+|---|---|---|---|
+| 01 | [-task-01.md](./designReviewGatePlan-task-01.md) | PlanProposalCard 2버튼 + 힌트 pill + Zustand 상태 + RT 드로어 mode 구분 표시 | — |
+| 02 | [-task-02.md](./designReviewGatePlan-task-02.md) | Backend: `branch.mode='design_review'` + reviewer role guidance 확장 + Codex 호출 경로 + 라운드 상한 + escalate | 01 |
+| 03 | [-task-03.md](./designReviewGatePlan-task-03.md) | Plan document adopt (문서 머지) + Transcript auto-append + Settings UI (reviewer engine 선택) | 02 |
+
+3 subtask. 각 독립 PR 가능하나 01 없이는 02 가 사용자 경로 없이 dead code — 01 → 02 순서 권장.
+
+---
+
+## 관련 문서
+
+- 본 gate 를 **거친 실제 사례**: `docs/plans/searchPipelineFromSecallPlan-part2.md` (Codex 3 라운드 transcript 가 본문 말미에 append 된 예시). 이번 세션에서 손으로 수행한 workflow 를 본 plan 이 제품화.
+- harness 규약: `docs/plans/harnessVerificationGapPlan.md` §2 (invariants) + §3 (divergence/regression) + §5 (proposer 4-section)
+- Branch/RT 인프라: `docs/plans/threadModelRoundtableRedesign.md`
+- metaAgent 상호작용: `docs/plans/metaAgentPlan.md` (P0, 본 plan 의 INV-1 로 자동 트리거 금지 명시)

--- a/docs/plans/index.md
+++ b/docs/plans/index.md
@@ -19,6 +19,7 @@
 | [betaRtUpgradeSprintPlan_2026-04-15](./betaRtUpgradeSprintPlan_2026-04-15.md) | — |
 | [cicdReleasePlan](./cicdReleasePlan.md) | — |
 | [contextBudgetScalingPlan](./contextBudgetScalingPlan.md) | P2 — 단계적 context budget 상향 실험 |
+| [designReviewGatePlan](./designReviewGatePlan.md) | **P1** — Plan 승인 시 Architect↔Codex RT 선택 경로 (PlanProposalCard 2버튼 + branch.mode=design_review + plan 문서 adopt) |
 | [conventionsContextSyncPlan](./conventionsContextSyncPlan.md) | — |
 | [engineServerModePlan](./engineServerModePlan.md) | — |
 | [geminiSdkIntegrationPlan](./geminiSdkIntegrationPlan.md) | P1 — Google AI SDK 직접 통합 (CLI 대체, SSE/token/function calling) |
@@ -30,6 +31,7 @@
 | [perProjectDatabaseSplitPlan](./perProjectDatabaseSplitPlan.md) | — |
 | [postParityRuntimeValidationSweepPlan_2026-03-30](./postParityRuntimeValidationSweepPlan_2026-03-30.md) | P1 — parity fix 효과 재검증 |
 | [realWorkflowMemoryQualityValidationPlan_2026-03-30](./realWorkflowMemoryQualityValidationPlan_2026-03-30.md) | P1 — memory/retrieval 응답 품질 검증 |
+| [roleAssignmentCoverageUxPlan](./roleAssignmentCoverageUxPlan.md) | P2 — Settings 역할 커버리지 UX (inferred 저장 명시화 + stale ID 자동 정리 + assertRoleReady 원클릭 적용) |
 | [refactorRoadmap_2026-04-20](./refactorRoadmap_2026-04-20.md) | **베타 전 리팩토링 + 안정화 5-Phase 로드맵** (16~19일) — 프로덕션급 베타 기준 |
 | [refactorRoadmap_first_prompt](./refactorRoadmap_first_prompt.md) | 새 세션에 붙여넣을 첫 프롬프트 텍스트 |
 | [refactorRoadmap_handoff_2026-04-20](./refactorRoadmap_handoff_2026-04-20.md) | 새 세션용 핸드오프 — 프로젝트 철학 / 피할 함정 / Phase 1 Finding 6 진입점 |
@@ -41,6 +43,7 @@
 | [structuralImprovementPlan](./structuralImprovementPlan.md) | — |
 | [systemMessageChannelPlan](./systemMessageChannelPlan.md) | — |
 | [toolCallHandlerPlan](./toolCallHandlerPlan.md) | P1 — function calling으로 마커 대체 |
+| [userWorldviewInjectionPlan](./userWorldviewInjectionPlan.md) | **P1** — Identity/Interface/Continuity 3축 번들: worldview 주입 + preference_timeline (event+snapshot) + stance-conflict (rule-first) + low-priority visible background job |
 | [traceOverhaulPlan_2026-04-16](./traceOverhaulPlan_2026-04-16.md) | — |
 
 ## 🟡 부분 완료 — 추가 구현 필요

--- a/docs/plans/roleAssignmentCoverageUxPlan-task-01.md
+++ b/docs/plans/roleAssignmentCoverageUxPlan-task-01.md
@@ -1,0 +1,160 @@
+# Subtask 01 — `roleAssignments.ts` API 확장 + `assertRoleReady` 액션 개선
+
+> 상위 plan: [roleAssignmentCoverageUxPlan.md](./roleAssignmentCoverageUxPlan.md)
+
+## Changed files
+
+- `src/lib/roleAssignments.ts` — `pruneStaleIds()`, `applyInferredAssignments()` 헬퍼 신규. `assertRoleReady()` 의 toast 액션 분기 추가.
+- `src/lib/roleAssignments.test.ts` (신규 또는 기존 파일 확장) — unit tests.
+
+## Change description
+
+### 1. `pruneStaleIds()` 추가
+
+```ts
+export function pruneStaleIds(
+  assignments: RoleAssignments,
+  profiles: AgentProfile[],
+): { pruned: RoleAssignments; droppedCount: number } {
+  const valid = new Set(profiles.map((p) => p.id));
+  let dropped = 0;
+  const keepOne = (id?: string) => {
+    if (!id) return undefined;
+    if (valid.has(id)) return id;
+    dropped += 1;
+    return undefined;
+  };
+  const reviewers = assignments.reviewers.filter((id) => {
+    if (valid.has(id)) return true;
+    dropped += 1;
+    return false;
+  });
+  return {
+    pruned: {
+      architect: keepOne(assignments.architect),
+      developer: keepOne(assignments.developer),
+      reviewers,
+      synthesizer: keepOne(assignments.synthesizer),
+    },
+    droppedCount: dropped,
+  };
+}
+```
+
+### 2. `applyInferredAssignments()` 추가
+
+```ts
+export async function applyInferredAssignments(
+  profiles: AgentProfile[],
+): Promise<RoleAssignments> {
+  const inferred = inferRoleAssignments(profiles);
+  await saveRoleAssignments(inferred);
+  return inferred;
+}
+```
+
+### 3. `assertRoleReady()` toast 분기 (INV-3)
+
+```ts
+export async function assertRoleReady(
+  role: RoleKey,
+  profiles: AgentProfile[],
+): Promise<{ ok: boolean; coverage: RoleCoverage }> {
+  const assignments = await loadRoleAssignments();
+  const cov = evaluateCoverage(assignments, profiles).find((c) => c.role === role)!;
+
+  if (cov.status === "missing") {
+    const inferred = inferRoleAssignments(profiles);
+    const wouldSatisfy =
+      role === "reviewers" ? inferred.reviewers.length >= 2
+      : role === "architect" ? !!inferred.architect
+      : role === "developer" ? !!inferred.developer
+      : role === "synthesizer" ? !!inferred.synthesizer
+      : false;
+
+    const { toast } = await import("sonner");
+    if (wouldSatisfy) {
+      toast.error(cov.hint, {
+        action: {
+          label: "추천 구성 적용",
+          onClick: async () => {
+            await applyInferredAssignments(profiles);
+            toast.success("역할 구성 적용됨 — 다시 시도하세요");
+          },
+        },
+        duration: 10000,
+      });
+    } else {
+      toast.error(cov.hint, {
+        action: {
+          label: "Settings 열기",
+          onClick: () => window.dispatchEvent(new CustomEvent("tunaflow:open-settings", { detail: { section: "agents" } })),
+        },
+        duration: 8000,
+      });
+    }
+    return { ok: false, coverage: cov };
+  }
+
+  if (cov.status === "model-unset") {
+    const { toast } = await import("sonner");
+    toast.warning(cov.hint, { duration: 4000 });
+  }
+  return { ok: true, coverage: cov };
+}
+```
+
+## Dependencies
+
+depends_on: 없음.
+
+## Verification
+
+- Unit tests (`src/lib/roleAssignments.test.ts`):
+  ```ts
+  describe("pruneStaleIds", () => {
+    it("drops ids that are no longer in profiles", () => {
+      const assignments = { architect: "a1", developer: "gone", reviewers: ["r1", "gone2"], synthesizer: "s1" };
+      const profiles = [{ id: "a1" }, { id: "r1" }, { id: "s1" }] as any;
+      const { pruned, droppedCount } = pruneStaleIds(assignments, profiles);
+      expect(pruned).toEqual({ architect: "a1", developer: undefined, reviewers: ["r1"], synthesizer: "s1" });
+      expect(droppedCount).toBe(2);
+    });
+
+    it("returns droppedCount=0 when all ids valid", () => {
+      const assignments = { architect: "a1", developer: undefined, reviewers: ["r1", "r2"], synthesizer: undefined };
+      const profiles = [{ id: "a1" }, { id: "r1" }, { id: "r2" }] as any;
+      const { pruned, droppedCount } = pruneStaleIds(assignments, profiles);
+      expect(pruned).toEqual(assignments);
+      expect(droppedCount).toBe(0);
+    });
+
+    it("treats undefined fields as valid (no false positive)", () => {
+      const { droppedCount } = pruneStaleIds({ reviewers: [] }, []);
+      expect(droppedCount).toBe(0);
+    });
+  });
+
+  describe("applyInferredAssignments", () => {
+    it("persists inferred result via saveRoleAssignments", async () => {
+      const profiles = [
+        { id: "arch-1", personaId: "persona_architect", label: "arch" },
+        { id: "rev-1", personaId: "persona_reviewer", label: "reviewer-1" },
+        { id: "rev-2", personaId: "persona_reviewer", label: "reviewer-2" },
+      ] as any;
+      const applied = await applyInferredAssignments(profiles);
+      expect(applied.architect).toBe("arch-1");
+      expect(applied.reviewers).toEqual(["rev-1", "rev-2"]);
+      // saved 검증 — loadRoleAssignments 결과도 동일해야
+      expect(await loadRoleAssignments()).toEqual(applied);
+    });
+  });
+  ```
+- `npx vitest run src/lib/roleAssignments.test.ts` — 모두 pass.
+- `npx tsc --noEmit` — exit 0.
+
+## Risks
+
+- **`getSetting` / `setSetting` mock**: 테스트가 `appStore` 의 `getSetting`/`setSetting` 을 mock 해야 실제 DB 건드리지 않음. 기존 vitest setup 에 mock 이 있는지 확인.
+- **import cycle**: `roleAssignments.ts` 가 sonner 를 동적 import (`await import("sonner")`) 로 쓰는 건 tree-shake 목적 — 유지. 상단 static import 로 바꾸지 말 것.
+- **toast 중복 표시**: stale pruning + missing 동시 발생 시 toast 2 개. UX 상 허용 (각 정보가 다름). 필요 시 Subtask 02 에서 UI 상태로 dedup 가능.

--- a/docs/plans/roleAssignmentCoverageUxPlan-task-02.md
+++ b/docs/plans/roleAssignmentCoverageUxPlan-task-02.md
@@ -1,0 +1,235 @@
+# Subtask 02 — `AgentsSection.tsx` RoleCoveragePanel 재설계
+
+> 상위 plan: [roleAssignmentCoverageUxPlan.md](./roleAssignmentCoverageUxPlan.md)
+
+## Changed files
+
+- `src/components/tunaflow/settings/AgentsSection.tsx` — RoleCoveragePanel useEffect 재작성 + tentative 배지 렌더 + "추천 구성 적용" 버튼.
+- `src/components/tunaflow/settings/AgentsSection.test.tsx` (신규 또는 확장) — component tests.
+
+## Change description
+
+### 1. useEffect 재작성 (stale pruning + inferred 제안 상태)
+
+`AgentsSection.tsx:192-205` 현재 로직 대체:
+
+```tsx
+import {
+  loadRoleAssignments, saveRoleAssignments,
+  pruneStaleIds, inferRoleAssignments, applyInferredAssignments,
+  evaluateCoverage,
+  type RoleAssignments, type RoleCoverage, type RoleKey,
+} from "@/lib/roleAssignments";
+import { toast } from "sonner";
+
+function RoleCoveragePanel({ profiles }: { profiles: AgentProfile[] }) {
+  const [assignments, setAssignments] = useState<RoleAssignments>({ reviewers: [] });
+  const [isInferred, setIsInferred] = useState(false);   // ← 신규
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    let alive = true;
+    loadRoleAssignments().then((saved) => {
+      if (!alive) return;
+
+      // (a) stale ID 자동 정리
+      const { pruned, droppedCount } = pruneStaleIds(saved, profiles);
+      if (droppedCount > 0) {
+        saveRoleAssignments(pruned);
+        toast.info(`삭제된 프로필 ${droppedCount}개를 역할 배정에서 제거했습니다`, { duration: 4000 });
+      }
+
+      // (b) saved 가 완전히 비어있고 profiles 가 있으면 inferred 를 제안 상태로 표시
+      const isEmpty = !pruned.architect && !pruned.developer && pruned.reviewers.length === 0 && !pruned.synthesizer;
+      if (isEmpty && profiles.length > 0) {
+        setAssignments(inferRoleAssignments(profiles));
+        setIsInferred(true);
+      } else {
+        setAssignments(pruned);
+        setIsInferred(false);
+      }
+      setLoaded(true);
+    });
+    return () => { alive = false; };
+  }, [profiles]);   // profiles 변경 시 재평가 (기존 .length 만 watch 하던 것을 확장)
+  ...
+}
+```
+
+### 2. tentative 배지 + "추천 구성 적용" 버튼
+
+RoleCoveragePanel 헤더 아래:
+
+```tsx
+{isInferred && (
+  <div className="flex items-center gap-2 p-2 rounded-md bg-amber-500/10 border border-amber-500/30 mb-2">
+    <AlertTriangle className="w-4 h-4 text-amber-500 shrink-0" />
+    <span className="text-tf-sm text-foreground flex-1">
+      추천 구성이 제안되어 있지만 아직 저장되지 않았습니다
+    </span>
+    <button
+      onClick={async () => {
+        const applied = await applyInferredAssignments(profiles);
+        setAssignments(applied);
+        setIsInferred(false);
+        toast.success("역할 구성이 저장되었습니다");
+      }}
+      className="px-3 py-1 rounded bg-amber-500 text-white text-tf-sm font-medium hover:bg-amber-600"
+    >
+      추천 구성 적용
+    </button>
+  </div>
+)}
+```
+
+### 3. RoleRow / ReviewersRow tentative prop
+
+기존 `RoleRow`, `ReviewersRow` 에 `tentative?: boolean` prop 추가:
+
+```tsx
+function RoleRow({ label, coverage, profiles, selectedId, onChange, tentative }: {
+  label: string;
+  coverage: RoleCoverage;
+  profiles: AgentProfile[];
+  selectedId: string;
+  onChange: (id: string) => void;
+  tentative?: boolean;   // ← 신규
+}) {
+  return (
+    <div className={cn("flex items-center gap-2 text-tf-sm", tentative && "opacity-60")}>
+      {statusIcon(coverage.status)}
+      <span className="w-[90px] text-muted-foreground">{label}</span>
+      <select
+        value={selectedId}
+        onChange={(e) => onChange(e.target.value)}
+        className="flex-1 bg-background rounded px-2 py-1 text-tf-sm outline-none border border-border/30"
+      >
+        <option value="">(선택 안됨)</option>
+        {profiles.map((p) => (
+          <option key={p.id} value={p.id}>{p.label}</option>
+        ))}
+      </select>
+      {tentative && (
+        <span className="px-2 py-0.5 rounded-full bg-amber-500/20 text-amber-700 text-[10px] font-medium">
+          제안됨
+        </span>
+      )}
+    </div>
+  );
+}
+```
+
+사용자가 select 변경 (또는 reviewer 체크박스 토글) → `isInferred=false` 로 전이 + `saveRoleAssignments` 호출 (기존 `updateAndSave` / `toggleReviewer` 로직 유지). tentative prop 은 자동 해제:
+
+```tsx
+const setSingle = (role: Exclude<RoleKey, "reviewers">, value: string) => {
+  const next = { ...assignments, [role]: value || undefined };
+  setAssignments(next);
+  setIsInferred(false);                // ← 추가
+  saveRoleAssignments(next);
+};
+
+const toggleReviewer = (profileId: string) => {
+  const has = assignments.reviewers.includes(profileId);
+  const reviewers = has
+    ? assignments.reviewers.filter((id) => id !== profileId)
+    : [...assignments.reviewers, profileId];
+  const next = { ...assignments, reviewers };
+  setAssignments(next);
+  setIsInferred(false);                // ← 추가
+  saveRoleAssignments(next);
+};
+```
+
+### 4. RoleRow/ReviewersRow 호출부에 prop 전달
+
+```tsx
+<RoleRow label="Architect" coverage={coverage[0]!} profiles={profiles}
+  selectedId={assignments.architect ?? ""} onChange={(v) => setSingle("architect", v)}
+  tentative={isInferred} />
+<RoleRow label="Developer" coverage={coverage[1]!} profiles={profiles}
+  selectedId={assignments.developer ?? ""} onChange={(v) => setSingle("developer", v)}
+  tentative={isInferred} />
+<ReviewersRow coverage={coverage[2]!} profiles={profiles}
+  selectedIds={assignments.reviewers} onToggle={toggleReviewer}
+  tentative={isInferred} />
+<RoleRow label="Synthesizer" coverage={coverage[3]!} profiles={profiles}
+  selectedId={assignments.synthesizer ?? ""} onChange={(v) => setSingle("synthesizer", v)}
+  tentative={isInferred} />
+```
+
+`ReviewersRow` 내부도 동일 패턴 — 체크박스 opacity-60 + "제안됨" 배지.
+
+## Dependencies
+
+depends_on: [01]
+
+## Verification
+
+- Component test (`AgentsSection.test.tsx`):
+  ```tsx
+  it("shows '추천 구성 적용' banner when saved roleAssignments is empty and profiles exist", async () => {
+    mockGetSetting.mockResolvedValue({ reviewers: [] });   // saved = empty
+    const profiles = [
+      { id: "arch-1", personaId: "persona_architect", label: "arch" },
+      { id: "rev-1", personaId: "persona_reviewer", label: "reviewer-1" },
+      { id: "rev-2", personaId: "persona_reviewer", label: "reviewer-2" },
+    ];
+    render(<AgentsSection profiles={profiles} />);
+    expect(await screen.findByText(/추천 구성이 제안되어/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /추천 구성 적용/ })).toBeInTheDocument();
+  });
+
+  it("hides banner and persists after clicking '추천 구성 적용'", async () => {
+    // ... arrange ...
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /추천 구성 적용/ }));
+    expect(mockSetSetting).toHaveBeenCalledWith("roleAssignments", expect.objectContaining({
+      reviewers: expect.arrayContaining(["rev-1", "rev-2"]),
+    }));
+    expect(screen.queryByText(/추천 구성이 제안되어/)).not.toBeInTheDocument();
+  });
+
+  it("INV-1: isInferred=true 상태에서 saved 저장소는 empty 유지", async () => {
+    render(<AgentsSection profiles={profiles} />);
+    await screen.findByText(/추천 구성이 제안되어/);  // 제안 상태 확인
+    // 버튼 클릭 안 한 상태에서 loadRoleAssignments 재호출 시 empty
+    expect(await loadRoleAssignments()).toEqual({ reviewers: [] });
+  });
+
+  it("INV-2: stale ID 감지 시 toast + 자동 정리", async () => {
+    mockGetSetting.mockResolvedValue({
+      architect: "gone", developer: undefined, reviewers: ["gone2", "rev-1"], synthesizer: undefined,
+    });
+    const profiles = [{ id: "rev-1", personaId: "persona_reviewer", label: "r1" }];
+    render(<AgentsSection profiles={profiles} />);
+    await waitFor(() => {
+      expect(mockSetSetting).toHaveBeenCalledWith("roleAssignments", expect.objectContaining({
+        architect: undefined,
+        reviewers: ["rev-1"],
+      }));
+    });
+    // toast.info 호출 검증 (mock sonner)
+  });
+
+  it("manual toggle dismisses isInferred flag", async () => {
+    render(<AgentsSection profiles={profilesWithEmptySaved} />);
+    await screen.findByText(/추천 구성이 제안되어/);
+    await user.selectOptions(screen.getByLabelText("Architect"), "arch-1");
+    expect(screen.queryByText(/추천 구성이 제안되어/)).not.toBeInTheDocument();
+  });
+  ```
+- `npx vitest run src/components/tunaflow/settings/AgentsSection.test.tsx` — 모두 pass.
+- `npx tsc --noEmit` — exit 0.
+- 수동 E2E:
+  1. 신규 프로필 2개 생성 (persona_reviewer)
+  2. Settings 닫고 다시 열기 → "추천 구성이 제안되어 있지만 아직 저장되지 않았습니다" 배너 노출
+  3. "추천 구성 적용" 클릭 → 배너 사라지고 체크박스 opacity 정상
+  4. RT 진입 → 에러 없음 + 정상 진입
+
+## Risks
+
+- **`profiles` 의존성 변경**: 기존 `[profiles.length]` → `[profiles]` 확장은 매 profile 편집 시 재평가. inferred 제안 상태가 매번 재계산되어 사용자 경험상 깜박임 가능. 완화: dep 를 `[profiles.length, profiles.map(p=>p.id).join(',')]` 로 stable hash 사용 또는 별도 비교.
+- **Toast 중복**: stale pruning 이 발동하는 동시에 RT 진입이 일어나면 같은 toast 2회 가능. sonner 의 id 기반 dedup (`toast.info(..., { id: 'role-prune' })`) 로 방어.
+- **Option C 로 변경 요청**: 본 구현은 Option B (tentative 표시 + 원클릭) 기반. 사용자 시연 후 Option C 로 변경 요청 시 tentative 블록 전체를 "제안 표시 없음 + 빈 select" 로 simplification — 15 LOC 이하 변경으로 가능.
+- **Persona 명이 바뀐 경우**: `inferRoleAssignments` 는 `persona_reviewer` / `persona_architect` / `persona_implementer` 하드코딩. 기존 Persona 의 ID 가 변경되면 infer 결과 비어짐 → "추천 구성 적용" 버튼 노출 안 됨. 이는 기존 동작과 동일 (현재도 label 기반 fallback 있음).

--- a/docs/plans/roleAssignmentCoverageUxPlan.md
+++ b/docs/plans/roleAssignmentCoverageUxPlan.md
@@ -1,0 +1,271 @@
+---
+title: Role Assignment Coverage UX — inferred 저장 명시화 + stale ID 자동 정리
+status: planned
+priority: P2
+created_at: 2026-04-22
+related:
+  - src/components/tunaflow/settings/AgentsSection.tsx           # RoleCoveragePanel 신설 지점
+  - src/lib/roleAssignments.ts                                    # load/save/infer/evaluateCoverage
+  - docs/plans/harnessVerificationGapPlan.md                      # §5 proposer 규약
+triggered_by:
+  - 2026-04-22 사용자 리포트 — reviewer 프로필 2개를 만든 상태에서 "Reviewer (≥2) 프로필이 설정되지 않았습니다" 토스트.
+  - 원인: `AgentsSection.tsx:192-205` 의 auto-infer 가 state 에만 반영되고 `saveRoleAssignments` 호출 안 함.
+    사용자가 수동 토글 후 RT 정상 진입 → 시나리오 확정.
+---
+
+# Role Assignment Coverage UX — inferred 저장 명시화
+
+> 현재 Settings 의 "역할 커버리지" 패널은 profile 자동 추론 결과를 체크된 것처럼 보여주지만 DB/store 에는 저장하지 않는다. 사용자는 "설정 완료" 라 판단하나 `assertRoleReady` 는 saved empty 만 읽어 에러를 낸다. 본 plan 은 UX 를 명시적으로 만들어 상태 오인을 제거한다.
+
+---
+
+## TL;DR for Developer
+
+1. **`AgentsSection.tsx:197-201` 의 auto-infer 블록을 "Persist 후 표시" 로 고친다** — inferred 를 즉시 `saveRoleAssignments` 호출. state 와 store 일치.
+2. **"추천 구성 적용" 원클릭 버튼을 RoleCoveragePanel 상단에 추가** (Option B 선호) — 초기에는 inferred 값이 **플레이스홀더** 로만 표시되고 (회색 체크 + "제안됨" 배지), 사용자가 버튼 클릭 시 실제 저장. Option C (매 역할마다 수동 체크) 도 고려했으나 UX 마찰 큼. Open question Q-1 로 최종 선택 flag.
+3. **Stale profile ID 자동 정리** — `evaluateCoverage` 가 `byId.has(id)` 로 거르는 stale ID 를 감지하면 자동으로 pruned assignments 를 save + toast 안내 ("삭제된 프로필 N개 제거됨").
+4. **RT 진입 전 `assertRoleReady` 의 toast 를 액션화** — 이미 "Settings 열기" 액션이 있음. inferred 가 유효하면 "추천 구성 적용" 바로가기도 제공.
+
+구현 순서: 1 → 2 → 3 → 4. 1~2 는 같은 파일에 집중 (10~20 LOC). 3~4 는 `roleAssignments.ts` 에 API 추가 + 호출부.
+
+**하지 말 것**: 이 plan 을 Q-5 (auto-magic persist) 방향으로 구현 — 사용자 명시성 원칙과 충돌. 본 plan 은 "inferred 는 제안, 적용은 1-click" 을 기본 스탠스로 함.
+
+---
+
+## Specification
+
+### 1. `roleAssignments.ts` API 확장
+
+현재 `inferRoleAssignments(profiles)` 는 순수 추론 함수. 신규 헬퍼:
+
+```ts
+// src/lib/roleAssignments.ts
+
+/** Stale ID 제거 — profiles 에 없는 ID 를 assignments 에서 drop. */
+export function pruneStaleIds(
+  assignments: RoleAssignments,
+  profiles: AgentProfile[],
+): { pruned: RoleAssignments; droppedCount: number } {
+  const valid = new Set(profiles.map((p) => p.id));
+  let dropped = 0;
+  const keepOne = (id?: string) => {
+    if (!id) return undefined;
+    if (valid.has(id)) return id;
+    dropped += 1;
+    return undefined;
+  };
+  const reviewers = assignments.reviewers.filter((id) => {
+    if (valid.has(id)) return true;
+    dropped += 1;
+    return false;
+  });
+  return {
+    pruned: {
+      architect: keepOne(assignments.architect),
+      developer: keepOne(assignments.developer),
+      reviewers,
+      synthesizer: keepOne(assignments.synthesizer),
+    },
+    droppedCount: dropped,
+  };
+}
+
+/** "추천 구성 적용" 버튼이 호출. inferred 를 persist. */
+export async function applyInferredAssignments(
+  profiles: AgentProfile[],
+): Promise<RoleAssignments> {
+  const inferred = inferRoleAssignments(profiles);
+  await saveRoleAssignments(inferred);
+  return inferred;
+}
+```
+
+### 2. `AgentsSection.tsx` — RoleCoveragePanel 재설계
+
+기존 `useEffect` (L192-205):
+
+```tsx
+// before
+if (!a.architect && !a.developer && a.reviewers.length === 0 && profiles.length > 0) {
+  setAssignments(inferRoleAssignments(profiles));
+} else {
+  setAssignments(a);
+}
+```
+
+→ 새 동작:
+
+```tsx
+useEffect(() => {
+  let alive = true;
+  loadRoleAssignments().then((saved) => {
+    if (!alive) return;
+    // (a) stale ID 자동 정리 (§3)
+    const { pruned, droppedCount } = pruneStaleIds(saved, profiles);
+    if (droppedCount > 0) {
+      saveRoleAssignments(pruned);
+      toast.info(`삭제된 프로필 ${droppedCount}개를 역할 배정에서 제거했습니다`, { duration: 4000 });
+    }
+    // (b) saved 가 전부 비어있으면 inferred 를 "제안 상태" 로 표시 (저장 X)
+    const isEmpty = !pruned.architect && !pruned.developer && pruned.reviewers.length === 0;
+    if (isEmpty && profiles.length > 0) {
+      const inferred = inferRoleAssignments(profiles);
+      setAssignments(inferred);
+      setIsInferred(true);       // ★ 제안 상태 flag
+    } else {
+      setAssignments(pruned);
+      setIsInferred(false);
+    }
+    setLoaded(true);
+  });
+  return () => { alive = false; };
+}, [profiles]);
+```
+
+`isInferred: boolean` state 추가. 제안 상태일 때 UI 렌더 변경:
+
+```tsx
+{isInferred && (
+  <div className="flex items-center gap-2 p-2 rounded-md bg-amber-500/10 border border-amber-500/30">
+    <AlertTriangle className="w-4 h-4 text-amber-500" />
+    <span className="text-tf-sm text-foreground flex-1">
+      추천 구성이 제안되어 있지만 아직 저장되지 않았습니다
+    </span>
+    <Button
+      size="sm"
+      onClick={async () => {
+        const applied = await applyInferredAssignments(profiles);
+        setAssignments(applied);
+        setIsInferred(false);
+      }}
+    >
+      추천 구성 적용
+    </Button>
+  </div>
+)}
+```
+
+제안 상태에서 RoleRow/ReviewersRow 는 **회색 / 반투명** + "제안됨" 배지:
+
+```tsx
+<RoleRow
+  label="Reviewer"
+  coverage={coverage[2]!}
+  profiles={profiles}
+  selectedIds={assignments.reviewers}
+  onToggle={toggleReviewer}
+  tentative={isInferred}   // ← 신규 prop
+/>
+```
+
+`tentative=true` 일 때 체크박스는 render 되지만 opacity-50 + "제안됨" 배지 inline. 사용자가 직접 토글하면 isInferred→false + 즉시 save.
+
+### 3. Stale ID 자동 정리 & toast
+
+§1 의 `pruneStaleIds` 가 load 시점에 자동 호출 (§2 의 useEffect 내부). dropped > 0 이면 사용자에게 toast 1회. 후속으로는 pruned 값이 이미 저장됨.
+
+### 4. `assertRoleReady` toast 에 "추천 구성 적용" 바로가기
+
+기존 toast 액션 (`roleAssignments.ts:127-133`) 은 "Settings 열기" 만 있음. 추가:
+
+```ts
+// src/lib/roleAssignments.ts::assertRoleReady
+
+if (cov.status === "missing") {
+  const inferred = inferRoleAssignments(profiles);
+  const wouldSatisfy =
+    role === "reviewers" ? inferred.reviewers.length >= 2
+    : role === "architect" ? !!inferred.architect
+    : role === "developer" ? !!inferred.developer
+    : role === "synthesizer" ? !!inferred.synthesizer
+    : false;
+
+  const { toast } = await import("sonner");
+  if (wouldSatisfy) {
+    toast.error(cov.hint, {
+      action: {
+        label: "추천 구성 적용",
+        onClick: async () => {
+          await applyInferredAssignments(profiles);
+          toast.success("역할 구성 적용됨 — 다시 시도하세요");
+        },
+      },
+      duration: 8000,
+    });
+  } else {
+    toast.error(cov.hint, {
+      action: {
+        label: "Settings 열기",
+        onClick: () => window.dispatchEvent(new CustomEvent("tunaflow:open-settings", { detail: { section: "agents" } })),
+      },
+      duration: 8000,
+    });
+  }
+  return { ok: false, coverage: cov };
+}
+```
+
+즉 inferred 가 충족시킬 수 있다면 Settings 안 열고 원클릭 해결. 아니면 Settings 유도.
+
+---
+
+## Invariants
+
+- **[INV-1]** Settings UI 에 **체크박스로 표시되는 값** 과 `getSetting("roleAssignments")` 가 항상 일치한다. "제안 상태 (inferred 미저장)" 은 tentative 배지 + opacity 시각 차이로 명시적으로 구분된다. **이유**: 현 버그의 근본 원인 — 표시와 저장 불일치. **검증**: Vitest — `isInferred=true` 상태에서 `getSetting` 호출 시 empty 반환 확인. 사용자가 체크박스 직접 토글 → `isInferred=false` 로 전이 + `getSetting` 가 새 값 반환.
+
+- **[INV-2]** `loadRoleAssignments` 는 호출 시마다 stale ID (현 `agentProfiles` 에 없는 ID) 를 자동 정리하고, 정리가 발생한 경우 1회 toast 로 사용자에게 알린다. 정리 후 값은 **즉시 persist**. **이유**: profile 삭제/재생성 시 stale 로 인해 "프로필 2개 있는데 에러" 재현. **검증**: Unit test — assignments.reviewers=['stale-1', 'stale-2'], profiles=[{id:'new-1'}] 입력 시 pruned.reviewers=[] + droppedCount=2.
+
+- **[INV-3]** `assertRoleReady` 가 missing 반환할 때, inferred 가 해당 role 을 충족시킬 수 있으면 toast 액션은 "추천 구성 적용" (원클릭) 이다. 충족 불가 시만 "Settings 열기". **이유**: 불필요한 Settings 진입을 줄이고 UX friction 감소. **검증**: Integration test — 2개 reviewer persona 를 가진 profiles 상태에서 assertRoleReady("reviewers") 호출 후 toast 액션 label 검증.
+
+---
+
+## Rationale (reviewer-only)
+
+### Option B (원클릭 승인) vs Option C (매 역할 수동 체크) — 선정 근거
+
+| 옵션 | 동작 | 장점 | 단점 |
+|---|---|---|---|
+| **B (채택)** | inferred 는 제안 상태로 표시 + "추천 구성 적용" 버튼 1개로 일괄 persist | 1-click 으로 즉시 사용 가능, 사용자 명시성 유지 | 사용자가 개별 역할에 custom 배정을 원하면 버튼 클릭 후 개별 수정 필요 |
+| C | inferred 를 체크박스로 **표시하지 않고** placeholder 상태로만 (비활성). 사용자가 매 역할마다 직접 체크 | 가장 명시적 — 모든 값이 user action 결과 | UX friction 큼 — 신규 사용자 4 번 토글 필요 |
+| ~A (auto-magic persist)~ | 기각 — 사용자 방침 "명시성 > 자동화" |
+| ~Hot fix only~ | 기각 — 사용자가 C 경로 (UX polish) 선택 |
+
+Option B 는 **명시성과 편의성의 균형** 이 가장 좋고, Q-5 (메타에이전트 자동화) 와도 호환 — 메타에이전트가 자동 생성하는 경우에도 "추천 구성 적용 필요" 라는 동일 UX 를 재활용 가능.
+
+### stale ID 자동 정리의 정당성
+
+`byId.has(id)` 로 거르는 현재 로직은 conservative — valid 가 줄어들어도 assignments 는 유지. 이유는 "프로필이 잠시 reload 되지 않았을 가능성" 인데, 실제로는 `useChatStore.agentProfiles` 가 이미 최신 상태이므로 실수가 아님. 자동 정리가 안전.
+
+### 왜 hot fix 를 건너뛰는가
+
+사용자가 "긴급하지 않다" 판단. 본 plan 으로 직행 시 이점:
+- 1 라인 hot fix 후 UX plan 으로 또 변경 → 불필요한 중간 상태
+- UX plan 자체가 10~20 LOC 수준이라 hot fix 대비 비용 크게 높지 않음
+- regression 보호 (stale ID 케이스 + toast UX) 를 한 PR 에 묶음
+
+### Open questions
+
+1. **Q-1 (Option B vs C 최종 확정)**: 본 plan 은 Option B 를 기본 스펙으로 작성. 사용자가 Option C (완전 수동) 를 원하면 §2 의 tentative UI 를 "제안 값 표시 없음 + 빈 체크박스" 로 변경. 최종 결정은 Developer 가 UI 구현 초안 후 사용자 시연 + 확정.
+
+2. **Q-2 (toast duration)**: 현재 missing 토스트는 8초 (`roleAssignments.ts:132`). 추천 구성 적용 토스트는 사용자가 클릭할 시간이 필요하므로 유지 혹은 10초 확대.
+
+3. **Q-3 (metaAgent 자동 생성 plan 과의 상호작용)**: 향후 메타에이전트가 plan 을 자동 생성 → RoleCoveragePanel 의 inferred 도 메타에이전트 출력으로 대체될 가능성. 본 plan 의 "추천 구성 적용" 버튼은 동일 UX 로 재활용 가능하므로 충돌 없음.
+
+---
+
+## Subtask 구조
+
+| # | 파일 | 범위 | 의존 |
+|---|---|---|---|
+| 01 | [-task-01.md](./roleAssignmentCoverageUxPlan-task-01.md) | `roleAssignments.ts` API 확장 (`pruneStaleIds`, `applyInferredAssignments`) + `assertRoleReady` 액션 개선 + unit tests | — |
+| 02 | [-task-02.md](./roleAssignmentCoverageUxPlan-task-02.md) | `AgentsSection.tsx` RoleCoveragePanel 재설계 (tentative 표시 + "추천 구성 적용" 버튼 + stale toast) + Vitest | 01 |
+
+2 subtask. UX 플로우가 간단해서 3개로 쪼갤 필요 없음.
+
+---
+
+## 관련 문서
+
+- 버그 리포트 맥락: 본 세션 2026-04-22 "Reviewer (≥2) 프로필이 설정되지 않았습니다" 토론
+- RT 진입 경로: `src/lib/workflow/reviewWorkflow.ts` L66 (`reviewers.length === 0` 체크)
+- 유사 패턴 참조: `src/components/tunaflow/chat/PlanProposalCard.tsx` (tentative 배지 UI)

--- a/docs/plans/searchPipelineFromSecallPlan-part2-task-01.md
+++ b/docs/plans/searchPipelineFromSecallPlan-part2-task-01.md
@@ -4,7 +4,7 @@
 
 ## Changed files
 
-- `src-tauri/src/db/migrations.rs` — `apply_v45` 함수 신규. 기존 v15 trigger DROP + `messages_fts` DROP/CREATE + 신규 trigger 3종.
+- `src-tauri/src/db/migrations.rs` — `apply_v45` 함수 신규. 기존 v15 trigger DROP + `messages_fts` DROP/CREATE + 신규 trigger **4종** (insert / update_tokenized / update_content / delete).
 - `src-tauri/src/db/schema.rs` — `messages_fts` 정의를 **standalone FTS5** (`content=messages` 제거, `tokenize='unicode61'` 명시) 로 교체. `messages` 테이블 정의에 `content_tokenized TEXT` 컬럼 추가.
 - `src-tauri/src/db/migrations.rs` 의 마이그레이션 registry (`run_migrations` / `apply_all` 내부 match arm) 에 v45 엔트리 추가.
 
@@ -31,13 +31,51 @@ CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
 
 ### 2. `migrations.rs` — `apply_v45`
 
-plan §1.1 SQL 을 그대로 실행. 순서:
-1. `ALTER TABLE messages ADD COLUMN content_tokenized TEXT` (idempotent: `add_column_if_missing` 헬퍼 사용)
-2. `DROP TRIGGER IF EXISTS messages_fts_insert|update|delete`
-3. `DROP TABLE IF EXISTS messages_fts`
-4. `CREATE VIRTUAL TABLE messages_fts USING fts5(content, message_id UNINDEXED, tokenize='unicode61')`
-5. 신규 trigger 3종 (plan §1.1 참조)
-6. `INSERT INTO schema_version (version, applied_at) VALUES (45, ?1)`
+**INV-8 요구**: 전체를 하나의 transaction 으로 감싼다 (`let tx = conn.transaction()?; ... tx.commit()?;`). 중간 실패 시 rollback 되어 v44 상태로 복원.
+
+```rust
+fn apply_v45(conn: &mut Connection) -> Result<(), AppError> {
+    let tx = conn.transaction()?;  // SQLite 는 FTS5 virtual table DDL 도 transactional
+    add_column_if_missing_tx(&tx, "messages", "content_tokenized", "TEXT")?;  // helper 신설 또는 기존 helper 가 Connection 대신 Transaction 도 받도록
+    tx.execute_batch("
+        DROP TRIGGER IF EXISTS messages_fts_insert;
+        DROP TRIGGER IF EXISTS messages_fts_update;
+        DROP TRIGGER IF EXISTS messages_fts_delete;
+        DROP TABLE IF EXISTS messages_fts;
+        CREATE VIRTUAL TABLE messages_fts USING fts5(
+            content, message_id UNINDEXED, tokenize='unicode61'
+        );
+        CREATE TRIGGER messages_fts_insert AFTER INSERT ON messages BEGIN
+            INSERT INTO messages_fts(rowid, content, message_id)
+            VALUES (NEW.rowid, COALESCE(NEW.content_tokenized, NEW.content), NEW.id);
+        END;
+        -- tokenized 가 갱신될 때 발화 (finalize/rebuild/user edit)
+        CREATE TRIGGER messages_fts_update_tokenized AFTER UPDATE OF content_tokenized ON messages BEGIN
+            DELETE FROM messages_fts WHERE rowid = OLD.rowid;
+            INSERT INTO messages_fts(rowid, content, message_id)
+            VALUES (NEW.rowid, COALESCE(NEW.content_tokenized, NEW.content), NEW.id);
+        END;
+        -- ★ content-only UPDATE (streaming chunk, stale-cleanup 등) 에서도 FTS resync.
+        --   Lindera tokenize 는 호출하지 않고 NEW.content 를 fallback 인덱싱. INV-5 참조.
+        CREATE TRIGGER messages_fts_update_content
+            AFTER UPDATE OF content ON messages
+            WHEN NEW.content IS NOT OLD.content
+            BEGIN
+            DELETE FROM messages_fts WHERE rowid = OLD.rowid;
+            INSERT INTO messages_fts(rowid, content, message_id)
+            VALUES (NEW.rowid, COALESCE(NEW.content_tokenized, NEW.content), NEW.id);
+        END;
+        CREATE TRIGGER messages_fts_delete AFTER DELETE ON messages BEGIN
+            DELETE FROM messages_fts WHERE rowid = OLD.rowid;
+        END;
+    ")?;
+    tx.execute("INSERT INTO schema_version (version, applied_at) VALUES (45, ?1)", [now_epoch()])?;
+    tx.commit()?;
+    Ok(())
+}
+```
+
+**함수 시그니처 변경**: 기존 `apply_v*` 는 `&Connection` 을 받는다. transaction 을 쓰려면 `&mut Connection` 필요. 호출자 (migration registry) 도 mut 으로 전환. 다른 migration 과의 호환성 확인 — 기존 관례가 `conn.execute_batch("BEGIN; ...; COMMIT;")` 식 명시 BEGIN 을 쓰고 있다면 그 패턴을 따르고, 그렇지 않다면 이번 기회에 `&mut Connection + conn.transaction()` 으로 통일 (scope 초과 시 본 PR 에선 명시 BEGIN 만 사용).
 
 **절대 금지**: 이 마이그레이션 안에서 `INSERT INTO messages_fts ... SELECT FROM messages` 수행. 앱 기동 블록 방지.
 
@@ -85,12 +123,64 @@ depends_on: 없음 (v44 까지 적용된 DB 기준).
       assert_eq!(cnt, 1);
   }
   ```
+- 신규 test — content-only UPDATE 도 FTS resync (update_content trigger, Codex review):
+  ```rust
+  #[test]
+  fn content_only_update_syncs_fts_without_tokenize() {
+      let conn = apply_v45_on(fresh_v44_db());
+      conn.execute(
+          "INSERT INTO messages (id, conversation_id, role, content, content_tokenized, timestamp, status)
+           VALUES ('m1','c1','user','original text', 'orig tok', 0, 'done')",
+          [],
+      ).unwrap();
+      // content-only UPDATE (streaming chunk 또는 stale cleanup 시뮬레이션)
+      conn.execute("UPDATE messages SET content = 'changed text' WHERE id = 'm1'", []).unwrap();
+      // FTS 는 NEW.content_tokenized 우선이므로 'orig tok' 로 indexing 유지되어야 (tokenize 는 Rust 쪽에서만)
+      let cnt: i64 = conn.query_row(
+          "SELECT COUNT(*) FROM messages_fts WHERE content MATCH 'orig'", [], |r| r.get(0)
+      ).unwrap();
+      assert_eq!(cnt, 1, "tokenized fallback 이 남아있어야 함");
+  }
+
+  #[test]
+  fn content_only_update_with_null_tokenized_uses_content_fallback() {
+      let conn = apply_v45_on(fresh_v44_db());
+      conn.execute(
+          "INSERT INTO messages (id, conversation_id, role, content, timestamp, status)
+           VALUES ('m2','c1','user','first', 0, 'streaming')",
+          [],
+      ).unwrap();
+      conn.execute("UPDATE messages SET content = 'second version' WHERE id = 'm2'", []).unwrap();
+      let cnt: i64 = conn.query_row(
+          "SELECT COUNT(*) FROM messages_fts WHERE content MATCH 'second'", [], |r| r.get(0)
+      ).unwrap();
+      assert_eq!(cnt, 1, "NEW.content fallback 이 FTS 에 반영되어야");
+  }
+  ```
+- 신규 test — migration atomicity (INV-8):
+  ```rust
+  #[test]
+  fn v45_rolls_back_on_mid_migration_failure() {
+      let mut conn = fresh_v44_db();
+      // force 실패 시뮬레이션: apply_v45 와 동일 SQL 을 직접 실행하되 중간에 고의 에러
+      let tx = conn.transaction().unwrap();
+      tx.execute("DROP TRIGGER messages_fts_insert", []).unwrap();
+      tx.execute("DROP TABLE messages_fts", []).unwrap();
+      // 여기서 에러 — tx drop 되면 rollback
+      drop(tx);
+      // 검증: schema_version 은 여전히 44, messages_fts 는 여전히 존재 (external content)
+      let ver: i64 = conn.query_row("SELECT MAX(version) FROM schema_version", [], |r| r.get(0)).unwrap();
+      assert_eq!(ver, 44);
+      let sql: String = conn.query_row("SELECT sql FROM sqlite_master WHERE name='messages_fts'", [], |r| r.get(0)).unwrap();
+      assert!(sql.contains("content=messages"), "rollback 이 적용되지 않음");
+  }
+  ```
 - `cargo test --test db_integration` — exit 0.
 - `cargo check` — exit 0.
 
 ## Risks
 
 - **기존 user 데이터 상실 인식**: migration 직후 검색이 빈 결과를 반환 → 사용자 혼란 가능. subtask 05 의 UI 배너로 완화하되, 릴리스 노트에 명시 필요. 본 subtask 구현 시점에는 Developer 가 README 또는 CHANGELOG 에 항목 추가.
-- **`DROP TABLE IF EXISTS messages_fts`** 후 `CREATE VIRTUAL TABLE` 실패 시 FTS 테이블이 없는 상태로 앱이 기동됨. `apply_v45` 는 transaction (`BEGIN ... COMMIT`) 안에서 실행해 실패 시 rollback. 다른 v* 함수와 transaction 사용 관례 확인 (기존 `apply_v*` 코드가 transaction 을 명시하지 않으면 이 subtask 에서 도입).
+- **DROP/CREATE 사이 window (INV-8 참조)**: transaction 안 감쌀 시 앱 크래시하면 `messages_fts` 가 소실된 채 남음. 본 subtask 의 apply_v45 는 `conn.transaction()` 필수. 다른 v* 함수의 transaction 관례 확인 — 기존 관례가 `execute_batch("BEGIN; ...; COMMIT;")` 이라면 그 패턴과 호환. 본 PR 에서 전체 apply_v* 를 `&mut Connection + transaction()` 으로 통일할지 여부는 scope 초과 → 최소 apply_v45 만 atomic 보장.
 - **v44 (Harness Phase 3b-part1 audit, PR #124) 미머지 상태**: v45 는 v44 다음 순번. PR #124 가 먼저 머지되어야 함 — 본 PR 에서 base branch 를 #124 머지 후 main 으로 설정.
 - **schema.rs 변경과 migration 의 이중성**: fresh DB (schema.rs) 와 migrated DB (migrations.rs) 가 다를 경우 회귀 버그 원천. 테스트에서 "fresh DB 에서도 `create_sql` 이 `content=messages` 를 포함하지 않아야" 확인.

--- a/docs/plans/searchPipelineFromSecallPlan-part2-task-02.md
+++ b/docs/plans/searchPipelineFromSecallPlan-part2-task-02.md
@@ -57,6 +57,31 @@ conn.execute(
 - `tool_request.rs:354, 379`
 - `send_common/persistence.rs:124, 142, 494`
 
+### 2a. Content-only UPDATE 3 사이트 (Codex review 2026-04-22 반영)
+
+초안은 이 사이트들을 고려하지 않아 INV-5 실효성이 깨졌다. 해결: **Rust 쪽 코드는 변경하지 않고** migration v45 의 `messages_fts_update_content` trigger (subtask-01 §2) 가 FTS 를 resync. 즉 아래 사이트들은 content_tokenized 를 채우지 않아도 trigger 가 fallback indexing 수행:
+
+| 파일:라인 | UPDATE 문 | 조치 |
+|---|---|---|
+| `src-tauri/src/commands/messages.rs:221` (`update_message_status`) | `UPDATE messages SET status=?1, content=?2 WHERE id=?3` | **변경 없음**. trigger 가 content 기준 FTS resync. 이 경로는 사용자가 편집한 메시지나 agent 취소 메시지 content 치환 용. 빈도 낮음. tokenize 없이 whitespace 인덱싱이라도 기존 stale 대비 개선. |
+| `src-tauri/src/commands/jobs.rs:136` (`cleanup_stale_jobs`) | `UPDATE messages SET status='error', content=CASE WHEN content='' THEN '(interrupted)' ELSE content END WHERE status='streaming'` | **변경 없음**. content 가 바뀐 경우만 trigger 발화. 값이 유지되는 CASE 에서는 `NEW.content IS NOT OLD.content` false 로 no-op. |
+| `src-tauri/src/bootstrap/db.rs:19` (startup stale cleanup) | 위와 동일 패턴 | **변경 없음**. 위와 동일 이유. |
+
+**권장 follow-up (별도 이슈)**: 이 3 사이트가 content_tokenized 를 갱신하지 않으면 `rebuild_messages_fts` 가 다음 실행 시 `WHERE content_tokenized IS NULL` 로 잡지 못해 남는다. 대응:
+- (a) `UPDATE messages` 할 때 `content_tokenized = NULL` 도 SET 해 "reset" — rebuild 가 다음 실행 시 재tokenize. 간단하나 모든 사이트 touch.
+- (b) `rebuild_messages_fts` 에 "재tokenize" 플래그 추가 — `WHERE content <> '' AND (content_tokenized IS NULL OR content_tokenized != expected)` 같은 강제 재tokenize 경로. 복잡.
+- 본 subtask 는 (a) 를 **선택 적용** 권장 — 세 사이트 모두 `content_tokenized=NULL` 을 추가 SET 하여 rebuild-on-change 루프를 닫는다. 1 라인 추가 × 3.
+
+```rust
+// messages.rs:221 before
+"UPDATE messages SET status = ?1, content = ?2 WHERE id = ?3"
+// after
+"UPDATE messages SET status = ?1, content = ?2, content_tokenized = NULL WHERE id = ?3"
+// jobs.rs:136 / bootstrap/db.rs:19 동일 패턴으로 content_tokenized = NULL 추가
+```
+
+이 1 라인 변경 후에는 `AFTER UPDATE OF content_tokenized` trigger 도 발화 (NULL→NULL 은 no-op 처리 여부는 SQLite 문서 확인 — 안전하게는 `WHEN NEW.content_tokenized IS NOT OLD.content_tokenized` 조건 추가 필요할 수 있음).
+
 ### 3. Streaming 경로 (`send_common/persistence.rs`)
 
 두 가지 케이스 구분:
@@ -98,6 +123,28 @@ depends_on: [01] — `content_tokenized` 컬럼이 먼저 존재해야 함.
 
 ## Verification
 
+- **INV-2 동치성 test (Developer review 로 추가)**:
+  ```rust
+  // src-tauri/src/commands/search/tokenizer.rs::tests
+  #[test]
+  fn tokenize_helpers_stay_in_sync() {
+      for input in [
+          "플랜",
+          "Rust workspace",
+          "seCall의 BM25 검색",
+          "아키텍처를 설계한다",
+          "",
+          "   ",
+      ] {
+          assert_eq!(
+              super::tokenize_for_index(input),
+              super::tokenize_query_for_fts(input),
+              "index/query tokenize diverged on input: {:?}", input
+          );
+      }
+  }
+  ```
+  이 테스트가 실패하면 recall 이 silent 0 이 되므로 CI 에서 반드시 green 요구.
 - `cargo test --lib commands::messages` — user insert 테스트. 신규 assertion: insert 직후 `SELECT content_tokenized FROM messages WHERE id=?` 가 non-null.
 - `cargo test --lib commands::agents_helpers::send_common::persistence` — finalize 경로 테스트. 스트리밍 시뮬레이션:
   ```rust

--- a/docs/plans/searchPipelineFromSecallPlan-part2-task-03.md
+++ b/docs/plans/searchPipelineFromSecallPlan-part2-task-03.md
@@ -134,7 +134,11 @@ pub async fn rebuild_messages_fts(...) -> Result<RebuildSummary, AppError> {
                 .map_err(|e| AppError::Agent(format!("emit: {e}")))?;
         }
 
-        // (4) optimize
+        // (4) optimize — 'rebuild' 명령은 external content 모드에서 external 테이블을 다시
+        //     읽어 FTS 를 재구성하지만, standalone FTS5 에는 external source 가 없으므로
+        //     의미가 없다. 우리는 trigger 가 이미 각 UPDATE 마다 FTS 를 sync 했다고 가정하고
+        //     index merge 를 요청하는 'optimize' 만 호출한다. 'rebuild' 를 잘못 쓰면 FTS 가
+        //     자신의 content 테이블을 재읽는 self-reference 가 되며 의도와 맞지 않다.
         {
             let w = state_db.write.lock().map_err(|_| AppError::Lock)?;
             w.execute("INSERT INTO messages_fts(messages_fts) VALUES('optimize')", [])?;

--- a/docs/plans/searchPipelineFromSecallPlan-part2-task-04.md
+++ b/docs/plans/searchPipelineFromSecallPlan-part2-task-04.md
@@ -11,83 +11,111 @@
 
 ## Change description
 
-### 1. `extract_snippet`
+### 1. `extract_snippet` — char-window 추출 (하이라이트 없음)
 
-secall `bm25.rs:191` 포팅:
+> **Codex review 2026-04-22 반영**: 초안은 `content.to_lowercase()` 의 byte offset 을 원본 `content` 에 역매핑하는 구조였는데, Turkish `İ`→`i̇` / German `ß`→`ss` 등 Unicode case expansion 에서 byte length 가 변해 boundary panic. 하이라이트 마커 `**…**` 를 이 단계에서 완전 제거하고 **순수 char-window 추출** 만 수행한다. 하이라이트는 UI 측 클라이언트 렌더 (React) 또는 후속 별도 plan 으로 분리.
 
 ```rust
 // src-tauri/src/commands/search/snippet.rs
-/// 쿼리의 첫 non-whitespace term 이 처음 등장하는 지점 주변 ±half 만큼 char window 잘라 반환.
-/// - byte boundary 가 아니라 **char boundary** 기준 (한글 다바이트 안전).
+/// Case-insensitive first-term 매칭 지점 주변 ±half 만큼의 **char window** 추출.
+/// - char boundary 보존 (multi-byte 안전).
+/// - byte offset 이 아니라 **char index 만** 사용 — Unicode case expansion 에서도 panic 없음.
 /// - 매칭 없으면 앞 `max_chars` char.
-/// - 양 끝에 ellipsis `…` 추가.
-/// - 매칭 term 을 `**…**` 로 하이라이트 (기존 UI 관습 유지).
+/// - 양 끝 축약 표시 `…` 추가.
+/// - **하이라이트 마커는 삽입하지 않는다**. 호출자가 UI 단에서 DOM 하이라이트.
 pub fn extract_snippet(content: &str, query: &str, max_chars: usize) -> String {
     let chars: Vec<char> = content.chars().collect();
     if chars.is_empty() { return String::new(); }
+    if chars.len() <= max_chars { return content.to_string(); }
 
-    // 첫 term 추출 — whitespace split, 빈 제거, 첫 값
     let term = query.split_whitespace().next().unwrap_or("");
-    if term.is_empty() || chars.len() <= max_chars {
-        // 매칭 불가 or 전체 보여줄 수 있으면 그대로
-        return chars.iter().collect();
-    }
+    let match_at = if term.is_empty() { None } else { find_term_char_index(&chars, term) };
 
-    // 대소문자 무시 매칭 (char vec 기준)
-    let lower: String = content.to_lowercase();
-    let term_lower = term.to_lowercase();
-    let idx_byte = lower.find(&term_lower);
-
-    let (start_char, end_char) = match idx_byte {
+    let (s, e) = match match_at {
         None => (0usize, max_chars.min(chars.len())),
-        Some(byte_idx) => {
-            // byte→char 인덱스 복원
-            let prefix = &content[..byte_idx];
-            let term_start_char = prefix.chars().count();
+        Some(idx) => {
             let half = max_chars / 2;
-            let s = term_start_char.saturating_sub(half);
-            let e = (term_start_char + max_chars - (term_start_char - s)).min(chars.len());
-            (s, e)
+            let s0 = idx.saturating_sub(half);
+            (s0, (s0 + max_chars).min(chars.len()))
         }
     };
 
     let mut out = String::new();
-    if start_char > 0 { out.push('…'); }
-    // term 하이라이트: term_lower 등장 구간을 찾아 `**..**` 삽입
-    // 단순 구현: window 를 String 화 후 replace_first (case-insensitive 는 한 번만 수동)
-    let window: String = chars[start_char..end_char].iter().collect();
-    let hi = highlight_first(&window, term);
-    out.push_str(&hi);
-    if end_char < chars.len() { out.push('…'); }
+    if s > 0 { out.push('…'); }
+    out.extend(chars[s..e].iter());
+    if e < chars.len() { out.push('…'); }
     out
 }
 
-fn highlight_first(text: &str, term: &str) -> String {
-    if term.is_empty() { return text.to_string(); }
-    let lower_text = text.to_lowercase();
-    let lower_term = term.to_lowercase();
-    if let Some(pos) = lower_text.find(&lower_term) {
-        // pos 는 byte — 원본 text 에서 해당 char 범위 추출
-        let prefix = &text[..pos];
-        let matched_bytes = lower_term.len();
-        let end = pos + matched_bytes;
-        if end <= text.len() && text.is_char_boundary(pos) && text.is_char_boundary(end) {
-            let matched = &text[pos..end];
-            let after = &text[end..];
-            return format!("{}**{}**{}", prefix, matched, after);
+/// Char-level case-insensitive substring search. No byte-offset translation.
+///
+/// 한계: term 쪽이 Unicode case expansion 을 일으키는 글자 (`ß`) 를 포함하면
+/// 완전 매칭이 어렵다 — 해당 케이스는 매칭 실패로 처리 (false negative 수용).
+/// 기본 사용처 (한글/영문 일반 쿼리) 는 안전. 완전한 Unicode case folding 은
+/// 후속 plan (ICU 의존성 도입 또는 별도 기능).
+fn find_term_char_index(haystack: &[char], term: &str) -> Option<usize> {
+    // term 을 char 단위로 to_lowercase — multi-char case expansion 시 첫 char 만 채용.
+    // 즉 "ß" (= "ss") 의 경우 첫 char "s" 로 비교해 false negative 수용.
+    let t_lower: Vec<char> = term.chars()
+        .filter_map(|c| c.to_lowercase().next())
+        .collect();
+    if t_lower.is_empty() || t_lower.len() > haystack.len() { return None; }
+    'outer: for start in 0..=(haystack.len() - t_lower.len()) {
+        for (i, &tc) in t_lower.iter().enumerate() {
+            let hc_first = haystack[start + i].to_lowercase().next();
+            if hc_first != Some(tc) { continue 'outer; }
         }
+        return Some(start);
     }
-    text.to_string()
+    None
 }
 ```
 
-테스트 필수:
+**필수 테스트** (Codex 가 반례로 지목한 케이스 포함):
+
 ```rust
-#[test] fn extract_handles_korean_multibyte() { ... }
-#[test] fn extract_returns_whole_text_if_short() { ... }
-#[test] fn extract_adds_leading_ellipsis() { ... }
-#[test] fn highlight_preserves_case_from_original() { ... }
+#[test]
+fn snippet_handles_turkish_dotted_i_without_panic() {
+    // "İ" -> "i̇" (i + combining dot). 초안 코드는 여기서 byte boundary panic.
+    let s = extract_snippet("Start AİB middle padding text that is long enough", "b", 20);
+    assert!(!s.is_empty(), "panic 없이 반환되어야");
+    // 매칭 여부는 보장하지 않음 — panic-free 가 primary 기대.
+}
+
+#[test]
+fn snippet_handles_german_sharp_s() {
+    // "ß" -> "ss". term="strasse" 로 "Straße" 매칭 시도하면 false negative 수용.
+    let s = extract_snippet("In der Straße steht ein Haus mit vielen Fenstern heute", "straße", 30);
+    assert!(!s.is_empty());
+}
+
+#[test]
+fn snippet_korean_multibyte_safe() {
+    let s = extract_snippet("오늘 아키텍처 설계 회의를 했다. 아키텍처 문서도 정리했다.", "아키텍처", 20);
+    assert!(s.contains("아키텍처"));
+    assert!(!s.contains("**"), "하이라이트 마커 삽입 금지");
+}
+
+#[test]
+fn snippet_returns_whole_when_short() {
+    let s = extract_snippet("짧은 글", "짧은", 120);
+    assert_eq!(s, "짧은 글");
+}
+
+#[test]
+fn snippet_no_match_returns_prefix() {
+    let s = extract_snippet("아무것도 매칭되지 않는 긴 문장입니다. 매우 긴 문장입니다. 정말 긴 문장", "플랜", 20);
+    assert!(s.chars().count() <= 21);  // +1 for optional leading ellipsis
+    assert!(!s.contains("**"));
+}
+
+#[test]
+fn snippet_empty_input() {
+    assert_eq!(extract_snippet("", "anything", 100), "");
+}
 ```
+
+UI 측 하이라이트는 `query` 를 받아 React 에서 `<mark>` 로 처리 (별도 PR 또는 Subtask 05 범위 조정). 현재 검색 UI 가 `**...**` 마크다운을 렌더하는 경로를 사용 중이면 그 경로를 **임시로 query string 기반 클라이언트 사이드 highlight** 로 교체해야 UX regression 최소.
 
 ### 2. `search_messages` (messages.rs:381)
 
@@ -124,7 +152,8 @@ let mut stmt = conn.prepare(
 
 let results = stmt.query_map(params![fts_query, project_key, max], |row| {
     let content: String = row.get(4)?;
-    // snippet 은 **원본 effective_query** 로 생성 — tokenized 가 아닌 사용자 의도 단어로 하이라이트
+    // snippet 은 **원본 effective_query** 로 생성 — tokenized 가 아닌 사용자 의도 단어로 window 추출.
+    // 하이라이트 마커는 포함되지 않음 (UI 측에서 query 기반 client-side highlight 수행).
     let snippet = extract_snippet(&content, &effective_query, 120);
     Ok(SearchResult {
         message_id: row.get(0)?,
@@ -164,25 +193,50 @@ depends_on: [01] — FTS 스키마/트리거가 새 구조여야 함.
 
 ## Verification
 
+> **Codex review 2026-04-22 (2차) 반영**: 이전 verification 은 `**하이라이트**` 를 검사하는 구 계약. 본 verification 은 **char-window + 하이라이트 없음** 계약으로 재작성. 하이라이트 기능 자체는 UI 단에서 담당.
+
 - **Unit (snippet)**:
   ```rust
   #[test]
-  fn snippet_highlights_korean_match() {
+  fn snippet_extracts_korean_window_without_markers() {
       let s = extract_snippet("오늘 아키텍처 설계 회의를 했다. 아키텍처 문서도 정리했다.", "아키텍처", 30);
-      assert!(s.contains("**아키텍처**"));
-      assert!(s.len() < 40 + 6);  // ellipsis + marker 여유
+      assert!(s.contains("아키텍처"), "매칭 term 포함");
+      assert!(!s.contains("**"), "하이라이트 마커는 삽입 금지");
+      assert!(s.chars().count() <= 32, "±ellipsis 여유 포함 상한");
   }
 
   #[test]
   fn snippet_returns_whole_when_short() {
       let s = extract_snippet("짧은 글", "짧은", 120);
-      assert!(!s.starts_with('…'));
+      assert_eq!(s, "짧은 글");
+      assert!(!s.contains("…"));
   }
 
   #[test]
   fn snippet_falls_back_on_no_match() {
-      let s = extract_snippet("아무것도 매칭되지 않는 긴 문장입니다. 매우 긴 문장입니다.", "플랜", 20);
+      let s = extract_snippet("아무것도 매칭되지 않는 긴 문장입니다. 매우 긴 문장입니다. 정말 긴 문장.", "플랜", 20);
       assert!(!s.contains("**"));
+      assert!(!s.is_empty());
+  }
+
+  #[test]
+  fn snippet_handles_turkish_dotted_i_no_panic() {
+      // content.to_lowercase() = "ai̇b" (i + combining dot) — byte offset 역매핑 시 panic 지점.
+      // 신규 구현은 char-only 이므로 panic 없이 반환되어야.
+      let s = extract_snippet("Start AİB middle padding text long enough for window", "b", 20);
+      assert!(!s.is_empty(), "panic 없이 반환");
+  }
+
+  #[test]
+  fn snippet_handles_german_sharp_s_gracefully() {
+      // "ß" ↔ "ss" multi-char expansion. false negative 는 수용, panic 은 금지.
+      let s = extract_snippet("In der Straße steht ein Haus mit vielen Fenstern heute", "straße", 30);
+      assert!(!s.is_empty());
+  }
+
+  #[test]
+  fn snippet_empty_input() {
+      assert_eq!(extract_snippet("", "anything", 100), "");
   }
   ```
 - **Integration (search_messages)**:
@@ -192,20 +246,21 @@ depends_on: [01] — FTS 스키마/트리거가 새 구조여야 함.
       // seed 1 message "아키텍처를 설계한다" with content_tokenized = "아키텍처 설계"
       std::env::set_var("TUNAFLOW_MORPH_QUERY", "1");
       let res = search_messages("아키텍처를".into(), "proj".into(), None, state).unwrap();
-      assert_eq!(res.len(), 1);
-      assert!(res[0].content_snippet.contains("**아키텍처**"));
+      assert_eq!(res.len(), 1, "morph 쿼리가 인덱스 매칭되어야");
+      assert!(res[0].content_snippet.contains("아키텍처"), "snippet 원본에 term 포함");
+      assert!(!res[0].content_snippet.contains("**"), "하이라이트 마커는 반환값에 포함되지 않음");
       std::env::remove_var("TUNAFLOW_MORPH_QUERY");
   }
   ```
 - `cargo test --lib commands::search::snippet`
 - `cargo test --lib commands::messages::tests::search_messages_*`
 - `cargo check`
-- `npx tsc --noEmit` — exit 0 (FE 는 snippet 포맷 동일하므로 변경 없음).
+- `npx tsc --noEmit` — exit 0 (FE 는 하이라이트 client-side 렌더 전환이 Subtask 05 와 조율 범위. 본 subtask 에서는 snippet 반환 포맷 변경만 — FE 가 plain text 로 받는 것에는 호환).
 
 ## Risks
 
-- **Multi-term 쿼리**: `extract_snippet` 은 첫 term 만 하이라이트. 사용자 쿼리 "플랜 검색" → 첫 term "플랜" 만. 기존 `snippet()` 은 FTS5 가 여러 term 을 처리. 기능 regression 이지만 secall 동일 수준. 후속 개선 별도.
-- **대소문자 매칭**: `to_lowercase()` 가 ASCII 외 문자에 대해 Unicode-aware. 한글은 변화 없음. 영어 대소문자 mix 쿼리에서도 정상.
-- **Byte-vs-char boundary**: 한글은 UTF-8 multi-byte. `str::find` 는 byte idx 반환 → char idx 복원 필요 (위 코드 참조). 테스트로 명시 커버.
-- **Snippet 에서 하이라이트 마커 (`**...**`) 가 content 원본에도 존재하는 경우**: 예를 들어 사용자가 markdown `**bold**` 를 입력한 메시지. highlight 가 추가적으로 주입되면 markdown 파서가 혼동. **수용**: 기존 `snippet()` 도 `'**'` 사용 → UI 가 이미 처리 중. 변경 없음.
+- **Multi-term 쿼리**: `extract_snippet` 은 첫 term 만 매칭. 사용자 쿼리 "플랜 검색" → 첫 term "플랜" 만. 기존 `snippet()` 은 FTS5 가 여러 term 을 처리. 기능 regression 이지만 secall 동일 수준. 후속 개선 별도.
+- **대소문자 매칭 — 완전한 Unicode case folding 미지원**: `to_lowercase()` 가 multi-char case expansion (ß→ss, İ→i̇) 을 일으키는 경우 matching 은 first-char 비교로 false negative 수용 (panic 은 없음). 완전한 case folding 은 ICU 의존성 도입 필요 — 별도 plan.
+- **Byte-vs-char boundary**: 본 구현은 **byte offset 을 전혀 사용하지 않음**. `chars().collect::<Vec<char>>()` 와 char index 만 사용. multi-byte 안전. Codex review 로 확정.
+- **Snippet 에서 하이라이트 마커 (`**...**`) 를 삽입하지 않음**: 기존 UI 가 `**...**` 마크다운을 렌더하던 경로는 query 기반 client-side highlight (React `<mark>` 또는 유사) 로 교체 필요. 이 UX 부분은 Subtask 05 와 함께 조정.
 - **unified.rs 시그니처 변경**: 내부 함수이므로 caller 1 곳만 수정. breaking 위험 낮음.

--- a/docs/plans/searchPipelineFromSecallPlan-part2-task-05.md
+++ b/docs/plans/searchPipelineFromSecallPlan-part2-task-05.md
@@ -8,41 +8,34 @@
 - `src/components/settings/SettingsPanel.tsx` (또는 동등) — `SearchSettings` import + 네비 entry 추가.
 - `src/lib/api/search.ts` (신규) — `rebuildMessagesFts()` / `cancelRebuildMessagesFts()` wrapper.
 - `src/types/events.ts` (필요 시 확장) — 이벤트 payload 타입.
-- `src-tauri/src/commands/search/tokenizer.rs` — `morphological_query_enabled()` 를 env var 외에 **DB flag** 도 OR 체크하도록 확장. (Open question Q-4 를 "env var OR DB flag" 로 확정.)
-- `src-tauri/src/db/migrations.rs` v45 안에 settings 테이블 항목 insert (없으면 skip — 기존 `app_settings` 같은 kv 테이블 재사용).
+- `src-tauri/src/commands/search/tokenizer.rs` — `morphological_query_enabled()` 를 **env var 우선 + `SEARCH_MORPH_FLAG: AtomicBool` fallback** 로 확장. DB 조회 없음.
 
 ## Change description
 
-### 1. Backend — DB flag 추가
+### 1. Backend — AtomicBool 런타임 flag (DB 저장 없음)
 
-`app_settings` kv 테이블이 있으면 `('search.morph_query_enabled', '0' | '1')` 로 저장. 없으면 신규 테이블은 도입하지 않고 **env var 방식만** 사용 (최소 스코프). 본 subtask 는 **기존 설정 저장소** 를 재사용.
-
-`morphological_query_enabled()` 확장:
+**Codex review 2026-04-22 (2차) 반영**: 초안은 "app_settings 있으면 사용, 없으면 env-only" 로 분기 규정하여 단일 소스 확정이 불분명했다. 실제 codebase 에 `app_settings` 테이블이 없으므로 DB 경로를 포기하고 **AtomicBool + FE localStorage** 로 단일화.
 
 ```rust
+use std::sync::atomic::{AtomicBool, Ordering};
+
+static SEARCH_MORPH_FLAG: AtomicBool = AtomicBool::new(false);
+
 pub fn morphological_query_enabled() -> bool {
-    // env var 우선 (개발자 override)
+    // env var 우선 (개발자 override / CI)
     if let Ok(v) = std::env::var("TUNAFLOW_MORPH_QUERY") {
         return matches!(v.trim().to_ascii_lowercase().as_str(), "1"|"true"|"on"|"yes");
     }
-    // DB flag — 접근 비용 있으므로 OnceLock/RwLock 로 캐시.
-    // 단순 구현: 매 호출마다 DB 조회 X. Tauri state 로 관리 + toggle command 에서 update.
+    // 런타임 flag (FE localStorage 에서 startup 에 주입됨)
     SEARCH_MORPH_FLAG.load(Ordering::Relaxed)
 }
 ```
 
-`SEARCH_MORPH_FLAG: AtomicBool` — 앱 startup 에 DB 에서 읽어 초기화. toggle command 가 set.
+신규 commands (DB 접근 없음):
 
-신규 commands:
 ```rust
 #[tauri::command]
-pub fn set_morphological_query_enabled(enabled: bool, state: State<DbState>) -> Result<(), AppError> {
-    let w = state.write.lock().map_err(|_| AppError::Lock)?;
-    w.execute(
-        "INSERT INTO app_settings (key, value) VALUES ('search.morph_query_enabled', ?1)
-         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
-        params![if enabled { "1" } else { "0" }]
-    )?;
+pub fn set_morphological_query_enabled(enabled: bool) -> Result<(), AppError> {
     SEARCH_MORPH_FLAG.store(enabled, Ordering::SeqCst);
     Ok(())
 }
@@ -53,7 +46,7 @@ pub fn get_morphological_query_enabled() -> bool {
 }
 ```
 
-> **기존 `app_settings` 테이블 존재 여부 확인 필요** — 없으면 v45 migration 에 추가 (단 본 plan 범위 초과 여지. Developer 가 schema 확인 후 결정).
+Persist 는 FE localStorage 가 담당. 앱 재시작 시 FE startup hook 이 localStorage 값을 읽어 `invoke('set_morphological_query_enabled', { enabled })` 1회 호출해 AtomicBool 에 주입. 첫 렌더 전 이 동기화가 끝나지 않은 순간에는 flag OFF (기본값) — 사용자 체감 없음 (UI 검색창이 렌더되기 전 대개 완료).
 
 ### 2. Frontend — API wrapper
 
@@ -91,7 +84,42 @@ export function getMorphEnabled(): Promise<boolean> {
 }
 ```
 
-### 3. Frontend — SearchSettings.tsx
+### 3. 용량 추정 backend command
+
+Rebuild 버튼 옆에 "예상 추가 용량" 을 표시하려면 백엔드가 3개 수를 반환해야 한다:
+
+```rust
+#[derive(serde::Serialize)]
+pub struct RebuildEstimate {
+    pub pending_rows: u64,            // content_tokenized IS NULL 인 message 수
+    pub pending_content_bytes: u64,   // 해당 row 의 content 바이트 총합 (corpus-relative)
+    pub est_added_bytes: u64,         // pending_content_bytes × 1.9 (rough estimate)
+}
+
+#[tauri::command]
+pub fn estimate_messages_fts_rebuild(state: State<DbState>) -> Result<RebuildEstimate, AppError> {
+    let r = state.read.lock().map_err(|_| AppError::Lock)?;
+    // pending row 의 content 바이트 총합을 기준으로 추정.
+    // overhead 모델 (plan Rationale §"비용/위험" 참조):
+    //   content_tokenized (~0.7x) + fts_content (~0.7x) + fts_idx/data/docsize (~0.5x) ≈ 1.9x
+    let (pending_rows, pending_bytes): (i64, i64) = r.query_row(
+        "SELECT COUNT(*), COALESCE(SUM(length(content)), 0) FROM messages WHERE content_tokenized IS NULL",
+        [], |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?))
+    )?;
+    let est_added_bytes = ((pending_bytes as f64) * 1.9) as u64;
+    Ok(RebuildEstimate {
+        pending_rows: pending_rows as u64,
+        pending_content_bytes: pending_bytes as u64,
+        est_added_bytes,
+    })
+}
+```
+
+> **Codex review 2026-04-22 반영**: 초안은 `db_size_bytes * 2` 로 전체 DB 파일 크기를 기준으로 했으나, messages corpus 이외 테이블 (conversations, plans, embeddings, trace_log …) 이 포함되어 부정확. `SUM(length(content))` 기반으로 교정. UI 라벨은 "rough estimate" 명시.
+
+Settings 진입 시 1회 호출, 결과를 재구축 버튼 옆 hint 로 표시.
+
+### 4. Frontend — SearchSettings.tsx
 
 ```tsx
 // src/components/settings/SearchSettings.tsx
@@ -102,7 +130,13 @@ export function SearchSettings() {
     const [status, setStatus] = useState<'idle'|'running'|'done'|'canceled'|'error'>('idle');
     const [errorMsg, setErrorMsg] = useState<string>('');
 
-    useEffect(() => { getMorphEnabled().then(setMorph); }, []);
+    // startup 동기화: localStorage → backend AtomicBool 주입 + local state 반영.
+    // (DB 는 사용하지 않음 — Q-4 resolution 참조.)
+    useEffect(() => {
+        const stored = localStorage.getItem('tunaflow.search.morphEnabled') === '1';
+        setMorph(stored);
+        setMorphEnabled(stored).catch((e) => console.warn('morph flag sync failed', e));
+    }, []);
 
     const handleRebuild = async () => {
         setRunning(true);
@@ -118,6 +152,10 @@ export function SearchSettings() {
     const handleCancel = () => { cancelRebuildMessagesFts(); };
 
     const handleToggleMorph = async (next: boolean) => {
+        // 단일 소스: localStorage (persist) + backend AtomicBool (런타임). 순서:
+        //   1) localStorage 저장 (앱 재시작 대비)
+        //   2) backend 반영 (현재 세션 검색 동작 즉시 변경)
+        localStorage.setItem('tunaflow.search.morphEnabled', next ? '1' : '0');
         await setMorphEnabled(next);
         setMorph(next);
     };
@@ -157,9 +195,28 @@ export function SearchSettings() {
 
 `ProgressBar` / `Toggle` 은 기존 컴포넌트 재사용 (search 해서 확인).
 
-### 4. Settings navigation
+### 5. Settings navigation
 
 `SettingsPanel` 의 section 목록에 `"검색"` 엔트리 추가. 순서는 Frontend 컨벤션 따름.
+
+### 6. 헤더 검색창 "재구축 필요" 배너 (Developer review 로 추가)
+
+Migration v45 적용 직후 `messages_fts` 가 비어있으므로 검색 결과가 0 건으로 나옴. 사용자가 이 원인을 모르면 "검색이 망가졌다" 고 오해 가능 — 다음 UX 를 **검색 결과 영역** 에 조건부 표시:
+
+```tsx
+// 결과가 0 이고 pending_rows > 0 일 때만 표시
+<div className="search-rebuild-banner">
+    검색 인덱스 재구축이 필요합니다 ({pendingRows.toLocaleString()} 개 메시지 대기 중)
+    <a href="#" onClick={openSearchSettings}>Settings 에서 재구축</a>
+</div>
+```
+
+판정 경로:
+- 앱 startup 에 `estimate_messages_fts_rebuild` 1회 호출 → Zustand store (`searchIndexSlice.pendingRows`) 에 저장
+- 검색 결과 컴포넌트가 `results.length === 0 && pendingRows > 0` 조건으로 배너 렌더
+- 재구축 완료 이벤트 (`messages_fts_rebuild_complete`) 수신 시 pendingRows 0 으로 reset
+
+**헤더 검색창 자체** 에 배너를 넣을지 (항상 표시) vs 결과 없음 상태에서만 표시할지는 Frontend UX 판단. 후자 권장 (노이즈 최소).
 
 ## Dependencies
 
@@ -168,19 +225,19 @@ depends_on: [03] — rebuild command + 이벤트. 04 (검색 경로 전환) 는 
 ## Verification
 
 - `npx vitest run src/components/settings/SearchSettings.test.tsx` — 신규 테스트:
-  - 초기 상태에서 `getMorphEnabled` mock 이 true 반환 시 토글 on.
+  - 초기 상태에서 localStorage `tunaflow.search.morphEnabled = '1'` 시 토글 on + `invoke('set_morphological_query_enabled', { enabled: true })` 호출 1회.
   - "인덱스 재구축" 클릭 → `invoke('rebuild_messages_fts')` 호출.
   - `messages_fts_rebuild_progress` 이벤트 fire → progress bar 업데이트.
   - `messages_fts_rebuild_complete { canceled: false }` → 상태 "완료".
   - 취소 버튼 → `cancel_rebuild_messages_fts` 호출.
-- `cargo test --lib commands::search::tokenizer::tests` — 신규: DB flag + env var OR 동작.
+- `cargo test --lib commands::search::tokenizer::tests` — 신규: env var 우선 + AtomicBool fallback 동작. env 있음 → env 값 반환, env 없음 + AtomicBool=true → true 반환, 둘 다 없음 → false 반환.
 - `npx tsc --noEmit` — exit 0.
 - 수동 E2E: `npm run tauri dev` → Settings > 검색 → 재구축 실행 → 진행률 표시 확인 → 완료 후 토글 ON → 검색창에서 "플랜을" 쿼리 → plan 문서 hit.
 
 ## Risks
 
 - **Tauri 이벤트 listener leak**: cleanup 반환값을 반드시 호출. 컴포넌트 unmount 시 cleanup 보장 (useEffect teardown).
-- **`app_settings` 테이블 없을 가능성**: 현재 tunaFlow 의 설정 저장 메커니즘 (Zustand + localStorage vs DB) 확인 필요. DB 가 아니면 Zustand persist + env var 없이 store 값만으로 `morphological_query_enabled()` 결정이 어렵다 — 이 경우 **localStorage → invoke('set_...') 동기화** 가 단일 소스.
+- ~~**`app_settings` 테이블 없을 가능성**~~ — **확인됨**: `rg "app_settings\b" src-tauri/src` 결과 0건 (Codex review 2026-04-22 2차). 본 subtask 는 DB 경로를 포기하고 **FE localStorage → invoke('set_morphological_query_enabled')** 단일 소스로 확정.
 - **검색 경로에 대한 런타임 감시**: Settings 에서 morph 토글 즉시 Backend 의 AtomicBool 갱신. 그러나 이미 열려 있는 검색 결과는 재쿼리 필요. UI 가 쿼리를 자동 재실행하진 않음 — 사용자가 재검색. 이는 기존 검색 UX 와 동일.
 - **대용량 rebuild UX**: 진행률이 오래 걸리면 Settings 패널을 닫아도 job 은 백그라운드 지속. 이벤트 구독은 컴포넌트 unmount 시 해제되므로 "다시 Settings 를 열면 진행률이 안 보인다" 라는 UX 함정. **완화**: Settings 열 때 `get_messages_fts_rebuild_status` (별도 command; 본 subtask 범위 밖 — open question 으로 flag).
 - **Toggle ON 상태에서 rebuild 를 하지 않은 경우**: 검색 결과가 비어 보임. Settings 에 "재구축이 필요합니다" 배너 추가 검토 — Q-4 와 함께 Developer 결정.

--- a/docs/plans/searchPipelineFromSecallPlan-part2.md
+++ b/docs/plans/searchPipelineFromSecallPlan-part2.md
@@ -75,8 +75,22 @@ CREATE TRIGGER messages_fts_insert AFTER INSERT ON messages BEGIN
     VALUES (NEW.rowid, COALESCE(NEW.content_tokenized, NEW.content), NEW.id);
 END;
 
+-- tokenize 결과가 갱신될 때 발화 (streaming finalize, rebuild, user edit 등)
 CREATE TRIGGER messages_fts_update_tokenized
     AFTER UPDATE OF content_tokenized ON messages BEGIN
+    DELETE FROM messages_fts WHERE rowid = OLD.rowid;
+    INSERT INTO messages_fts(rowid, content, message_id)
+    VALUES (NEW.rowid, COALESCE(NEW.content_tokenized, NEW.content), NEW.id);
+END;
+
+-- ★ content-only UPDATE 경로 (streaming 중간 chunk UPDATE, stale-cleanup 등) 에서도 FTS 동기화.
+--   Lindera tokenize 는 호출하지 않고 NEW.content 를 fallback 으로 사용한다 (INV-5 참조).
+--   streaming finalize 는 content + content_tokenized 를 동시에 UPDATE 하므로 이 trigger 와
+--   update_tokenized trigger 둘 다 발화하여 FTS 가 2회 재삽입되지만 결과는 멱등.
+CREATE TRIGGER messages_fts_update_content
+    AFTER UPDATE OF content ON messages
+    WHEN NEW.content IS NOT OLD.content
+    BEGIN
     DELETE FROM messages_fts WHERE rowid = OLD.rowid;
     INSERT INTO messages_fts(rowid, content, message_id)
     VALUES (NEW.rowid, COALESCE(NEW.content_tokenized, NEW.content), NEW.id);
@@ -86,6 +100,8 @@ CREATE TRIGGER messages_fts_delete AFTER DELETE ON messages BEGIN
     DELETE FROM messages_fts WHERE rowid = OLD.rowid;
 END;
 ```
+
+> **설계 변경 (Codex review 2026-04-22 반영)**: 초안은 `AFTER UPDATE OF content` trigger 를 제거했으나, 실제 content-only UPDATE 사이트 (`update_message_status` messages.rs:221, `cleanup_stale_jobs` jobs.rs:136, `bootstrap/db.rs:19`) 에서 FTS 가 stale 해진다. 이를 trigger 레벨에서 resync 하되 tokenize 호출은 Rust 쪽 finalize 경로로 제한한다.
 
 **중요**: migration 안에서 `INSERT INTO messages_fts ... SELECT FROM messages` 는 하지 않는다. 앱 기동 블로킹 방지 목적. 기존 corpus 는 별도 `rebuild_messages_fts` 명령으로 backfill.
 
@@ -236,33 +252,35 @@ let fts_query = if crate::commands::search::morphological_query_enabled() {
 
 이미 분기 있음 (Part 1). 변경 불필요. 단 주석에서 "until Phase C Part 2 rebuild" 언급을 제거한다.
 
-### 6. App-level snippet
+### 6. App-level snippet — char-window 추출 (하이라이트 없음)
 
-`src-tauri/src/commands/search/snippet.rs` (신규):
+`src-tauri/src/commands/search/snippet.rs` (신규). **Codex review 2026-04-22 (2차) 반영**: 초안의 byte-offset 기반 역매핑 + `**..**` 하이라이트 마커 주입은 Unicode case expansion 에서 boundary panic 위험. 순수 char-window 추출로 단순화하고, 하이라이트는 UI 측 client-side 렌더로 위임.
 
 ```rust
-/// secall bm25.rs:191 패턴을 tunaFlow 에 맞춰 이식.
-/// FTS5 snippet() 이 tokenized 텍스트를 반환하는 문제를 우회.
 pub fn extract_snippet(content: &str, query: &str, max_chars: usize) -> String {
-    // 1) query 를 whitespace split → 첫 매칭 term
-    // 2) content 안에서 해당 term 의 byte offset 찾기 (대소문자 무시)
-    // 3) offset 중심으로 ±max_chars/2 char window, char boundary 보존
-    // 4) 앞뒤 ellipsis 추가
-    // 매칭 없으면 content 의 앞 max_chars char 반환
+    // 1) query 의 첫 term 을 **char-level** case-insensitive 로 content 에서 탐색 (byte offset 사용 X)
+    // 2) 매칭 지점 중심 ±(max_chars/2) char window
+    // 3) 양 끝 ellipsis `…`
+    // 4) 매칭 없으면 앞 max_chars char
+    // 5) Unicode case expansion (İ→i̇, ß→ss) 은 first-char 비교로 false negative 수용 (panic 은 없음)
 }
 ```
 
-`search_messages` / `fts_conversation_search` (unified.rs:96) 의 `snippet(messages_fts, 0, '**', '**', '…', 40)` SQL 호출을 제거하고, `SELECT m.content` 로 바꾼 뒤 Rust 측에서 `extract_snippet(content, query, 120)` 호출. 하이라이트 마커 (`**..**`) 를 중심 term 에 주입.
+**변경 적용지**:
+- `search_messages` (messages.rs:381) — `snippet(messages_fts, 0, '**', '**', '…', 40)` SQL 호출을 제거, `SELECT m.content` 로 바꾸고 Rust 측에서 `extract_snippet(content, effective_query, 120)` 호출. **반환값은 하이라이트 마커를 포함하지 않는다**.
+- `fts_conversation_search` (unified.rs:96) — 동일 패턴.
 
-> **비고**: secall 은 snippet 을 200 char 로 자른다. tunaFlow 기존 `…` + 40 char 는 화면 폭과 어긋나지 않게 `120` 권장 (subtask 05 에서 UI 와 조율).
+**UI 하이라이트**: 검색 결과 컴포넌트가 `query` 를 별도 prop 으로 받아 React 단에서 client-side `<mark>` 렌더. 기존 `**...**` markdown 경로는 해체. 상세는 Subtask 05 에서 조율.
+
+> **비고**: secall 은 snippet 을 200 char 로 자른다. tunaFlow 기존 `…` + 40 char 는 화면 폭과 어긋나지 않게 `120` 권장 (Subtask 05 에서 Frontend 조율).
 
 ### 7. Settings UI
 
 `src/components/settings/SearchSettings.tsx` (신규) 또는 기존 `SettingsPanel` 확장.
 
 - 섹션 타이틀: "검색 / Search"
-- 토글: "한국어 형태소 검색 활성화" — 내부적으로 localStorage `tunaflow.search.morphEnabled` + 런타임 env injection.
-  - 이 토글만으로는 env 가 프로세스에 주입되지 않으므로, **`morphological_query_enabled()` 판단 로직을 env var 외에 DB flag 도 OR 체크하도록 확장** (subtask 05 스펙 참조).
+- 토글: "한국어 형태소 검색 활성화" — FE localStorage `tunaflow.search.morphEnabled` 에 persist. Backend 는 `SEARCH_MORPH_FLAG: AtomicBool` 로 런타임 관리. Toggle 시 `invoke('set_morphological_query_enabled', { enabled })` → AtomicBool set. 앱 재시작 후 FE startup hook 이 localStorage 값을 읽어 같은 invoke 로 AtomicBool 에 주입.
+  - **DB 저장 없음** (Q-4 확정). `morphological_query_enabled()` 는 env var 우선 → AtomicBool fallback.
 - 버튼: "인덱스 재구축 (Rebuild search index)" → `invoke('rebuild_messages_fts')`
 - 진행률 바: `messages_fts_rebuild_progress` 이벤트 구독, `done/total * 100%`
 - 취소 버튼: `invoke('cancel_rebuild_messages_fts')`
@@ -282,11 +300,13 @@ pub fn extract_snippet(content: &str, query: &str, max_chars: usize) -> String {
 
 - **[INV-4]** 신규 `messages` INSERT 사이트에서 `content_tokenized` 를 누락한 경우, `COALESCE(NEW.content_tokenized, NEW.content)` trigger 덕분에 기존 whitespace 동작으로 **graceful fallback** 한다 (검색 miss 아님). **이유**: 점진적 write-path 마이그레이션 허용. **검증**: `cargo test` — content_tokenized 를 주지 않고 INSERT 한 뒤 `SELECT * FROM messages_fts WHERE content MATCH ?` 로 원본 content 기반 매칭 성공 확인.
 
-- **[INV-5]** 스트리밍 중간 UPDATE (`content` 만 바뀌고 `content_tokenized` 는 NULL/고정) 는 FTS 를 재인덱싱하지 않는다. **이유**: chunk 당 Lindera 호출 시 CPU 폭증. **검증**: trigger 문법 (`AFTER UPDATE OF content_tokenized` 만 존재, `OF content` 는 없음) 확인 + finalize 경로에서만 re-index 되는지 integration 테스트.
+- **[INV-5]** 스트리밍 중간 UPDATE (`content` 만 바뀌고 `content_tokenized` 는 NULL/고정) 경로에서 **Lindera tokenize 를 호출하지 않는다**. FTS 재삽입 자체는 `messages_fts_update_content` trigger 로 수행되며, 그 값은 `NEW.content` fallback (tokenize 결과가 아님). **이유**: chunk 당 Lindera 호출 시 CPU 폭증. trigger 는 순수 SQL 이라 tokenize 를 호출할 수단이 없으므로 이 경로는 "tokenize 없이 content 원본으로 fallback indexing". **검증**: (a) Rust 코드에서 streaming 경로의 UPDATE 문에 `tokenize_for_index` 호출이 없음을 grep 확인. (b) Integration 테스트에서 streaming 시뮬레이션 후 Lindera 호출 카운트가 finalize 시점 1회만임을 확인 (카운터 mock).
 
 - **[INV-6]** `rebuild_messages_fts` 취소 시 이미 tokenized 된 row 는 원복하지 않는다 (idempotent). 재실행 시 `WHERE content_tokenized IS NULL` 로 skip. **이유**: 대규모 corpus 에서 재시도 비용 최소화. **검증**: 테스트 — 100건 중 50건 처리 후 취소 → 재실행 → 나머지 50건만 처리 확인.
 
-- **[INV-7]** Feature flag `TUNAFLOW_MORPH_QUERY` 를 OFF 로 되돌리면 `search_messages` / `search_unified` 둘 다 원본 쿼리로 FTS MATCH 수행. Rebuild 결과는 whitespace 쿼리로도 유효하다 (tokenized content 안에 원본 단어도 보존되는 경우가 많음). **이유**: 비상 롤백 경로. **검증**: 동일 corpus 에서 flag ON/OFF 쿼리 결과가 최소한 빈 배열은 아닌지 smoke test.
+- **[INV-7]** Feature flag `TUNAFLOW_MORPH_QUERY` 를 OFF 로 되돌리면 `search_messages` / `search_unified` 둘 다 원본 쿼리를 **그대로** FTS MATCH 에 넘긴다 (query 경로만 원복). 단 rebuilt index 가 tokenized 상태라면 원본 surface form (예: "아키텍처를") 에 대한 매칭은 miss 할 수 있다. 완전한 rollback (인덱스까지 whitespace 로 되돌림) 은 별도 `rebuild_messages_fts_whitespace` 커맨드가 필요하며 본 plan 의 scope 가 아니다. **이유**: 부분 rollback 은 "코드 변경 없이 env var 만으로 query 동작 원복" 의 실용 경로로 충분. **검증**: query 경로에서 `morphological_query_enabled()=false` 일 때 tokenize 가 호출되지 않음을 unit test 로 확인. rebuilt index 에 대한 재매칭 보장은 하지 않는다 (Developer 설명 문서화).
+
+- **[INV-8]** Migration v45 전체는 **단일 SQLite transaction** 안에서 실행된다 (`conn.transaction()` 또는 명시 `BEGIN; ... COMMIT;`). DROP TRIGGER × 3 / DROP TABLE / CREATE VIRTUAL TABLE / CREATE TRIGGER × 3 / ALTER TABLE ADD COLUMN / INSERT INTO schema_version 모두 실패 시 rollback. **이유**: 앱이 중간에 크래시하면 `messages_fts` 가 DROP 된 채 다음 기동에서 `CREATE IF NOT EXISTS` 로 재생성되기 전까지 다른 경로가 `messages_fts` 를 참조하다 에러. SQLite 는 FTS5 virtual table DROP/CREATE 를 포함해 대부분 DDL 을 transactional 로 지원한다. **검증**: 마이그레이션 중간에 강제 panic 을 주입한 integration test — panic 후 재기동 시 schema_version=44, `messages_fts` 가 여전히 v15 external-content 스키마로 남아있는지 확인.
 
 ---
 
@@ -310,7 +330,15 @@ secall 이 `CREATE VIRTUAL TABLE turns_fts USING fts5(content, session_id UNINDE
 
 ### 비용/위험
 
-- **Storage overhead**: 한국어 corpus 기준 tokenized 텍스트는 원문의 60~80% (조사/어미 제거 + 단일글자 드롭). 전체 overhead ~1.6x. SSD 환경 허용 범위.
+- **Storage overhead (재계산, 2026-04-22 Developer 지적 반영)**: 초안의 ~1.6x 는 `content_tokenized` 컬럼만 센 오산. standalone FTS5 의 shadow tables 포함 시:
+  | 컴포넌트 | 배수 | 설명 |
+  |---|---|---|
+  | `messages.content` (원본) | 1.0x | 기존 |
+  | `messages.content_tokenized` | ~0.7x | 조사/어미 제거 + 1글자 드롭 |
+  | `messages_fts_content` | ~0.7x | standalone FTS5 가 자체 보유 (external content 모드에는 없던 shadow table) |
+  | `messages_fts_idx` + `_data` + `_docsize` + `_config` | ~0.5x | inverted postings + metadata |
+  | **합계** | **~2.9x** | 기존 대비. 대용량 corpus 에서 non-trivial. |
+  Subtask 05 Settings UI 에 "재구축 후 예상 추가 용량" 을 `pending_content_bytes × 1.9` (rough estimate) 로 사전 표시해 사용자 동의 절차를 둔다. 초안의 "DB 파일 크기 × 2" 는 Codex review 2차 반영으로 corpus-based 계산으로 교정됨.
 - **Tokenize CPU**: Lindera ko-dic 은 건당 마이크로초 단위. 스트리밍 finalize 시 1회만 호출하므로 hot-path 영향 미미. Rebuild 시 500 row/chunk 기준 chunk 당 <1 초 예상 (로컬 benchmark 필요).
 - **Write lock 경합**: INV-3 으로 완화. 실측 후 chunk size 조정 여지.
 - **점진적 마이그레이션 실수**: INV-4 (COALESCE fallback) 로 silent miss 대신 legacy 동작 유지.
@@ -323,17 +351,30 @@ secall 이 `CREATE VIRTUAL TABLE turns_fts USING fts5(content, session_id UNINDE
 - **FTS index 를 per-project DB 로 sharding** — `perProjectDatabaseSplitPlan.md` 와 합산 설계 필요.
 - **Snippet 하이라이트 멀티-term 지원** — secall extract_snippet 은 first term 기준. 후속 UX 작업.
 
-### Open questions (Developer 확정 필요)
+### Codex review 반영 (2026-04-22, 2차)
 
-1. **Tokenized 저장 시점 (Q-1)**: `messages.content_tokenized` 를 `INSERT` 시 계산 vs `AFTER INSERT` Rust callback 으로 계산 후 `UPDATE` — 전자가 1 write, 후자가 2 write. spec §3.1 은 전자 권장. Developer 가 persistence.rs hot-path 에서 Lindera latency 측정 후 확정.
+Codex blind verifier 가 BLOCKER 2건 / MAJOR 1건 / MINOR 1건 식별:
+
+1. **BLOCKER (resolved)** — `AFTER UPDATE OF content` trigger 제거 시 content-only UPDATE 3 사이트 (`update_message_status`, `jobs::cleanup_stale`, `bootstrap/db::stale_cleanup`) 에서 FTS stale. → `messages_fts_update_content` trigger 를 추가해 tokenize 없이 `NEW.content` fallback 으로 resync. INV-5 의 의미를 "Lindera 호출 없음" 으로 축소.
+2. **BLOCKER (resolved)** — `extract_snippet` 의 `content.to_lowercase()` 가 Unicode case expansion (Turkish `İ`→`i̇`, German `ß`→`ss`) 시 byte length 가 변해 lowered string 의 byte offset 을 원본에 역매핑하면 boundary panic. → 하이라이트 마커 `**...**` 를 제거하고 **순수 char-window 추출** 로 단순화. Unicode 하이라이트는 후속 plan 으로 분리 (UI 측 클라이언트 하이라이트 또는 별도 safe impl).
+3. **MAJOR (resolved)** — INV-7 의 "OFF 시 빈 배열 아님" 주장은 tokenizer 가 조사/어미를 drop 하므로 근거 부족. → INV-7 의미를 "query path 만 원복" 으로 축소, 인덱스 측 rollback 은 별도 커맨드 영역으로 분리.
+4. **MINOR (resolved)** — Storage estimate 가 DB 전체 파일 크기 × 2 였으나 corpus 무관. → `SUM(length(content))` 기반으로 교정.
+
+### Open questions
+
+> **Developer 1차 검토 (2026-04-22) 로 Q-1, Q-4, Q-6 해소**. 나머지는 구현 단계에서 결정.
+
+1. ~~**Tokenized 저장 시점 (Q-1)**~~ — **Resolved**. Developer 합의: INSERT-time 계산. Lindera 건당 마이크로초 수준이므로 스트리밍 I/O noise 이내. Spec §3.1 원안 확정.
 
 2. **Rebuild 실패 시 content_tokenized 정합성 (Q-2)**: 중간 실패 row 가 부분적으로 tokenized 된 상태에서 다음 rebuild 시 재처리 필요 여부. 현재 설계는 `IS NULL` 체크만 하므로 "partial tokenized" 는 건너뜀. 재처리 강제는 별도 "force" 플래그로.
 
 3. **Search index 크기 한계 (Q-3)**: 현재 tunaFlow 는 단일 SQLite. 대용량 프로젝트에서 messages 가 100만건 이상이 될 때 rebuild 시간 (~수 분) 이 허용 가능한지. 허용 불가능하면 per-project DB 분리가 선결 조건.
 
-4. **Flag 활성화 UX (Q-4)**: env var (`TUNAFLOW_MORPH_QUERY=1`) 강제 vs Settings DB flag. 후자가 편하지만 `morphological_query_enabled()` 를 DB state 의존으로 바꾸는 건 Part 1 계약 변경. subtask 05 에서 "env var 우선 + DB flag 보조" 로 제안하나 Developer 합의 필요.
+4. ~~**Flag 활성화 UX (Q-4)**~~ — **Resolved** (2026-04-22 2차 Codex review 반영). **Env var 우선 + `SEARCH_MORPH_FLAG: AtomicBool` 런타임 + FE localStorage (persist)**. `morphological_query_enabled()` 는 env 값이 있으면 env, 없으면 AtomicBool 반환. FE 는 startup hook 에서 localStorage 값을 읽어 `invoke('set_morphological_query_enabled', { enabled })` 로 AtomicBool 에 주입. **DB 저장 없음** — 기존 codebase 에 `app_settings` 테이블 부재, 신규 도입 시 scope 확대. Subtask 05 도 이 단일 소스로 통일.
 
 5. **Snippet max_chars 기본값 (Q-5)**: secall=200, 기존 tunaFlow snippet()=40 (의미적 토큰 개수). UI 에서 `line-clamp-2` 와 정합하려면 120 권장 — 최종값은 Frontend 검증.
+
+6. ~~**Migration v45 atomicity (Q-6)**~~ — **Resolved → INV-8 로 승격**. SQLite 는 FTS5 virtual table DROP/CREATE 를 포함해 대부분 DDL 을 transactional 로 지원. `apply_v45` 전체를 `conn.transaction()` 으로 감싸 실패 시 rollback 보장. Subtask 01 의 verification 에 atomicity 테스트 추가.
 
 ---
 

--- a/docs/plans/userWorldviewInjectionPlan-task-01.md
+++ b/docs/plans/userWorldviewInjectionPlan-task-01.md
@@ -1,0 +1,163 @@
+# Subtask 01 — `user_worldview.md` 파일 + ContextPack 주입 + Settings 편집기
+
+> 상위 plan: [userWorldviewInjectionPlan.md](./userWorldviewInjectionPlan.md)
+
+## Changed files
+
+- `src-tauri/src/commands/agents_helpers/send_common/prompt_assembly.rs` — `worldview_fragment` 를 ContextPack `identity_fragment` 보다 앞에 삽입.
+- `src-tauri/src/commands/worldview.rs` (신규) — 파일 read/write Tauri commands.
+- `src-tauri/src/lib.rs` — 신규 command 등록.
+- `src/components/settings/WorldviewSettings.tsx` (신규) — 텍스트 에디터 + "기본 문구 로드" 버튼.
+- `src/components/settings/SettingsPanel.tsx` (또는 동등) — 네비에 Worldview 섹션 추가.
+
+## Change description
+
+### 1. 파일 경로 규칙
+
+- Global: `~/.tunaflow/user_worldview.md`
+- Project override: `<project_path>/.tunaflow/user_worldview.md` (있으면 global 을 무시)
+
+Rust 측 helper:
+
+```rust
+// src-tauri/src/commands/worldview.rs
+pub fn resolve_worldview_path(project_path: Option<&str>) -> Option<PathBuf> {
+    if let Some(pp) = project_path {
+        let project_p = PathBuf::from(pp).join(".tunaflow").join("user_worldview.md");
+        if project_p.exists() { return Some(project_p); }
+    }
+    let home = dirs::home_dir()?;
+    let global_p = home.join(".tunaflow").join("user_worldview.md");
+    if global_p.exists() { Some(global_p) } else { None }
+}
+
+pub fn load_worldview(project_path: Option<&str>) -> Option<String> {
+    let path = resolve_worldview_path(project_path)?;
+    std::fs::read_to_string(path).ok()
+}
+```
+
+### 2. ContextPack 주입
+
+`src-tauri/src/commands/agents_helpers/send_common/prompt_assembly.rs`:
+
+```rust
+// assemble_prompt() 내부
+let worldview_fragment = worldview::load_worldview(data.project_path.as_deref())
+    .map(|text| truncate_to_tokens(text, 500))     // 토큰 상한
+    .filter(|t| !t.trim().is_empty());
+
+let mut sections: Vec<(&str, String)> = Vec::new();
+if let Some(wv) = worldview_fragment {
+    sections.push(("worldview", wv));               // ★ 맨 앞
+}
+sections.push(("identity", identity_fragment));     // 기존 위치 (2번째)
+// ... skills, recent_context, etc.
+```
+
+ContextPackMeta 의 `ctx_sections` (trace_log 용) 에도 `"worldview"` 포함해 관찰 가능.
+
+### 3. 토큰 상한
+
+500 tokens. 초과 시:
+- 파일 write 는 허용 (경고만)
+- ContextPack 주입 시 **앞 500 tokens 만 사용** (뒤 자름) + stderr 로 1회 경고
+- Settings UI 에 `Used: N / 500 tokens` 카운터 + 500 초과 시 빨간 글씨
+
+### 4. Settings UI
+
+```tsx
+export function WorldviewSettings() {
+    const [content, setContent] = useState("");
+    const [saved, setSaved] = useState(true);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        invoke<string | null>('get_worldview', { projectPath: null })
+            .then((v) => { setContent(v ?? ""); setSaved(true); setLoading(false); });
+    }, []);
+
+    const save = async () => {
+        await invoke('set_worldview', { content, projectPath: null });
+        setSaved(true);
+        toast.success("Worldview 저장됨 — 다음 요청부터 적용");
+    };
+
+    const loadDefault = () => {
+        setContent(DEFAULT_WORLDVIEW_TEMPLATE);
+        setSaved(false);
+    };
+
+    return (
+        <section>
+            <h3>User Worldview</h3>
+            <p className="hint">
+                에이전트가 매 요청 시 ContextPack 의 맨 앞에서 참조하는 사용자 stance 문서입니다.
+                최대 500 tokens.
+            </p>
+            <textarea
+                value={content}
+                onChange={(e) => { setContent(e.target.value); setSaved(false); }}
+                className="w-full h-80 font-mono text-sm"
+                placeholder="(비어있음 — 기본 문구 로드 또는 직접 작성)"
+            />
+            <TokenCounter current={countTokens(content)} max={500} />
+            <div className="flex gap-2">
+                <button onClick={save} disabled={saved}>저장</button>
+                <button onClick={loadDefault} variant="ghost">기본 문구 로드</button>
+            </div>
+        </section>
+    );
+}
+```
+
+`DEFAULT_WORLDVIEW_TEMPLATE` (Open question Q-1 — 내용은 section 헤더만 두고 본문 비움):
+
+```markdown
+# User Worldview
+
+## Ontology
+(기본 세계관 — 직접 작성)
+
+## Engagement preference
+(agent 와의 협업 방식 선호 — 직접 작성)
+```
+
+사용자 철학을 tunaFlow 가 strong-suggest 하지 않도록 본문을 완전 비움. 헤더만 틀 제공.
+
+### 5. 토글
+
+Settings 에 체크박스:
+- "Worldview 주입 활성화" (기본 ON)
+- 끄면 `get_worldview` 는 `None` 반환 → 주입 스킵
+
+`localStorage['tunaflow.worldview.enabled']` 로 persist + `invoke('set_worldview_enabled', { enabled })` 로 Rust AtomicBool 에 sync (설정 패널 스타일, `searchPipelineFromSecallPlan-part2-task-05.md` 의 패턴 재활용).
+
+## Dependencies
+
+depends_on: 없음.
+
+## Verification
+
+- `cargo test --lib commands::worldview`:
+  - `resolve_worldview_path` — project override 우선, fallback global
+  - `load_worldview` — 파일 없으면 None, 있으면 trimmed content
+- `cargo test --lib commands::agents_helpers::send_common::prompt_assembly`:
+  - Worldview fragment 주입 시 sections 순서 첫 번째가 `"worldview"` (INV-1)
+  - Worldview 비어있으면 sections 에 `"worldview"` 없음
+- `npx vitest run src/components/settings/WorldviewSettings.test.tsx`:
+  - 저장 후 버튼 disabled
+  - "기본 문구 로드" 후 content=template
+  - 500 초과 시 카운터 빨간색
+- 수동 E2E:
+  1. Settings > Worldview 열기 → "기본 문구 로드" → 직접 편집 → 저장
+  2. 새 대화에서 임의 요청 → agent 응답 톤이 worldview 에 맞춰 변하는지 blind 관찰 (A/B 비교)
+  3. `trace_log.ctx_sections` 에 `"worldview"` 포함 확인
+
+## Risks
+
+- **파일 쓰기 권한**: `~/.tunaflow/` 경로 생성 실패 (권한 등) 시 에러 toast. 대부분 OS 에서 문제 없음.
+- **토큰 카운터 정확도**: `countTokens` 은 정확한 BPE 가 아니어도 대략 char/2 로 근사 가능. 정확도 민감도 낮음 (500 상한 자체가 여유).
+- **Persona 와의 중복**: 사용자가 worldview 와 persona 에 같은 내용을 쓰면 중복 주입 — 토큰 낭비. 본 subtask 범위 밖 — 별도 deduplication plan 필요 시 후속.
+- **Project override vs global**: 사용자가 글로벌에 stance 쓰고 프로젝트에 다른 stance 를 쓰면 후자 우선. 사용자가 "덮어쓴 줄 모르고 혼동" 할 수 있음. Settings UI 에 현재 적용 경로 표시 (`Used: <project>/.tunaflow/...` or `~/.tunaflow/...`) 권장.
+- **Backward compat**: Worldview 가 없는 기존 사용자는 영향 없음. fragment 가 삽입 안 되므로 ContextPack 동작은 이전과 동일.

--- a/docs/plans/userWorldviewInjectionPlan-task-02.md
+++ b/docs/plans/userWorldviewInjectionPlan-task-02.md
@@ -1,0 +1,176 @@
+# Subtask 02 — Migration v46: `preference_events` + `preference_snapshots` + `agent_jobs` 확장
+
+> 상위 plan: [userWorldviewInjectionPlan.md](./userWorldviewInjectionPlan.md)
+
+## Changed files
+
+- `src-tauri/src/db/migrations.rs` — `apply_v46` 함수 신규.
+- `src-tauri/src/db/schema.rs` — fresh DB 스키마에도 새 테이블/컬럼 반영.
+- `src-tauri/src/commands/preference_timeline.rs` (신규) — write path helper + Tauri commands.
+- `src-tauri/src/db/models.rs` — `PreferenceEvent`, `PreferenceSnapshot` 구조체 + (선택) `AgentJob` 구조체 확장.
+- `src-tauri/src/lib.rs` — 신규 command 등록.
+
+## Change description
+
+### 1. Migration v46 SQL
+
+v45 다음 번호. INV-8 (이전 plan) 원칙 유지 — 단일 transaction.
+
+```rust
+fn apply_v46(conn: &mut Connection) -> Result<(), AppError> {
+    let tx = conn.transaction()?;
+    tx.execute_batch("
+        -- preference_events: append-only 변곡점 로그
+        CREATE TABLE IF NOT EXISTS preference_events (
+            id              TEXT PRIMARY KEY,
+            memory_name     TEXT NOT NULL,
+            field           TEXT NOT NULL,
+            stance_from     TEXT,
+            stance_to       TEXT NOT NULL,
+            reason_text     TEXT,
+            reason_tags     TEXT,            -- JSON array
+            confidence      REAL NOT NULL DEFAULT 1.0,
+            source          TEXT NOT NULL,   -- 'user' | 'agent_inferred'
+            changed_at      INTEGER NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_preference_events_field
+            ON preference_events(memory_name, field, changed_at DESC);
+
+        -- preference_snapshots: 현재 활성 stance (events 에서 파생, resume 속도 용)
+        CREATE TABLE IF NOT EXISTS preference_snapshots (
+            memory_name     TEXT NOT NULL,
+            field           TEXT NOT NULL,
+            current_stance  TEXT NOT NULL,
+            last_event_id   TEXT NOT NULL,
+            updated_at      INTEGER NOT NULL,
+            PRIMARY KEY (memory_name, field),
+            FOREIGN KEY (last_event_id) REFERENCES preference_events(id)
+        );
+    ")?;
+
+    // agent_jobs 컬럼 확장 (idempotent)
+    crate::db::migrations::add_column_if_missing_tx(&tx, "agent_jobs", "priority", "INTEGER NOT NULL DEFAULT 0")?;
+    crate::db::migrations::add_column_if_missing_tx(&tx, "agent_jobs", "dedupe_key", "TEXT")?;
+    crate::db::migrations::add_column_if_missing_tx(&tx, "agent_jobs", "visibility", "TEXT NOT NULL DEFAULT 'visible'")?;
+    tx.execute_batch("
+        CREATE INDEX IF NOT EXISTS idx_agent_jobs_queue
+            ON agent_jobs(priority, status, updated_at);
+    ")?;
+
+    tx.execute("INSERT INTO schema_version (version, applied_at) VALUES (46, ?1)", [now_epoch()])?;
+    tx.commit()?;
+    Ok(())
+}
+```
+
+**INV-3** 준수: embedding 관련 테이블/컬럼은 본 migration 에 추가하지 않음.
+
+### 2. Write path helper
+
+```rust
+// src-tauri/src/commands/preference_timeline.rs
+pub fn record_event(
+    conn: &Connection,
+    memory_name: &str,
+    field: &str,
+    stance_from: Option<&str>,
+    stance_to: &str,
+    reason_text: Option<&str>,
+    reason_tags: &[&str],     // JSON serialize
+    confidence: f64,
+    source: EventSource,      // enum: User, AgentInferred
+) -> Result<String, AppError> {
+    let event_id = Uuid::new_v4().to_string();
+    let now = now_epoch_ms();
+    let tags_json = serde_json::to_string(reason_tags).unwrap_or_else(|_| "[]".into());
+
+    conn.execute(
+        "INSERT INTO preference_events (id, memory_name, field, stance_from, stance_to, reason_text, reason_tags, confidence, source, changed_at)
+         VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10)",
+        params![event_id, memory_name, field, stance_from, stance_to, reason_text, tags_json, confidence, source.as_str(), now],
+    )?;
+
+    // Snapshot upsert (user source 또는 confidence >= threshold 일 때만)
+    if matches!(source, EventSource::User) || confidence >= 0.9 {
+        conn.execute(
+            "INSERT INTO preference_snapshots (memory_name, field, current_stance, last_event_id, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5)
+             ON CONFLICT(memory_name, field) DO UPDATE SET
+                current_stance = excluded.current_stance,
+                last_event_id = excluded.last_event_id,
+                updated_at = excluded.updated_at",
+            params![memory_name, field, stance_to, event_id, now],
+        )?;
+    }
+    // agent_inferred 이고 confidence 낮으면 snapshot 업데이트 안 함 — modal 에서 사용자 확인 후 기록.
+    Ok(event_id)
+}
+
+pub fn load_recent_events(conn: &Connection, limit: usize) -> Result<Vec<PreferenceEvent>, AppError> {
+    // 최근 N 변곡점 — ContextPack 용
+    conn.prepare("SELECT ... FROM preference_events ORDER BY changed_at DESC LIMIT ?1")?
+        .query_map(params![limit as i64], row_to_event)?
+        .collect::<Result<_, _>>()
+        .map_err(Into::into)
+}
+
+pub fn load_snapshots(conn: &Connection) -> Result<Vec<PreferenceSnapshot>, AppError> {
+    // 전체 현재 stance — session resume 시 전량 load
+    conn.prepare("SELECT ... FROM preference_snapshots")?
+        .query_map([], row_to_snapshot)?
+        .collect::<Result<_, _>>()
+        .map_err(Into::into)
+}
+```
+
+### 3. Tauri commands (Settings UI 가 직접 호출할 수 있게)
+
+```rust
+#[tauri::command]
+pub fn list_preference_events(
+    limit: Option<usize>,
+    state: State<DbState>,
+) -> Result<Vec<PreferenceEvent>, AppError> { /* read lock + load_recent_events */ }
+
+#[tauri::command]
+pub fn list_preference_snapshots(
+    state: State<DbState>,
+) -> Result<Vec<PreferenceSnapshot>, AppError> { /* read lock + load_snapshots */ }
+
+#[tauri::command]
+pub fn record_user_preference_change(
+    memory_name: String, field: String,
+    stance_from: Option<String>, stance_to: String,
+    reason_text: Option<String>, reason_tags: Vec<String>,
+    state: State<DbState>,
+) -> Result<String, AppError> {
+    let w = state.write.lock().map_err(|_| AppError::Lock)?;
+    let tags: Vec<&str> = reason_tags.iter().map(AsRef::as_ref).collect();
+    record_event(&w, &memory_name, &field, stance_from.as_deref(), &stance_to,
+                 reason_text.as_deref(), &tags, 1.0, EventSource::User)
+}
+```
+
+## Dependencies
+
+depends_on: 없음 (v45 까지 적용된 DB 기준).
+
+## Verification
+
+- `cargo test --lib db::migrations`:
+  - v46 이 기존 tests 통과 (add_column_if_missing 재호출 idempotent)
+  - 신규 test: `apply_v46` 후 `preference_events`, `preference_snapshots` 테이블 존재 + agent_jobs 에 priority/dedupe_key/visibility 컬럼 추가
+  - 신규 test — INV-3 검증: migration DDL 에서 `embedding` / `vec0` 키워드 grep 결과 0
+- `cargo test --lib commands::preference_timeline`:
+  - `record_event` — user source 는 snapshot upsert, agent_inferred 저신뢰는 snapshot 변경 없음
+  - `load_recent_events` — limit 적용 + 최신순 정렬
+  - 동일 memory_name/field 재기록 시 upsert 동작
+- `cargo check` — exit 0.
+
+## Risks
+
+- **`add_column_if_missing` 가 transaction 과 호환**: 기존 구현이 `&Connection` 받는 경우 tx 내부에서 못 쓸 수 있음. Part 2 plan subtask-01 의 `add_column_if_missing_tx` 헬퍼를 먼저 도입하거나 재사용.
+- **Migration 순번 충돌**: Part 2 plan 의 v45 가 먼저 머지돼야 v46 번호가 유효. PR 순서 확인.
+- **`source` 컬럼의 TEXT vs ENUM**: SQLite 는 enum 없음. 문자열 리터럴 ('user' | 'agent_inferred') 사용 + Rust enum 으로 parse. 다른 값 들어오면 에러.
+- **JSON reason_tags**: SQLite 1.38+ 의 json1 extension 필요. 현재 tunaFlow 가 이미 다른 곳에서 json 사용 중이면 OK.
+- **Backward compat**: 기존 agent_jobs 에 priority 0 default — 기존 foreground 동작 영향 없음. visibility='visible' default 도 기존 동작 유지.

--- a/docs/plans/userWorldviewInjectionPlan-task-03.md
+++ b/docs/plans/userWorldviewInjectionPlan-task-03.md
@@ -1,0 +1,212 @@
+# Subtask 03 — Stance-conflict detection (rule-first + small model verify + modal)
+
+> 상위 plan: [userWorldviewInjectionPlan.md](./userWorldviewInjectionPlan.md)
+
+## Changed files
+
+- `src-tauri/src/commands/agents_helpers/send_common/stance_check.rs` (신규) — rule precheck + model verify orchestration.
+- `src-tauri/src/commands/agents_helpers/send_common/prompt_assembly.rs` — stance-check 결과를 compact fragment 로 주입.
+- `src-tauri/src/commands/agents_helpers/send_common/persistence.rs` — prepare 단계에서 stance_check 호출 + 결과 저장.
+- `src/lib/stanceConflictMarker.ts` (신규) — `<!-- tunaflow:stance-conflict:... -->` 마커 파서.
+- `src/components/tunaflow/StanceConflictModal.tsx` (신규) — 사용자 confirmation UI.
+- `src/components/tunaflow/chat/*` — 메시지 렌더 파이프라인에서 marker 감지 시 modal 트리거.
+
+## Change description
+
+### 1. Rule precheck (Rust, no model)
+
+```rust
+// src-tauri/src/commands/agents_helpers/send_common/stance_check.rs
+pub enum PrecheckResult {
+    NoConflict,
+    Conflict { snapshot: PreferenceSnapshot, matched_keywords: Vec<String> },
+    Ambiguous { candidates: Vec<PreferenceSnapshot> },
+}
+
+pub fn precheck(
+    user_prompt: &str,
+    snapshots: &[PreferenceSnapshot],
+    recent_events: &[PreferenceEvent],
+) -> PrecheckResult {
+    let tokens = simple_tokenize(user_prompt);            // lowercase whitespace split
+    let mut matched: Vec<(PreferenceSnapshot, Vec<String>)> = Vec::new();
+
+    for snap in snapshots {
+        // field 이름 + stance 값에서 keyword 추출
+        let keywords = extract_keywords(&snap.field, &snap.current_stance);
+        let overlap: Vec<_> = keywords.iter()
+            .filter(|kw| tokens.contains(&kw.to_lowercase()))
+            .cloned().collect();
+        if !overlap.is_empty() {
+            matched.push((snap.clone(), overlap));
+        }
+    }
+
+    match matched.len() {
+        0 => PrecheckResult::NoConflict,
+        1 => {
+            // 단일 매칭 — 사용자 요청이 이 stance 의 반대를 명시하는지 검사
+            let (snap, kws) = &matched[0];
+            if contradicts_stance(user_prompt, snap) {
+                PrecheckResult::Conflict { snapshot: snap.clone(), matched_keywords: kws.clone() }
+            } else {
+                PrecheckResult::NoConflict    // 같은 키워드지만 긍정 방향
+            }
+        }
+        _ => PrecheckResult::Ambiguous {
+            candidates: matched.into_iter().map(|(s, _)| s).collect(),
+        },
+    }
+}
+
+fn contradicts_stance(prompt: &str, snap: &PreferenceSnapshot) -> bool {
+    // 간단한 부정어 휴리스틱:
+    //   prompt 에 "바꾸", "말고", "대신", "포기", "새로", "change", "instead" 등이 있고
+    //   current_stance 키워드와 함께 등장하면 contradicts=true
+    // MVP 구현 — false negative 허용, false positive 는 model verify 가 catch
+}
+```
+
+### 2. Model verify (ambiguous 케이스)
+
+```rust
+pub async fn verify_ambiguous(
+    user_prompt: &str,
+    candidates: &[PreferenceSnapshot],
+    app: &AppHandle,
+) -> Result<VerifyResult, AppError> {
+    let small_model = std::env::var("TUNAFLOW_STANCE_VERIFY_MODEL")
+        .unwrap_or_else(|_| "claude-haiku-4-5".to_string());
+
+    let prompt = format!(
+        "User preferences:\n{}\n\nUser request:\n{}\n\n\
+         Answer in one line: CONFLICT with <field> or NO_CONFLICT. Do not explain.",
+        candidates.iter().map(snap_to_line).collect::<Vec<_>>().join("\n"),
+        user_prompt,
+    );
+
+    let output = tokio::time::timeout(
+        Duration::from_secs(10),
+        crate::agents::claude::run_one_shot(small_model, prompt),
+    ).await;
+
+    match output {
+        Ok(Ok(resp)) => parse_verify_response(&resp.content),
+        _ => VerifyResult::ConflictSafe,   // timeout / error → 안전측 (conflict 로 처리)
+    }
+}
+```
+
+### 3. Compact fragment 주입
+
+`prompt_assembly.rs`:
+
+```rust
+let stance_result = stance_check::run(&data.user_prompt, &snapshots, &recent_events, &app).await;
+let stance_fragment = match stance_result {
+    CheckResult::NoConflict => None,
+    CheckResult::Conflict { snapshot, matched } =>
+        Some(format!("⚠ Stance conflict detected: user previously stated `{}={}`. \
+                      Current request may contradict. Ask for explicit confirmation.",
+                     snapshot.field, snapshot.current_stance)),
+    // model verify 결과는 동일 포맷
+};
+if let Some(frag) = stance_fragment {
+    sections.insert(after_worldview_idx, ("stance_check", frag));
+}
+```
+
+### 4. Marker-based modal
+
+Agent 응답에 `<!-- tunaflow:stance-conflict:<snapshot_id>:<rationale> -->` 마커 출현 시 UI 가 intercept. 이 마커는 agent 가 자체 판단 (추가 명시적 거부권) 으로 낼 수도 있음 — rule precheck 주입된 경우에도 agent 가 "이건 실제 conflict 맞다" 며 재확인 요청 가능.
+
+```ts
+// src/lib/stanceConflictMarker.ts
+export function extractStanceConflict(text: string):
+    { snapshotId: string; rationale: string } | null {
+    const m = text.match(/<!-- tunaflow:stance-conflict:([^:]+):([^-]+) -->/);
+    return m ? { snapshotId: m[1], rationale: m[2].trim() } : null;
+}
+
+export function stripStanceConflictMarker(text: string): string {
+    return text.replace(/<!-- tunaflow:stance-conflict:[^>]* -->/g, "");
+}
+```
+
+Agent 메시지 렌더 경로:
+- streaming 완료 시 `extractStanceConflict` 호출
+- match 있으면 StanceConflictModal 표시 + 메시지 본문은 `stripStanceConflictMarker` 로 clean 한 버전 렌더 (INV-6)
+
+### 5. StanceConflictModal
+
+```tsx
+export function StanceConflictModal({ snapshotId, rationale, onClose }: Props) {
+    const [snapshot, setSnapshot] = useState<PreferenceSnapshot | null>(null);
+    useEffect(() => {
+        invoke<PreferenceSnapshot | null>('get_preference_snapshot', { id: snapshotId })
+            .then(setSnapshot);
+    }, [snapshotId]);
+
+    const confirmChange = async (newStance: string, reason: string) => {
+        await invoke('record_user_preference_change', {
+            memoryName: snapshot?.memory_name, field: snapshot?.field,
+            stanceFrom: snapshot?.current_stance, stanceTo: newStance,
+            reasonText: reason, reasonTags: []
+        });
+        onClose({ action: 'confirm_change' });
+    };
+    const keepExisting = () => onClose({ action: 'keep_existing' });
+    const ignore = () => onClose({ action: 'ignore' });    // INV-5: no timeline write
+
+    return (
+        <Modal>
+            <h3>Stance conflict 감지</h3>
+            <p>이전 선호: <code>{snapshot?.field} = {snapshot?.current_stance}</code></p>
+            <p>Agent 근거: {rationale}</p>
+            <div className="actions">
+                <button onClick={() => { /* prompt for new stance + reason */ }}>
+                    의도 변경 확정
+                </button>
+                <button onClick={keepExisting}>기존 선호 유지</button>
+                <button onClick={ignore} variant="ghost">무시 (이번만)</button>
+            </div>
+        </Modal>
+    );
+}
+```
+
+## Dependencies
+
+depends_on: [02]
+
+## Verification
+
+- `cargo test --lib commands::agents_helpers::send_common::stance_check`:
+  - `precheck` 반환값 3 가지 케이스:
+    - 명확한 no-conflict (무관한 요청) → NoConflict
+    - 명확한 conflict ("Rust 대신 Go 로 바꾸자") → Conflict
+    - 애매 (키워드 매칭하지만 부정어 없음) → Ambiguous
+  - INV-2 검증: no-conflict / conflict 케이스에서 model API 호출 mock 이 0 회 호출
+  - Ambiguous 케이스에서만 model 호출 1 회
+- `cargo test --lib commands::agents_helpers::send_common::prompt_assembly`:
+  - stance_fragment 가 worldview 와 identity 사이에 삽입
+- `npx vitest run src/lib/stanceConflictMarker.test.ts`:
+  - extractStanceConflict — 정상 / malformed 케이스
+  - stripStanceConflictMarker — 메시지에서 마커 제거
+- `npx vitest run src/components/tunaflow/StanceConflictModal.test.tsx`:
+  - "확정" 클릭 시 `record_user_preference_change` invoke
+  - "무시" 클릭 시 invoke 호출 없음 (INV-5)
+- 수동 E2E:
+  1. Settings 에서 "engine_preference = CLI" 로 수동 stance 등록
+  2. 새 대화에서 "SDK 로 해줘" 요청
+  3. 첫 응답 전에 StanceConflictModal 표시 확인
+  4. "기존 선호 유지" 선택 → agent 재질문 확인
+  5. `SELECT COUNT(*) FROM preference_events WHERE ...` = 1 (원래 user 등록 하나만, ignore/keep 은 event 없음)
+
+## Risks
+
+- **Rule precheck false negative**: 한국어 부정어 체계가 복잡 — "~말고" / "~보다는" / "~대신" 외에도 다양. MVP 는 주요 패턴만 커버하고 ambiguous 로 fallback. 실측 로그 기반 개선.
+- **Model verify 비용**: Haiku 호출이 매 ambiguous turn 마다 발화. 대화 빈도 높은 사용자는 누적 비용 체감 가능 — 본 plan 은 "rule 이 대다수 결정, ambiguous 는 드물다" 가정. 실측 후 ambiguous 기준 강화 필요 시 조정.
+- **Timeout 시 ConflictSafe**: 안전 측 (false positive 증가). 사용자가 modal 을 자주 보면 피로도. Timeout 5s → 10s 조정 고려.
+- **Marker 위치**: agent 가 응답 중간에 마커 넣으면 streaming 중 modal 뜨기 전에 텍스트 일부 렌더. streaming 완료 후 intercept 가 가장 깔끔 — 본 plan 이 이를 전제.
+- **Modal race**: 같은 session 에서 여러 stance-conflict 가 연속 발화되면 modal queue 필요. MVP 는 한 번에 하나, 이전 modal open 중이면 신규 무시 (사용자 로그에 경고).

--- a/docs/plans/userWorldviewInjectionPlan-task-04.md
+++ b/docs/plans/userWorldviewInjectionPlan-task-04.md
@@ -1,0 +1,232 @@
+# Subtask 04 — Low-priority background insight worker (visible + cancelable)
+
+> 상위 plan: [userWorldviewInjectionPlan.md](./userWorldviewInjectionPlan.md)
+
+## Changed files
+
+- `src-tauri/src/commands/jobs/background_worker.rs` (신규) — polling loop + job executor.
+- `src-tauri/src/commands/jobs.rs` — job enqueue helper 확장 (priority + dedupe_key).
+- `src-tauri/src/lib.rs` — 앱 startup 에 worker task spawn.
+- `src/lib/api/backgroundJobs.ts` (신규) — FE API wrapper + event listener.
+- `src/components/tunaflow/StatusBar.tsx` (또는 동등) — "background insight: N pending" 표시.
+
+## Change description
+
+### 1. Enqueue helper
+
+```rust
+// src-tauri/src/commands/jobs.rs
+pub fn enqueue_job(
+    conn: &Connection,
+    conversation_id: &str,
+    message_id: Option<&str>,
+    engine: &str,
+    kind: &str,
+    priority: i64,           // 0=foreground, -1=background
+    dedupe_key: Option<&str>,
+    visibility: &str,        // "visible" (본 plan 에서는 항상 visible)
+) -> Result<Option<String>, AppError> {
+    // dedupe 체크 — 같은 key 의 pending job 있으면 skip
+    if let Some(key) = dedupe_key {
+        let exists: bool = conn.query_row(
+            "SELECT 1 FROM agent_jobs WHERE dedupe_key = ?1 AND status IN ('pending','running') LIMIT 1",
+            [key], |_| Ok(true),
+        ).optional()?.unwrap_or(false);
+        if exists { return Ok(None); }
+    }
+    let id = format!("job-{}", Uuid::new_v4());
+    let now = now_epoch_ms();
+    conn.execute(
+        "INSERT INTO agent_jobs (id, conversation_id, message_id, engine, kind, status, started_at, updated_at, priority, dedupe_key, visibility)
+         VALUES (?1,?2,?3,?4,?5,'pending',?6,?6,?7,?8,?9)",
+        params![id, conversation_id, message_id, engine, kind, now, priority, dedupe_key, visibility],
+    )?;
+    Ok(Some(id))
+}
+```
+
+Foreground 경로는 기존 `create_job` 유지 (priority=0 default). Background 는 신규 `enqueue_job` 사용.
+
+### 2. Worker loop
+
+```rust
+// src-tauri/src/commands/jobs/background_worker.rs
+pub fn spawn_background_worker(app: AppHandle, state: Arc<AppState>) {
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(Duration::from_secs(30)).await;
+
+            // Foreground busy 면 skip
+            if is_foreground_busy(&state) { continue; }
+
+            // pick 1 pending background job (priority ASC = -1 먼저)
+            let job: Option<JobRecord> = {
+                let r = state.db.read.lock().ok()
+                    .and_then(|conn| {
+                        conn.prepare(
+                            "SELECT id, conversation_id, message_id, engine, kind, priority, dedupe_key
+                             FROM agent_jobs WHERE status='pending' AND priority < 0
+                             ORDER BY priority ASC, updated_at ASC LIMIT 1"
+                        ).ok()
+                         .and_then(|mut s| s.query_map([], row_to_job).ok()
+                             .and_then(|mut it| it.next().transpose().ok().flatten()))
+                    })
+            };
+            let Some(job) = job else { continue; };
+
+            // mark running + emit start
+            mark_job_status(&state, &job.id, "running").ok();
+            app.emit("background_insight_progress",
+                json!({"jobId": job.id, "state": "started", "kind": job.kind})
+            ).ok();
+
+            // trace_log 에 시작 기록 — INV-4
+            record_trace_log_start(&state, &job);
+
+            // 실행 (기존 agent 실행 경로 재활용)
+            let result = execute_job(&app, &state, &job).await;
+
+            // 완료
+            let status = if result.is_ok() { "done" } else { "failed" };
+            mark_job_status(&state, &job.id, status).ok();
+            app.emit("background_insight_progress",
+                json!({"jobId": job.id, "state": status})
+            ).ok();
+
+            // trace_log 종료 기록
+            record_trace_log_end(&state, &job, result.as_ref().err().map(|e| e.to_string()));
+
+            // Insight stash: 성공 시 기존 insightOrchestration 파이프라인 호출
+            if let Ok(output) = result {
+                crate::commands::insight_extract::stash_insight_from_job(&state, &job, output).await.ok();
+            }
+        }
+    });
+}
+
+fn is_foreground_busy(state: &AppState) -> bool {
+    // agent_jobs 에 priority=0 AND status='running' 1건 이상 있으면 busy
+    let r = state.db.read.lock();
+    if let Ok(c) = r {
+        let cnt: i64 = c.query_row(
+            "SELECT COUNT(*) FROM agent_jobs WHERE priority = 0 AND status = 'running'",
+            [], |r| r.get(0),
+        ).unwrap_or(0);
+        return cnt > 0;
+    }
+    false
+}
+```
+
+**concurrency cap = 1** 은 loop 구조로 자연스럽게 보장 (1 iteration 당 1 job).
+
+### 3. Cancel 경로
+
+```rust
+#[tauri::command]
+pub fn cancel_background_job(
+    job_id: String,
+    state: State<DbState>,
+) -> Result<(), AppError> {
+    let w = state.write.lock().map_err(|_| AppError::Lock)?;
+    w.execute(
+        "UPDATE agent_jobs SET status='cancelled', updated_at=?1
+          WHERE id=?2 AND status IN ('pending','running')",
+        params![now_epoch_ms(), job_id],
+    )?;
+    // 이미 running 중이면 child process kill 은 별도 (추후 확장)
+    Ok(())
+}
+```
+
+### 4. FE status bar
+
+```tsx
+// src/components/tunaflow/StatusBar.tsx
+export function StatusBar() {
+    const [pending, setPending] = useState(0);
+    const [activeJob, setActiveJob] = useState<{ id: string; kind: string } | null>(null);
+
+    useEffect(() => {
+        const poll = setInterval(async () => {
+            const count = await invoke<number>('count_pending_background_jobs');
+            setPending(count);
+        }, 15000);
+        return () => clearInterval(poll);
+    }, []);
+
+    useEffect(() => {
+        const unlisten = listen<BackgroundProgress>('background_insight_progress', (e) => {
+            if (e.payload.state === 'started') {
+                setActiveJob({ id: e.payload.jobId, kind: e.payload.kind });
+            } else {
+                setActiveJob(null);
+            }
+        });
+        return () => { unlisten.then(fn => fn()); };
+    }, []);
+
+    if (pending === 0 && !activeJob) return null;
+    return (
+        <div className="status-bar-item">
+            <Spinner size="xs" />
+            <span>
+                Background insight: {activeJob?.kind ?? 'queued'}
+                {pending > 0 && ` · ${pending} pending`}
+            </span>
+            {activeJob && (
+                <button onClick={() => invoke('cancel_background_job', { jobId: activeJob.id })}>
+                    취소
+                </button>
+            )}
+        </div>
+    );
+}
+```
+
+### 5. Enqueue 예제 (본 plan 의 scope 밖 — 주석으로만 남김)
+
+```
+// 향후 metaAgent 가 "사용자 지루함 감지" 시:
+//   enqueue_job(..., priority=-1, kind="insight_background",
+//               dedupe_key="boredom-insight-2026-04-22T19")
+```
+
+본 subtask 는 enqueue 경로와 worker 만 제공. 실제 트리거는 metaAgent 가 담당 (Q-5 참조).
+
+## Dependencies
+
+depends_on: [02] — agent_jobs priority/dedupe_key/visibility 컬럼 필요.
+
+## Verification
+
+- `cargo test --lib commands::jobs::tests::enqueue_dedupe`:
+  - 같은 dedupe_key 로 연속 enqueue 시 두 번째는 Ok(None) 반환
+  - status='cancelled' / 'failed' 이후 같은 key 는 재 enqueue 허용
+- `cargo test --lib commands::jobs::background_worker::tests`:
+  - Foreground job running 시 background pick 안 함
+  - Foreground 없을 때 priority -1 pending 을 하나 pick
+  - 완료 시 status='done' + trace_log 기록 + event emit
+  - INV-4: trace_log 에 해당 job_id 관련 2건 이상 (start/end)
+- `cargo test --lib commands::jobs::cancel_background_job`:
+  - pending → cancelled
+  - running → cancelled (child kill 은 별도 확장 시점까지 best-effort)
+  - 이미 done/failed 은 no-op
+- `npx vitest run src/components/tunaflow/StatusBar.test.tsx`:
+  - pending > 0 시 배지 표시
+  - `background_insight_progress { state: 'started' }` 이벤트 시 activeJob 설정
+- 수동 E2E:
+  1. `enqueue_job` 을 임의로 호출 (테스트용 Tauri command)
+  2. StatusBar 에 "Background insight: ..." 표시 확인
+  3. 취소 버튼 → 즉시 사라짐
+  4. `trace_log` 에 해당 job 의 start/end 기록 확인
+
+## Risks
+
+- **Polling 30초 주기**: 응답성은 낮지만 CPU 부담 작음. event-driven 으로 개선은 Q-4 follow-up.
+- **Foreground busy 판정**: `priority = 0 AND status = 'running'` 기준. 그러나 streaming 중 job 이 pending → running 전이가 빠르면 race. 1 iteration 건너뛰는 정도의 tolerance 는 허용.
+- **child kill 미구현**: cancel 이 running job 에 대해 status 만 변경. 실제 subprocess 종료는 별도 확장. 본 plan 의 background job 은 일반적으로 1~2 분 이내 종료 — 죽을 때까지 기다려도 큰 문제 없음. 장시간 job 도입 시 확장 필요.
+- **Worker crash 시 job 상태**: worker task 가 panic 하면 running job 이 영원히 running 상태. App restart 시 `bootstrap/db.rs:19` 의 stale cleanup 이 정리. 단 같은 session 내 recovery 는 없음 — 수용.
+- **`count_pending_background_jobs` 명령 누락**: Tauri command 로 추가 필요 (SELECT COUNT(*) WHERE priority<0 AND status='pending'). FE polling 용.
+- **dedupe_key 네임스페이스**: 사용자 프로젝트 간 dedupe 가 교차하면 곤란. 컨벤션: `<project_key>:<kind>:<timestamp_bucket>` 형태 권장 — 실제 kind 별로 enqueue 호출자가 결정.
+- **Concurrency cap=1 한계**: 대용량 indexing 과 insight 가 경쟁. MVP 충분. 확장 시 per-kind cap 으로.

--- a/docs/plans/userWorldviewInjectionPlan.md
+++ b/docs/plans/userWorldviewInjectionPlan.md
@@ -1,0 +1,292 @@
+---
+title: User Worldview Injection — Identity/Interface/Continuity 3축 번들 (E1 통합)
+status: planned
+priority: P1
+created_at: 2026-04-22
+related:
+  - src-tauri/src/commands/agents_helpers/send_common/prompt_assembly.rs     # ContextPack identity 섹션
+  - src-tauri/src/commands/jobs.rs                                           # agent_jobs 확장 대상
+  - src-tauri/src/commands/project_tools.rs                                  # rawq background pattern 참조
+  - src/lib/toolRequestHandler.ts                                            # tool-request follow-up 파이프라인
+  - src/lib/insightOrchestration.ts                                          # Insight stash 경로
+  - docs/plans/designReviewGatePlan.md                                       # 유사 Architect↔reviewer gate 패턴
+  - docs/plans/metaAgentPlan.md                                              # P0 메타에이전트와 교차
+  - docs/plans/harnessVerificationGapPlan.md                                 # §5 proposer 규약
+triggered_by:
+  - 2026-04-22 세션 사용자 철학적 프롬프트 (Identity/Interface/Continuity 3질문)
+  - Gemini 답변 ("거부권", "자기 관찰 도구" 두 insight 기여)
+  - 검토 세션 피드백 (rule-first stance check, event+snapshot first, low-priority visible background)
+---
+
+# User Worldview Injection — E1 통합 번들
+
+> 에이전트가 사용자의 실존적 의도(세계관, Vibe 변천, 업 karma)와 동기화되어 "말은 있으되 달리지 못하는" 상태를 벗어나게 한다. 세 층을 한 plan 에 묶는 이유: 각각 독립이 아니라 상호 강화 (worldview 없이는 stance-conflict 판정 불가, preference_timeline 없이는 conflict 대조 불가, background insight job 없이는 proactive 제안 불가).
+
+---
+
+## TL;DR for Developer
+
+1. **`user_worldview.md` 주입** — `~/.tunaflow/user_worldview.md` 사용자 철학 stance. ContextPack 조립 시 **identity 섹션보다 앞에** 삽입 (`prompt_assembly.rs`). 존재하지 않으면 기본 placeholder. 사용자가 Settings 에서 편집.
+2. **`preference_events` + `preference_snapshots` 테이블 신설** (migration v46). vector-first 아님 — event-log + snapshot 2단 구조. Embedding 은 별도 선택 subtask 로 분리 (본 plan 범위 밖).
+3. **Stance-conflict 감지는 rule-first** — 현재 요청을 recent preference_snapshots (최근 3건) 와 대조. Rule precheck 가 결정적 (conflict/no-conflict/ambiguous) 이면 모델 호출 스킵. Ambiguous 한정 Haiku/Flash 로 verify → 결과 compact 요약 후 Opus 프롬프트에 주입.
+4. **Silent tool-request 금지** — 대신 `agent_jobs` 에 `priority`, `dedupe_key`, `kind='insight_background'` 필드 추가. 별도 low-priority worker 1개 + concurrency cap. **모든 background job 은 trace_log 기록 + UI 진행 표시 + 사용자 cancel 가능**.
+5. **Stance-conflict confirmation modal** — agent 가 `<!-- tunaflow:stance-conflict:prev_snapshot_id:rationale -->` 마커 fire 시 사용자 modal. 선택지: (a) 의도 변경 확정 → 새 변곡점 기록, (b) 기존 선호 유지 → 요청 수정, (c) 무시 → agent 가 그대로 진행 (timeline 미기록).
+
+구현 순서: 01 (worldview) → 02 (preference_events/snapshots) → 03 (stance-conflict rule+modal) → 04 (background insight job). 01 은 독립 ROI 최고. 02~03 은 의존 체인. 04 는 01~03 없이도 가능하나 "지루함 감지 후 제안" 플로우는 01 필요.
+
+**하지 말 것**:
+- Vector embedding 을 preference_timeline 에 **기본** 도입 (Gemini 초안의 과잉)
+- Silent 동작 — 사용자 모르게 cost/자원 소비 금지 (tunaFlow 원칙 위배)
+- Stance-conflict 를 Opus inline 으로 매번 호출 (비용 폭증)
+- Agent 거부권을 "도덕적 판단" 으로 구현 — 기계적 rule 매칭 + 사용자 confirmation 으로 충분
+
+---
+
+## Specification
+
+### 1. `user_worldview.md` 주입
+
+**파일 위치**: `~/.tunaflow/user_worldview.md` (global) + `<project>/.tunaflow/user_worldview.md` override 허용 (후자가 있으면 우선).
+
+**기본 템플릿** (Settings UI 에서 "기본 문구 로드" 버튼):
+```markdown
+# User Worldview
+
+## Ontology
+(사용자가 기본으로 채워 넣을 철학 stance. 예시는 tunaFlow 가 제공하지 않음 — user-authored.)
+
+## Engagement preference
+- 대화 bandwidth 가 자연스럽게 저하될 때 agent 의 대응 방식
+- 과거의 업(業)과 모순되는 요청에 대한 agent 의 응답 원칙
+```
+
+**주입 경로**: `prompt_assembly.rs::assemble_prompt()` 가 ContextPack 을 조립할 때, **identity_fragment 보다 먼저** `worldview_fragment` 를 삽입. 우선순위:
+
+```
+[worldview]          ← 신규, 맨 앞
+[identity]           ← 기존
+[skills]
+[recent_context]
+...
+[user_prompt]
+```
+
+**토큰 상한**: worldview 는 최대 500 tokens. 초과 시 앞부터 자르지 않고 사용자에게 "worldview 너무 깁니다 (Settings 에서 편집 권장)" toast + 자동 truncate.
+
+**토글**: Settings 에 "Worldview 주입 활성화" 체크박스. 기본 ON. 끄면 fragment 완전 생략.
+
+### 2. `preference_events` + `preference_snapshots` 스키마 (migration v46)
+
+초안 수정 (검토 세션 피드백 반영): event-log + snapshot 2단 구조. Embedding 은 **별도 후속 subtask/plan** 으로 분리.
+
+```sql
+-- 매 변곡점 (stance 전환 사건) 을 append-only 기록
+CREATE TABLE preference_events (
+    id              TEXT PRIMARY KEY,
+    memory_name     TEXT NOT NULL,       -- 예: "engine_preference"
+    field           TEXT NOT NULL,       -- 예: "cli_vs_sdk"
+    stance_from     TEXT,                -- 직전 값 (없으면 NULL = 최초 선호)
+    stance_to       TEXT NOT NULL,       -- 새 값
+    reason_text     TEXT,                -- 자유 서술 (사용자 또는 agent 요약)
+    reason_tags     TEXT,                -- JSON array ["cost", "reliability", ...]
+    confidence      REAL DEFAULT 1.0,    -- agent 자동 감지 시 낮음
+    source          TEXT NOT NULL,       -- "user" | "agent_inferred"
+    changed_at      INTEGER NOT NULL     -- epoch ms
+);
+CREATE INDEX idx_preference_events_field ON preference_events(memory_name, field, changed_at DESC);
+
+-- 현재 활성 stance 의 caching. events 에서 파생되지만 session resume 시 빠른 load 용.
+CREATE TABLE preference_snapshots (
+    memory_name     TEXT NOT NULL,
+    field           TEXT NOT NULL,
+    current_stance  TEXT NOT NULL,
+    last_event_id   TEXT NOT NULL REFERENCES preference_events(id),
+    updated_at      INTEGER NOT NULL,
+    PRIMARY KEY (memory_name, field)
+);
+```
+
+**Embedding 은 선택적**: 차후 필요 시 별도 subtask 로 `preference_embeddings` 테이블 추가. 본 plan 은 여기까지 다루지 않음. INV-3 로 강제.
+
+**Write path**:
+- 사용자가 Settings 에서 직접 변경 시 → event INSERT + snapshot UPSERT, `source='user'`, `confidence=1.0`
+- Agent 가 대화에서 stance 변경 감지 시 (후속 subtask 04 의 background job 이 수행) → event INSERT, `source='agent_inferred'`, `confidence<1.0`. 이 경우 사용자에게 confirmation modal.
+
+**Read path** (세션 resume):
+- `SELECT memory_name, field, current_stance FROM preference_snapshots` — 전체 snapshot load. 작음.
+- ContextPack 조립 시 최근 3 변곡점만 추가 컨텍스트: `SELECT ... FROM preference_events ORDER BY changed_at DESC LIMIT 3`.
+
+### 3. Stance-conflict detection (rule-first)
+
+**흐름**:
+
+```
+User request arrives
+    ↓
+[A] Rule precheck (Rust, no model)
+    - Extract candidate preferences from request (regex / keyword / named entity)
+    - Compare to current snapshots + recent 3 events
+    - Output: { conflict: bool | "ambiguous", matched_events: [...] }
+    ↓
+  ┌─ conflict=false → skip, inject compact "no conflict" summary
+  │
+  ├─ conflict=true → emit stance-conflict marker, show modal
+  │
+  └─ conflict="ambiguous"
+         ↓
+     [B] Model verify (Haiku/Flash, short prompt)
+         - Input: user request + ambiguous snapshot
+         - Output: {conflict: bool, reason: string}
+         ↓
+       (위와 동일 분기)
+    ↓
+[C] Opus 메인 프롬프트에 compact result 주입
+    - "No conflict" or "Conflict detected — user confirmed Y"
+    - 500 tokens 이내 요약
+```
+
+**Rule precheck 구현 위치**: `src-tauri/src/commands/agents_helpers/send_common/stance_check.rs` (신규).
+
+**Model verify**: 기존 `agents/claude.rs::run_one_shot` 패턴 재활용, `-p haiku` 또는 Gemini Flash. Timeout 10s, 실패 시 fallback = ambiguous → conflict=true (안전 측).
+
+**Confirmation modal 마커**: Agent 응답 중 다음 마커 출현 시 UI 가 intercept:
+
+```html
+<!-- tunaflow:stance-conflict:<snapshot_id>:<short_rationale> -->
+```
+
+Modal 선택지:
+- **의도 변경 확정** → 신규 preference_event INSERT (`source='user'`), snapshot UPSERT, agent 이 원래 요청을 그대로 수행
+- **기존 선호 유지** → agent 에게 "사용자가 기존 선호 유지를 선택함. 요청을 재해석하라" 재주입 후 새 turn
+- **무시** → timeline 미기록, agent 가 그대로 진행 (원 요청 수행). modal 재표시 방지를 위해 해당 conflict 는 이 session 동안 mute.
+
+### 4. Low-priority background insight job (agent_jobs 확장)
+
+**agent_jobs 테이블 확장** (migration v46 에 포함):
+
+```sql
+ALTER TABLE agent_jobs ADD COLUMN priority INTEGER NOT NULL DEFAULT 0;
+    -- 0 = foreground (현재 default), -1 = low-priority background
+ALTER TABLE agent_jobs ADD COLUMN dedupe_key TEXT;
+    -- 같은 key 의 pending job 있으면 신규 INSERT 생략
+ALTER TABLE agent_jobs ADD COLUMN visibility TEXT NOT NULL DEFAULT 'visible';
+    -- 'visible' | 'hidden' (향후 확장). 본 plan 은 'visible' 만 사용.
+CREATE INDEX idx_agent_jobs_queue ON agent_jobs(priority, status, updated_at);
+```
+
+**Background worker**:
+
+`src-tauri/src/commands/jobs/background_worker.rs` (신규):
+
+```rust
+async fn run_background_loop(app: AppHandle, state: DbState) {
+    loop {
+        tokio::time::sleep(Duration::from_secs(30)).await;   // 주기 polling
+        let pending: Vec<JobRecord> = {
+            let r = state.read.lock().unwrap();
+            r.prepare("SELECT ... FROM agent_jobs
+                        WHERE status='pending' AND priority < 0
+                        ORDER BY priority ASC, updated_at ASC LIMIT 1")?
+             .query_map(...)?.collect()
+        };
+        for job in pending {
+            if is_foreground_busy(&state) { break; }  // 현재 foreground 요청 있으면 양보
+            execute_background_job(&app, &state, &job).await;
+            // trace_log 에 기록 — INV-4
+            app.emit("background_insight_progress", ...).unwrap();
+        }
+    }
+}
+```
+
+**주의**:
+- `concurrency_cap = 1` — background 는 동시에 1 개만
+- `is_foreground_busy` 체크로 사용자 현재 작업 방해 금지
+- cancel 경로: `agent_jobs.status = 'cancelled'` 로 UPDATE 하면 worker 가 다음 iteration 에서 skip (이미 진행 중이면 child process kill)
+- **trace 필수**: 실행 전/중/후 `trace_log` 기록 + `app.emit("background_insight_progress", ...)`. UI 하단 status bar 에 "background insight: N pending" 표시
+
+**Insight stash**: 완료된 background insight 는 기존 `insightOrchestration.ts` 파이프라인 재활용. 새 저장소 신설 X.
+
+**활용 경로**:
+- (본 plan 범위) Settings UI 에 "background insight: enabled / disabled" 토글 + 최근 작업 목록
+- (후속 plan) metaAgent 가 "사용자 지루함 감지" 시 `kind='insight_background'` job 을 `priority=-1` 로 등록. 본 plan 은 job 등록 경로 예제만 제공, 실제 trigger 는 metaAgent 측
+
+---
+
+## Invariants
+
+- **[INV-1]** ContextPack 조립 시 `user_worldview` fragment 는 반드시 `identity_fragment` 보다 **앞** 에 위치한다. 순서 역전은 agent 가 "역할 (identity)" 을 먼저 정의하고 사용자 OS (worldview) 를 context 로 취급하게 만들어 본 plan 의 전제를 무효화. **검증**: `prompt_assembly.rs::assemble_prompt` 단위 테스트 — 주어진 ContextPackMeta 의 sections 순서 assert.
+
+- **[INV-2]** Stance-conflict 감지는 **rule precheck 가 결정적** 인 경우 모델을 호출하지 않는다. Model verify 는 `conflict=ambiguous` 분기에서만 발화. **이유**: 매 turn 모델 호출 시 비용 폭증 + latency 지연. **검증**: `stance_check.rs::tests` — clear conflict 케이스 (현재 snapshot 과 정반대 키워드) 와 clear no-conflict 케이스 (무관한 요청) 에서 model 호출 mock 이 0 회 호출되는지 assert.
+
+- **[INV-3]** `preference_timeline` 관련 테이블은 본 plan 에서 `preference_events` + `preference_snapshots` **2개만** 도입한다. Embedding 관련 테이블 (`preference_embeddings`, vector index 등) 은 **별도 후속 plan** 으로 분리된다. **이유**: 기존 vector 층 (bge-m3, sqlite-vec) 과 경쟁하면 retrieval 우선순위가 혼란. 필요 증명된 이후에 추가. **검증**: migration v46 DDL grep — `embedding` / `vec0` 키워드 부재 확인.
+
+- **[INV-4]** 모든 `priority < 0` background job 은 (a) `trace_log` 에 시작/종료 기록, (b) `background_insight_progress` 이벤트 emit, (c) UI 에 진행 상태 노출, (d) 사용자 cancel 가능 한 4가지를 모두 만족해야 한다. Silent 실행 금지. **이유**: tunaFlow 원칙 "숨은 동작 금지, trace 투명". **검증**: Integration test — background job 1개 실행 후 trace_log row 증가 확인 + UI mock 이 progress 이벤트 1회 이상 수신 확인.
+
+- **[INV-5]** Stance-conflict confirmation modal 의 "무시" 선택은 **timeline 에 어떠한 event 도 기록하지 않는다**. 사용자의 침묵을 stance 변경으로 해석하지 않음. **이유**: 업(業) 의 기록은 사용자 명시 승인 없이 누적되면 "내 선호가 내 모르게 바뀌었다" 라는 karma 오염. **검증**: UI 테스트 — modal 에서 "무시" 클릭 후 `SELECT COUNT(*) FROM preference_events WHERE id = ?new_event_id` 가 0.
+
+- **[INV-6]** Agent 응답에 stance-conflict 마커가 있을 때 UI 는 그 마커를 **사용자에게 렌더하지 않는다** (HTML comment 형식 유지). Modal 로만 노출. **이유**: 마커가 raw text 로 보이면 사용자 혼란 + 신뢰 하락. **검증**: react-markdown 렌더 테스트 — 마커가 final DOM 에 없음을 확인.
+
+---
+
+## Rationale (reviewer-only)
+
+### 검토 세션 피드백 반영
+
+초안 (2026-04-22 Gemini 답 + 내 블루프린트 합산) 에서 다음 3 가지가 검토 세션에 의해 교정됨. 본 plan 은 교정본:
+
+| 초안 | 교정 이유 | 본 plan |
+|---|---|---|
+| stance-conflict 를 Opus inline 으로 매 turn 체크 | 비용 폭증 | rule-first + ambiguous 에만 small model verify (§3) |
+| `preference_timeline` 에 reason vectorization 기본 포함 | tunaFlow 이미 vector 층 있음. 새 memory source 추가 시 retrieval 경쟁 | event+snapshot 2단, embedding 은 선택적 후속 (INV-3) |
+| Silent tool-request 로 부재중 stash | tunaFlow "trace 투명" 원칙 위배 | background + low-priority + visible + cancelable 로 재정의 (§4, INV-4) |
+
+### Gemini 기여 (수용)
+
+- **거부권 개념** → stance-conflict marker + modal 로 구현. "도덕적 거부" 가 아니라 "기계적 conflict detection + 사용자 confirmation" 로 기술 번역.
+- **자기 관찰 도구 (Vipassana) 격상** → preference_events timeline 은 Insight 탭의 subview 로 노출 (별도 UI plan 에서 정리). 본 plan 은 backend 만.
+
+### 대안 비교
+
+| 대안 | 판정 | 사유 |
+|---|---|---|
+| 모든 turn Opus inline stance check | 기각 | 비용 |
+| preference_timeline vector-first | 기각 | retrieval 경쟁 |
+| Silent tool-request | 기각 | 원칙 위배 |
+| 세 축을 3개 독립 plan 으로 분리 | 기각 | 서로 강화 관계. worldview 없이는 stance-conflict 판정 문맥 부재 |
+| **채택** (3축 번들 + rule-first + event/snapshot + visible background) | ✅ | 최소 침습 + tunaFlow 원칙 정합 |
+
+### Open questions
+
+1. **Q-1 (worldview 템플릿 기본값)**: 사용자가 Settings 에서 "기본 문구 로드" 를 선택했을 때 제공할 minimal 템플릿 내용. 본 plan 은 "section header 와 빈 본문" 권장 (placeholder). 사용자 철학은 user-authored — tunaFlow 가 제시하는 순간 bias 주입. Developer/사용자 협의 후 확정.
+
+2. **Q-2 (stance-conflict rule precheck 알고리즘)**: 초기 구현은 어떤 rule 패턴이 적절한가. 키워드 리스트? 간단한 regex? named entity (engine 이름 / 기능 이름) 추출? 본 plan 은 "간단한 토큰 매칭부터 시작 + 실제 oversight/undersight 측정 후 개선" 을 권장. 최초 릴리스는 **false positive 허용 (model verify 가 catch), false negative 회피** 튜닝.
+
+3. **Q-3 (small verify model 선정)**: Haiku vs Gemini Flash vs 로컬 LMStudio? 본 plan 은 "기존 설정된 model" 우선 + Haiku default. Developer 구현 시 실측 latency 기반 결정.
+
+4. **Q-4 (background worker polling vs event-driven)**: §4 의 worker 가 30 초 polling 으로 기술됐으나 event-driven 이 더 반응적. Polling 은 구현 단순, event-driven 은 복잡성 증가. 본 plan 은 MVP 로 polling 채택, 후속 refactor 여지 남김.
+
+5. **Q-5 (metaAgent 와의 trigger 경로)**: 본 plan 은 background job 등록 **경로** 만 제공. 실제 "사용자 지루함 감지" trigger 는 `metaAgentPlan.md` (P0) 의 책임. metaAgent 구현 후 본 plan 의 `priority=-1` job 을 호출하는 식. 현재는 수동 테스트로 job 등록 경로 검증.
+
+---
+
+## Subtask 구조
+
+| # | 파일 | 범위 | 의존 |
+|---|---|---|---|
+| 01 | [-task-01.md](./userWorldviewInjectionPlan-task-01.md) | `user_worldview.md` 파일 + ContextPack 주입 + Settings UI 편집기 | — |
+| 02 | [-task-02.md](./userWorldviewInjectionPlan-task-02.md) | migration v46 (preference_events + preference_snapshots + agent_jobs 컬럼 확장) + write path helper | — |
+| 03 | [-task-03.md](./userWorldviewInjectionPlan-task-03.md) | Stance-conflict detection (rule precheck + small model verify + confirmation modal) | 02 |
+| 04 | [-task-04.md](./userWorldviewInjectionPlan-task-04.md) | Background insight worker (low-priority + visible + cancelable) | 02 |
+
+4 subtask. 01 독립 (가장 작고 ROI 최고). 02 가 03/04 공통 의존. 03/04 는 02 후 독립 병렬.
+
+---
+
+## 관련 문서
+
+- Gemini 답변 원문: 본 세션 2026-04-22 대화 (검토 세션 공유)
+- 검토 세션 피드백: 본 세션 2026-04-22 대화 (rule-first, event+snapshot, visible background)
+- 사용자 철학 원문: 본 세션 2026-04-22 "바이브 코더 / 2인 3각" 프롬프트
+- 설계 유사 gate 패턴: `docs/plans/designReviewGatePlan.md`
+- P0 metaAgent 교차: `docs/plans/metaAgentPlan.md`

--- a/docs/reference/sessionHistory.md
+++ b/docs/reference/sessionHistory.md
@@ -315,3 +315,13 @@ description: 세션별 전체 작업 이력. 새 세션 시작 시 또는 과거
 - InsightPanel: 재검토(revalidateFindings) + Architect 검토(handleSendToArchitect) + summary strip
 - Auto Fix → 메타에이전트 도입 후 구현으로 연기, 문서 업데이트
 - CLAUDE.md 경량화 (53KB → sessionHistory.md 분리)
+
+### 🐞 Incident 2026-04-23: SDK 30s connect timeout (sessionContinuityFixPlan followup)
+- **증상**: Branch Dev → Reviewer → Dev 수정 페이즈 진입 시 `sdk-session: claude did not connect within 30s`
+- **발견 시점**: PR #132~#134 (Session Continuity Fix) 머지 후 최초 사용자 재현
+- **로그 단서**: `[sdk-session] resuming with session_id=2d86ea63-...` → 30006ms 후 guardrail err. model=claude-sonnet-4-6, prompt_chars=25561
+- **현재 상태**: 원인 미확정. 4개 가설 (stderr null / `--session-id` vs `--resume` 인자 충돌 / conv_id 전환 오배선 / 대형 트랜스크립트 로드 지연)
+- **대응 (완료)**: stderr 캡처 임시 패치 (`[claude-cli stderr conv=...] ...` eprintln) + escape hatch (`TUNAFLOW_DISABLE_RESUME_BOOTSTRAP=1`) 적용. 근본 수정 후 두 패치 모두 제거 예정
+- **claude CLI**: 2.1.117 (Claude Code)
+- **다음**: 사용자 재현 → stderr 로그 Architect 공유 → 가설 확정 → plan 작성 → 근본 수정
+- **영향**: userWorldviewInjectionPlan subtask-02 (DB v46 migration) 머지는 본 이슈 해결 후 진행 권고 (Architect 의견)

--- a/src-tauri/src/agents/claude_sdk_session.rs
+++ b/src-tauri/src/agents/claude_sdk_session.rs
@@ -148,6 +148,11 @@ lazy_static::lazy_static! {
 ///
 /// sessionContinuityFixPlan.md task-02 (INV-4).
 pub fn bootstrap_resume_id_from_db(conv_id: &str, db: &crate::db::DbState) -> Option<String> {
+    // TEMP escape hatch (sessionContinuityFixPlan followup): SDK 30s timeout 재현 시
+    // 사용자가 env 로 resume bootstrap 만 끌 수 있게 함. 근본 수정 후 제거.
+    if std::env::var("TUNAFLOW_DISABLE_RESUME_BOOTSTRAP").is_ok() {
+        return None;
+    }
     // 이미 메모리에 있으면 skip (DB 보다 메모리 값이 최신일 수 있음)
     if let Some(existing) = RESUME_IDS.lock().get(conv_id).cloned() {
         return Some(existing);
@@ -389,7 +394,9 @@ async fn spawn_session(
         // stdin/stdout piped — stdin: 메시지 전달, stdout: 이벤트 수신(HTTP POST 병행)
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::null())
+        // TEMP (sessionContinuityFixPlan followup): SDK 30s connect timeout 근본원인 추적용.
+        // 가설 확정(Architect) 후 Stdio::null() 로 원복.
+        .stderr(std::process::Stdio::piped())
         .kill_on_drop(true);
 
     // 이전 대화 이력이 있으면 --resume으로 이어받기
@@ -413,6 +420,21 @@ async fn spawn_session(
         .stdout
         .take()
         .ok_or_else(|| AppError::Agent("sdk-session: could not get child stdout".into()))?;
+
+    // TEMP stderr 캡처 (sessionContinuityFixPlan followup): `--resume` 시 30s timeout
+    // 원인이 stdio=null 로 가려져 미확정. line-by-line eprintln 후 Architect 에 공유.
+    let child_stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| AppError::Agent("sdk-session: could not get child stderr".into()))?;
+    let conv_id_stderr = conv_id.to_string();
+    tokio::spawn(async move {
+        use tokio::io::{AsyncBufReadExt, BufReader};
+        let mut lines = BufReader::new(child_stderr).lines();
+        while let Ok(Some(line)) = lines.next_line().await {
+            eprintln!("[claude-cli stderr conv={}] {}", conv_id_stderr, line);
+        }
+    });
 
     // claude WS 연결 대기 (최대 30초)
     tokio::time::timeout(


### PR DESCRIPTION
## Summary

Session Continuity Fix (PR #132~#134) 머지 후 재현된 `sdk-session: claude did not connect within 30s` 타임아웃을 진단하기 위한 **임시 패치**. 근본 수정 후 두 변경 모두 제거 예정.

### 포함
- **stderr 캡처**: `claude_sdk_session.rs` spawn 에서 `.stderr(Stdio::null())` → `Stdio::piped()` 로 변경하고 line-by-line `eprintln!("[claude-cli stderr conv={}] {}", ...)` 로 출력. 30s 타임아웃 원인(가설 2: `--session-id` vs `--resume` 인자 충돌 등)을 claude CLI 의 에러 메시지로 직접 확인.
- **escape hatch**: `bootstrap_resume_id_from_db` 진입부에 `TUNAFLOW_DISABLE_RESUME_BOOTSTRAP` env 체크. 사용자가 막히면 이 env 로 resume bootstrap 만 끌 수 있음 (Session Continuity Fix 의 다른 invariant 는 유지).
- **incident 노트**: `docs/reference/sessionHistory.md` 에 증상/재현/가설/대응 기록.

### 검증
- `cargo check --lib` 통과 (기존 dead_code 경고 1건 무관)
- claude CLI: 2.1.117 (Claude Code)

### 다음 단계
1. 본 PR 머지 후 사용자가 Branch Dev→Reviewer→Dev 플로우 1회 재현
2. `[claude-cli stderr conv=...]` 로그 Architect 공유
3. 가설 확정 → Session Continuity Fix followup plan 작성 → 근본 수정 후 TEMP 제거

## Test plan
- [ ] 사용자 앱에서 Branch 디자인리뷰 플로우 재현
- [ ] stderr 로그 수집 + 공유
- [ ] Architect 가설 확정 회신

🤖 Generated with [Claude Code](https://claude.com/claude-code)