### PR TITLE
feat(worldview): subtask-01 — user_worldview.md + ContextPack 주입 + Settings UI

### DIFF
--- a/src-tauri/src/commands/agents_helpers/send_common/prompt_assembly.rs
+++ b/src-tauri/src/commands/agents_helpers/send_common/prompt_assembly.rs
@@ -160,6 +160,13 @@ pub fn assemble_prompt(
         included_sections.push("previous-impl".into());
     }
 
+    // User Worldview — 사용자 stance 문서. identity 바로 앞에 삽입 (INV-1).
+    // skip_static 에 영향받지 않음: 파일 기반이지만 CLAUDE.md/AGENTS.md 에 sync 되지 않는 별도 경로.
+    if let Some(worldview_text) = crate::commands::worldview::load_for_injection(data.project_path.as_deref()) {
+        sections.push(format!("## User Worldview\n\n{}", worldview_text));
+        included_sections.push("worldview".into());
+    }
+
     // Identity + Persona section
     {
         let (identity_block, persona_block) = parse_identity_and_persona(identity_fragment);
@@ -660,4 +667,94 @@ pub fn build_normalized_prompt_with_budget(
         context_mode_override, context_budget_cap, user_profile_json,
     );
     assemble_prompt(&data, persona_fragment)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn empty_context_data(project_path: Option<String>) -> ContextData {
+        ContextData {
+            conversation_id: "conv-test".into(),
+            project_path,
+            prompt: "hi".into(),
+            is_branch: false,
+            has_active_plan: false,
+            current_messages: vec![],
+            parent_messages: vec![],
+            plan_section: None,
+            plan_document: None,
+            findings_section: None,
+            artifacts_section: None,
+            retrieval_chunks: vec![],
+            document_chunks: vec![],
+            compressed_memory: None,
+            compressed_memory_source: None,
+            cross_session_data: vec![],
+            thread_inheritance: None,
+            agent_role_doc: None,
+            previous_impl_status: None,
+            active_skills: vec![],
+            cross_session_ids: vec![],
+            persona_fragment: None,
+            context_mode_override: None,
+            context_budget_cap: None,
+            user_profile: None,
+            conventions_synced: false,
+            is_session_continuation: false,
+        }
+    }
+
+    /// INV-1 (userWorldviewInjectionPlan-task-01): worldview 는 identity 바로 앞.
+    /// project/platform/agent-role 은 worldview 앞에 유지.
+    #[test]
+    fn worldview_injected_immediately_before_identity() {
+        let tmp = TempDir::new().unwrap();
+        let project_dir = tmp.path().to_path_buf();
+        let wv_path = project_dir.join(".tunaflow").join("user_worldview.md");
+        fs::create_dir_all(wv_path.parent().unwrap()).unwrap();
+        fs::write(&wv_path, "# stance\n\n본 사용자는 CLI-first 원칙을 따른다.").unwrap();
+
+        let data = empty_context_data(Some(project_dir.to_string_lossy().to_string()));
+        let identity_fragment = "## Identity\n\ntunaFlow test agent.";
+        let (_assembled, _sys, meta) = assemble_prompt(&data, Some(identity_fragment));
+
+        let idx_worldview = meta.sections.iter().position(|s| s == "worldview");
+        let idx_identity = meta.sections.iter().position(|s| s == "identity");
+
+        assert!(idx_worldview.is_some(), "worldview 섹션이 주입되어야 함");
+        assert!(idx_identity.is_some(), "identity 섹션은 항상 존재");
+        assert_eq!(
+            idx_worldview.unwrap() + 1,
+            idx_identity.unwrap(),
+            "worldview 는 identity 바로 앞이어야 함 (INV-1)"
+        );
+
+        // project/platform/agent-role 은 worldview 앞에 있어야 함 (단, 이 테스트에선 agent-role 없음)
+        let idx_platform = meta.sections.iter().position(|s| s == "platform");
+        if let Some(p) = idx_platform {
+            assert!(p < idx_worldview.unwrap(), "platform 은 worldview 앞");
+        }
+    }
+
+    #[test]
+    fn worldview_absent_when_file_missing() {
+        let tmp = TempDir::new().unwrap();
+        let project_dir = tmp.path().to_path_buf();
+        // 파일 생성 안 함
+        let data = empty_context_data(Some(project_dir.to_string_lossy().to_string()));
+        let (_assembled, _sys, meta) = assemble_prompt(&data, Some("## Identity\n\ntest"));
+
+        // 전역 ~/.tunaflow/user_worldview.md 가 실제 머신에 있으면 "worldview" 가 있을 수 있음.
+        // 그 경우도 identity 바로 앞이라는 INV-1 은 유지되어야 함.
+        if let Some(idx_wv) = meta.sections.iter().position(|s| s == "worldview") {
+            let idx_id = meta.sections.iter().position(|s| s == "identity").unwrap();
+            assert_eq!(idx_wv + 1, idx_id, "global worldview 도 identity 바로 앞이어야 함");
+        } else {
+            // worldview 없으면 identity 는 여전히 존재
+            assert!(meta.sections.iter().any(|s| s == "identity"));
+        }
+    }
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -40,3 +40,4 @@ pub mod mobile;
 pub mod pty;
 pub mod secrets;
 pub mod attachments;
+pub mod worldview;

--- a/src-tauri/src/commands/worldview.rs
+++ b/src-tauri/src/commands/worldview.rs
@@ -1,0 +1,249 @@
+//! User Worldview 파일 기반 stance 주입 (userWorldviewInjectionPlan subtask-01).
+//!
+//! 경로 해결:
+//! - project override: `<project>/.tunaflow/user_worldview.md` (있으면 우선)
+//! - global:           `~/.tunaflow/user_worldview.md`
+//!
+//! ContextPack 주입은 `prompt_assembly.rs` 가 `load_for_injection()` 을 호출해
+//! identity 섹션 **바로 앞** 에 삽입. 토큰 상한 500.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use serde::Deserialize;
+
+use crate::errors::AppError;
+use crate::guardrail::estimate_tokens;
+
+pub const WORLDVIEW_MAX_TOKENS: usize = 500;
+
+/// ContextPack 주입 토글 (Settings UI 에서 제어). 기본 ON.
+static WORLDVIEW_ENABLED: AtomicBool = AtomicBool::new(true);
+
+/// `<project>/.tunaflow/user_worldview.md` 우선, 없으면 `~/.tunaflow/user_worldview.md`.
+pub fn resolve_worldview_path(project_path: Option<&str>) -> Option<PathBuf> {
+    if let Some(pp) = project_path {
+        let project_p = PathBuf::from(pp).join(".tunaflow").join("user_worldview.md");
+        if project_p.exists() {
+            return Some(project_p);
+        }
+    }
+    let home = dirs::home_dir()?;
+    let global_p = home.join(".tunaflow").join("user_worldview.md");
+    if global_p.exists() { Some(global_p) } else { None }
+}
+
+/// 파일 내용 raw 로드 (Settings UI/테스트 용). trim 포함.
+pub fn load_worldview(project_path: Option<&str>) -> Option<String> {
+    let path = resolve_worldview_path(project_path)?;
+    std::fs::read_to_string(path)
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// `prompt_assembly.rs` 용: enabled 플래그 + 500 토큰 상한 적용.
+/// 상한 초과 시 **앞 부분만** 사용 (char 경계 안전). 경고 1회 eprintln.
+pub fn load_for_injection(project_path: Option<&str>) -> Option<String> {
+    if !WORLDVIEW_ENABLED.load(Ordering::Relaxed) {
+        return None;
+    }
+    let raw = load_worldview(project_path)?;
+    Some(truncate_to_tokens(&raw, WORLDVIEW_MAX_TOKENS))
+}
+
+/// 추정 토큰 상한을 초과하면 char 단위로 앞부분만 반환. char 경계 안전 (Unicode panic 방지).
+/// Codex round-3 review 반영: `str::split_at` 의 byte index 기반 panic 회피 위해 char_indices 사용.
+pub fn truncate_to_tokens(text: &str, max_tokens: usize) -> String {
+    let current = estimate_tokens(text);
+    if current <= max_tokens {
+        return text.to_string();
+    }
+    // Binary-search 대신 선형 근사 — estimate_tokens 의 (ascii/4 + cjk*2/3) 휴리스틱에 맞춰
+    // char 비율 만큼 자른 뒤 안전하게 char 경계로 round-down.
+    let ratio = max_tokens as f64 / current as f64;
+    let total_chars = text.chars().count();
+    let target_chars = (total_chars as f64 * ratio).floor() as usize;
+    let cut_byte = text
+        .char_indices()
+        .nth(target_chars)
+        .map(|(i, _)| i)
+        .unwrap_or_else(|| text.len());
+    let truncated = &text[..cut_byte];
+    eprintln!(
+        "[worldview] truncated {} → {} chars (est tokens {} → {})",
+        total_chars,
+        target_chars,
+        current,
+        estimate_tokens(truncated)
+    );
+    truncated.to_string()
+}
+
+// ─────────────────────────── Tauri commands ───────────────────────────
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorldviewReadInput {
+    pub project_path: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorldviewWriteInput {
+    pub content: String,
+    pub project_path: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorldviewEnabledInput {
+    pub enabled: bool,
+}
+
+#[tauri::command]
+pub fn get_worldview(input: WorldviewReadInput) -> Result<Option<String>, AppError> {
+    Ok(load_worldview(input.project_path.as_deref()))
+}
+
+/// 현재 적용 경로 (project override 또는 global). 파일이 아직 없으면 저장 대상 경로도 global.
+#[tauri::command]
+pub fn get_worldview_path(input: WorldviewReadInput) -> Result<Option<String>, AppError> {
+    Ok(resolve_worldview_path(input.project_path.as_deref())
+        .map(|p| p.to_string_lossy().to_string()))
+}
+
+#[tauri::command]
+pub fn set_worldview(input: WorldviewWriteInput) -> Result<(), AppError> {
+    // 저장 경로: project override 파일이 이미 존재하면 그곳, 아니면 global.
+    // 사용자가 명시적으로 project override 를 만들 때는 <project>/.tunaflow 디렉터리를
+    // 먼저 만들어야 하므로 여기선 global 기본. (override 편집은 사용자가 파일을 직접
+    // 만든 뒤 편집 — Settings UI 에서 현재 적용 경로를 표시.)
+    let target = if let Some(pp) = input.project_path.as_deref() {
+        let project_p = PathBuf::from(pp).join(".tunaflow").join("user_worldview.md");
+        if project_p.exists() {
+            project_p
+        } else {
+            global_path()?
+        }
+    } else {
+        global_path()?
+    };
+
+    if let Some(parent) = target.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| {
+            AppError::Agent(format!("worldview: create dir failed: {}", e))
+        })?;
+    }
+    std::fs::write(&target, input.content).map_err(|e| {
+        AppError::Agent(format!("worldview: write failed: {}", e))
+    })?;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn get_worldview_enabled() -> Result<bool, AppError> {
+    Ok(WORLDVIEW_ENABLED.load(Ordering::Relaxed))
+}
+
+#[tauri::command]
+pub fn set_worldview_enabled(input: WorldviewEnabledInput) -> Result<(), AppError> {
+    WORLDVIEW_ENABLED.store(input.enabled, Ordering::Relaxed);
+    Ok(())
+}
+
+fn global_path() -> Result<PathBuf, AppError> {
+    let home = dirs::home_dir()
+        .ok_or_else(|| AppError::Agent("worldview: home_dir() None".into()))?;
+    Ok(home.join(".tunaflow").join("user_worldview.md"))
+}
+
+// ─────────────────────────── Tests ───────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn resolve_prefers_project_override_when_present() {
+        let tmp = TempDir::new().unwrap();
+        let project_dir = tmp.path().to_path_buf();
+        let override_path = project_dir.join(".tunaflow").join("user_worldview.md");
+        fs::create_dir_all(override_path.parent().unwrap()).unwrap();
+        fs::write(&override_path, "# override").unwrap();
+
+        let resolved = resolve_worldview_path(Some(project_dir.to_str().unwrap()));
+        assert_eq!(resolved, Some(override_path));
+    }
+
+    #[test]
+    fn resolve_returns_none_when_neither_exists() {
+        let tmp = TempDir::new().unwrap();
+        let project_dir = tmp.path().to_path_buf();
+        // global 은 홈 의존이라 체크 생략. project override 만 없으면 None 이거나 global.
+        let resolved = resolve_worldview_path(Some(project_dir.to_str().unwrap()));
+        // global 파일이 실제 테스트 머신에 있을 수도 있으므로 assertion 완화:
+        // project override 경로로 돌아오지 않았음을 확인.
+        assert!(resolved
+            .as_ref()
+            .map(|p| !p.starts_with(&project_dir))
+            .unwrap_or(true));
+    }
+
+    #[test]
+    fn load_returns_trimmed_content() {
+        let tmp = TempDir::new().unwrap();
+        let project_dir = tmp.path().to_path_buf();
+        let path = project_dir.join(".tunaflow").join("user_worldview.md");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, "  \n# Hi\n  ").unwrap();
+
+        let loaded = load_worldview(Some(project_dir.to_str().unwrap()));
+        assert_eq!(loaded.as_deref(), Some("# Hi"));
+    }
+
+    #[test]
+    fn load_filters_empty_content_to_none() {
+        let tmp = TempDir::new().unwrap();
+        let project_dir = tmp.path().to_path_buf();
+        let path = project_dir.join(".tunaflow").join("user_worldview.md");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, "   \n   ").unwrap();
+
+        let loaded = load_worldview(Some(project_dir.to_str().unwrap()));
+        assert!(loaded.is_none());
+    }
+
+    #[test]
+    fn truncate_noop_when_under_limit() {
+        let input = "hello world";
+        assert_eq!(truncate_to_tokens(input, 500), input);
+    }
+
+    #[test]
+    fn truncate_handles_cjk_without_panic() {
+        // CJK char 는 estimate_tokens 에서 가중치 2/3. char 경계에서 cut 해야 Unicode panic 방지.
+        let text: String = "안녕하세요 반갑습니다 ".repeat(500);
+        let out = truncate_to_tokens(&text, 100);
+        assert!(out.len() < text.len());
+        // char 경계 검증 — 유효 UTF-8 이어야 함
+        assert!(std::str::from_utf8(out.as_bytes()).is_ok());
+    }
+
+    #[test]
+    fn load_for_injection_respects_disabled_flag() {
+        // 상태 오염 방지를 위해 테스트 끝에 복구
+        let prev = WORLDVIEW_ENABLED.load(Ordering::Relaxed);
+        WORLDVIEW_ENABLED.store(false, Ordering::Relaxed);
+        let tmp = TempDir::new().unwrap();
+        let project_dir = tmp.path().to_path_buf();
+        let path = project_dir.join(".tunaflow").join("user_worldview.md");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, "# stance").unwrap();
+        let got = load_for_injection(Some(project_dir.to_str().unwrap()));
+        WORLDVIEW_ENABLED.store(prev, Ordering::Relaxed);
+        assert!(got.is_none());
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -278,6 +278,12 @@ pub fn run() {
             commands::attachments::save_attachment,
             commands::attachments::delete_attachment,
             commands::attachments::cleanup_attachments,
+            // Worldview — 사용자 stance 파일 + ContextPack 주입 토글
+            commands::worldview::get_worldview,
+            commands::worldview::get_worldview_path,
+            commands::worldview::set_worldview,
+            commands::worldview::get_worldview_enabled,
+            commands::worldview::set_worldview_enabled,
             // PTY
             commands::pty::pty_spawn,
             commands::pty::pty_write,

--- a/src/components/tunaflow/SettingsPanel.tsx
+++ b/src/components/tunaflow/SettingsPanel.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { cn } from "@/lib/utils";
-import { X, Bot, UserCircle, Zap, Cpu, Terminal, Smartphone, User, HelpCircle } from "lucide-react";
+import { X, Bot, UserCircle, Zap, Cpu, Terminal, Smartphone, User, HelpCircle, Globe } from "lucide-react";
 import { SkillsPanel } from "./context-panel/SkillsPanel";
 import { AgentsSection } from "./settings/AgentsSection";
 import { PersonasSection } from "./settings/PersonasSection";
@@ -9,11 +9,13 @@ import { TerminalSection } from "./settings/TerminalSection";
 import { MobileSection } from "./settings/MobileSection";
 import { ProfileSection } from "./settings/ProfileSection";
 import { HelpSection } from "./settings/HelpSection";
+import { WorldviewSettings } from "./settings/WorldviewSettings";
 
-type SettingsSection = "profile" | "agents" | "personas" | "skills" | "runtime" | "terminal" | "mobile" | "help";
+type SettingsSection = "profile" | "worldview" | "agents" | "personas" | "skills" | "runtime" | "terminal" | "mobile" | "help";
 
 const SECTIONS: { id: SettingsSection; label: string; icon: React.ReactNode }[] = [
   { id: "profile", label: "Profile", icon: <User className="w-4 h-4" /> },
+  { id: "worldview", label: "Worldview", icon: <Globe className="w-4 h-4" /> },
   { id: "agents", label: "Agents", icon: <Bot className="w-4 h-4" /> },
   { id: "personas", label: "Personas", icon: <UserCircle className="w-4 h-4" /> },
   { id: "skills", label: "Skills", icon: <Zap className="w-4 h-4" /> },
@@ -29,7 +31,7 @@ interface SettingsPanelProps {
 }
 
 export function SettingsPanel({ onClose, initialSection }: SettingsPanelProps) {
-  const valid: SettingsSection[] = ["profile", "agents", "personas", "skills", "runtime", "terminal", "mobile", "help"];
+  const valid: SettingsSection[] = ["profile", "worldview", "agents", "personas", "skills", "runtime", "terminal", "mobile", "help"];
   const initial = (initialSection && valid.includes(initialSection as SettingsSection))
     ? (initialSection as SettingsSection)
     : "profile";
@@ -69,6 +71,7 @@ export function SettingsPanel({ onClose, initialSection }: SettingsPanelProps) {
           <div className="flex-1 min-w-0 border-l border-border/30 overflow-y-auto">
             <div className="p-5">
               {activeSection === "profile" && <ProfileSection />}
+              {activeSection === "worldview" && <WorldviewSettings />}
               {activeSection === "agents" && <AgentsSection />}
               {activeSection === "personas" && <PersonasSection />}
               {activeSection === "skills" && (

--- a/src/components/tunaflow/settings/WorldviewSettings.tsx
+++ b/src/components/tunaflow/settings/WorldviewSettings.tsx
@@ -1,0 +1,164 @@
+import { useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { toast } from "sonner";
+import { Globe, FileText } from "lucide-react";
+
+const WORLDVIEW_MAX_TOKENS = 500;
+
+const DEFAULT_WORLDVIEW_TEMPLATE = `# User Worldview
+
+## Ontology
+(기본 세계관 — 직접 작성)
+
+## Engagement preference
+(agent 와의 협업 방식 선호 — 직접 작성)
+`;
+
+// guardrail::estimate_tokens 와 동일한 휴리스틱 (ascii/4 + cjk*2/3).
+function estimateTokens(text: string): number {
+  let ascii = 0;
+  let cjk = 0;
+  for (const ch of text) {
+    const code = ch.codePointAt(0) ?? 0;
+    const isCjk =
+      (code >= 0x4e00 && code <= 0x9fff) ||
+      (code >= 0x3040 && code <= 0x30ff) ||
+      (code >= 0xac00 && code <= 0xd7af);
+    if (isCjk) cjk += 1;
+    else ascii += 1;
+  }
+  return Math.floor(ascii / 4) + Math.floor((cjk * 2) / 3);
+}
+
+export function WorldviewSettings() {
+  const [content, setContent] = useState<string>("");
+  const [saved, setSaved] = useState<boolean>(true);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [enabled, setEnabled] = useState<boolean>(true);
+  const [appliedPath, setAppliedPath] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const [wv, path, en] = await Promise.all([
+          invoke<string | null>("get_worldview", { input: { projectPath: null } }),
+          invoke<string | null>("get_worldview_path", { input: { projectPath: null } }),
+          invoke<boolean>("get_worldview_enabled"),
+        ]);
+        setContent(wv ?? "");
+        setAppliedPath(path);
+        setEnabled(en);
+        setSaved(true);
+      } catch (err) {
+        console.error("[worldview] load failed", err);
+        toast.error("Worldview 로드 실패");
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  const tokens = estimateTokens(content);
+  const overLimit = tokens > WORLDVIEW_MAX_TOKENS;
+
+  const handleSave = async () => {
+    try {
+      await invoke("set_worldview", { input: { content, projectPath: null } });
+      setSaved(true);
+      const newPath = await invoke<string | null>("get_worldview_path", {
+        input: { projectPath: null },
+      });
+      setAppliedPath(newPath);
+      toast.success("Worldview 저장됨 — 다음 요청부터 적용");
+    } catch (err) {
+      console.error("[worldview] save failed", err);
+      toast.error(`저장 실패: ${err}`);
+    }
+  };
+
+  const handleLoadDefault = () => {
+    setContent(DEFAULT_WORLDVIEW_TEMPLATE);
+    setSaved(false);
+  };
+
+  const handleToggleEnabled = async (next: boolean) => {
+    try {
+      await invoke("set_worldview_enabled", { input: { enabled: next } });
+      setEnabled(next);
+      toast.success(next ? "Worldview 주입 활성화" : "Worldview 주입 비활성화");
+    } catch (err) {
+      console.error("[worldview] toggle failed", err);
+      toast.error(`토글 실패: ${err}`);
+    }
+  };
+
+  return (
+    <div className="space-y-5">
+      <div>
+        <h2 className="text-[14px] font-[550] text-foreground mb-1 flex items-center gap-2">
+          <Globe className="w-4 h-4" />
+          User Worldview
+        </h2>
+        <p className="text-[12px] text-muted-foreground leading-relaxed">
+          에이전트가 매 요청 시 ContextPack 의 identity 바로 앞에서 참조하는 사용자 stance 문서입니다.
+          최대 {WORLDVIEW_MAX_TOKENS} tokens.
+        </p>
+      </div>
+
+      {/* Toggle */}
+      <label className="flex items-center gap-2 text-[12px] text-foreground/80 cursor-pointer">
+        <input
+          type="checkbox"
+          checked={enabled}
+          onChange={(e) => handleToggleEnabled(e.target.checked)}
+          className="accent-primary"
+        />
+        Worldview 주입 활성화
+      </label>
+
+      {/* Editor */}
+      <div className="space-y-2">
+        <textarea
+          value={content}
+          disabled={loading}
+          onChange={(e) => {
+            setContent(e.target.value);
+            setSaved(false);
+          }}
+          placeholder="(비어있음 — 기본 문구 로드 또는 직접 작성)"
+          className="w-full h-72 font-mono text-[12px] bg-background border border-border/40 rounded-md px-3 py-2 text-foreground placeholder:text-muted-foreground/40 focus:outline-none focus:border-ring/50 resize-none"
+        />
+        <div className="flex items-center justify-between text-[11px]">
+          <span className={overLimit ? "text-red-500 font-medium" : "text-muted-foreground/70"}>
+            {tokens} / {WORLDVIEW_MAX_TOKENS} tokens
+            {overLimit ? " — 앞부분만 주입됨" : ""}
+          </span>
+          {appliedPath && (
+            <span className="text-muted-foreground/60 inline-flex items-center gap-1 truncate max-w-[60%]">
+              <FileText className="w-3 h-3 shrink-0" />
+              <span className="truncate" title={appliedPath}>{appliedPath}</span>
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Actions */}
+      <div className="flex items-center gap-2">
+        <button
+          onClick={handleSave}
+          disabled={saved || loading}
+          className="px-3 py-1.5 text-[12px] font-medium rounded-md bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        >
+          저장
+        </button>
+        <button
+          onClick={handleLoadDefault}
+          disabled={loading}
+          className="px-3 py-1.5 text-[12px] font-medium rounded-md text-foreground/70 hover:text-foreground hover:bg-accent transition-colors"
+        >
+          기본 문구 로드
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

userWorldviewInjectionPlan **subtask-01** 구현. 사용자 stance 문서를 ContextPack 의 identity 섹션 **바로 앞** (INV-1) 에 삽입.

### Backend (`commands/worldview.rs` 신규)
- `resolve_worldview_path`: project override `<project>/.tunaflow/user_worldview.md` 우선, fallback `~/.tunaflow/user_worldview.md`
- `load_worldview`: raw content (trim, empty→None)
- `load_for_injection`: enabled 플래그 + 500 token **char-safe truncation** (Codex round-3 Unicode panic 반영, `char_indices` 경계)
- Tauri commands: `get_worldview`, `get_worldview_path`, `set_worldview`, `get_worldview_enabled`, `set_worldview_enabled`
- `WORLDVIEW_ENABLED` AtomicBool (기본 ON)

### ContextPack (`prompt_assembly.rs`)
- project / platform / agent-role / previous-impl 다음, identity **바로 앞** 에 worldview push
- `conventions_synced` 와 무관 — worldview 는 CLAUDE.md/AGENTS.md sync 경로에 들어가지 않음
- `ctx_sections` 에 `"worldview"` 추가 — trace_log 관찰 가능

### Frontend
- `WorldviewSettings.tsx`: textarea + 기본 템플릿 로드 + 토글 + 토큰 카운터(500 초과 시 빨강 + "앞부분만 주입됨") + 현재 적용 경로 표시
- `SettingsPanel`: Worldview 섹션 nav 추가 (Globe 아이콘, Profile 다음)

### 검증
- `commands::worldview` **7 tests**: resolve override/none, load trimmed/empty, truncate noop/CJK, disabled flag
- `commands::agents_helpers::send_common::prompt_assembly` **2 tests**: INV-1 인접성 / 파일 없으면 section 부재
- Rust **403 → 412** tests, Frontend **293** tests, TypeScript `tsc --noEmit` 모두 통과

## 수동 E2E (사용자)
1. Settings > Worldview 열기 → "기본 문구 로드" → 본문 편집 → 저장
2. 새 대화 요청 → agent 응답 톤 / trace_log `ctx_sections` 에 `"worldview"` 확인
3. 비활성화 토글 → 다음 요청에서 worldview fragment 부재 확인
4. 토큰 500 초과 작성 → 저장 허용 + 주입 시 앞부분만 사용 (stderr 경고 1회)

## 범위 (Architect 정정)
- 적용: sdk-session (Branch chat) ContextPack 경로
- 미적용: RT (`-p` one-shot) — 매 turn full 재주입이 정상

## 다음
- subtask-02 (migration v46 + preference_events/snapshots + agent_jobs 확장)
- subtask-03 (stance-conflict rule+modal) — 02 의존
- subtask-04 (background insight job 스켈레톤) — 02 의존

## Test plan
- [x] Rust unit tests (412 통과)
- [x] Frontend tests (293 통과)
- [x] TypeScript `tsc --noEmit`
- [ ] 사용자 수동 E2E (위 4단계)

🤖 Generated with [Claude Code](https://claude.com/claude-code)