### PR TITLE
docs: Token Policy 명문화 (README 5번째 설계 특징 + reference)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -45,6 +45,9 @@ Plan 은 Architect(Claude Opus) 가 작성하고, 독립된 Reviewer(Codex, blin
 ### CLI-first — 구독 요금제 내에서 최대치
 기본 경로는 Claude Code / Codex / Gemini **CLI**. SDK(API 과금) 는 fallback 으로만 씁니다. 이미 구독 중인 사용자가 추가 토큰 비용 없이 모든 기능을 쓸 수 있도록 설계됐습니다.
 
+### 품질 우선 — tunaFlow 는 토큰 절약 도구가 아님
+결과물 품질이 최우선입니다. identity 문서 / worldview / 분석 요약 같은 맥락 자료는 agent 응답 품질에 기여하면 **AGENTS.md 수준 (1,500~3,000 tokens)** 으로 풍부하게 허용합니다. 대신 회피하는 낭비 축은 **중복** — 이미 claude 세션 버퍼에 있는 컨텍스트를 tunaFlow 가 또 주입하거나, stale 한 압축본이 현재 요청에 섞이거나, 같은 정보가 여러 섹션에 복사되는 것. 여기서 "lean" 은 "극단 압축" 이 아니라 **"중복 없음"** 입니다.
+
 ---
 
 ## 주요 기능

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ Experiment with the same topic by branching it to multiple agents (**Branch**). 
 ### CLI-first — Maximizing existing subscriptions
 The primary execution paths are via Claude Code, Codex, and Gemini **CLI**. The SDK (API billing) is used only as a fallback. This is designed so users with existing subscriptions can utilize all features without additional token costs.
 
+### Quality over token thrift — tunaFlow is not a token-saving app
+Output quality comes first. Identity documents, worldview files, and analysis summaries are allowed to be rich (AGENTS.md-level, 1,500–3,000 tokens) when that richness improves agent output. The wasteful axis we do avoid is **redundancy** — re-injecting context already held in the claude session buffer, stale compression leaking into current requests, or the same information doubled across sections. Here, "lean" means "no redundancy", not "compressed to the minimum".
+
 ---
 
 ## Key Features

--- a/docs/reference/tokenPolicyReference.md
+++ b/docs/reference/tokenPolicyReference.md
@@ -1,0 +1,36 @@
+---
+title: Token Policy
+updated_at: 2026-04-23
+canonical: true
+status: active
+owner: tunaFlow-core
+---
+
+# Token Policy
+
+tunaFlow 는 토큰 절감 도구가 아닙니다. 목표는 품질 좋은 결과물이며, 토큰은 이를 뒷받침하는 자원입니다. 단 **중복 / stale / doubling** 은 품질 저하 요인이므로 회피 대상입니다.
+
+## 허용 (품질 우선 — 길이 제약 걸지 않음)
+
+- `user_worldview.md`, `AGENTS.md`, `persona` 등 context 문서: **1,500~3,000 tokens** 허용
+- identity_summary / 프로젝트 정체성 분석 산출물: 동일 수준
+- recent_context 주입은 필요한 본문 길이를 자르지 않음
+- Deep Review / 분석 LLM 출력은 구체성 우선, 짧게 강제하지 않음
+
+## 회피 (품질 저하 = 토큰 낭비)
+
+1. **중복 재주입** — 이미 claude 세션 buffer 에 있는 내용을 tunaFlow 가 ContextPack 으로 또 주입. Session Continuity Fix Plan INV-1 참조.
+2. **Stale context** — 1년 전 대화 요약이 현재 요청에 그대로 붙음. compression + decay 원칙 유지.
+3. **Doubling** — 같은 정보가 worldview + preference + persona 여러 곳에 복사되는 경우.
+4. **불필요한 tool 호출 반복** — rawq 검색 결과가 이미 context 에 충분한데 agent 가 같은 쿼리를 되풀이.
+
+## 실전 기준
+
+- 새 기능 설계 시 "이거 길어도 되나?" 고민할 때: **품질에 기여하면 OK**. 중복인지만 점검.
+- "토큰 아끼려고 자르자" 는 기각. "정보를 중복 없이 정제하자" 는 허용.
+
+## 관련 문서
+
+- `docs/plans/sessionContinuityFixPlan.md` — 중복 재주입 방지 INV
+- `docs/plans/longTermMemoryRoadmapPlan_2026-03-30.md` — compressed memory decay
+- `docs/reference/coding-convention.md` — 전체 코드 관례


### PR DESCRIPTION
## Summary
- tunaFlow 의 토큰 철학을 외부 랜딩 (README.md / README.ko.md) + 내부 규약 (docs/reference/tokenPolicyReference.md) 양쪽에 명문화
- 허용 기준 (품질 우선, AGENTS.md 수준 1.5~3K tokens 허용) / 회피 기준 (중복 / stale / doubling) 구분

## Test plan
- [ ] README.md 영문 본 GitHub 프리뷰 — "Design Features" 섹션 5번째 포인트 렌더 확인
- [ ] README.ko.md "설계 특징" 섹션 5번째 포인트 렌더 확인
- [ ] docs/reference/tokenPolicyReference.md 링크 참조 (sessionContinuityFixPlan / longTermMemoryRoadmapPlan / coding-convention) 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)