### PR TITLE
docs(plans): Karma/Identity 파이프라인 분리 — projectIdentityAnalysisPlan

### DIFF
--- a/docs/plans/index.md
+++ b/docs/plans/index.md
@@ -28,6 +28,7 @@
 | [metaAgentInitialSetupPlan_2026-04-16](./metaAgentInitialSetupPlan_2026-04-16.md) | — |
 | [metaAgentOnboardingPlan_2026-04-16](./metaAgentOnboardingPlan_2026-04-16.md) | — |
 | [metaAgentPlan](./metaAgentPlan.md) | **P0** — 메타에이전트. 온보딩, 이슈 감지, 우선순위 제안. 모든 프로젝트 대상 |
+| [projectIdentityAnalysisPlan](./projectIdentityAnalysisPlan.md) | **P1** — Artifacts 기반 "Karma" 파이프라인: 6 타입 자동 생성 + plan 3개/volume 10 trigger + identity_summary 분석 + ContextPack 주입 + Insight 정체성 뷰 (metaAgent 의존) |
 | [perProjectDatabaseSplitPlan](./perProjectDatabaseSplitPlan.md) | — |
 | [postParityRuntimeValidationSweepPlan_2026-03-30](./postParityRuntimeValidationSweepPlan_2026-03-30.md) | P1 — parity fix 효과 재검증 |
 | [realWorkflowMemoryQualityValidationPlan_2026-03-30](./realWorkflowMemoryQualityValidationPlan_2026-03-30.md) | P1 — memory/retrieval 응답 품질 검증 |
@@ -44,7 +45,7 @@
 | [structuralImprovementPlan](./structuralImprovementPlan.md) | — |
 | [systemMessageChannelPlan](./systemMessageChannelPlan.md) | — |
 | [toolCallHandlerPlan](./toolCallHandlerPlan.md) | P1 — function calling으로 마커 대체 |
