### PR TITLE
fix(workflow): streaming 중 marker/verdict 조기 감지 차단 (P1)

### DIFF
--- a/src/components/tunaflow/context-panel/DevProgressView.tsx
+++ b/src/components/tunaflow/context-panel/DevProgressView.tsx
@@ -542,7 +542,7 @@ export function DevProgressView({ plan, onPlanUpdate }: DevProgressViewProps) {
                     <option key={p.id} value={p.id}>{p.label} ({p.engine}{p.model ? `/${p.model.slice(0, 24)}` : ""})</option>
                   ))}
                 </select>
-                <button onClick={handleStartReview} disabled={busy || !selectedReviewerId}
+                <button onClick={handleStartReview} disabled={busy || !selectedReviewerId || branchRunning}
                   className={cn("flex items-center gap-1 px-2.5 py-1 rounded-md text-[10px] font-medium disabled:opacity-50 transition-colors",
                     reviewVerdict ? "bg-amber-500/10 text-amber-600 hover:bg-amber-500/20" : "bg-status-approved/10 text-status-approved hover:bg-status-approved/20",
                   )}>

--- a/src/lib/workflow/services/reviewVerdict.ts
+++ b/src/lib/workflow/services/reviewVerdict.ts
@@ -30,6 +30,9 @@ export function extractLatestReviewVerdict(
   let latest: ParsedReviewVerdict | null = null;
   for (const msg of messages) {
     if (msg.role !== "assistant") continue;
+    // Streaming 중인 reviewer 의 자유 서술에 "verdict: ..." 가 우연히 포함될 수 있어
+    // `status === "done"` 이 된 최종 메시지만 verdict 추출 대상으로 한다.
+    if (msg.status !== "done") continue;
     if (sinceTs !== undefined && msg.timestamp < sinceTs) continue;
     if (hasReviewVerdict(msg.content)) {
       const v = extractReviewVerdict(msg.content);
@@ -70,7 +73,9 @@ export function collectAndAggregateVerdicts(
   messages: Message[],
   sinceTs?: number,
 ): EffectiveVerdict | null {
-  const all = scanAllReviewerVerdicts(messages, sinceTs);
+  // Streaming-중 메시지는 verdict 대상에서 제외 (자유 서술 오매칭 방지).
+  const doneMessages = messages.filter((m) => m.status === "done");
+  const all = scanAllReviewerVerdicts(doneMessages, sinceTs);
   if (all.length >= 2) {
     const agg = aggregateReviewVerdicts(all);
     if (!agg) return null;

--- a/src/lib/workflow/services/subtaskCompletion.ts
+++ b/src/lib/workflow/services/subtaskCompletion.ts
@@ -42,10 +42,13 @@ export function detectCompletedSubtasks(
   messages: Message[],
   subtasks: readonly PlanSubtask[],
 ): SubtaskCompletionState {
-  const markerNums = scanCompletedSubtasks(messages);
-  const hasImplCompleteMarker = messages.some(
-    (m) => m.role === "assistant" && hasImplComplete(m.content),
+  // Streaming-중인 assistant 메시지의 중간 content 에 마커가 섞여 있어도 감지하지 않는다.
+  // `m.status === "done"` 이 된 뒤에야 완료 신호로 취급 (워크플로 버튼 조기 활성화 방지).
+  const doneAssistant = messages.filter(
+    (m) => m.role === "assistant" && m.status === "done",
   );
+  const markerNums = scanCompletedSubtasks(doneAssistant);
+  const hasImplCompleteMarker = doneAssistant.some((m) => hasImplComplete(m.content));
   const dbDoneNums = new Set(
     subtasks.filter((s) => s.status === "done").map((s) => s.idx + 1),
   );

--- a/src/tests/workflowServices.test.ts
+++ b/src/tests/workflowServices.test.ts
@@ -28,6 +28,16 @@ const msg = (role: Message["role"], content: string, timestamp = 0): Message => 
   status: "done",
 });
 
+/** Streaming 상태의 assistant 메시지 — verdict/마커 포함해도 감지 대상 아님. */
+const streamingMsg = (content: string, timestamp = 0): Message => ({
+  id: `m-${timestamp}-streaming`,
+  conversationId: "branch:b1",
+  role: "assistant",
+  content,
+  timestamp,
+  status: "streaming",
+});
+
 const planEvent = (eventType: string, createdAt = 0, detail?: string): PlanEvent => ({
   id: `e-${createdAt}-${eventType}`,
   planId: "p1",
@@ -80,6 +90,20 @@ describe("detectCompletedSubtasks", () => {
     expect(state.markerNums.size).toBe(0);
     expect(state.hasImplCompleteMarker).toBe(false);
   });
+
+  it("streaming assistant with marker is ignored until status=done", () => {
+    // Dev 가 응답 streaming 중인 동안 content 에 마커가 이미 포함될 수 있지만,
+    // 완료 신호로 취급하면 "Review 시작" 버튼이 조기 활성화되는 버그를 유발한다.
+    const messages = [
+      streamingMsg("<!-- tunaflow:subtask-done:1 -->"),
+      streamingMsg("done <!-- tunaflow:impl-complete -->"),
+    ];
+    const subtasks = [subtask(0)];
+    const state = detectCompletedSubtasks(messages, subtasks);
+    expect(state.markerNums.size).toBe(0);
+    expect(state.hasImplCompleteMarker).toBe(false);
+    expect(state.allComplete).toBe(false);
+  });
 });
 
 describe("extractLatestReviewVerdict", () => {
@@ -110,6 +134,23 @@ describe("extractLatestReviewVerdict", () => {
     );
     expect(preSince).toBeNull();
   });
+
+  it("streaming reviewer with verdict keyword is ignored", () => {
+    // Reviewer 가 자유 서술 중 "verdict: pass 가능성" 같은 표현을 쓸 수 있어
+    // streaming 상태에서는 verdict 추출 대상에서 제외되어야 한다.
+    const freeform = "아직 검토 중이고 verdict: pass 일 가능성이 높지만 확정은 아닙니다.";
+    expect(extractLatestReviewVerdict([streamingMsg(freeform, 1)])).toBeNull();
+  });
+
+  it("streaming verdict is ignored even when a prior done verdict exists", () => {
+    // 같은 라운드에서 이전 reviewer 의 done verdict 뒤에 후속 reviewer 가 streaming 중이라면,
+    // 최신 "latest" 는 done 인 앞 verdict 여야 한다 (streaming 중간값으로 덮어쓰지 않음).
+    const out = extractLatestReviewVerdict([
+      msg("assistant", v1, 1),
+      streamingMsg(v2, 2),
+    ]);
+    expect(out?.verdict).toBe("fail");
+  });
 });
 
 describe("collectAndAggregateVerdicts", () => {
@@ -124,6 +165,22 @@ describe("collectAndAggregateVerdicts", () => {
 
   it("no verdict markers return null", () => {
     expect(collectAndAggregateVerdicts([msg("assistant", "nope")])).toBeNull();
+  });
+
+  it("streaming messages are excluded from aggregation", () => {
+    // 2 명 streaming + 1 명 done verdict → reviewerCount 1 (fallback 단일 경로)
+    const done =
+      "<!-- tunaflow:review-verdict -->\nverdict: fail\nfindings: []\n<!-- /tunaflow:review-verdict -->";
+    const streamingVerdict =
+      "<!-- tunaflow:review-verdict -->\nverdict: pass\nfindings: []\n<!-- /tunaflow:review-verdict -->";
+    const out = collectAndAggregateVerdicts([
+      streamingMsg(streamingVerdict, 1),
+      msg("assistant", done, 2),
+      streamingMsg(streamingVerdict, 3),
+    ]);
+    expect(out?.reviewerCount).toBe(1);
+    expect(out?.verdict).toBe("fail");
+    expect(out?.votes).toBeUndefined(); // 집계 아닌 단일 fallback
   });
 });
 


### PR DESCRIPTION
## Summary

Architect 진단 P1 hot fix. Dev/Reviewer 가 streaming 중인 메시지의 **중간 content 만 보고** 버튼이 조기 활성화되는 2건 버그 수정.

### 증상
1. Dev streaming 중 "Review 시작" 버튼 활성화
2. Reviewer verdict 확정 전 자유 서술 중 "re-work" / "done" 버튼 활성화

### 근본 원인
marker/verdict 감지 함수가 \`message.status\` 를 보지 않고 \`content\` 만 검사. fallback regex \`verdict:\s*(pass|fail|conditional)\` 가 streaming 중 Reviewer 자유 서술 ("verdict: pass 일 가능성이...") 에도 매칭.

### 수정 (4 파일, +70/-5)
- **\`subtaskCompletion.ts\`** — \`detectCompletedSubtasks\` 가 assistant 메시지를 \`status === "done"\` 으로 사전 필터 후 스캔
- **\`reviewVerdict.ts\`** — \`extractLatestReviewVerdict\` 에서 streaming 메시지 skip, \`collectAndAggregateVerdicts\` 에서 scanAllReviewerVerdicts 호출 전 done-only 필터
- **\`DevProgressView.tsx:545\`** — "Review 시작" disabled 에 \`branchRunning\` 추가 (이중 안전장치)

### 테스트 (+4)
- streaming assistant 마커 무시 (subtask-done / impl-complete 둘 다)
- streaming reviewer 자유 서술 "verdict: pass 가능성" → null
- streaming + done 혼재 시 done verdict 만 latest
- streaming 혼재 aggregation 도 done-only 로 reviewerCount 계산

Frontend **293 → 297** tests, TypeScript \`tsc --noEmit\` 통과.

## 검증 (수동)
- Dev 1 턴 진행 중 Review 버튼 disabled 확인
- Reviewer 1 턴 진행 중 re-work / done 버튼 미노출 (verdict 추출 안 되므로)

## 범위
독립 PR (userWorldview / i18n / search-part2 과 무관). P1 사용자 방해 이슈라 즉시 머지 권장.

## Test plan
- [x] Frontend unit tests (297 통과)
- [x] TypeScript \`tsc --noEmit\`
- [ ] 사용자 수동 재현 (Dev 턴 / Reviewer 턴 각 1회)

🤖 Generated with [Claude Code](https://claude.com/claude-code)