### PR TITLE
feat(identity): subtask-01 Phase B — rework_reason / finding_success / finding_failure

### DIFF
--- a/src/lib/workflow/helpers.ts
+++ b/src/lib/workflow/helpers.ts
@@ -2,7 +2,7 @@
  * Shared workflow helpers — slug, project path, branch creation, artifacts.
  */
 import { invoke } from "@tauri-apps/api/core";
-import type { Branch, Plan } from "@/types";
+import type { Branch, Plan, PlanSubtask } from "@/types";
 import * as planApi from "../api/plans";
 import * as artifactApi from "../api/artifacts";
 import * as failureLessonsApi from "../api/failureLessons";
@@ -164,6 +164,106 @@ export async function saveFailureLessons(plan: Plan, findings: string[]): Promis
 }
 
 // ─── Artifact creation ─────────────────────────────────────────────────────
+
+/** subtask-01 Phase B: Rework 진입 시 `rework_reason` identity-input artifact.
+ *  cycle 은 plan_events.review_failed 개수 기반 derive (plans.rework_cycle 컬럼 없음). */
+export async function createReworkReasonArtifact(
+  plan: Plan,
+  verdict: ParsedReviewVerdict,
+  cycle: number,
+): Promise<void> {
+  try {
+    const content = {
+      cycle,
+      findings: verdict.findings,
+      root_cause_hint: verdict.recommendations.join("; "),
+    };
+    await invoke("create_identity_artifact", {
+      input: {
+        kind: "rework_reason",
+        conversationId: plan.conversationId,
+        planId: plan.id,
+        subtaskId: null,
+        title: `Rework ${cycle}: ${plan.title}`,
+        content,
+      },
+    });
+  } catch (e) {
+    console.warn("[identity-artifact] rework_reason failed:", e);
+  }
+}
+
+/** subtask-01 Phase B: review 통과 + subtask done 확정 시 `finding_success` artifact.
+ *  classifier 가 결정한 subtask 에 대해 1건씩 호출. */
+export async function createFindingSuccessArtifact(
+  plan: Plan,
+  subtask: PlanSubtask,
+  agentEngine: string | undefined,
+): Promise<void> {
+  try {
+    const content = {
+      subtask_id: subtask.id,
+      subtask_idx: subtask.idx,
+      duration_ms: null as number | null,
+      agent_engine: agentEngine ?? null,
+      notes: null as string | null,
+    };
+    await invoke("create_identity_artifact", {
+      input: {
+        kind: "finding_success",
+        conversationId: plan.conversationId,
+        planId: plan.id,
+        subtaskId: subtask.id,
+        title: `Subtask ${subtask.idx + 1} success: ${subtask.title}`,
+        content,
+      },
+    });
+  } catch (e) {
+    console.warn("[identity-artifact] finding_success failed:", e);
+  }
+}
+
+/** subtask-01 Phase B: review fail 시 failed_subtask_ids 각 id 에 대해 `finding_failure`. */
+export async function createFindingFailureArtifact(
+  plan: Plan,
+  subtask: PlanSubtask,
+  verdict: ParsedReviewVerdict,
+  agentEngine: string | undefined,
+  evidenceMessageId: string | null,
+): Promise<void> {
+  try {
+    const content = {
+      subtask_id: subtask.id,
+      subtask_idx: subtask.idx,
+      failure_kind: inferFailureKind(verdict.findings),
+      agent_engine: agentEngine ?? null,
+      evidence_msg_id: evidenceMessageId,
+    };
+    await invoke("create_identity_artifact", {
+      input: {
+        kind: "finding_failure",
+        conversationId: plan.conversationId,
+        planId: plan.id,
+        subtaskId: subtask.id,
+        title: `Subtask ${subtask.idx + 1} failure: ${subtask.title}`,
+        content,
+      },
+    });
+  } catch (e) {
+    console.warn("[identity-artifact] finding_failure failed:", e);
+  }
+}
+
+/** findings 문장 내 키워드로 failure_kind 를 추정. 없으면 "other" fallback.
+ *  가벼운 분류로 identity 분석기의 input 다양성 확보가 목적 — 정확도 필수 아님. */
+function inferFailureKind(findings: string[]): string {
+  const joined = findings.join(" ").toLowerCase();
+  if (/scope|범위/.test(joined)) return "scope_violation";
+  if (/blocker|block|막힘/.test(joined)) return "blocker";
+  if (/test|테스트/.test(joined)) return "test_failure";
+  if (/convention|관례/.test(joined)) return "convention";
+  return "other";
+}
 
 /** projectIdentityAnalysisPlan subtask-01: verdict 확정 시 `review_outcome` 구조화
  *  identity-input artifact 를 생성. 기존 `createVerdictArtifact` (review-findings 마크다운)

--- a/src/lib/workflow/reviewWorkflow.ts
+++ b/src/lib/workflow/reviewWorkflow.ts
@@ -15,9 +15,13 @@ import {
   saveFailureLessons,
   createVerdictArtifact,
   createReviewOutcomeArtifact,
+  createReworkReasonArtifact,
+  createFindingSuccessArtifact,
+  createFindingFailureArtifact,
   createTestReportArtifact,
   getPlanSlug,
 } from "./helpers";
+import { classifyIdentityArtifacts, computeReworkRound } from "./services/identityArtifactClassifier";
 import type { CreateBranchResult } from "./helpers";
 import { syncResultReport, syncReviewReport } from "./reportSync";
 import {
@@ -218,6 +222,21 @@ export async function processReviewVerdict(
   const reviewRound = (plan.versionMinor || 0) + 1;
   await createReviewOutcomeArtifact(plan, verdict, undefined, reviewRound);
 
+  // Phase B: subtask 별 finding_success / finding_failure. pass/fail 구분 없이
+  // classifier 가 판정 (failed_subtask_ids 있으면 failure, 없고 done 이면 success).
+  // pass 시 failed_subtask_ids 는 빈 배열 → 모든 done 이 success 로 떨어짐.
+  try {
+    const subtasks = await planApi.listSubtasks(plan.id);
+    const { successes, failures } = classifyIdentityArtifacts(subtasks, verdict);
+    const agentEngine = plan.developerEngine ?? undefined;
+    await Promise.all([
+      ...successes.map((st) => createFindingSuccessArtifact(plan, st, agentEngine)),
+      ...failures.map((st) => createFindingFailureArtifact(plan, st, verdict, agentEngine, null)),
+    ]);
+  } catch (e) {
+    console.warn("[identity-artifact] subtask classification failed:", e);
+  }
+
   if (verdict.verdict === "pass") {
     await planApi.updatePlanPhase(plan.id, "done");
     await planApi.updatePlanStatus(plan.id, "done");
@@ -272,6 +291,18 @@ export async function processReviewVerdict(
     await planApi.createPlanEvent(plan.id, "review_failed", "reviewer", detail);
     await saveFailureLessons(plan, verdict.findings);
     await createVerdictArtifact(plan, verdict);
+
+    // Phase B: Rework 진입 시 rework_reason identity-input artifact.
+    // cycle 은 review_failed plan-event 개수 (방금 추가한 건 포함). plans.rework_cycle
+    // 컬럼이 없어 derive. computeDoomLoopState 와 달리 escalation window 무관한
+    // 누적 count — identity 분석은 plan 전체 생애주기를 보기 위함.
+    try {
+      const eventsAfterFail = await planApi.listPlanEvents(plan.id);
+      const cycle = computeReworkRound(eventsAfterFail);
+      await createReworkReasonArtifact(plan, verdict, cycle);
+    } catch (e) {
+      console.warn("[identity-artifact] rework_reason failed:", e);
+    }
 
     // Tier 2 트리거 — projectKey 조회 후 fail 누적 카운트 체크.
     try {

--- a/src/lib/workflow/services/identityArtifactClassifier.ts
+++ b/src/lib/workflow/services/identityArtifactClassifier.ts
@@ -1,0 +1,62 @@
+/**
+ * Identity artifact classifier (projectIdentityAnalysisPlan subtask-01 Phase B).
+ *
+ * Review verdict + plan subtasks 를 입력으로 받아 subtask 별 identity-input
+ * artifact 종류를 결정. emit 경로에서 순수 로직 분리 — classifier 는 DB 접근
+ * 이나 invoke 없이 `{successes, failures}` 만 반환. 호출자가 각 subtask 에 대해
+ * 적절한 invoke 를 수행.
+ *
+ * 판정 규칙 (subtask §3.4/§3.5 + Architect 보수적 정의):
+ *   - `failed_subtask_ids` 포함 (idx+1 기준 1-based) → `finding_failure`
+ *   - 그 외이면서 `status === "done"` → `finding_success`
+ *   - 그 외 (in_progress / todo / abandoned) → 분류 skip
+ */
+import type { PlanSubtask } from "@/types";
+import type { ParsedReviewVerdict } from "@/lib/planProposalParser";
+
+export interface IdentityArtifactClassification {
+  /** finding_success 로 emit 될 subtask 들. */
+  successes: PlanSubtask[];
+  /** finding_failure 로 emit 될 subtask 들. */
+  failures: PlanSubtask[];
+}
+
+/**
+ * verdict 의 failed_subtask_ids (1-based) 와 subtasks.idx (0-based) 를 맞춰
+ * success / failure 버킷으로 나눈다. 중복 id 는 set 으로 normalize.
+ *
+ * verdict.verdict 가 "pass" 이면 `failed_subtask_ids` 는 비어있어야 하므로
+ * 모든 done subtask 가 success 로 떨어짐. fail 이면 ids 에 있는 건 failure,
+ * 나머지 done 은 success (부분 실패 허용).
+ */
+export function classifyIdentityArtifacts(
+  subtasks: readonly PlanSubtask[],
+  verdict: ParsedReviewVerdict,
+): IdentityArtifactClassification {
+  const failedSet = new Set<number>(verdict.failedSubtaskIds ?? []);
+  const successes: PlanSubtask[] = [];
+  const failures: PlanSubtask[] = [];
+  for (const st of subtasks) {
+    const oneBased = st.idx + 1;
+    if (failedSet.has(oneBased)) {
+      failures.push(st);
+    } else if (st.status === "done") {
+      successes.push(st);
+    }
+    // todo / in_progress / abandoned — 분류 대상 아님 (review 결과 직접 반영 없음)
+  }
+  return { successes, failures };
+}
+
+/**
+ * `review_failed` plan-event 개수로 현재 rework round 를 계산한다. verdict
+ * fail 이 막 처리되어 event 를 추가한 직후 호출한다고 가정 — "방금 포함된"
+ * fail event 까지 카운트한다. computeDoomLoopState 와 달리 escalation window
+ * 와 무관하게 누적 count (plan 생성 이후 총 fail round). Architect 주석에 따라
+ * plans.rework_cycle 컬럼이 없어 plan_events derive 로 대체.
+ */
+export function computeReworkRound(
+  planEvents: readonly { eventType: string }[],
+): number {
+  return planEvents.filter((e) => e.eventType === "review_failed").length;
+}