-| [userWorldviewInjectionPlan](./userWorldviewInjectionPlan.md) | **P1** — Identity/Interface/Continuity 3축 번들: worldview 주입 + preference_timeline (event+snapshot) + stance-conflict (rule-first) + low-priority visible background job |
+| [userWorldviewInjectionPlan](./userWorldviewInjectionPlan.md) | P1 (**partial**) — Identity 축 (worldview 주입) 만 유지, subtask-01 머지 완료 (PR #144). Interface/Continuity 축은 2026-04-23 `projectIdentityAnalysisPlan` 으로 이관. 자세한 사유는 본 plan 의 superseded_subtasks 섹션 |
 | [traceOverhaulPlan_2026-04-16](./traceOverhaulPlan_2026-04-16.md) | — |
 
 ## 🟡 부분 완료 — 추가 구현 필요

--- a/docs/plans/projectIdentityAnalysisPlan-task-01.md
+++ b/docs/plans/projectIdentityAnalysisPlan-task-01.md
@@ -1,0 +1,209 @@
+# Subtask 01 — Artifact 자동 생성 지점 보강 (6 타입)
+
+> 상위 plan: [projectIdentityAnalysisPlan.md](./projectIdentityAnalysisPlan.md)
+
+## Changed files
+
+- `src-tauri/src/commands/agents_helpers/send_common/persistence.rs` — `finalize_engine_run` 류에 `decision` / `finding_success` / `finding_failure` 자동 생성 경로.
+- `src-tauri/src/commands/roundtable_helpers/persist.rs` — Review verdict 확정 시 `review_outcome` 자동 생성.
+- `src-tauri/src/commands/plans.rs` (또는 plan lifecycle 담당 모듈) — Plan 승인 / Rework 진입 / Plan 완료 지점에 각각 `decision` / `rework_reason` / `workflow_milestone` 자동 생성.
+- `src-tauri/src/commands/artifacts.rs` — `create_identity_input_artifact(ArtifactKind::*)` 헬퍼 + 자동 생성용 validator.
+- `src-tauri/src/db/models.rs` — `ArtifactKind` enum (상수 6개 + `IdentitySummary` 7번째).
+
+## Change description
+
+### 1. `ArtifactKind` enum 신설
+
+```rust
+// src-tauri/src/db/models.rs
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
+pub enum ArtifactKind {
+    Decision,
+    ReviewOutcome,
+    ReworkReason,
+    FindingSuccess,
+    FindingFailure,
+    WorkflowMilestone,
+    IdentitySummary,   // 분석 output. subtask-03 에서 사용.
+}
+
+impl ArtifactKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Decision => "decision",
+            Self::ReviewOutcome => "review_outcome",
+            Self::ReworkReason => "rework_reason",
+            Self::FindingSuccess => "finding_success",
+            Self::FindingFailure => "finding_failure",
+            Self::WorkflowMilestone => "workflow_milestone",
+            Self::IdentitySummary => "identity_summary",
+        }
+    }
+    pub fn is_identity_input(&self) -> bool {
+        !matches!(self, Self::IdentitySummary)
+    }
+}
+```
+
+### 2. `create_identity_input_artifact` 헬퍼
+
+```rust
+// src-tauri/src/commands/artifacts.rs
+pub fn create_identity_input_artifact(
+    conn: &Connection,
+    kind: ArtifactKind,
+    conversation_id: Option<&str>,
+    plan_id: Option<&str>,
+    subtask_id: Option<&str>,
+    title: &str,
+    content_json: serde_json::Value,
+) -> Result<String, AppError> {
+    // INV-1 enforcement: IdentitySummary 는 이 헬퍼로 만들 수 없음 (subtask-03 의 별도 경로)
+    if !kind.is_identity_input() {
+        return Err(AppError::BadRequest(
+            "create_identity_input_artifact rejects IdentitySummary kind".into()
+        ));
+    }
+    let id = format!("art-{}", Uuid::new_v4());
+    let now = now_epoch_ms();
+    conn.execute(
+        "INSERT INTO artifacts (id, conversation_id, branch_id, subtask_id, plan_id, type, title, content, status, created_at, updated_at)
+         VALUES (?1,?2,NULL,?3,?4,?5,?6,?7,'draft',?8,?8)",
+        params![
+            id, conversation_id, subtask_id, plan_id,
+            kind.as_str(), title,
+            content_json.to_string(),
+            now,
+        ],
+    )?;
+    Ok(id)
+}
+```
+
+### 3. 자동 생성 경로 6개
+
+각각 "워크플로우 이벤트 발생 시점" 에 1회 호출. 대화 내용 파싱으로 감정 추론 금지 (INV-1).
+
+#### 3.1 `decision` — Plan 승인 / 경로 선택
+
+위치: `plans.rs::approve_plan` (또는 plan.phase='approved' 전이)
+
+```rust
+let content = serde_json::json!({
+    "what": "plan_approved",
+    "plan_slug": plan.slug,
+    "previous_phase": "subtask_review",
+    "approved_by": "user",
+});
+create_identity_input_artifact(
+    &conn, ArtifactKind::Decision,
+    Some(&plan.conversation_id), Some(&plan.id), None,
+    &format!("Plan '{}' approved", plan.title),
+    content,
+)?;
+```
+
+추가 시점:
+- 엔진 전환 (`set_conversation_engine` 호출 시 `previous != current` 면)
+- 사용자가 designReviewGate 에서 "force_approve" 선택 시 (blocker 잔존 plan 승인)
+
+#### 3.2 `review_outcome` — Review verdict 확정
+
+위치: `roundtable_helpers/persist.rs` 또는 Review verdict parse 완료 지점
+
+```rust
+let content = serde_json::json!({
+    "verdict": verdict.verdict,                     // "pass" | "fail" | "escalate_to_human"
+    "rubric": verdict.rubric,                       // {plan_coverage, code_quality, test_coverage, convention}
+    "findings_count": verdict.findings.len(),
+    "failed_subtask_ids": verdict.failed_subtask_ids,
+    "reviewer_engine": reviewer_profile.engine,
+    "round": round_number,
+});
+```
+
+#### 3.3 `rework_reason` — Rework 진입
+
+위치: `plans.rs::handle_rework` (phase → `rework`)
+
+```rust
+let content = serde_json::json!({
+    "cycle": plan.rework_cycle,
+    "findings": prev_verdict.findings,
+    "root_cause_hint": prev_verdict.recommendations.join("; "),
+});
+```
+
+#### 3.4 `finding_success` — Dev 가 subtask 를 scope 내 완료
+
+위치: `subtaskCompletion.ts` / `syncSubtaskCompletion` (Rust) 의 DB status='done' 전이 지점
+
+```rust
+let content = serde_json::json!({
+    "subtask_id": subtask.id,
+    "duration_ms": calculated_duration,
+    "agent_engine": impl_branch.engine,
+    "notes": null,
+});
+```
+
+**생성 조건**: subtask status 'in_progress' → 'done' 전이 **AND** 해당 subtask 에 대한 직전 review 가 pass. 단순 DB status 만 보면 noise 증가.
+
+#### 3.5 `finding_failure` — Dev 응답이 scope 벗어남 / blocker
+
+위치: Review verdict=fail + failed_subtask_ids 있는 경우 각 subtask 에 대해 1건
+
+```rust
+let content = serde_json::json!({
+    "subtask_id": subtask.id,
+    "failure_kind": "scope_violation" | "blocker" | "test_failure" | "convention",
+    "agent_engine": impl_branch.engine,
+    "evidence_msg_id": verdict_message_id,
+});
+```
+
+**생성 조건**: review_outcome verdict=fail, 해당 subtask 가 `failed_subtask_ids` 에 포함.
+
+#### 3.6 `workflow_milestone` — Plan 완료 / 머지
+
+위치: `plans.rs::complete_plan` + PR 머지 훅 (있다면)
+
+```rust
+let content = serde_json::json!({
+    "milestone_kind": "plan_done" | "pr_merged" | "release_tagged",
+    "plan_id": plan.id,
+    "summary": <1-line plan summary>,
+});
+```
+
+### 4. Dedup / noise guard
+
+- 같은 (conversation_id, type, hash(content)) 가 1 분 이내 중복 생성 시 skip (fat-finger 보호)
+- `status='draft'` 로 저장 후 subtask-03 의 분석기가 `status='analyzed'` 로 mark
+
+## Dependencies
+
+depends_on: 없음 (artifacts 테이블은 이미 존재, 새 migration 불필요).
+
+## Verification
+
+- `cargo test --lib commands::artifacts::create_identity_input_artifact`:
+  - 6 종 타입 각각 성공 생성
+  - IdentitySummary 타입은 Err 반환 (INV-1)
+- 각 자동 생성 경로 integration test:
+  - `approve_plan` 호출 시 `decision` artifact 1건 추가
+  - Review verdict 파싱 시 `review_outcome` 1건 추가
+  - fail + failed_subtask_ids=[1,2] 시 `finding_failure` 2건 추가
+  - Rework 진입 시 `rework_reason` 1건 + 이전 `review_outcome` 는 유지
+  - Plan 완료 시 `workflow_milestone` 1건
+- Negative test:
+  - 임의 user message 에 "결정" 같은 한국어 포함 → 자동 artifact 생성 되지 **않음** (INV-1 surveillance 금지)
+- `cargo check` — exit 0.
+
+## Risks
+
+- **Dedup 범위**: 1 분 내 same-content 중복 차단은 conservative. 실제로 legitimate 한 중복 (재진입 등) 을 block 할 수 있음. 실측 후 조정.
+- **finding_success 판정 기준**: "review pass AND subtask done" 조합이 실제로 어떤 시점에 정확히 판정되는지 — review round 가 전체 plan 에 한 번만 돌 수도, subtask 별로 돌 수도. 현재 tunaFlow 는 plan 단위 review 가 기본 — 따라서 "해당 subtask 가 그 review 의 failed_ids 에 없으면 success" 로 정의. 명시.
+- **Enum 도입 side-effect**: `ArtifactKind` enum 이 기존 `String type` 필드와 공존. 기존 코드가 자유 문자열을 쓰고 있으면 enum parse 실패 지점 발생 가능. Parse 실패 시 "unknown" 으로 fallback + 경고 로그, enum 확장 고려.
+- **artifacts 테이블 row 증가율**: plan 당 평균 4~8 개 artifact 자동 생성 예상 → 월 수십~수백 row. archive 없이는 몇 년 후 수만 row. 당장 문제 아니지만 `longTermMemoryRoadmapPlan` 의 decay 정책과 연동 후속 고려.
+- **역사적 artifact 누적 없음**: 본 subtask 머지 시점 이후부터 artifact 가 쌓이므로 **최초 `identity_summary` 는 data 빈곤 가능성** (subtask-02 의 threshold guard 가 이걸 방어 — 10개 미만이면 분석 skip).

--- a/docs/plans/projectIdentityAnalysisPlan-task-02.md
+++ b/docs/plans/projectIdentityAnalysisPlan-task-02.md
@@ -1,0 +1,245 @@
+# Subtask 02 — metaAgent trigger (2 조건 AND) + analysis job
+
+> 상위 plan: [projectIdentityAnalysisPlan.md](./projectIdentityAnalysisPlan.md)
+>
+> **선행 의존**: `docs/plans/metaAgentPlan.md` (P0) 의 metaAgent 기본 구조. metaAgent 가 아직 구현 전이면 본 subtask 는 metaAgent 의 첫 실사용 예제로도 기능.
+
+## Changed files
+
+- `src-tauri/src/commands/meta_agent.rs` (신규 또는 확장) — trigger 감시 + analysis job enqueue.
+- `src-tauri/src/commands/meta_agent/identity_trigger.rs` (신규) — `should_trigger_identity_analysis` 함수 + 관련 쿼리.
+- `src-tauri/src/commands/agent_jobs.rs` (또는 jobs.rs) — `kind='identity_analysis'` 지원.
+- `src-tauri/src/commands/plans.rs` — `complete_plan` 말미에서 metaAgent trigger 체크 훅 추가.
+- `src/components/tunaflow/settings/IdentityAnalysisSettings.tsx` (신규) — threshold 튜닝 UI.
+- `src-tauri/src/db/migrations.rs` — 변경 **없음** (artifacts 재사용, 새 테이블 X).
+
+## Change description
+
+### 1. Trigger 함수
+
+```rust
+// src-tauri/src/commands/meta_agent/identity_trigger.rs
+
+pub struct IdentityTriggerDecision {
+    pub should_run: bool,
+    pub done_plan_count: i64,
+    pub eligible_artifact_count: i64,
+    pub threshold: i64,           // current Settings value
+    pub reason: &'static str,     // debug trail: "count_mod3" / "volume_min" / "ok"
+}
+
+pub fn evaluate_identity_trigger(
+    conn: &Connection,
+    project_key: &str,
+) -> Result<IdentityTriggerDecision, AppError> {
+    // 조건 A: plan done count % 3 == 0
+    let done_count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM plans WHERE status='done' AND project_key=?1",
+        [project_key], |r| r.get(0),
+    )?;
+    if done_count == 0 || done_count % 3 != 0 {
+        return Ok(IdentityTriggerDecision {
+            should_run: false, done_plan_count: done_count,
+            eligible_artifact_count: 0, threshold: load_threshold(conn)?,
+            reason: "count_mod3",
+        });
+    }
+
+    // 이전 identity_summary 시점
+    let last_summary_at: i64 = conn.query_row(
+        "SELECT COALESCE(MAX(created_at), 0) FROM artifacts
+          WHERE type='identity_summary'
+            AND conversation_id IN (SELECT id FROM conversations WHERE project_key=?1)",
+        [project_key], |r| r.get(0),
+    )?;
+
+    // 조건 B: eligible artifact volume
+    let eligible_count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM artifacts
+          WHERE type IN ('decision','review_outcome','rework_reason',
+                         'finding_success','finding_failure','workflow_milestone')
+            AND created_at > ?1
+            AND conversation_id IN (SELECT id FROM conversations WHERE project_key=?2)",
+        params![last_summary_at, project_key], |r| r.get(0),
+    )?;
+    let threshold = load_threshold(conn)?;
+    if eligible_count < threshold {
+        return Ok(IdentityTriggerDecision {
+            should_run: false, done_plan_count: done_count,
+            eligible_artifact_count: eligible_count, threshold,
+            reason: "volume_min",
+        });
+    }
+
+    Ok(IdentityTriggerDecision {
+        should_run: true, done_plan_count: done_count,
+        eligible_artifact_count: eligible_count, threshold,
+        reason: "ok",
+    })
+}
+
+fn load_threshold(conn: &Connection) -> Result<i64, AppError> {
+    // 우선 env var override (dev/test 용)
+    if let Ok(v) = std::env::var("TUNAFLOW_IDENTITY_ANALYSIS_THRESHOLD") {
+        if let Ok(n) = v.parse::<i64>() { return Ok(n); }
+    }
+    // DB 설정 (Settings UI 에서 관리)
+    conn.query_row(
+        "SELECT value FROM app_settings WHERE key='identity_analysis.min_artifacts'",
+        [], |r| r.get::<_, String>(0),
+    ).ok()
+     .and_then(|s| s.parse::<i64>().ok())
+     .map(Ok)
+     .unwrap_or(Ok(10))   // default = 10
+}
+```
+
+**`app_settings` 테이블 선행 필요**: 현재 tunaFlow 에 app_settings 테이블이 없으면 별도 plan 또는 본 subtask 에 migration 추가. 일단 본 subtask 는 env var 또는 상수 default=10 으로 진행 가능. Settings UI 는 localStorage + FE 에서 rust 측 set command 호출 패턴도 허용.
+
+### 2. Trigger 훅 연결
+
+`complete_plan` 말미 (plan.status='done' 전이 성공 후):
+
+```rust
+// src-tauri/src/commands/plans.rs
+pub fn complete_plan(...) -> Result<(), AppError> {
+    // ... 기존 transition 로직 ...
+
+    // Fire-and-forget trigger check. 실패해도 plan 완료에는 영향 없음.
+    let project_key = plan.project_key.clone();
+    let app_handle = app.clone();
+    tokio::task::spawn_blocking(move || {
+        let conn = state.read.lock().ok()?;
+        let decision = evaluate_identity_trigger(&conn, &project_key).ok()?;
+        if decision.should_run {
+            enqueue_identity_analysis_job(&app_handle, &project_key, decision);
+        }
+        Some(())
+    });
+
+    Ok(())
+}
+```
+
+### 3. Analysis job enqueue
+
+`agent_jobs` 재사용. kind 확장:
+
+```rust
+pub fn enqueue_identity_analysis_job(
+    app: &AppHandle,
+    project_key: &str,
+    decision: IdentityTriggerDecision,
+) {
+    let job_id = format!("id-analysis-{}-{}", project_key, now_epoch_ms());
+
+    // agent_jobs INSERT (기존 스키마 재사용, priority=-1 background)
+    // metadata: project_key + since_ts + until_ts (decision.done_plan_count 기준)
+    // subtask-03 의 분석 에이전트가 이 job 을 pick up
+
+    app.emit("identity_analysis_triggered", serde_json::json!({
+        "jobId": job_id, "projectKey": project_key,
+        "donePlanCount": decision.done_plan_count,
+        "eligibleArtifacts": decision.eligible_artifact_count,
+    })).ok();
+}
+```
+
+### 4. 수동 트리거 command
+
+Settings UI 에서 "지금 분석" 버튼이 호출:
+
+```rust
+#[tauri::command]
+pub async fn trigger_identity_analysis_now(
+    project_key: String,
+    force: bool,                // true 면 threshold 무시
+    state: State<'_, DbState>,
+    app: AppHandle,
+) -> Result<IdentityTriggerDecision, AppError> {
+    let conn = state.read.lock().map_err(|_| AppError::Lock)?;
+    let mut decision = evaluate_identity_trigger(&conn, &project_key)?;
+    if force { decision.should_run = true; decision.reason = "forced"; }
+    if decision.should_run {
+        drop(conn);
+        enqueue_identity_analysis_job(&app, &project_key, decision.clone());
+    }
+    Ok(decision)
+}
+```
+
+Settings UI 에서 decision 반환값 렌더 — threshold 미달 시 `done_plan_count`, `eligible_artifact_count`, `threshold` 숫자 표시해 사용자가 "왜 안 돌지?" 이해.
+
+### 5. Settings UI (IdentityAnalysisSettings.tsx)
+
+```tsx
+export function IdentityAnalysisSettings() {
+    const [threshold, setThreshold] = useState(10);
+    const [latest, setLatest] = useState<IdentityTriggerDecision | null>(null);
+    const projectKey = useChatStore((s) => s.selectedProjectKey);
+
+    useEffect(() => { loadThreshold().then(setThreshold); }, []);
+
+    const runNow = async (force: boolean) => {
+        const decision = await invoke<IdentityTriggerDecision>(
+            'trigger_identity_analysis_now', { projectKey, force }
+        );
+        setLatest(decision);
+    };
+
+    return (
+        <section>
+            <h3>Identity Analysis</h3>
+            <div className="setting-row">
+                <label>최소 artifact 수 (threshold)</label>
+                <input type="number" value={threshold} min={3} max={50}
+                    onChange={(e) => {
+                        const v = Number(e.target.value);
+                        setThreshold(v);
+                        saveThreshold(v);
+                    }} />
+                <p className="hint">
+                    이전 분석 이후 누적된 eligible artifact 수가 이 값 이상이고
+                    Plan done count 가 3의 배수일 때 분석이 실행됩니다. 기본 10.
+                </p>
+            </div>
+            <div className="setting-row">
+                <button onClick={() => runNow(false)}>지금 확인</button>
+                <button onClick={() => runNow(true)} variant="ghost">강제 실행 (threshold 무시)</button>
+            </div>
+            {latest && (
+                <div className="trigger-status">
+                    <div>Plans done: {latest.done_plan_count} ({latest.done_plan_count % 3 === 0 ? "OK" : `need ${3 - latest.done_plan_count % 3} more`})</div>
+                    <div>Eligible artifacts: {latest.eligible_artifact_count} / {latest.threshold}</div>
+                    <div>Status: {latest.should_run ? "analysis enqueued" : `skipped (${latest.reason})`}</div>
+                </div>
+            )}
+        </section>
+    );
+}
+```
+
+## Dependencies
+
+depends_on: [01] — 자동 생성되는 artifact 가 있어야 trigger 조건 B 가 의미 있음.
+
+## Verification
+
+- `cargo test --lib commands::meta_agent::identity_trigger`:
+  - `count_mod3` fail: done_count=1 → should_run=false
+  - `count_mod3` fail: done_count=2 → should_run=false
+  - `count_mod3` OK but `volume_min` fail: done_count=3, eligible=5 → should_run=false
+  - All OK: done_count=3, eligible=10 → should_run=true
+  - `volume_min` threshold 설정 변경 반영: env var / DB 값
+- Integration: `complete_plan` 호출 후 trigger 훅 발화 mock 으로 캡쳐
+- Force mode: `trigger_identity_analysis_now(force=true)` 에서 threshold 조건 bypass 확인
+- `cargo test --lib commands::agent_jobs` — 새 kind='identity_analysis' enqueue 성공
+- `npx vitest run src/components/tunaflow/settings/IdentityAnalysisSettings.test.tsx`
+
+## Risks
+
+- **threshold 초기값 적정성**: 10 이 적절한지 실측 불가. 초기 3~6개월 후 평균 분석 횟수 / 분석 결과 품질 rating 수집해 조정 (Open question Q-1).
+- **app_settings 테이블 부재**: 현재 없을 수 있음. 우선 env var + 상수 default. 후속 plan 에서 kv 테이블 도입 시 이식.
+- **Spawn blocking in complete_plan**: plan 완료 경로에서 async 훅을 spawn. panic 하면 plan 완료 로그에는 영향 없으나 silent fail. `eprintln!` / trace 로 감지 가능하게.
+- **race condition**: 2 플랜이 동시 complete 하면 trigger 훅이 같은 순간 2 번 → analysis job 2 개 enqueue 가능. `agent_jobs.dedupe_key='identity-analysis-{project}-{period_start}'` 로 보호 (이미 subtask-04 범위의 기본 장치 활용).
+- **metaAgent plan 미구현 시**: 본 subtask 가 metaAgent 의 first concrete use case 로 기능하나, metaAgent plan 의 governance / authorization 구조가 없으면 "metaAgent 가 자기 판단으로 실행" 이 사용자 통제 밖으로 느껴질 수 있음. Settings 토글 (`identity_analysis.enabled` default=true) 로 사용자가 끌 수 있게.

--- a/docs/plans/projectIdentityAnalysisPlan-task-03.md
+++ b/docs/plans/projectIdentityAnalysisPlan-task-03.md
@@ -1,0 +1,285 @@
+# Subtask 03 — 분석 prompt template + `identity_summary` artifact + ContextPack selector
+
+> 상위 plan: [projectIdentityAnalysisPlan.md](./projectIdentityAnalysisPlan.md)
+
+## Changed files
+
+- `src-tauri/src/agents/identity_analyzer.rs` (신규) — prompt assembly + LLM 호출 + 결과 파싱.
+- `src-tauri/src/commands/artifacts.rs` — `create_identity_summary` 전용 helper (INV-1 bypass for analyzer).
+- `src-tauri/src/commands/agents_helpers/send_common/prompt_assembly.rs` — ContextPack 에 `fetch_latest_identity_summary` 주입.
+- `src-tauri/src/db/models.rs` — `IdentitySummary` section parser types.
+
+## Change description
+
+### 1. Prompt template (고정 섹션 + 예산)
+
+```rust
+// src-tauri/src/agents/identity_analyzer.rs
+
+const IDENTITY_PROMPT_TEMPLATE: &str = r#"
+You are synthesizing project identity from the last completed plans' artifacts.
+
+## Input metadata
+- Project: {project_key}
+- Period: {since} ~ {until}
+- Plan done count (cumulative): {done_plan_count}
+
+## Input artifacts (workflow-derived, 6 types)
+Sorted by type then chronological. DO NOT treat user messages as input.
+
+{artifacts_serialized}
+
+## Output requirements
+Produce markdown with EXACTLY these sections and token budgets.
+
+Rules:
+- Do not narrate.
+- Write terse operational guidance.
+- Prefer bullets over prose.
+- Every line must be reusable as future instruction to an agent.
+- If evidence is insufficient for a section, write "(insufficient evidence)" rather than inventing.
+
+### Project identity  (150-250 tokens)
+Nature / stage / primary users. One-line summary first, then bullets.
+
+### User working preference  (300-500 tokens)
+- Decision patterns observed (cite artifact ids)
+- Preferred constraints / styles
+- Explicit avoid-list
+
+### Agent operating preference  (300-500 tokens)
+- Which engine succeeds at which task category
+- Common failure modes per engine
+- Recommended delegation pattern
+
+### Recent inflection points  (exactly 3 items, 100-150 tokens each)
+For each:
+- What changed (1 line)
+- Why (cite artifact id)
+- When (date)
+
+### Do / Avoid  (200-300 tokens)
+- Bullets only. No prose.
+- Split into "Do" and "Avoid" lists explicitly.
+
+## Total budget: 1,350 ~ 2,050 tokens. Exceeding or missing sections trigger regeneration.
+"#;
+```
+
+### 2. Input artifact serialization
+
+6 타입 각 block, type 별 정렬 (Codex Q2 의 "입력 discipline"):
+
+```rust
+fn serialize_artifacts_for_prompt(artifacts: &[Artifact]) -> String {
+    let mut grouped: HashMap<&str, Vec<&Artifact>> = HashMap::new();
+    for a in artifacts {
+        grouped.entry(a.type_.as_str()).or_default().push(a);
+    }
+    let order = ["decision", "review_outcome", "rework_reason",
+                 "finding_success", "finding_failure", "workflow_milestone"];
+    let mut out = String::new();
+    for t in &order {
+        if let Some(items) = grouped.get(t) {
+            out.push_str(&format!("### {} ({} items)\n", t, items.len()));
+            let mut sorted: Vec<_> = items.iter().collect();
+            sorted.sort_by_key(|a| a.created_at);
+            for a in sorted {
+                out.push_str(&format!(
+                    "- [{}] {} @ {}: {}\n",
+                    a.id, a.title,
+                    fmt_ts(a.created_at),
+                    summarize_content(&a.content, 100),  // content JSON 을 80-100 chars 로 축약
+                ));
+            }
+            out.push('\n');
+        }
+    }
+    out
+}
+```
+
+### 3. LLM 호출 + 검증 루프
+
+```rust
+pub async fn run_identity_analysis(
+    app: &AppHandle, state: &DbState,
+    project_key: &str, job_id: &str,
+) -> Result<String, AppError> {  // returns new identity_summary artifact id
+    // 1. Collect input artifacts (since last summary)
+    let (since_ts, until_ts) = resolve_period(state, project_key)?;
+    let input_artifacts = list_eligible_artifacts(state, project_key, since_ts, until_ts)?;
+
+    // 2. Build prompt
+    let serialized = serialize_artifacts_for_prompt(&input_artifacts);
+    let prompt = IDENTITY_PROMPT_TEMPLATE
+        .replace("{project_key}", project_key)
+        .replace("{since}", &fmt_ts(since_ts))
+        .replace("{until}", &fmt_ts(until_ts))
+        .replace("{done_plan_count}", &count_done_plans(state, project_key)?.to_string())
+        .replace("{artifacts_serialized}", &serialized);
+
+    // 3. Call LLM. Default = metaAgent's configured engine (Opus 권장 — 분석 품질 우선).
+    //    temperature 낮게 (0.3), max_tokens = 2500 (여유).
+    let response = call_llm_with_retry(&prompt, 2).await?;
+
+    // 4. Validate sections & budgets
+    let validation = validate_identity_summary_sections(&response);
+    if !validation.is_ok() {
+        // 1 회 재생성 시도 — "Regenerate. Previous output missed: {missing_sections}"
+        let retry_prompt = format!("{}\n\nPrevious output missed: {:?}. Regenerate strictly.",
+                                   prompt, validation.missing);
+        let retry = call_llm_with_retry(&retry_prompt, 1).await?;
+        if !validate_identity_summary_sections(&retry).is_ok() {
+            return Err(AppError::Agent(
+                "identity_analysis: section validation failed after retry".into(),
+            ));
+        }
+        return finalize_artifact(state, project_key, &retry, input_artifacts).await;
+    }
+
+    finalize_artifact(state, project_key, &response, input_artifacts).await
+}
+
+async fn finalize_artifact(
+    state: &DbState, project_key: &str, content: &str,
+    inputs: Vec<Artifact>,
+) -> Result<String, AppError> {
+    // 5. Prefix with YAML frontmatter
+    let refs: Vec<&str> = inputs.iter().map(|a| a.id.as_str()).collect();
+    let frontmatter = format!(
+        "---\nproject_key: {}\nperiod_start: {}\nperiod_end: {}\nartifact_refs: [{}]\nsupersedes: {}\n---\n\n",
+        project_key, since, until, refs.join(","),
+        latest_summary_id(state, project_key)?.unwrap_or_default(),
+    );
+    let full_content = format!("{}{}", frontmatter, content);
+
+    // 6. create_identity_summary artifact
+    let id = create_identity_summary(
+        state, project_key,
+        format!("Identity — {} ({})", project_key, fmt_period(since, until)),
+        full_content,
+    )?;
+
+    // 7. Mark input artifacts as analyzed (optional)
+    for inp in inputs {
+        update_artifact_status(state, &inp.id, "analyzed").ok();
+    }
+    Ok(id)
+}
+```
+
+### 4. `create_identity_summary` (analyzer 전용)
+
+```rust
+// src-tauri/src/commands/artifacts.rs
+pub fn create_identity_summary(
+    state: &DbState, project_key: &str,
+    title: String, content: String,
+) -> Result<String, AppError> {
+    let id = format!("identity-{}-{}", project_key, now_epoch_ms());
+    let conn = state.write.lock().map_err(|_| AppError::Lock)?;
+    conn.execute(
+        "INSERT INTO artifacts (id, conversation_id, branch_id, subtask_id, plan_id, type, title, content, status, created_at, updated_at)
+         VALUES (?1, NULL, NULL, NULL, NULL, 'identity_summary', ?2, ?3, 'final', ?4, ?4)",
+        params![id, title, content, now_epoch_ms()],
+    )?;
+    Ok(id)
+}
+```
+
+본 함수는 `create_identity_input_artifact` 의 INV-1 enforcement (IdentitySummary 거부) 를 우회하는 **분석 전용 경로**. `state.identity_analyzer_trusted=true` 같은 guard 를 주거나 단순히 호출 site 를 analyzer 모듈로 제한.
+
+### 5. Section validation
+
+```rust
+// src-tauri/src/db/models.rs
+pub struct IdentitySectionValidation {
+    pub has_all_sections: bool,
+    pub missing: Vec<&'static str>,
+    pub budget_ok: bool,
+    pub offending_sections: Vec<(&'static str, usize)>,   // (name, actual_tokens)
+}
+
+const REQUIRED_SECTIONS: &[(&str, (usize, usize))] = &[
+    ("### Project identity", (150, 250)),
+    ("### User working preference", (300, 500)),
+    ("### Agent operating preference", (300, 500)),
+    ("### Recent inflection points", (300, 450)),   // 3 × (100~150)
+    ("### Do / Avoid", (200, 300)),
+];
+
+pub fn validate_identity_summary_sections(content: &str) -> IdentitySectionValidation {
+    // 1. 각 section header 존재?
+    // 2. 각 section 내용의 추정 token 수 (word count * 1.3 근사) 가 예산의 ±20% 범위?
+    // 3. missing + offending 나열
+}
+```
+
+### 6. ContextPack selector 확장
+
+```rust
+// src-tauri/src/commands/agents_helpers/send_common/prompt_assembly.rs
+use crate::commands::artifacts::fetch_latest_identity_summary;
+
+// assemble_prompt() 내부, worldview_fragment 삽입 직후:
+let identity_fragment = data.project_key.as_deref()
+    .and_then(|pk| fetch_latest_identity_summary(state, pk).ok())
+    .map(|a| strip_frontmatter(&a.content).to_string());
+if let Some(s) = identity_fragment {
+    sections.push(("project_identity", s));
+}
+```
+
+`fetch_latest_identity_summary`:
+```rust
+pub fn fetch_latest_identity_summary(
+    state: &DbState, project_key: &str,
+) -> Result<Artifact, AppError> {
+    let conn = state.read.lock().map_err(|_| AppError::Lock)?;
+    let row = conn.query_row(
+        "SELECT * FROM artifacts
+          WHERE type='identity_summary'
+            AND content LIKE '%project_key: ' || ?1 || '%'
+          ORDER BY created_at DESC LIMIT 1",
+        [project_key], row_to_artifact,
+    )?;
+    Ok(row)
+}
+```
+
+**LIKE 검색은 frontmatter 기반 임시 해결책**. 더 깔끔한 건 별도 메타 테이블 or artifacts 에 `project_key` 컬럼 추가 — 단 schema 변경 피하려 frontmatter + LIKE 로.
+
+## Dependencies
+
+depends_on: [02] — analysis job 이 enqueue 되어야 본 analyzer 가 실행됨.
+
+## Verification
+
+- `cargo test --lib agents::identity_analyzer`:
+  - Prompt template 에 필수 키워드 포함 (Do not narrate / token budget)
+  - `serialize_artifacts_for_prompt` — type 별 그룹 + 정렬 + summary 길이 제한
+  - Section validation — 누락 섹션 / 예산 초과 / OK 케이스
+  - Retry 로직 — 첫 응답 실패 시 1 회 재생성, 재실패 시 Err
+- `cargo test --lib commands::artifacts::fetch_latest_identity_summary`:
+  - project 별 최신 1건 반환
+  - 없으면 Err (NotFound)
+- `cargo test --lib commands::agents_helpers::send_common::prompt_assembly`:
+  - identity_fragment 가 worldview 뒤, identity_fragment 앞 위치
+  - 없으면 sections 에 미포함
+- Manual E2E:
+  1. 10+ eligible artifact 준비
+  2. `trigger_identity_analysis_now(force=true)` 호출
+  3. agent_jobs 상태 → running → done
+  4. `list_artifacts(type='identity_summary')` 로 신규 artifact 확인
+  5. 본문이 5 섹션 모두 + 예산 범위
+  6. 다음 chat 요청에 ContextPack 으로 주입되는지 trace_log 확인
+
+## Risks
+
+- **LLM 섹션 미준수 빈도**: 실측해야 함. 1 회 재생성 후에도 fail 이 흔하면 prompt 강화 / 모델 상향 / temperature 하향 등 튜닝. 본 subtask 는 2 라운드까지만 retry, 이후 실패는 ERR 로 job 마감.
+- **Token budget 추정 정확도**: `word_count * 1.3` 은 한글/영문 혼합에서 오차. tiktoken 직접 사용도 가능하나 의존성 추가. 초기는 휴리스틱, 후속 고도화.
+- **frontmatter + LIKE 쿼리**: n 개 artifact 전체 scan. project 당 identity_summary 수는 월 수개 수준이라 성능 문제 없음. but scale 시 artifacts 테이블에 project_key 컬럼 추가 고려.
+- **프롬프트 언어 선택**: 본 template 은 영어 (i18nPlan 방침 + LLM 성능). identity_summary content 도 영어 산출. Insight 탭 UI (subtask-04) 에서 한국어 사용자에게 표시할 때 auto-translate 추가 여부는 별도 논의.
+- **Frontmatter 오염**: content 앞 frontmatter 가 ContextPack 에 주입되면 불필요 토큰. `strip_frontmatter` 함수로 주입 직전 제거.
+- **Analyzer 의 권한 분리**: 현재는 metaAgent 단독 구현 허용 (INV-6). 향후 dedicated analyst persona 로 분리 시 본 `run_identity_analysis` 를 persona runtime 아래로 이동 + metaAgent 는 enqueue 까지만.

--- a/docs/plans/projectIdentityAnalysisPlan-task-04.md
+++ b/docs/plans/projectIdentityAnalysisPlan-task-04.md
@@ -1,0 +1,219 @@
+# Subtask 04 — Insight 탭 "정체성 뷰" UI
+
+> 상위 plan: [projectIdentityAnalysisPlan.md](./projectIdentityAnalysisPlan.md)
+
+## Changed files
+
+- `src/components/tunaflow/context-panel/IdentityView.tsx` (신규) — 최신 identity_summary 렌더 + 변곡점 timeline + diff 뷰.
+- `src/components/tunaflow/context-panel/InsightPanel.tsx` (또는 상위 라우터) — Identity 탭 엔트리 추가.
+- `src/lib/api/identityAnalysis.ts` (신규) — FE wrapper (list/fetch/trigger).
+- `src/lib/parseIdentitySummary.ts` (신규) — markdown 섹션 파서.
+- `src/types/identity.ts` (신규) — type 정의.
+
+## Change description
+
+### 1. FE API wrapper
+
+```ts
+// src/lib/api/identityAnalysis.ts
+import { invoke } from '@tauri-apps/api/core';
+
+export type IdentitySummary = {
+    id: string;
+    title: string;
+    content: string;             // frontmatter + sections markdown
+    created_at: number;
+    // frontmatter parsed
+    projectKey: string;
+    periodStart: number;
+    periodEnd: number;
+    artifactRefs: string[];
+    supersedes?: string;
+};
+
+export function listIdentitySummaries(projectKey: string): Promise<IdentitySummary[]> {
+    return invoke('list_identity_summaries', { projectKey });
+}
+
+export function fetchIdentitySummary(id: string): Promise<IdentitySummary> {
+    return invoke('get_artifact', { id }).then(parseIdentitySummary);
+}
+
+export function triggerIdentityAnalysis(projectKey: string, force = false) {
+    return invoke('trigger_identity_analysis_now', { projectKey, force });
+}
+
+export function fetchArtifactRefs(ids: string[]): Promise<Artifact[]> {
+    return Promise.all(ids.map(id => invoke<Artifact>('get_artifact', { id })));
+}
+```
+
+### 2. Section parser
+
+```ts
+// src/lib/parseIdentitySummary.ts
+export type ParsedIdentity = {
+    frontmatter: {
+        projectKey: string;
+        periodStart: number;
+        periodEnd: number;
+        artifactRefs: string[];
+        supersedes?: string;
+    };
+    sections: {
+        projectIdentity: string;
+        userWorkingPreference: string;
+        agentOperatingPreference: string;
+        inflectionPoints: Array<{ what: string; why: string; when: string; artifactId?: string }>;
+        doAvoid: { do: string[]; avoid: string[] };
+    };
+};
+
+export function parseIdentitySummary(content: string): ParsedIdentity {
+    const fm = extractFrontmatter(content);
+    const body = stripFrontmatter(content);
+
+    // section header 기준 split
+    const sections = splitBySections(body, [
+        "### Project identity",
+        "### User working preference",
+        "### Agent operating preference",
+        "### Recent inflection points",
+        "### Do / Avoid",
+    ]);
+
+    return {
+        frontmatter: fm,
+        sections: {
+            projectIdentity: sections[0]?.trim() ?? "",
+            userWorkingPreference: sections[1]?.trim() ?? "",
+            agentOperatingPreference: sections[2]?.trim() ?? "",
+            inflectionPoints: parseInflectionPoints(sections[3] ?? ""),
+            doAvoid: parseDoAvoid(sections[4] ?? ""),
+        },
+    };
+}
+```
+
+Parser 는 best-effort — 섹션 누락 시 빈 문자열 / 빈 배열. UI 측에서 "(데이터 없음)" 렌더.
+
+### 3. IdentityView 컴포넌트
+
+```tsx
+// src/components/tunaflow/context-panel/IdentityView.tsx
+import { useState, useEffect } from "react";
+import { ChevronRight, RefreshCw, AlertTriangle, Clock } from "lucide-react";
+import { listIdentitySummaries, triggerIdentityAnalysis, fetchArtifactRefs } from "@/lib/api/identityAnalysis";
+import { parseIdentitySummary } from "@/lib/parseIdentitySummary";
+
+export function IdentityView({ projectKey }: { projectKey: string }) {
+    const [summaries, setSummaries] = useState<IdentitySummary[]>([]);
+    const [selected, setSelected] = useState<IdentitySummary | null>(null);
+    const [busy, setBusy] = useState(false);
+    const [triggerResult, setTriggerResult] = useState<IdentityTriggerDecision | null>(null);
+
+    useEffect(() => {
+        listIdentitySummaries(projectKey).then((list) => {
+            setSummaries(list);
+            setSelected(list[0] ?? null);
+        });
+    }, [projectKey]);
+
+    const parsed = selected ? parseIdentitySummary(selected.content) : null;
+
+    const handleManualRun = async (force: boolean) => {
+        setBusy(true);
+        try {
+            const decision = await triggerIdentityAnalysis(projectKey, force);
+            setTriggerResult(decision);
+            // 결과 완료되면 identity_analysis_completed 이벤트 리스너가 list 재로드
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    if (!selected) {
+        return (
+            <EmptyState>
+                <p>아직 정체성 분석 결과가 없습니다.</p>
+                <p className="hint">
+                    Plan 3개 완료 + eligible artifact 10개 누적 시 자동 실행됩니다.
+                </p>
+                <button onClick={() => handleManualRun(true)} disabled={busy}>
+                    강제 분석 실행
+                </button>
+                {triggerResult && <TriggerStatus result={triggerResult} />}
+            </EmptyState>
+        );
+    }
+
+    return (
+        <div className="identity-view">
+            <Header summary={selected} summaries={summaries} onSelect={setSelected} />
+            <RunButton onClick={handleManualRun} busy={busy} />
+
+            <Section title="Project identity" content={parsed!.sections.projectIdentity} defaultOpen />
+            <Section title="User working preference" content={parsed!.sections.userWorkingPreference} />
+            <Section title="Agent operating preference" content={parsed!.sections.agentOperatingPreference} />
+            <InflectionPointsTimeline points={parsed!.sections.inflectionPoints} />
+            <DoAvoidLists items={parsed!.sections.doAvoid} />
+
+            {parsed!.frontmatter.supersedes && (
+                <DiffLink prevId={parsed!.frontmatter.supersedes} currentId={selected.id} />
+            )}
+            <ArtifactRefsLink refs={parsed!.frontmatter.artifactRefs} />
+        </div>
+    );
+}
+```
+
+### 4. 하위 컴포넌트
+
+- **InflectionPointsTimeline**: 3 변곡점을 시간순 카드로. 각 카드에 artifact id → 클릭 시 원본 artifact 조회 (side drawer).
+- **DoAvoidLists**: "Do" 와 "Avoid" 리스트를 색으로 구분 (녹색/빨강 subtle).
+- **DiffLink**: 이전 summary 와 이번 summary 의 섹션별 diff. 문자열 diff 라이브러리 없이 단순 비교 (추후 `diff-match-patch` 도입 가능).
+- **ArtifactRefsLink**: frontmatter 의 `artifactRefs` 개수 + 펼치면 list. Read-only.
+- **TriggerStatus**: decision 결과 (done_plan_count / eligible_artifact_count / threshold / reason) 렌더.
+
+### 5. Insight 탭 통합
+
+`InsightPanel` 상단 탭 구조 (기존 Insight 6 카테고리) 옆에 **"Identity"** 탭 추가:
+
+```tsx
+<Tabs>
+  <Tab id="insights">Insight</Tab>
+  <Tab id="identity">Identity</Tab>
+</Tabs>
+{active === "identity" && <IdentityView projectKey={projectKey} />}
+```
+
+## Dependencies
+
+depends_on: [03] — identity_summary artifact 가 생성돼야 list 에 내용이 있음.
+
+## Verification
+
+- `npx vitest run src/lib/parseIdentitySummary.test.ts`:
+  - 정상 5 섹션 markdown → 모든 섹션 비어있지 않음
+  - 1 섹션 누락 → 해당 섹션만 "" 반환 + 나머지 정상
+  - 전부 누락 → 모든 섹션 "" + throw X
+  - frontmatter 파싱 (projectKey / periodStart / periodEnd / artifactRefs[])
+- `npx vitest run src/components/tunaflow/context-panel/IdentityView.test.tsx`:
+  - summary 없을 때 EmptyState + "강제 분석 실행" 버튼
+  - summary 있을 때 5 섹션 렌더
+  - "지금 분석" 버튼 클릭 → `trigger_identity_analysis_now` invoke
+- Manual E2E:
+  1. subtask-03 실행 후 identity_summary 1건 생성됨
+  2. Insight 탭 > Identity 탭 진입
+  3. 5 섹션 렌더 확인 (Project identity / User working / Agent operating / Inflection points / Do/Avoid)
+  4. 변곡점 카드 클릭 → artifact drawer 열림
+  5. "강제 분석 실행" 클릭 → 새 identity_summary 생성 → list 자동 업데이트
+
+## Risks
+
+- **Parser 견고성**: LLM 이 section header 를 정확히 "### Project identity" 로 쓰지 않을 수 있음 (e.g. "## Project Identity" 또는 번역). subtask-03 의 validator 가 이를 강제하지만 legacy summary (구버전 LLM 출력) 가 있으면 parser fail. fallback: 섹션 parse 실패 시 raw markdown 전체를 single section 으로 렌더.
+- **LLM 영어 출력 → 한국어 사용자 UX**: identity_summary 는 영어 고정 (i18nPlan + subtask-03). 한국어 사용자에게 UI 는 i18n 적용하되 본문은 영어 그대로 렌더. 후속에서 client-side 번역 (Settings 토글) 고려.
+- **Diff 계산 비용**: 전체 summary 2K tokens × 2개 diff = 클라이언트 상에서 충분히 빠름. 단 "diff-match-patch" 같은 lib 도입 전까지는 naive line-by-line diff.
+- **Event subscribe 누수**: `identity_analysis_completed` 이벤트 리스너를 useEffect cleanup 에서 반드시 unlisten. 잊으면 listener 누적.
+- **Empty state 에서의 UX**: 프로젝트 초기 사용자는 "왜 비어있지?" 혼란. EmptyState 에 "Plan 3개 완료 + artifact 10개 누적" 조건 + 현재 카운트 표시 권장 (subtask-02 의 TriggerStatus 재활용).
+- **강제 실행 남용**: 사용자가 "강제 분석" 을 자주 누르면 LLM 호출 비용 누적. 1 분 쿨다운 또는 "최근 실행 표시" 로 UX 가이드. 강제는 주로 디버깅/실험 용도.

--- a/docs/plans/projectIdentityAnalysisPlan.md
+++ b/docs/plans/projectIdentityAnalysisPlan.md
@@ -1,0 +1,306 @@
+---
+title: Project Identity Analysis — Artifacts 기반 "Karma" 파이프라인
+status: planned
+priority: P1
+created_at: 2026-04-23
+related:
+  - src-tauri/src/commands/artifacts.rs                                       # CRUD 이미 완료
+  - src-tauri/src/db/schema.rs                                                # artifacts 테이블 (L250)
+  - src-tauri/src/commands/insight_extract.rs                                 # 기존 분석 파이프라인 참조
+  - src/lib/insightOrchestration.ts                                           # 입력 discipline 참조 패턴
+  - src-tauri/src/commands/agents_helpers/send_common/prompt_assembly.rs      # ContextPack selector 확장 대상
+  - docs/plans/metaAgentPlan.md                                               # P0 — trigger + orchestration 주체
+  - docs/plans/longTermMemoryRoadmapPlan_2026-03-30.md                        # 기존 memory 계층 (중복 아님, source priority 관계)
+  - docs/plans/userWorldviewInjectionPlan.md                                  # subtask-01 보유. 02~04 는 본 plan 으로 이관
+  - docs/reference/tokenPolicyReference.md                                    # 품질 우선 철학
+triggered_by:
+  - 2026-04-23 사용자 설계 리마인드: "Artifacts 의 원 의도 = 사용자 결정 + agent finding 누적 → 비정기 분석 → 사용자 취향 + agent 성향 → 프로젝트 정체성"
+  - Codex 자문 답변 (2026-04-23) — verdict: adjust, artifact type taxonomy + trigger guard 확정 후 진행 권고
+supersedes_sections_of:
+  - userWorldviewInjectionPlan.md (subtask-02: preference_events/snapshots, subtask-03: stance-conflict, subtask-04: background job)
+---
+
+# Project Identity Analysis — Artifacts → 정체성 파이프라인
+
+> tunaFlow 의 **"Karma 시스템"** 엔지니어링 번역. 사용자 철학 ("죽음=Resume, 연기법, 업") 의 구체화 경로.
+>
+> 핵심 가설: **Artifacts 에 이미 누적되고 있는 "사용자 결정 + agent finding"** 을 **정기 분석** 하면, 사용자 취향 / agent 성향 / 프로젝트 정체성을 추출할 수 있다. 이 정체성 산출물이 ContextPack 에 주입되면 agent 의 매 응답이 프로젝트 누적 맥락에 더 부합한다.
+
+---
+
+## TL;DR for Developer
+
+1. **Artifact 자동 생성 지점 보강** — 워크플로우의 6 타입 (`decision` / `review_outcome` / `rework_reason` / `finding_success` / `finding_failure` / `workflow_milestone`) 을 시점별로 자동 insert. 자유 감정 추론 / 대화 분석 금지 (surveillance 방지).
+2. **metaAgent 가 trigger 감시** — `plans WHERE status='done' AND project_key=?` count 가 3의 배수 도달 **AND** 이전 `identity_summary` 이후 누적된 eligible artifacts ≥ 10 일 때만 analysis job enqueue.
+3. **분석 에이전트가 `identity_summary` 생성** — 고정 섹션 + 토큰 예산 템플릿으로. 총 1,350~2,050 tokens. 프롬프트에 "Do not narrate. Prefer bullets over prose." 명시.
+4. **`identity_summary` 는 artifacts 테이블 재사용** (신규 memory 계층 X). `type='identity_summary'`, `content` = 섹션형 markdown, `period='YYYY-MM'` 메타.
+5. **ContextPack selector 확장** — `identity_summary` 의 최신 본문을 `worldview` 섹션 옆에 주입. 상세 input artifacts 는 agent tool-request on-demand.
+6. **Insight 탭 "정체성 뷰"** — 최신 summary + 변곡점 timeline. 사용자 자기 관찰 도구.
+
+구현 순서: 01 → 02 → 03 → 04. 01 없이는 02 가 돌아도 input 빈곤 (fail mode a). 03 이 안정적으로 섹션 준수한 후에 04 가 UX 가치.
+
+**하지 말 것**:
+- 자동 감정 추론 / 자유 대화 분석 (surveillance)
+- `preference_events` / `preference_snapshots` 별도 테이블 (artifacts 재사용이 설계 의도)
+- identity_summary 를 500~800 tokens 로 극단 압축 (Token Policy 위배 — 품질 우선)
+- 새 memory 계층 신설 (compressed_memory / insight_extract 와 "source priority" 로 병존)
+- time-based cron (plan 활동량과 무관한 trigger 는 idle 프로젝트에서 낭비)
+
+---
+
+## Specification
+
+### 1. Artifact 자동 생성 — 6 타입
+
+모든 자동 생성은 **워크플로우 이벤트 기반** (사용자 action 또는 확실한 agent 상태 전이). 대화 감정 추론 금지.
+
+| type | 생성 시점 | 의미 | `content` 구조 |
+|---|---|---|---|
+| `decision` | 사용자가 Plan 승인 / 엔진 전환 / 경로 선택 | 의도 변곡점 | `{ what, rationale?, previous_stance? }` |
+| `review_outcome` | Review verdict 완료 (pass/fail/escalate) | 품질 스냅샷 | `{ verdict, rubric{4D}, findings_count, failed_subtask_ids }` |
+| `rework_reason` | Rework 진입 | 실패 카테고리 | `{ cycle, findings[], root_cause_hint }` |
+| `finding_success` | Dev 가 subtask 를 scope 내로 완료 | agent 효율 신호 | `{ subtask_id, duration_ms, agent_engine, notes? }` |
+| `finding_failure` | Dev 응답이 plan spec 벗어남 / blocker 발생 | agent 한계 신호 | `{ subtask_id, failure_kind, agent_engine, evidence_msg_id }` |
+| `workflow_milestone` | Plan 완료 / PR 머지 / 릴리스 | 기준점 | `{ milestone_kind, plan_id, summary }` |
+
+**필드 공통**:
+- `artifacts.type` 위 6개 중 하나
+- `artifacts.title` = 사람이 읽을 1-line 요약
+- `artifacts.content` = JSON 문자열 (해석 유연성)
+- `artifacts.conversation_id` / `branch_id` / `subtask_id` / `plan_id` = 연결 맥락
+- `artifacts.status` = `'draft'` 기본 → 분석기가 `'analyzed'` 로 mark 가능
+
+### 2. Trigger guard — 2 조건 AND
+
+`src-tauri/src/commands/meta_agent.rs` (또는 metaAgent 가 구현될 모듈) 에서:
+
+```rust
+pub fn should_trigger_identity_analysis(
+    conn: &Connection, project_key: &str,
+) -> Result<bool, AppError> {
+    // 조건 A: plan done count 가 3의 배수
+    let done_count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM plans WHERE status='done' AND project_key=?1",
+        [project_key], |r| r.get(0),
+    )?;
+    if done_count == 0 || done_count % 3 != 0 { return Ok(false); }
+
+    // 조건 B: 이전 identity_summary 이후 누적된 eligible artifacts >= 10
+    let last_summary_at: i64 = conn.query_row(
+        "SELECT COALESCE(MAX(created_at), 0) FROM artifacts
+          WHERE type='identity_summary'
+            AND (content_json_extract_project_key(content) = ?1
+                 OR conversation_id IN (SELECT id FROM conversations WHERE project_key=?1))",
+        [project_key], |r| r.get(0),
+    )?;
+    let eligible_count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM artifacts
+          WHERE type IN ('decision','review_outcome','rework_reason',
+                         'finding_success','finding_failure','workflow_milestone')
+            AND created_at > ?1
+            AND conversation_id IN (SELECT id FROM conversations WHERE project_key=?2)",
+        params![last_summary_at, project_key], |r| r.get(0),
+    )?;
+    if eligible_count < 10 { return Ok(false); }
+
+    Ok(true)
+}
+```
+
+**최초 기본값**: threshold = 10. Settings 에 `tunaflow.identity_analysis.min_artifacts` 로 노출 → 사용자 튜닝 가능. 초기 운영 3~6 개월 데이터 수집 후 default 재조정.
+
+### 3. 분석 에이전트 prompt template — 고정 섹션 + 예산
+
+```
+# Project Identity Synthesis Prompt
+
+You are synthesizing project identity from the last 3 completed plans' artifacts.
+
+## Input
+- Project: <project_key>
+- Period: <since_ts> ~ <until_ts>
+- Artifacts (filtered to 6 workflow-derived types, sorted by type then time):
+  <ARTIFACTS_SERIALIZED>
+
+## Output requirements
+Produce a markdown document with EXACTLY these sections and token budgets.
+Do not narrate. Write terse operational guidance. Prefer bullets over prose.
+Every line must be reusable as future instruction to an agent.
+
+### Project identity  (150-250 tokens)
+- Nature / stage / primary users
+
+### User working preference  (300-500 tokens)
+- Decision patterns observed
+- Preferred constraints / styles
+- Explicit avoid-list
+
+### Agent operating preference  (300-500 tokens)
+- Which engine succeeds at which task category
+- Common failure modes per engine
+- Recommended delegation pattern
+
+### Recent inflection points  (3 items, 100-150 tokens each)
+For each: what changed, why (evidence artifact id), when.
+
+### Do / Avoid  (200-300 tokens)
+- Bullets. No prose.
+```
+
+**프롬프트 INV**:
+- 단일 섹션 누락 시 재생성
+- 섹션 예산 ±20% 초과 시 재생성 요청 (최대 2 라운드)
+- 모든 bullet 은 향후 agent instruction 으로 재사용 가능한 형태 (운영 규약 톤)
+
+### 4. `identity_summary` artifact 저장
+
+기존 `create_artifact` 재사용:
+
+```rust
+create_artifact(CreateArtifactInput {
+    conversation_id: None,              // 프로젝트 전역 (conversation 무관)
+    branch_id: None,
+    subtask_id: None,
+    plan_id: None,
+    artifact_type: "identity_summary".into(),
+    title: format!("Identity — {} ({}~{})", project_key, since, until),
+    content: <markdown_output>,         // 섹션형 markdown 본문
+    status: "final".into(),
+})
+```
+
+**메타 저장**: `content` 상단에 frontmatter 로 `project_key` / `period_start` / `period_end` / `artifact_refs: [<id>...]` 주입. 이전 summary 와의 diff 는 frontmatter 에 `supersedes: <prev_id>` 로 연결.
+
+### 5. ContextPack selector 확장
+
+`src-tauri/src/commands/agents_helpers/send_common/prompt_assembly.rs` 에:
+
+```rust
+// 기존 worldview 주입 경로 옆에 identity_summary 추가
+let identity_fragment = fetch_latest_identity_summary(data.project_key.as_deref())
+    .map(|a| a.content)                 // 본문 전체 (1,350~2,050 tokens 범위)
+    .filter(|c| !c.trim().is_empty());
+
+if let Some(s) = identity_fragment {
+    sections.push(("project_identity", s));   // worldview 와 identity 사이 또는 identity 뒤
+}
+```
+
+**위치 규칙** (Session Continuity INV 와 정합):
+```
+[project] [platform] [agent-role] ...
+[worldview]           ← 사용자 수동 stance (subtask-01)
+[project_identity]    ← 분석 생성 정체성 (본 plan)
+[identity_fragment]   ← agent 역할 identity
+[skills] [recent_context] ...
+[user_prompt]
+```
+
+worldview 는 사용자가 직접 쓴 철학, project_identity 는 분석 추출 결과. 두 문서가 충돌하면 worldview 가 우선 — 프롬프트 프리픽스에 "User-authored worldview takes priority over analysis-derived identity on conflict." 한 줄 명시.
+
+**상세 input artifacts 는 on-demand**: identity_summary 본문에 `artifact_refs` 나열 → agent 가 필요 시 tool-request `fetch_artifact` 로 조회.
+
+### 6. Insight 탭 "정체성 뷰" UI
+
+`src/components/tunaflow/context-panel/InsightPanel.tsx` (또는 동등) 에 새 서브뷰:
+
+- **최신 identity_summary** — 6 섹션 접힌 상태로 각각 expand
+- **변곡점 timeline** — `inflection_points` 섹션 파싱해 시간순 타임라인 카드
+- **이전 summary 와 diff** — `supersedes` 체인 따라가기 버튼
+- **수동 분석 트리거** — "지금 분석 시작" 버튼 (threshold 미달이어도 강제 실행)
+
+UI 는 읽기 전용 + 1 action 버튼만. 편집 금지 (분석 결과 훼손 방지).
+
+---
+
+## Invariants
+
+- **[INV-1]** 자동 artifact 생성은 명시된 **6 타입 (decision / review_outcome / rework_reason / finding_success / finding_failure / workflow_milestone) 한정**. 대화 감정 추론 / 자유 surveillance / user behavior mining 은 구현하지 않는다. **이유**: Codex Q1 지적 — taxonomy 가 넓어지면 personalization 이 아닌 surveillance 로 인식. 사용자 신뢰 훼손. **검증**: `grep "create_artifact" src-tauri/src -r` 결과의 `type` 인자가 위 7개 (identity_summary 포함) 외 값을 생성하지 않음. integration test — "random user message 가 자동 artifact 를 만드는지" negative case.
+
+- **[INV-2]** identity analysis trigger 는 **2 조건 AND** 로만 발동: (a) `plans done_count % 3 == 0` **그리고** (b) 이전 summary 이후 eligible artifacts ≥ 10 (Settings 로 튜닝 가능). pure count 또는 time-based cron 은 금지. **이유**: Codex Q4 지적 — pure count 는 큰/작은 plan weight 불균형, time-based 는 idle 프로젝트에서 낭비. **검증**: `should_trigger_identity_analysis` unit test — 두 조건 각각의 단독 통과/실패 케이스 + AND 조합 케이스.
+
+- **[INV-3]** `identity_summary` 는 **고정 섹션 + 토큰 예산 템플릿** 을 강제한다. 섹션 누락 시 재생성. 섹션별 예산 ±20% 초과 시 최대 2 라운드까지 재요청. 프롬프트에는 "Do not narrate. Prefer bullets over prose. Every line must be reusable as future instruction." 가 포함된다. **이유**: Codex Q2/Q5 지적 — generic summary 방지는 출력 길이 제약보다 **입력 discipline + 출력 구조 강제** 가 본질. **검증**: identity_summary 생성 테스트 — 섹션 parser 가 5개 섹션 모두 감지 + 각 섹션 토큰 수가 예산 ±20% 범위.
+
+- **[INV-4]** **새 memory 계층을 신설하지 않는다**. `artifact type='identity_summary'` + ContextPack selector 확장으로만 구현. `compressed_memory` (대화 continuity) / `insight_extract` (코드/테스트 분석) / `identity_summary` (협업 취향/성향) 는 **source priority 가 다른 3 층 병존** 관계. **이유**: Codex Q3 지적 + `longTermMemoryRoadmapPlan` 의 Structured Task Memory 관점. **검증**: migration 변경 없음 (schema.rs diff 0). 새 테이블 생성 PR 금지.
+
+- **[INV-5]** ContextPack 주입은 `identity_summary` **본문 (1,350~2,050 tokens)** 까지만. 상세 input artifacts (analysis 재료) 는 주입하지 않고 `artifact_refs` 만 포함해 agent 가 필요 시 tool-request 로 조회. **이유**: Token Policy (`tokenPolicyReference.md`) 의 "중복 회피" — 본문과 원본을 동시 주입하면 doubling. **검증**: ContextPack assemble 후 `fetch_latest_identity_summary` 가 본문 1건만 반환, `list_artifacts(type IN 6types)` 호출은 없음.
+
+- **[INV-6]** **metaAgent** 는 trigger 감시 + prompt assembly + artifact creation 요청 범위. 실제 요약 생성 LLM 호출은 **dedicated persona 로 분리 가능** (옵션, 본 plan 범위 안에서는 metaAgent 단독 구현도 허용). **이유**: Codex Q7 + metaAgent plan 의 "프로세스 관리자, 제안만" 역할 정의. **검증**: metaAgent 코드가 요약 생성 LLM 호출 로직을 직접 포함하지 않음 (persona 분리 구현 시), 또는 metaAgent 내부 함수로 격리 (단독 구현 시).
+
+---
+
+## Rationale (reviewer-only)
+
+### Codex 자문 반영 (2026-04-23)
+
+Codex 가 adjust verdict 를 내리며 강조한 3 조건:
+
+1. **artifact type taxonomy 먼저 확정** → 본 plan 의 6 타입으로 고정. surveillance 경계.
+2. **trigger guard (volume threshold)** → threshold 10 초기값 (사용자 판단), Settings 로 튜닝.
+3. **입력 discipline** → 프롬프트 템플릿에서 type별 정렬 + 좁은 범위 + 구조 강제.
+
+추가로 Codex Q5 의 fail mode a+b+c 조합 (artifact 빈약 → generic summary → agent 응답 영향 미미) 에 대해:
+- subtask-01 이 artifact 자동 생성 경로를 보강 (a 방어)
+- INV-2 volume threshold 가 generic 직접 방지 (b 방어)
+- INV-5 본문 주입 + on-demand 상세 조회가 agent 활용 경로 최적화 (c 방어)
+
+### Karma 철학의 번역
+
+사용자의 원 비유 ("죽음=Resume, 연기법, 업") 를 엔지니어링으로:
+
+| 철학 개념 | 엔지니어링 매핑 |
+|---|---|
+| 업(業) 의 누적 | `artifacts` 6 타입 자동 생성 |
+| 연기법 (인과) | `decision` → `rework_reason` → `finding_failure` 같은 사건 연쇄 |
+| 세션 간 의도 전달 | `identity_summary` 를 ContextPack 주입 |
+| Vipassana (자기 관찰) | Insight 탭 "정체성 뷰" |
+| 구도 (성장) | 이전 summary 와 diff → 변곡점 조회 |
+
+이 매핑은 tunaFlow 의 "2인 3각 협업 + 인간지능 주도" 원 취지와 정합. 자동화는 **기록 + 요약** 까지만, 판단은 사용자 몫.
+
+### 대안 비교
+
+| 대안 | 판정 | 사유 |
+|---|---|---|
+| 새 `preference_events` / `preference_snapshots` 테이블 (초기 userWorldview 설계) | 기각 | Artifacts 재사용으로 불필요. 중복 memory 계층. |
+| stance-conflict marker + modal (초기 설계) | 기각 | LLM 자연 능력에 맡김. UX 침습 과다. |
+| Time-based cron (월 1회) | 기각 | Idle 프로젝트에서 낭비, 활발한 프로젝트에서 부족 |
+| Pure count trigger (plan 3개만) | 기각 | 큰/작은 plan weight 불균형 |
+| compressed_memory 확장으로 대체 | 기각 | 대화 continuity 용도와 취향 분석 용도는 source priority 다름 |
+| **채택** (6 타입 artifact + 2조건 trigger + 고정 섹션 template + ContextPack selector 확장) | ✅ | Codex adjust 방향 + 사용자 철학 + 기존 인프라 최대 재활용 |
+
+### Open questions
+
+1. **Q-1 threshold 튜닝**: 초기 10 이 적절한가? 3~6 개월 실운영 후 Settings 의 default 재조정 기준은 무엇인가? (예: 월 평균 분석 횟수 목표값, identity_summary 품질 rating 기반)
+
+2. **Q-2 dedicated persona 분리 시점**: 초기 구현은 metaAgent 단독이 단순하나, 분석 품질이 낮으면 dedicated analyst persona (temperature 낮춤 + 섹션 template 엄격) 가 유리. 분리 판단 기준 (예: 섹션 예산 위반율 > X%)?
+
+3. **Q-3 cold start**: 프로젝트 첫 analysis 시점 이전의 artifact 는 분석 대상이 없음 — 첫 summary 의 품질이 낮을 가능성. 최초 N개 artifact 까지 skip 전략 유효한가?
+
+4. **Q-4 에이전트 응답 반영 측정**: identity_summary 가 ContextPack 에 들어간 이후 agent 응답 품질이 실제로 향상됐는지 어떻게 측정? (예: 같은 conv 에서 ON/OFF A/B, 사용자 재생성 요청율)
+
+5. **Q-5 다국어**: identity_summary 의 언어는? 프로젝트 기본 언어 (한국어) vs 영어 고정 (i18nPlan 의 "프롬프트 영어 통일" 원칙). 본 plan 은 **영어 고정** 권장 (LLM 성능 + 토큰 효율) — 단 Insight 탭 UI 는 i18n 적용.
+
+---
+
+## Subtask 구조
+
+| # | 파일 | 범위 | 의존 |
+|---|---|---|---|
+| 01 | [-task-01.md](./projectIdentityAnalysisPlan-task-01.md) | Artifact 자동 생성 지점 보강 (6 타입 각각의 trigger 경로) | — |
+| 02 | [-task-02.md](./projectIdentityAnalysisPlan-task-02.md) | metaAgent trigger (2 조건) + analysis job orchestration | 01 |
+| 03 | [-task-03.md](./projectIdentityAnalysisPlan-task-03.md) | 분석 prompt template + identity_summary artifact + ContextPack selector | 02 |
+| 04 | [-task-04.md](./projectIdentityAnalysisPlan-task-04.md) | Insight 탭 "정체성 뷰" UI (읽기 전용 + 수동 트리거 버튼) | 03 |
+
+4 subtask. 순차 의존. 01 이 가장 큰 (워크플로우 여러 지점 touch), 04 가 가장 작음.
+
+---
+
+## 관련 문서
+
+- Karma 철학 근거: 본 세션 2026-04-22 사용자 철학적 프롬프트 (Identity/Interface/Continuity 3질문)
+- Codex 자문 transcript: 본 세션 2026-04-23 Q1~Q7 답변
+- Token Policy: `docs/reference/tokenPolicyReference.md` (품질 우선 + 중복 회피)
+- userWorldview 축소: 본 plan 이 `userWorldviewInjectionPlan` 의 subtask-02~04 를 대체
+- 기존 memory 계층: `longTermMemoryRoadmapPlan_2026-03-30.md` (Phase 1-3 완료)
+- metaAgent 의존: `metaAgentPlan.md` (P0, 실제 구현 필요)

--- a/docs/plans/userWorldviewInjectionPlan-task-02.md
+++ b/docs/plans/userWorldviewInjectionPlan-task-02.md
@@ -1,3 +1,9 @@
+> ⚠️ **SUPERSEDED (2026-04-23)** — 본 subtask 는 구현되지 않음.
+>
+> Artifacts 재사용이 사용자 원 설계 의도임이 확인됨 (2026-04-23 세션). 별도 `preference_events` / `preference_snapshots` 테이블 신설 대신 `docs/plans/projectIdentityAnalysisPlan.md` 의 **subtask-01** (artifact 자동 생성 6 타입) 로 이관됨.
+>
+> 본 파일은 git history 보존 목적으로 유지. Developer 는 `docs/archive/plans/superseded/` 로 git mv 고려.
+
 # Subtask 02 — Migration v46: `preference_events` + `preference_snapshots` + `agent_jobs` 확장
 
 > 상위 plan: [userWorldviewInjectionPlan.md](./userWorldviewInjectionPlan.md)

--- a/docs/plans/userWorldviewInjectionPlan-task-03.md
+++ b/docs/plans/userWorldviewInjectionPlan-task-03.md
@@ -1,3 +1,9 @@
+> ⚠️ **SUPERSEDED / DEPRECATED (2026-04-23)** — 본 subtask 는 **설계 자체가 폐기됨**.
+>
+> 2026-04-23 사용자 리마인드: stance-conflict 판정은 rule + model verify + modal 엔진이 아니라 **LLM 자연 능력 + ContextPack 에 `worldview` / `identity_summary` 주입** 으로 충분. Modal 은 UX 침습 과다. agent 가 응답 안에서 자연스럽게 "현실적 관점" 제공하는 수준이 적합.
+>
+> 필요 시 `docs/ideas/stanceConflictStrongIdea.md` 로 idea 만 보존 가능. 본 파일은 git history 보존 목적으로 유지. Developer 는 `docs/archive/plans/superseded/` 로 git mv 고려.
+
 # Subtask 03 — Stance-conflict detection (rule-first + small model verify + modal)
 
 > 상위 plan: [userWorldviewInjectionPlan.md](./userWorldviewInjectionPlan.md)

--- a/docs/plans/userWorldviewInjectionPlan-task-04.md
+++ b/docs/plans/userWorldviewInjectionPlan-task-04.md
@@ -1,3 +1,9 @@
+> ⚠️ **SUPERSEDED (2026-04-23)** — 본 subtask 는 구현되지 않음.
+>
+> Background job 스켈레톤만 단독 머지되면 dead feature 리스크 (사용자 원 설계: metaAgent 와 묶여 의미 생김). `docs/plans/projectIdentityAnalysisPlan.md` 의 **subtask-02** (metaAgent trigger + analysis job) 로 이관됨.
+>
+> 본 파일은 git history 보존 목적으로 유지. Developer 는 `docs/archive/plans/superseded/` 로 git mv 고려.
+
 # Subtask 04 — Background Job 스켈레톤 (enqueue API + UI status + pending cancel)
 
 > 상위 plan: [userWorldviewInjectionPlan.md](./userWorldviewInjectionPlan.md)

--- a/docs/plans/userWorldviewInjectionPlan.md
+++ b/docs/plans/userWorldviewInjectionPlan.md
@@ -1,282 +1,110 @@
 ---
-title: User Worldview Injection — Identity/Interface/Continuity 3축 번들 (E1 통합)
-status: planned
+title: User Worldview Injection — Identity 축 (Interface/Continuity 축은 projectIdentityAnalysisPlan 으로 이관)
+status: partial (subtask-01 merged, subtask-02~04 superseded)
 priority: P1
 created_at: 2026-04-22
+updated_at: 2026-04-23
 related:
-  - src-tauri/src/commands/agents_helpers/send_common/prompt_assembly.rs     # ContextPack identity 섹션
-  - src-tauri/src/commands/jobs.rs                                           # agent_jobs 확장 대상
-  - src-tauri/src/commands/project_tools.rs                                  # rawq background pattern 참조
-  - src/lib/toolRequestHandler.ts                                            # tool-request follow-up 파이프라인
-  - src/lib/insightOrchestration.ts                                          # Insight stash 경로
-  - docs/plans/designReviewGatePlan.md                                       # 유사 Architect↔reviewer gate 패턴
-  - docs/plans/metaAgentPlan.md                                              # P0 메타에이전트와 교차
-  - docs/plans/harnessVerificationGapPlan.md                                 # §5 proposer 규약
-triggered_by:
-  - 2026-04-22 세션 사용자 철학적 프롬프트 (Identity/Interface/Continuity 3질문)
-  - Gemini 답변 ("거부권", "자기 관찰 도구" 두 insight 기여)
-  - 검토 세션 피드백 (rule-first stance check, event+snapshot first, low-priority visible background)
+  - src-tauri/src/commands/worldview.rs                                       # Rust helper (subtask-01 구현물)
+  - src-tauri/src/commands/agents_helpers/send_common/prompt_assembly.rs      # ContextPack worldview 주입 위치
+  - src/components/tunaflow/settings/WorldviewSettings.tsx                    # Settings UI
+  - docs/plans/projectIdentityAnalysisPlan.md                                 # subtask-02~04 를 대체하는 신규 plan
+  - docs/reference/tokenPolicyReference.md                                    # 품질 우선 철학
+superseded_subtasks:
+  - subtask-02 (preference_events / preference_snapshots) → projectIdentityAnalysisPlan (artifacts 재사용)
+  - subtask-03 (stance-conflict rule + model verify + modal) → 설계 폐기 (LLM 자연 능력에 맡김)
+  - subtask-04 (background job skeleton) → projectIdentityAnalysisPlan subtask-02 (metaAgent trigger) 로 이관
 ---
 
-# User Worldview Injection — E1 통합 번들
+# User Worldview Injection (축소판)
 
-> 에이전트가 사용자의 실존적 의도(세계관, Vibe 변천, 업 karma)와 동기화되어 "말은 있으되 달리지 못하는" 상태를 벗어나게 한다. 세 층을 한 plan 에 묶는 이유: 각각 독립이 아니라 상호 강화 (worldview 없이는 stance-conflict 판정 불가, preference_timeline 없이는 conflict 대조 불가, background insight job 없이는 proactive 제안 불가).
-
-> **적용 범위**: 본 plan 의 모든 로직 (worldview 주입 / preference_timeline / stance-conflict / background insight job) 은 **sdk-session 경로 (Branch chat) 한정**. RT (`-p` one-shot) 는 매 turn full ContextPack 을 재주입하는 것이 정상 동작이며 본 plan 대상 아님. INV-1 이하의 모든 invariant, ContextPack 주입 변경, tool-request 핸들링은 `claude_sdk_session::spawn_session` 경로에만 영향을 준다. RT 경로 (`roundtable_helpers/*`, `agents/claude.rs::run_one_shot`) 는 본 plan 이 건드리지 않는다.
-
----
-
-## TL;DR for Developer
-
-1. **`user_worldview.md` 주입** — `~/.tunaflow/user_worldview.md` 사용자 철학 stance. ContextPack 조립 시 **identity 섹션보다 앞에** 삽입 (`prompt_assembly.rs`). 존재하지 않으면 기본 placeholder. 사용자가 Settings 에서 편집.
-2. **`preference_events` + `preference_snapshots` 테이블 신설** (migration v46). vector-first 아님 — event-log + snapshot 2단 구조. Embedding 은 별도 선택 subtask 로 분리 (본 plan 범위 밖).
-3. **Stance-conflict 감지는 rule-first** — 현재 요청을 recent preference_snapshots (최근 3건) 와 대조. Rule precheck 가 결정적 (conflict/no-conflict/ambiguous) 이면 모델 호출 스킵. Ambiguous 한정 Haiku/Flash 로 verify → 결과 compact 요약 후 Opus 프롬프트에 주입.
-4. **Silent tool-request 금지** — 대신 `agent_jobs` 에 `priority`, `dedupe_key`, `visibility` 컬럼 + `kind='insight_background'` 추가. 본 plan 의 Subtask 04 는 **enqueue API + UI status surface + pending cancel 까지만** (Codex round-1/2 review 반영 — scope 축소). Worker 실행 경로 / trace_log 통합 / insight stash 연결은 별도 plan (metaAgent 착수 시점) 위임.
-5. **Stance-conflict confirmation modal** — agent 가 `<!-- tunaflow:stance-conflict:<memory_name>:<field>:<rationale> -->` 마커 fire 시 사용자 modal. 두 composite key 는 `preference_snapshots` PK 와 정합. 선택지: (a) 의도 변경 확정 → 새 변곡점 기록, (b) 기존 선호 유지 → 요청 수정, (c) 무시 → agent 가 그대로 진행 (timeline 미기록).
-
-구현 순서: 01 (worldview) → 02 (preference_events/snapshots) → 03 (stance-conflict rule+modal) → 04 (background insight job). 01 은 독립 ROI 최고. 02~03 은 의존 체인. 04 는 01~03 없이도 가능하나 "지루함 감지 후 제안" 플로우는 01 필요.
-
-**하지 말 것**:
-- Vector embedding 을 preference_timeline 에 **기본** 도입 (Gemini 초안의 과잉)
-- Silent 동작 — 사용자 모르게 cost/자원 소비 금지 (tunaFlow 원칙 위배)
-- Stance-conflict 를 Opus inline 으로 매번 호출 (비용 폭증)
-- Agent 거부권을 "도덕적 판단" 으로 구현 — 기계적 rule 매칭 + 사용자 confirmation 으로 충분
+> **현재 범위**: 사용자가 직접 작성하는 철학 stance (`user_worldview.md`) 를 ContextPack 에 주입하는 **Identity 축** 만.
+>
+> 2026-04-22 초안에서 3축 번들 (Identity / Interface / Continuity) 로 설계됐으나, 2026-04-23 사용자 리마인드 + Codex 자문 결과:
+> - **Interface 축 (stance-conflict)** 은 agent 에게 LLM 자연 능력으로 맡기는 게 옳음 → 별도 장치 불필요
+> - **Continuity 축 (preference_timeline)** 은 Artifacts 의 원 설계 의도 (사용자 결정 + agent finding 누적 → 비정기 분석 → 정체성) 에 이미 포함 → `projectIdentityAnalysisPlan` 으로 이관
+> - 결과: 본 plan 은 **Identity 축 (worldview 주입)** 만 유지, 나머지 축은 superseded
+>
+> Subtask-01 은 **PR #144 로 머지 완료** (2026-04-22 23:38 UTC). 본 plan 은 운영 참고용 기록.
 
 ---
 
-## Specification
+## 적용 범위
 
-### 1. `user_worldview.md` 주입
-
-**파일 위치**: `~/.tunaflow/user_worldview.md` (global) + `<project>/.tunaflow/user_worldview.md` override 허용 (후자가 있으면 우선).
-
-**기본 템플릿** (Settings UI 에서 "기본 문구 로드" 버튼):
-```markdown
-# User Worldview
-
-## Ontology
-(사용자가 기본으로 채워 넣을 철학 stance. 예시는 tunaFlow 가 제공하지 않음 — user-authored.)
-
-## Engagement preference
-- 대화 bandwidth 가 자연스럽게 저하될 때 agent 의 대응 방식
-- 과거의 업(業)과 모순되는 요청에 대한 agent 의 응답 원칙
-```
-
-**주입 경로**: `prompt_assembly.rs::assemble_prompt()` 가 ContextPack 을 조립할 때, **identity_fragment 보다 먼저** `worldview_fragment` 를 삽입. 우선순위:
-
-```
-[project]            ← 기존
-[platform]           ← 기존
-[agent-role]         ← 기존
-...
-[worldview]          ← 신규, identity 바로 앞
-[identity]           ← 기존
-[skills]
-[recent_context]
-...
-[user_prompt]
-```
-
-**토큰 상한**: worldview 는 최대 500 tokens. 초과 시 앞부터 자르지 않고 사용자에게 "worldview 너무 깁니다 (Settings 에서 편집 권장)" toast + 자동 truncate.
-
-**토글**: Settings 에 "Worldview 주입 활성화" 체크박스. 기본 ON. 끄면 fragment 완전 생략.
-
-### 2. `preference_events` + `preference_snapshots` 스키마 (migration v46)
-
-초안 수정 (검토 세션 피드백 반영): event-log + snapshot 2단 구조. Embedding 은 **별도 후속 subtask/plan** 으로 분리.
-
-```sql
--- 매 변곡점 (stance 전환 사건) 을 append-only 기록
-CREATE TABLE preference_events (
-    id              TEXT PRIMARY KEY,
-    memory_name     TEXT NOT NULL,       -- 예: "engine_preference"
-    field           TEXT NOT NULL,       -- 예: "cli_vs_sdk"
-    stance_from     TEXT,                -- 직전 값 (없으면 NULL = 최초 선호)
-    stance_to       TEXT NOT NULL,       -- 새 값
-    reason_text     TEXT,                -- 자유 서술 (사용자 또는 agent 요약)
-    reason_tags     TEXT,                -- JSON array ["cost", "reliability", ...]
-    confidence      REAL DEFAULT 1.0,    -- agent 자동 감지 시 낮음
-    source          TEXT NOT NULL,       -- "user" | "agent_inferred"
-    changed_at      INTEGER NOT NULL     -- epoch ms
-);
-CREATE INDEX idx_preference_events_field ON preference_events(memory_name, field, changed_at DESC);
-
--- 현재 활성 stance 의 caching. events 에서 파생되지만 session resume 시 빠른 load 용.
-CREATE TABLE preference_snapshots (
-    memory_name     TEXT NOT NULL,
-    field           TEXT NOT NULL,
-    current_stance  TEXT NOT NULL,
-    last_event_id   TEXT NOT NULL REFERENCES preference_events(id),
-    updated_at      INTEGER NOT NULL,
-    PRIMARY KEY (memory_name, field)
-);
-```
-
-**Embedding 은 선택적**: 차후 필요 시 별도 subtask 로 `preference_embeddings` 테이블 추가. 본 plan 은 여기까지 다루지 않음. INV-3 로 강제.
-
-**Write path**:
-- 사용자가 Settings 에서 직접 변경 시 → event INSERT + snapshot UPSERT, `source='user'`, `confidence=1.0`
-- Agent 가 대화에서 stance 변경 감지 시 (후속 subtask 04 의 background job 이 수행) → event INSERT, `source='agent_inferred'`, `confidence<1.0`. 이 경우 사용자에게 confirmation modal.
-
-**Read path** (세션 resume):
-- `SELECT memory_name, field, current_stance FROM preference_snapshots` — 전체 snapshot load. 작음.
-- ContextPack 조립 시 최근 3 변곡점만 추가 컨텍스트: `SELECT ... FROM preference_events ORDER BY changed_at DESC LIMIT 3`.
-
-### 3. Stance-conflict detection (rule-first)
-
-**흐름**:
-
-```
-User request arrives
-    ↓
-[A] Rule precheck (Rust, no model)
-    - Extract candidate preferences from request (regex / keyword / named entity)
-    - Compare to current snapshots + recent 3 events
-    - Output: { conflict: bool | "ambiguous", matched_events: [...] }
-    ↓
-  ┌─ conflict=false → skip, inject compact "no conflict" summary
-  │
-  ├─ conflict=true → emit stance-conflict marker, show modal
-  │
-  └─ conflict="ambiguous"
-         ↓
-     [B] Model verify (Haiku/Flash, short prompt)
-         - Input: user request + ambiguous snapshot
-         - Output: {conflict: bool, reason: string}
-         ↓
-       (위와 동일 분기)
-    ↓
-[C] Opus 메인 프롬프트에 compact result 주입
-    - "No conflict" or "Conflict detected — user confirmed Y"
-    - 500 tokens 이내 요약
-```
-
-**Rule precheck 구현 위치**: `src-tauri/src/commands/agents_helpers/send_common/stance_check.rs` (신규).
-
-**Model verify**: 기존 `agents/claude.rs::run_one_shot` 패턴 재활용, `-p haiku` 또는 Gemini Flash. Timeout 10s, 실패 시 fallback = **`Unknown`** 상태 (Codex round-1 review 반영). UI 는 Unknown 을 modal 이 아닌 **inline warning (soft-confirm)** 으로 렌더. modal 발생은 **결정적 Conflict 에만** 국한해 사용자 피로도 폭증 방지.
-
-**Confirmation modal 마커** (composite key PK 와 정합, 하이픈 안전 non-greedy 파싱):
-
-```html
-<!-- tunaflow:stance-conflict:<memory_name>:<field>:<short_rationale> -->
-```
-
-`<memory_name>` 과 `<field>` 는 `preference_snapshots` 의 composite primary key. Modal 이 `get_preference_snapshot(memory_name, field)` Tauri command 호출로 단일 snapshot 조회. `<short_rationale>` 은 하이픈/개행 포함 가능.
-
-**규약**: `memory_name` 과 `field` 값은 **`:` 문자를 포함하지 않는다**. marker parser 구분자 충돌 방지. Subtask 02 의 `validate_pref_identifier` 가 write 시점에 강제.
-
-Modal 선택지:
-- **의도 변경 확정** → 신규 preference_event INSERT (`source='user'`), snapshot UPSERT, agent 이 원래 요청을 그대로 수행
-- **기존 선호 유지** → agent 에게 "사용자가 기존 선호 유지를 선택함. 요청을 재해석하라" 재주입 후 새 turn
-- **무시** → timeline 미기록, agent 가 그대로 진행 (원 요청 수행). modal 재표시 방지를 위해 해당 conflict 는 이 session 동안 mute.
-
-### 4. Low-priority background insight job (agent_jobs 확장)
-
-**agent_jobs 테이블 확장** (migration v46 에 포함):
-
-```sql
-ALTER TABLE agent_jobs ADD COLUMN priority INTEGER NOT NULL DEFAULT 0;
-    -- 0 = foreground (현재 default), -1 = low-priority background
-ALTER TABLE agent_jobs ADD COLUMN dedupe_key TEXT;
-    -- 같은 key 의 pending job 있으면 신규 INSERT 생략
-ALTER TABLE agent_jobs ADD COLUMN visibility TEXT NOT NULL DEFAULT 'visible';
-    -- 'visible' | 'hidden' (향후 확장). 본 plan 은 'visible' 만 사용.
-CREATE INDEX idx_agent_jobs_queue ON agent_jobs(priority, status, updated_at);
-```
-
-**Subtask 04 scope** (Codex round-1/2 review 2026-04-23 반영 — 축소):
-
-본 plan 의 Subtask 04 는 **스켈레톤만** 제공:
-- `enqueue_job` helper (priority / dedupe_key / visibility 수용)
-- `cancel_background_job` Tauri command — pending 보장, running best-effort (status 플래그만)
-- `count_pending_background_jobs` Tauri command
-- Frontend StatusBar 컴포넌트 (polling + event listener — worker 가 emit 시 표시)
-
-**제공하지 않음** (별도 plan, metaAgent 착수 시점):
-- Worker loop 실제 실행 경로 (`execute_job`, polling scheduler)
-- trace_log 기록 통합 (기존 `insert_trace_log_with_context` 재사용 여부 후속 결정)
-- Insight stash 연결 (`insightOrchestration` 파이프라인 통합)
-- Cooperative cancel token / subprocess kill
-- 실제 trigger 측 (metaAgent 가 enqueue 호출)
-
-**본 plan 머지 직후 동작**: `enqueue_job(priority=-1, ...)` 호출 시 row 가 `status='pending'` 으로 머물고, 실행될 executor 는 없음. StatusBar 는 "N pending" 표시 + 사용자 cancel 가능. 후속 plan (metaAgentPlan 의 subtask 또는 별도 worker executor plan) 이 worker 를 얹어야 실행. 이는 축소된 INV-4 정의 (pending 보장 / running best-effort) 와 정합.
+본 plan 의 모든 로직 (worldview 주입) 은 **sdk-session 경로 (Branch chat) 한정**. RT (`-p` one-shot) 는 매 turn full ContextPack 을 재주입하는 것이 정상 동작이며 본 plan 대상 아님.
 
 ---
 
-## Invariants
+## 구현 완료 요약 (subtask-01)
 
-- **[INV-1]** ContextPack 조립 시 `user_worldview` fragment 는 반드시 `identity_fragment` 보다 **앞** 에 위치한다. 순서 역전은 agent 가 "역할 (identity)" 을 먼저 정의하고 사용자 OS (worldview) 를 context 로 취급하게 만들어 본 plan 의 전제를 무효화. **검증**: `prompt_assembly.rs::assemble_prompt` 단위 테스트 — 주어진 ContextPackMeta 의 sections 순서 assert.
+1. **`user_worldview.md` 파일 체계**
+   - Global: `~/.tunaflow/user_worldview.md`
+   - Project override: `<project_path>/.tunaflow/user_worldview.md` (있으면 global 무시)
 
-- **[INV-2]** Stance-conflict 감지는 **rule precheck 가 결정적** 인 경우 모델을 호출하지 않는다. Model verify 는 `conflict=ambiguous` 분기에서만 발화. **이유**: 매 turn 모델 호출 시 비용 폭증 + latency 지연. **검증**: `stance_check.rs::tests` — clear conflict 케이스 (현재 snapshot 과 정반대 키워드) 와 clear no-conflict 케이스 (무관한 요청) 에서 model 호출 mock 이 0 회 호출되는지 assert.
+2. **ContextPack 주입**
+   - `prompt_assembly.rs::assemble_prompt()` 가 `identity_fragment` 바로 앞에 `worldview_fragment` 삽입
+   - 순서: `project → platform → agent-role → ... → worldview → identity → skills → recent_context → ... → user_prompt`
 
-- **[INV-3]** `preference_timeline` 관련 테이블은 본 plan 에서 `preference_events` + `preference_snapshots` **2개만** 도입한다. Embedding 관련 테이블 (`preference_embeddings`, vector index 등) 은 **별도 후속 plan** 으로 분리된다. **이유**: 기존 vector 층 (bge-m3, sqlite-vec) 과 경쟁하면 retrieval 우선순위가 혼란. 필요 증명된 이후에 추가. **검증**: migration v46 DDL grep — `embedding` / `vec0` 키워드 부재 확인.
+3. **Settings UI**
+   - `src/components/settings/WorldviewSettings.tsx` — 편집기 + "기본 문구 로드" 버튼
+   - 토큰 제한: Token Policy (`docs/reference/tokenPolicyReference.md`) 기준 — AGENTS.md 수준 **1,500~3,000 tokens 허용**. 2026-04-22 초안의 "500 tokens 상한" 은 토큰 절감 편향이었고, Token Policy 확정으로 상향 조정.
 
-- **[INV-4]** 모든 `priority < 0` background job 은 (a) UI 에 진행/대기 상태 노출 (visibility), (b) **pending 상태의 cancel 은 보장**, running 상태의 cancel 은 best-effort (status 플래그만 변경, subprocess kill 은 후속) 를 만족해야 한다. Silent 실행 금지. **이유**: tunaFlow 원칙 "숨은 동작 금지, trace 투명". 본 plan 의 Subtask 04 는 enqueue + UI surface + pending cancel 까지만 커버 (Codex round-1/2 review 2026-04-23 반영). Worker 실행, `trace_log` 기록, `background_insight_progress` 이벤트 emit 은 후속 plan 이 추가할 때 본 INV 를 확장 준수해야 한다. **검증**: Integration test — `enqueue_job` 으로 pending row 생성 → `cancel_background_job` → `status='cancelled'` 확인 + 이후 pending 쿼리에서 제외.
-
-- **[INV-5]** Stance-conflict confirmation modal 의 "무시" 선택은 **timeline 에 어떠한 event 도 기록하지 않는다**. 사용자의 침묵을 stance 변경으로 해석하지 않음. **이유**: 업(業) 의 기록은 사용자 명시 승인 없이 누적되면 "내 선호가 내 모르게 바뀌었다" 라는 karma 오염. **검증**: UI 테스트 — modal 에서 "무시" 클릭 후 `SELECT COUNT(*) FROM preference_events WHERE id = ?new_event_id` 가 0.
-
-- **[INV-6]** Agent 응답에 stance-conflict 마커가 있을 때 UI 는 그 마커를 **사용자에게 렌더하지 않는다** (HTML comment 형식 유지). Modal 로만 노출. **이유**: 마커가 raw text 로 보이면 사용자 혼란 + 신뢰 하락. **검증**: react-markdown 렌더 테스트 — 마커가 final DOM 에 없음을 확인.
-
----
-
-## Rationale (reviewer-only)
-
-### 검토 세션 피드백 반영
-
-초안 (2026-04-22 Gemini 답 + 내 블루프린트 합산) 에서 다음 3 가지가 검토 세션에 의해 교정됨. 본 plan 은 교정본:
-
-| 초안 | 교정 이유 | 본 plan |
-|---|---|---|
-| stance-conflict 를 Opus inline 으로 매 turn 체크 | 비용 폭증 | rule-first + ambiguous 에만 small model verify (§3) |
-| `preference_timeline` 에 reason vectorization 기본 포함 | tunaFlow 이미 vector 층 있음. 새 memory source 추가 시 retrieval 경쟁 | event+snapshot 2단, embedding 은 선택적 후속 (INV-3) |
-| Silent tool-request 로 부재중 stash | tunaFlow "trace 투명" 원칙 위배 | background + low-priority + visible + cancelable 로 재정의 (§4, INV-4) |
-
-### Gemini 기여 (수용)
-
-- **거부권 개념** → stance-conflict marker + modal 로 구현. "도덕적 거부" 가 아니라 "기계적 conflict detection + 사용자 confirmation" 로 기술 번역.
-- **자기 관찰 도구 (Vipassana) 격상** → preference_events timeline 은 Insight 탭의 subview 로 노출 (별도 UI plan 에서 정리). 본 plan 은 backend 만.
-
-### 대안 비교
-
-| 대안 | 판정 | 사유 |
-|---|---|---|
-| 모든 turn Opus inline stance check | 기각 | 비용 |
-| preference_timeline vector-first | 기각 | retrieval 경쟁 |
-| Silent tool-request | 기각 | 원칙 위배 |
-| 세 축을 3개 독립 plan 으로 분리 | 기각 | 서로 강화 관계. worldview 없이는 stance-conflict 판정 문맥 부재 |
-| **채택** (3축 번들 + rule-first + event/snapshot + visible background) | ✅ | 최소 침습 + tunaFlow 원칙 정합 |
-
-### Open questions
-
-1. **Q-1 (worldview 템플릿 기본값)**: 사용자가 Settings 에서 "기본 문구 로드" 를 선택했을 때 제공할 minimal 템플릿 내용. 본 plan 은 "section header 와 빈 본문" 권장 (placeholder). 사용자 철학은 user-authored — tunaFlow 가 제시하는 순간 bias 주입. Developer/사용자 협의 후 확정.
-
-2. **Q-2 (stance-conflict rule precheck 알고리즘)**: 초기 구현은 어떤 rule 패턴이 적절한가. 키워드 리스트? 간단한 regex? named entity (engine 이름 / 기능 이름) 추출? 본 plan 은 "간단한 토큰 매칭부터 시작 + 실제 oversight/undersight 측정 후 개선" 을 권장. 최초 릴리스는 **false positive 허용 (model verify 가 catch), false negative 회피** 튜닝.
-
-3. **Q-3 (small verify model 선정)**: Haiku vs Gemini Flash vs 로컬 LMStudio? 본 plan 은 "기존 설정된 model" 우선 + Haiku default. Developer 구현 시 실측 latency 기반 결정.
-
-4. **Q-4 (background worker polling vs event-driven)**: §4 의 worker 가 30 초 polling 으로 기술됐으나 event-driven 이 더 반응적. Polling 은 구현 단순, event-driven 은 복잡성 증가. 본 plan 은 MVP 로 polling 채택, 후속 refactor 여지 남김.
-
-5. **Q-5 (metaAgent 와의 trigger 경로)**: 본 plan 은 background job 등록 **경로** 만 제공. 실제 "사용자 지루함 감지" trigger 는 `metaAgentPlan.md` (P0) 의 책임. metaAgent 구현 후 본 plan 의 `priority=-1` job 을 호출하는 식. 현재는 수동 테스트로 job 등록 경로 검증.
+4. **토글**
+   - Settings 에 "Worldview 주입 활성화" 체크박스. 기본 ON. 끄면 fragment 완전 생략.
 
 ---
 
-## Subtask 구조
+## Invariants (남은 INV)
 
-| # | 파일 | 범위 | 의존 |
-|---|---|---|---|
-| 01 | [-task-01.md](./userWorldviewInjectionPlan-task-01.md) | `user_worldview.md` 파일 + ContextPack 주입 + Settings UI 편집기 | — |
-| 02 | [-task-02.md](./userWorldviewInjectionPlan-task-02.md) | migration v46 (preference_events + preference_snapshots + agent_jobs 컬럼 확장) + write path helper | — |
-| 03 | [-task-03.md](./userWorldviewInjectionPlan-task-03.md) | Stance-conflict detection (rule precheck + small model verify + confirmation modal) | 02 |
-| 04 | [-task-04.md](./userWorldviewInjectionPlan-task-04.md) | Background insight worker (low-priority + visible + cancelable) | 02 |
+- **[INV-1]** ContextPack 조립 시 `user_worldview` fragment 는 반드시 `identity_fragment` **바로 앞** 에 위치한다. project / platform / agent-role 등 identity 앞 섹션들은 그대로 유지 — worldview 가 이들을 앞지르지 않는다. **이유**: agent 가 자신의 역할 (identity) 을 정의하기 전에 사용자 OS (worldview) 를 먼저 받아야 한다는 원 설계 의도. **검증**: `prompt_assembly.rs::assemble_prompt` 단위 테스트 — sections 순서에서 `"worldview"` 가 `"identity"` 바로 앞 인덱스.
 
-4 subtask. 01 독립 (가장 작고 ROI 최고). 02 가 03/04 공통 의존. 03/04 는 02 후 독립 병렬.
+- **[INV-2]** Worldview 콘텐츠는 사용자가 **자유롭게 작성** 한다. tunaFlow 는 기본 템플릿 외에는 내용에 개입하지 않는다 (placeholder 제공, stance 예시 제공 금지). **이유**: 사용자 철학에 대한 bias 주입 방지. **검증**: 기본 템플릿이 section 헤더만 포함하고 본문은 비어 있는지 확인.
+
+- **[INV-3]** Worldview 는 **사용자 대면 stance 문서**이며, 분석 산출물 (`identity_summary`, `projectIdentityAnalysisPlan` 범위) 과 **별도의 ContextPack 섹션**으로 공존한다. 두 문서 충돌 시 worldview 가 우선 — 프롬프트 주입 시 "User-authored worldview takes priority over analysis-derived identity on conflict." 한 줄 명시. **이유**: 자동 분석 결과가 사용자 의식적 선언을 덮지 않도록. **검증**: `projectIdentityAnalysisPlan` 의 ContextPack selector 확장 후 integration test — 두 섹션이 각각 `"worldview"` / `"project_identity"` 로 분리 렌더.
+
+(기존 INV-4~8 은 superseded subtask 소속이라 제거)
+
+---
+
+## Superseded subtasks
+
+아래 3개는 **본 plan 에서 구현하지 않음**. 파일은 archive 또는 deprecated 표기 후 git history 로 보존:
+
+### subtask-02: `preference_events` + `preference_snapshots` (migration v46)
+- **Supersede 이유**: `artifacts` 테이블 재사용이 사용자 원 설계 의도. 별도 테이블 신설은 중복 memory 계층.
+- **이관처**: `projectIdentityAnalysisPlan-task-01.md` (artifact 자동 생성 6 타입)
+
+### subtask-03: Stance-conflict (rule + model verify + modal)
+- **Supersede 이유**: 사용자 요청 vs 과거 선호 판정은 rule/model/modal 엔진보다 **LLM 자연 능력 + ContextPack 주입** 로 충분. Modal 은 UX 침습 과다. 필요 시 agent 가 응답 안에서 자연스럽게 현실 감각 제공.
+- **이관처**: 없음 (폐기). 필요 시 `docs/ideas/stanceConflictStrongIdea.md` 로 idea 만 보존.
+
+### subtask-04: Background insight worker skeleton
+- **Supersede 이유**: metaAgent 구현과 묶어 진행하는 편이 자연스러움. 스켈레톤 단독 머지는 dead feature 리스크.
+- **이관처**: `projectIdentityAnalysisPlan-task-02.md` (metaAgent trigger + analysis job)
+
+---
+
+## Rationale (간략)
+
+### 축소의 근거
+
+2026-04-22 초안은 Identity / Interface / Continuity 3축을 한 plan 에 묶었다. 이는 Gemini 의 "거부권" insight 와 검토 세션의 피드백을 합친 결과였으나, 2026-04-23 사용자 리마인드로 다음이 명확해졌다:
+
+1. **tunaFlow 원 취지 = 2인 3각 협업 도구** (사용자 확인)
+2. **"불편한 동반자" 는 tunaFlow 정체성 맞음** — 단 구현 수단은 rule + modal 이 아니라 **LLM 에게 context 를 주면 자연스럽게** 수행
+3. **Artifacts 는 이미 사용자 결정 + agent finding 누적 → 분석 → 정체성 추출** 이라는 원 의도를 가진 인프라 — 별도 preference 테이블 신설 중복
+
+결과적으로 본 plan 은 **사용자 수동 stance (worldview)** 에만 집중하고, 자동 분석 / 변곡점 timeline / 정체성 추출은 `projectIdentityAnalysisPlan` 이 담당.
+
+### 토큰 정책 조정
+
+초안의 worldview 500 tokens 상한은 `docs/reference/tokenPolicyReference.md` 의 "품질 우선" 원칙과 충돌. **1,500~3,000 tokens 로 상향**. Subtask-01 이 이미 머지된 이후의 후속 조정이며, 기존 짧은 worldview 는 그대로 작동 + 사용자가 길게 작성해도 ContextPack 에 full 주입.
 
 ---
 
 ## 관련 문서
 
-- Gemini 답변 원문: 본 세션 2026-04-22 대화 (검토 세션 공유)
-- 검토 세션 피드백: 본 세션 2026-04-22 대화 (rule-first, event+snapshot, visible background)
-- 사용자 철학 원문: 본 세션 2026-04-22 "바이브 코더 / 2인 3각" 프롬프트
-- 설계 유사 gate 패턴: `docs/plans/designReviewGatePlan.md`
-- P0 metaAgent 교차: `docs/plans/metaAgentPlan.md`
+- 구현 PR: #144 (merged 2026-04-22)
+- Token Policy: `docs/reference/tokenPolicyReference.md`
+- 후속 대체 plan: `docs/plans/projectIdentityAnalysisPlan.md`
+- Archive 대상: `userWorldviewInjectionPlan-task-02.md`, `-task-03.md`, `-task-04.md` (Developer 가 git mv 로 `docs/archive/plans/superseded/` 이동)


### PR DESCRIPTION
## Summary

- **신규 plan**: `projectIdentityAnalysisPlan.md` (+ 4 subtask) — Artifacts 기반 정체성 분석 파이프라인
- **축소**: `userWorldviewInjectionPlan` 의 subtask-02~04 superseded, subtask-01 (worldview 주입, PR #144 완료) 만 유지
- Codex 자문 (2026-04-23) adjust verdict 반영

## 주요 결정

- Artifact type 6 + identity_summary (총 7)
- Trigger = done_plans % 3 == 0 AND eligible >= 10 (Settings 튜닝 가능)
- identity_summary = 1,350~2,050 tokens, 고정 5 섹션 + 예산 + "Do not narrate" 프롬프트 (Token Policy 준수)
- 새 DB 테이블 신설 X — artifacts 테이블 재사용
- metaAgent 가 trigger + orchestration 주체 (P0 metaAgent plan 선행 의존)

## 제외/폐기 (Artifacts 재사용으로 해결)

- `preference_events` / `preference_snapshots` (중복 memory 계층)
- stance-conflict rule + model verify + modal (LLM 자연 능력에 맡김)

## 후속 착수 순서 (Architect 권고)

- subtask-01~03: search part-2 완료 후 (send_common / roundtable_helpers overlap 회피)
- subtask-04 (Insight 탭 UI): 독립 파일, 병렬 가능

## Test plan

- [ ] \`docs/plans/projectIdentityAnalysisPlan.md\` 본문 + 5 섹션 + INV 6개 렌더 확인
- [ ] subtask 4개 파일 Verification 섹션 구체성 확인
- [ ] \`userWorldviewInjectionPlan.md\` superseded_subtasks frontmatter 확인
- [ ] subtask 02/03/04 상단 SUPERSEDED 배너 렌더 확인
- [ ] \`index.md\` 신규 plan 등록 + userWorldview 상태 변경 렌더 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)