### PR TITLE
fix(sdk-session): --session-id vs --resume 상호배타 (Branch 30s timeout hot fix)

### DIFF
--- a/src-tauri/src/agents/claude_sdk_session.rs
+++ b/src-tauri/src/agents/claude_sdk_session.rs
@@ -379,7 +379,6 @@ async fn spawn_session(
     let mut cmd = TokioCommand::new("claude");
     cmd.arg("--print")
         .arg("--sdk-url").arg(&sdk_url)
-        .arg("--session-id").arg(&session_id)
         .arg("--model").arg(model)
         .arg("--input-format").arg("stream-json")
         .arg("--output-format").arg("stream-json")
@@ -399,10 +398,16 @@ async fn spawn_session(
         .stderr(std::process::Stdio::piped())
         .kill_on_drop(true);
 
-    // 이전 대화 이력이 있으면 --resume으로 이어받기
+    // `--session-id` vs `--resume` 상호배타 (claude CLI 2.1.x 제약).
+    //   - resume 있음: claude 가 prior session_id 를 이어받으므로 `--session-id` 생략
+    //   - resume 없음: `--session-id <router-uuid>` 로 신규 세션 식별자 부여
+    // WS routing 은 `sdk_url` 경로의 router UUID 기반이므로 claude 내부 session_id
+    // 와 무관하게 정상 동작. sessionContinuityFixPlan.md 의 hot fix (Architect 지시).
     if let Some(resume_id) = resume_session_id {
         cmd.arg("--resume").arg(resume_id);
-        eprintln!("[sdk-session] resuming with session_id={} model={}", resume_id, model);
+        eprintln!("[sdk-session] resuming with session_id={} model={} (--session-id 생략)", resume_id, model);
+    } else {
+        cmd.arg("--session-id").arg(&session_id);
     }
 
     let mut child = cmd


### PR DESCRIPTION
## Summary

Session Continuity Fix (PR #132~#134) 머지 후 Branch Dev→Reviewer→Dev 진입 시 발생한 \`sdk-session: claude did not connect within 30s\` 의 **Architect 지시 hot fix**.

### 원인 (가설 2 확정)
claude CLI 2.1.117 은 spawn 인자 \`--session-id <uuid>\` 와 \`--resume <sid>\` 를 동시에 받으면 내부 session_id 충돌로 WS 연결이 수립되지 않음.

### 수정
\`claude_sdk_session::spawn_session\` 한 곳:
- \`resume_session_id\` 있음 → \`--resume\` 만, \`--session-id\` 생략
- \`resume_session_id\` 없음 → \`--session-id <router-uuid>\` 만

WS routing 은 \`sdk_url\` 경로의 router UUID 기반이므로 claude 내부 session_id 와 무관하게 정상 동작.

### 범위
- ✅ sdk-session (Branch chat)
- ❌ RT (\`-p\` one-shot) — 별도 CLI 경로, 본 수정 영향 없음

### 검증 대상 (사용자 재현)
1. Branch 직접 이어가기 (Dev turn 1 → Dev turn 2)
2. Branch Dev → Review → Dev (원 재현 시나리오) ← **주요 타깃**
3. 신규 Branch 첫 send (resume 없음 경로 regression 가드)
4. claude 가 --resume 실패 후 새 sid 반환 시 INV-6 auto-invalidate 정상 발동

### 체크
- \`cargo check --lib\` 통과
- claude CLI: 2.1.117

## Test plan
- [ ] 시나리오 1 통과
- [ ] 시나리오 2 통과
- [ ] 시나리오 3 regression 없음
- [ ] 시나리오 4 INV-6 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)