--- a/src/lib/workflow/services/index.ts
+++ b/src/lib/workflow/services/index.ts
@@ -10,3 +10,4 @@ export * from "./reviewVerdict";
 export * from "./doomLoopDetector";
 export * from "./reviewBranchReuse";
 export * from "./fileDisposition";
+export * from "./identityArtifactClassifier";

--- a/src/tests/workflowServices.test.ts
+++ b/src/tests/workflowServices.test.ts
@@ -6,8 +6,11 @@ import {
   computeDoomLoopState,
   computeFindingOverlap,
   shouldReuseReviewBranch,
+  classifyIdentityArtifacts,
+  computeReworkRound,
 } from "@/lib/workflow/services";
 import type { Branch, Message, PlanEvent, PlanSubtask } from "@/types";
+import type { ParsedReviewVerdict } from "@/lib/planProposalParser";
 
 const subtask = (idx: number, status: PlanSubtask["status"] = "in_progress"): PlanSubtask => ({
   id: `st-${idx}`,
@@ -298,5 +301,84 @@ describe("shouldReuseReviewBranch", () => {
   it("rejects when the branch row is missing from the list", () => {
     const d = shouldReuseReviewBranch(plan, [], "roundtable");
     expect(d.reuse).toBe(false);
+  });
+});
+
+describe("classifyIdentityArtifacts (subtask-01 Phase B)", () => {
+  const verdict = (
+    v: "pass" | "fail" | "conditional",
+    failedIds: number[] = [],
+  ): ParsedReviewVerdict => ({
+    verdict: v,
+    rubric: undefined,
+    findings: [],
+    recommendations: [],
+    failedSubtaskIds: failedIds,
+    raw: "",
+  });
+
+  it("pass verdict + all done → everyone is success", () => {
+    const subtasks = [subtask(0, "done"), subtask(1, "done"), subtask(2, "done")];
+    const { successes, failures } = classifyIdentityArtifacts(subtasks, verdict("pass"));
+    expect(successes.map((s) => s.idx)).toEqual([0, 1, 2]);
+    expect(failures).toEqual([]);
+  });
+
+  it("fail verdict with failed_ids splits success and failure", () => {
+    const subtasks = [subtask(0, "done"), subtask(1, "done"), subtask(2, "done")];
+    const { successes, failures } = classifyIdentityArtifacts(
+      subtasks,
+      verdict("fail", [2]), // idx 1 (1-based 2)
+    );
+    expect(successes.map((s) => s.idx)).toEqual([0, 2]);
+    expect(failures.map((s) => s.idx)).toEqual([1]);
+  });
+
+  it("in_progress/todo subtasks are excluded from both buckets", () => {
+    const subtasks = [
+      subtask(0, "done"),
+      subtask(1, "in_progress"),
+      subtask(2, "todo"),
+      subtask(3, "abandoned"),
+    ];
+    const { successes, failures } = classifyIdentityArtifacts(subtasks, verdict("pass"));
+    expect(successes.map((s) => s.idx)).toEqual([0]);
+    expect(failures).toEqual([]);
+  });
+
+  it("failed_id 우선권 — done 인 subtask 도 failed_ids 에 들어있으면 failure", () => {
+    const subtasks = [subtask(0, "done"), subtask(1, "done")];
+    const { successes, failures } = classifyIdentityArtifacts(
+      subtasks,
+      verdict("fail", [1]), // idx 0 (1-based 1)
+    );
+    expect(failures.map((s) => s.idx)).toEqual([0]);
+    expect(successes.map((s) => s.idx)).toEqual([1]);
+  });
+
+  it("empty subtasks returns empty buckets", () => {
+    const r = classifyIdentityArtifacts([], verdict("pass"));
+    expect(r.successes).toEqual([]);
+    expect(r.failures).toEqual([]);
+  });
+});
+
+describe("computeReworkRound (subtask-01 Phase B)", () => {
+  it("counts only review_failed events", () => {
+    const events = [
+      planEvent("approved", 1),
+      planEvent("review_failed", 2),
+      planEvent("review_failed", 3),
+      planEvent("review_passed", 4),
+    ];
+    expect(computeReworkRound(events)).toBe(2);
+  });
+
+  it("returns 0 when no fail events", () => {
+    expect(computeReworkRound([planEvent("approved", 1)])).toBe(0);
+  });
+
+  it("returns 0 for empty list", () => {
+    expect(computeReworkRound([])).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

projectIdentityAnalysisPlan subtask-01 **Phase B** 구현. Phase A 의 \`review_outcome\` 한 건에 더해 **subtask 단위 success/failure + plan 단위 rework_reason** 을 verdict 확정 시점에 emit.

### Classifier (pure, testable)
- \`services/identityArtifactClassifier.ts\`:
  - \`classifyIdentityArtifacts(subtasks, verdict)\` — \`failed_subtask_ids\` (1-based) 기준 failure 우선, 그 외 \`status='done'\` 만 success. \`in_progress\`/\`todo\`/\`abandoned\` 는 두 버킷 모두에서 제외 (Architect 보수적 정의).
  - \`computeReworkRound(planEvents)\` — \`review_failed\` 개수로 rework cycle derive. \`plans.rework_cycle\` 컬럼 없음 → plan_events 기반 (Architect 관찰 포인트 #2 반영).

### Helpers (\`workflow/helpers.ts\`)
- \`createReworkReasonArtifact(plan, verdict, cycle)\` — cycle + findings + root_cause_hint
- \`createFindingSuccessArtifact(plan, subtask, agentEngine)\`
- \`createFindingFailureArtifact(plan, subtask, verdict, engine, evidenceMsgId)\`
- \`inferFailureKind\` — findings 키워드 기반 failure_kind 분류 (scope_violation / blocker / test_failure / convention / other). identity 분석 input 다양성 확보 — 정확도 필수 아님

### Integration (\`reviewWorkflow.ts::processReviewVerdict\`)
- verdict 확정 직후 (**pass/fail/conditional 무관**) classifier 실행 → subtask 별 emit
  - pass: \`failed_ids\` 비어 있음 → 모든 done subtask 가 success
  - fail: failed_ids 에 있으면 failure, 나머지 done 은 success (부분 실패 허용)
- fail 분기에만 \`rework_reason\` 추가 emit (cycle = 방금 추가된 review_failed 포함 누적 count)

### 테스트 (\`workflowServices.test.ts\` +8)
- \`classifyIdentityArtifacts\` **5건**: pass all-done / fail split / in_progress 제외 / failed_id 우선권 / empty
- \`computeReworkRound\` **3건**: 정상 카운트 / 0 fail / 빈 list

Frontend **297 → 305** tests, Rust **432** 유지, \`tsc --noEmit\` 통과.

## Phase B 완료 상태 (plan §3.3~3.5)
- ✅ \`rework_reason\` (§3.3) — fail verdict 시 cycle 포함 emit
- ✅ \`finding_success\` (§3.4) — 보수적 정의 "failed_ids 에 없고 status=done"
- ✅ \`finding_failure\` (§3.5) — failed_ids 각 id 별 1건 + failure_kind 추정

## INV 준수
- **INV-1 surveillance 금지**: 대화 내용 파싱 아님. verdict marker + subtask status + plan_events 만 입력. failure_kind 는 **reviewer 가 작성한 findings** 에서 키워드 분류 — reviewer output 해석이지 사용자 대화 surveillance 아님.
- **Dedup**: Phase A 의 1분 window 가 그대로 적용됨 (같은 subtask 에 동일 content 재 emit 차단).

## 후속
- Phase B 실데이터 관찰 (verdict.failedSubtaskIds 채워지는 빈도 등)
- metaAgent Phase 4 (bg worker) / Phase 3 (identity trigger) 착수
- subtask-03 (identity_summary 분석 prompt) + subtask-04 (Insight UI)

## Test plan
- [x] \`npx vitest run src/tests/workflowServices.test.ts\` (35 통과)
- [x] \`npx vitest run\` (305 통과)
- [x] \`cargo test --lib\` (432 통과)
- [x] \`npx tsc --noEmit\`
- [ ] 실제 Plan 리뷰 pass/fail 흐름에서 artifacts 테이블 row 수 검증 (수동 E2E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)