### PR TITLE
docs(plans): userWorldviewInjection — sdk-session(Branch) 적용 범위 명시

### DIFF
--- a/docs/plans/userWorldviewInjectionPlan.md
+++ b/docs/plans/userWorldviewInjectionPlan.md
@@ -22,6 +22,8 @@ triggered_by:
 
 > 에이전트가 사용자의 실존적 의도(세계관, Vibe 변천, 업 karma)와 동기화되어 "말은 있으되 달리지 못하는" 상태를 벗어나게 한다. 세 층을 한 plan 에 묶는 이유: 각각 독립이 아니라 상호 강화 (worldview 없이는 stance-conflict 판정 불가, preference_timeline 없이는 conflict 대조 불가, background insight job 없이는 proactive 제안 불가).
 
+> **적용 범위**: 본 plan 의 모든 로직 (worldview 주입 / preference_timeline / stance-conflict / background insight job) 은 **sdk-session 경로 (Branch chat) 한정**. RT (`-p` one-shot) 는 매 turn full ContextPack 을 재주입하는 것이 정상 동작이며 본 plan 대상 아님. INV-1 이하의 모든 invariant, ContextPack 주입 변경, tool-request 핸들링은 `claude_sdk_session::spawn_session` 경로에만 영향을 준다. RT 경로 (`roundtable_helpers/*`, `agents/claude.rs::run_one_shot`) 는 본 plan 이 건드리지 않는다.
+
 ---
 
 ## TL;DR for Developer


### PR DESCRIPTION
## Summary

Architect 정정 수용 — userWorldviewInjectionPlan TL;DR 상단에 **적용 범위** 1줄 추가. Codex reviewer 가 RT 적용성을 재질의하지 않도록 plan 본문에서 authoritative scope 를 고정.

### 반영 내용
> **적용 범위**: 본 plan 의 모든 로직 (worldview 주입 / preference_timeline / stance-conflict / background insight job) 은 **sdk-session 경로 (Branch chat) 한정**. RT (\`-p\` one-shot) 는 매 turn full ContextPack 을 재주입하는 것이 정상 동작이며 본 plan 대상 아님.

### 근거
- `session_freshness.rs:17` 정책과 정합 ("적용 대상: claude --sdk-url" / "적용 제외: claude -p CLI 모드")
- Session Continuity Fix 의 스코프와 동일
- SDK 30s timeout 디버깅 과정에서 Branch/RT CLI 경로 분기 재확인

## Test plan
- [ ] Codex review round 에서 "RT 적용성" 질의 없이 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)