### PR TITLE
feat(identity): subtask-03 — identity analyzer + ContextPack 주입 + worker dispatcher wire

### DIFF
--- a/src-tauri/src/agents/identity_analyzer.rs
+++ b/src-tauri/src/agents/identity_analyzer.rs
@@ -1,0 +1,603 @@
+//! projectIdentityAnalysisPlan subtask-03 — identity 분석 실행 경로.
+//!
+//! 입력: 최근 period 의 6 타입 identity-input artifact.
+//! 출력: `identity_summary` 타입 artifact 1건 (고정 5 섹션 markdown + frontmatter).
+//!
+//! LLM 호출은 CLI-first 원칙 (`agents::claude::run`) 을 재사용. 테스트는
+//! `InvokeAnalyzer::Stub` 으로 LLM 호출을 격리한다.
+//!
+//! Invariants:
+//! - 섹션 누락 / 예산 초과 → 1 회 재생성 시도. 재실패 시 job='failed'.
+//! - 출력 content 앞에 `---\nproject_key: ...\n---` frontmatter 부착 (ContextPack
+//!   주입 시 strip).
+//! - 분석 output 은 `create_identity_summary` (analyzer 전용) 로만 저장되며,
+//!   자동 생성 경로 (`create_identity_input_artifact`) 는 IdentitySummary kind 거부.
+
+use std::collections::HashMap;
+
+use rusqlite::{params, Connection};
+use serde::Serialize;
+
+use crate::agents::claude::{run as run_claude, RunInput};
+use crate::db::models::Artifact;
+use crate::errors::AppError;
+
+// ─── Prompt template ────────────────────────────────────────────────────────
+
+pub const IDENTITY_PROMPT_TEMPLATE: &str = r#"You are synthesizing project identity from the last completed plans' artifacts.
+
+## Input metadata
+- Project: {project_key}
+- Period: {since} ~ {until}
+- Plan done count (cumulative): {done_plan_count}
+
+## Input artifacts (workflow-derived, 6 types)
+Sorted by type then chronological. DO NOT treat user messages as input.
+
+{artifacts_serialized}
+
+## Output requirements
+Produce markdown with EXACTLY these sections and token budgets.
+
+Rules:
+- Do not narrate.
+- Write terse operational guidance.
+- Prefer bullets over prose.
+- Every line must be reusable as future instruction to an agent.
+- If evidence is insufficient for a section, write "(insufficient evidence)" rather than inventing.
+
+### Project identity  (150-250 tokens)
+Nature / stage / primary users. One-line summary first, then bullets.
+
+### User working preference  (300-500 tokens)
+- Decision patterns observed (cite artifact ids)
+- Preferred constraints / styles
+- Explicit avoid-list
+
+### Agent operating preference  (300-500 tokens)
+- Which engine succeeds at which task category
+- Common failure modes per engine
+- Recommended delegation pattern
+
+### Recent inflection points  (exactly 3 items, 100-150 tokens each)
+For each:
+- What changed (1 line)
+- Why (cite artifact id)
+- When (date)
+
+### Do / Avoid  (200-300 tokens)
+- Bullets only. No prose.
+- Split into "Do" and "Avoid" lists explicitly.
+
+## Total budget: 1,350 ~ 2,050 tokens. Exceeding or missing sections trigger regeneration.
+"#;
+
+pub const ARTIFACT_TYPE_ORDER: &[&str] = &[
+    "decision",
+    "review_outcome",
+    "rework_reason",
+    "finding_success",
+    "finding_failure",
+    "workflow_milestone",
+];
+
+/// content (JSON string) 을 max_chars 만큼 축약. JSON 파싱 실패 시 원문 앞부분을 반환.
+pub fn summarize_content(content: &str, max_chars: usize) -> String {
+    let trimmed = content.trim();
+    let compact = trimmed.replace('\n', " ");
+    let mut end = 0usize;
+    for (i, _) in compact.char_indices() {
+        if i >= max_chars {
+            break;
+        }
+        end = i + 1;
+    }
+    if compact.chars().count() > max_chars {
+        format!("{}...", &compact[..end])
+    } else {
+        compact
+    }
+}
+
+/// Input artifact 들을 type 별로 그룹핑 후 timestamp 순 정렬. 프롬프트 본문에
+/// 들어갈 markdown 생성.
+pub fn serialize_artifacts_for_prompt(artifacts: &[Artifact]) -> String {
+    let mut grouped: HashMap<&str, Vec<&Artifact>> = HashMap::new();
+    for a in artifacts {
+        grouped.entry(a.artifact_type.as_str()).or_default().push(a);
+    }
+    let mut out = String::new();
+    for t in ARTIFACT_TYPE_ORDER {
+        if let Some(items) = grouped.get(t) {
+            let mut sorted: Vec<&&Artifact> = items.iter().collect();
+            sorted.sort_by_key(|a| a.created_at);
+            out.push_str(&format!("### {} ({} items)\n", t, sorted.len()));
+            for a in sorted {
+                out.push_str(&format!(
+                    "- [{}] {} @ {}: {}\n",
+                    a.id,
+                    a.title,
+                    a.created_at,
+                    summarize_content(&a.content, 100),
+                ));
+            }
+            out.push('\n');
+        }
+    }
+    out
+}
+
+/// 프롬프트 최종 조립. token budget / 재생성 힌트 (hint) 는 caller 가 posthoc 추가.
+pub fn build_prompt(
+    project_key: &str,
+    since: i64,
+    until: i64,
+    done_plan_count: i64,
+    artifacts: &[Artifact],
+) -> String {
+    let serialized = serialize_artifacts_for_prompt(artifacts);
+    IDENTITY_PROMPT_TEMPLATE
+        .replace("{project_key}", project_key)
+        .replace("{since}", &since.to_string())
+        .replace("{until}", &until.to_string())
+        .replace("{done_plan_count}", &done_plan_count.to_string())
+        .replace("{artifacts_serialized}", &serialized)
+}
+
+// ─── Section validation ─────────────────────────────────────────────────────
+
+/// 필수 섹션 헤더 + token budget 범위 (하한, 상한).
+/// Recent inflection points 는 3 × (100~150) 합산 범위.
+pub const REQUIRED_SECTIONS: &[(&str, (usize, usize))] = &[
+    ("### Project identity", (150, 250)),
+    ("### User working preference", (300, 500)),
+    ("### Agent operating preference", (300, 500)),
+    ("### Recent inflection points", (300, 450)),
+    ("### Do / Avoid", (200, 300)),
+];
+
+#[derive(Debug, Clone, Serialize)]
+pub struct IdentitySectionValidation {
+    pub has_all_sections: bool,
+    pub missing: Vec<String>,
+    pub budget_ok: bool,
+    /// (섹션명, 실제 추정 tokens)
+    pub offending_sections: Vec<(String, usize)>,
+}
+
+impl IdentitySectionValidation {
+    pub fn is_ok(&self) -> bool {
+        self.has_all_sections && self.budget_ok
+    }
+}
+
+/// word count * 1.3 휴리스틱으로 token 추정. tiktoken 의존성 없이 근사.
+/// CJK 의 경우 word_count 가 작아 과소 추정 가능 — 실측 후 튜닝 (subtask Risk).
+pub fn estimate_tokens(s: &str) -> usize {
+    let words = s.split_whitespace().count();
+    ((words as f64) * 1.3).round() as usize
+}
+
+pub fn validate_identity_summary_sections(content: &str) -> IdentitySectionValidation {
+    let mut missing = Vec::new();
+    let mut offending = Vec::new();
+
+    for (header, (lo, hi)) in REQUIRED_SECTIONS {
+        let Some(start) = content.find(header) else {
+            missing.push((*header).to_string());
+            continue;
+        };
+        let body_start = start + header.len();
+        // 다음 "### " 헤더 전까지 또는 끝
+        let rel_end = content[body_start..].find("\n### ").unwrap_or(content.len() - body_start);
+        let body = &content[body_start..body_start + rel_end];
+        let tokens = estimate_tokens(body);
+        // ±20% 여유 (LLM 출력 편차 수용)
+        let tolerant_lo = (*lo as f64 * 0.8) as usize;
+        let tolerant_hi = (*hi as f64 * 1.2) as usize;
+        if tokens < tolerant_lo || tokens > tolerant_hi {
+            offending.push(((*header).to_string(), tokens));
+        }
+    }
+    IdentitySectionValidation {
+        has_all_sections: missing.is_empty(),
+        missing,
+        budget_ok: offending.is_empty(),
+        offending_sections: offending,
+    }
+}
+
+// ─── Frontmatter ────────────────────────────────────────────────────────────
+
+/// 분석 결과 앞에 붙일 YAML frontmatter. ContextPack 주입 시 `strip_frontmatter`
+/// 로 제거해 토큰 낭비 방지.
+pub fn build_frontmatter(
+    project_key: &str,
+    since: i64,
+    until: i64,
+    artifact_refs: &[&str],
+    supersedes: Option<&str>,
+) -> String {
+    let refs_csv = artifact_refs.join(",");
+    let sup = supersedes.unwrap_or("");
+    format!(
+        "---\nproject_key: {}\nperiod_start: {}\nperiod_end: {}\nartifact_refs: [{}]\nsupersedes: {}\n---\n\n",
+        project_key, since, until, refs_csv, sup
+    )
+}
+
+/// ContextPack 주입 전 frontmatter 제거. `---` 블록이 content 시작부에 있으면 2
+/// 번째 `---` 직후까지 잘라낸다. 없으면 원문 그대로.
+pub fn strip_frontmatter(content: &str) -> &str {
+    if !content.starts_with("---") {
+        return content;
+    }
+    // 첫 줄의 --- 이후 두 번째 --- 를 찾는다
+    let after_first = &content[3..];
+    if let Some(idx) = after_first.find("\n---") {
+        let body_start = 3 + idx + 4; // "\n---" (4 chars)
+        content[body_start..].trim_start_matches(|c: char| c == '\n' || c.is_whitespace())
+    } else {
+        content
+    }
+}
+
+// ─── LLM 호출 (injection 가능) ─────────────────────────────────────────────
+
+/// LLM 호출 경로 — 테스트는 Stub 으로 LLM 호출을 격리한다.
+pub enum InvokeAnalyzer {
+    /// 실제 claude CLI 호출. CLI-first 원칙.
+    Real { model: Option<String> },
+    /// 테스트용 고정 응답.
+    #[cfg(test)]
+    Stub(String),
+    /// 테스트용 — 1회차 실패 2회차 성공 시뮬레이션.
+    #[cfg(test)]
+    StubSequence { responses: std::sync::Mutex<Vec<String>> },
+}
+
+impl InvokeAnalyzer {
+    pub fn call(&self, prompt: &str) -> Result<String, AppError> {
+        match self {
+            Self::Real { model } => {
+                let out = run_claude(RunInput {
+                    prompt: prompt.to_string(),
+                    model: model.clone(),
+                    system_prompt: None,
+                    resume_token: None,
+                    project_path: None,
+                    image_paths: vec![],
+                })?;
+                Ok(out.content)
+            }
+            #[cfg(test)]
+            Self::Stub(s) => Ok(s.clone()),
+            #[cfg(test)]
+            Self::StubSequence { responses } => {
+                let mut guard = responses.lock().map_err(|_| AppError::Lock)?;
+                if guard.is_empty() {
+                    return Err(AppError::Agent("StubSequence exhausted".into()));
+                }
+                Ok(guard.remove(0))
+            }
+        }
+    }
+}
+
+// ─── Orchestration ──────────────────────────────────────────────────────────
+
+/// 분석 실행 결과 — artifact id + 검증 요약.
+pub struct IdentityAnalysisOutcome {
+    pub artifact_id: String,
+    pub regenerated: bool,
+}
+
+/// 분석 파이프라인 core. Sync — worker 의 spawn_blocking 블록 안에서 호출한다.
+/// 재시도는 1회 (최초 1 + 재생성 1 = 총 2회 LLM 호출).
+///
+/// steps:
+/// 1. eligible artifacts + period 수집
+/// 2. prompt build + LLM 호출
+/// 3. 섹션/예산 검증
+/// 4. 실패 시 hint 추가해 1회 재생성
+/// 5. frontmatter 부착 + `create_identity_summary` 저장
+/// 6. 입력 artifact 를 status='analyzed' 로 mark (선택)
+pub fn run_identity_analysis_inner(
+    conn: &Connection,
+    project_key: &str,
+    invoker: &InvokeAnalyzer,
+) -> Result<IdentityAnalysisOutcome, AppError> {
+    // 1. period + inputs
+    let since_ts = last_summary_ts(conn, project_key)?;
+    let until_ts = crate::db::migrations::now_epoch_ms();
+    let inputs = list_eligible_artifacts(conn, project_key, since_ts, until_ts)?;
+    if inputs.is_empty() {
+        return Err(AppError::BadRequest(
+            "identity_analysis: no eligible artifacts in window".into(),
+        ));
+    }
+    let done_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM plans p JOIN conversations c ON p.conversation_id = c.id \
+             WHERE p.status='done' AND c.project_key = ?1",
+            [project_key],
+            |r| r.get(0),
+        )
+        .unwrap_or(0);
+
+    // 2. prompt + first LLM call
+    let prompt = build_prompt(project_key, since_ts, until_ts, done_count, &inputs);
+    let first = invoker.call(&prompt)?;
+
+    // 3. validate
+    let validation = validate_identity_summary_sections(&first);
+    let (final_content, regenerated) = if validation.is_ok() {
+        (first, false)
+    } else {
+        // 4. retry once with explicit hint
+        let hint = format!(
+            "\n\nPrevious output did not satisfy requirements: missing_sections={:?}, offending={:?}. Regenerate strictly.",
+            validation.missing, validation.offending_sections
+        );
+        let retry_prompt = format!("{}{}", prompt, hint);
+        let retry = invoker.call(&retry_prompt)?;
+        let retry_validation = validate_identity_summary_sections(&retry);
+        if !retry_validation.is_ok() {
+            return Err(AppError::Agent(format!(
+                "identity_analysis: validation failed after retry (missing={:?})",
+                retry_validation.missing
+            )));
+        }
+        (retry, true)
+    };
+
+    // 5. frontmatter + persist
+    let refs: Vec<&str> = inputs.iter().map(|a| a.id.as_str()).collect();
+    let previous = latest_summary_id(conn, project_key)?;
+    let frontmatter = build_frontmatter(project_key, since_ts, until_ts, &refs, previous.as_deref());
+    let full_content = format!("{}{}", frontmatter, final_content);
+
+    let title = format!("Identity — {} ({} artifacts)", project_key, inputs.len());
+    let artifact_id = crate::commands::artifacts::create_identity_summary(conn, project_key, &title, &full_content)?;
+
+    // 6. mark inputs analyzed (best-effort)
+    for input in &inputs {
+        let _ = conn.execute(
+            "UPDATE artifacts SET status = 'analyzed', updated_at = ?1 WHERE id = ?2 AND status = 'draft'",
+            params![crate::db::migrations::now_epoch_ms(), input.id],
+        );
+    }
+
+    Ok(IdentityAnalysisOutcome {
+        artifact_id,
+        regenerated,
+    })
+}
+
+// ─── Helpers — period / inputs ─────────────────────────────────────────────
+
+fn last_summary_ts(conn: &Connection, project_key: &str) -> Result<i64, AppError> {
+    let ts: i64 = conn
+        .query_row(
+            "SELECT COALESCE(MAX(a.created_at), 0) FROM artifacts a \
+             JOIN conversations c ON a.conversation_id = c.id \
+             WHERE a.type='identity_summary' AND c.project_key = ?1",
+            [project_key],
+            |r| r.get(0),
+        )
+        .unwrap_or(0);
+    Ok(ts)
+}
+
+fn latest_summary_id(conn: &Connection, project_key: &str) -> Result<Option<String>, AppError> {
+    let id: Option<String> = conn
+        .query_row(
+            "SELECT a.id FROM artifacts a \
+             JOIN conversations c ON a.conversation_id = c.id \
+             WHERE a.type='identity_summary' AND c.project_key = ?1 \
+             ORDER BY a.created_at DESC LIMIT 1",
+            [project_key],
+            |r| r.get(0),
+        )
+        .ok();
+    Ok(id)
+}
+
+fn list_eligible_artifacts(
+    conn: &Connection,
+    project_key: &str,
+    since_ts: i64,
+    until_ts: i64,
+) -> Result<Vec<Artifact>, AppError> {
+    let placeholders = ARTIFACT_TYPE_ORDER
+        .iter()
+        .enumerate()
+        .map(|(i, _)| format!("?{}", i + 4))
+        .collect::<Vec<_>>()
+        .join(",");
+    let sql = format!(
+        "SELECT a.id, a.conversation_id, a.branch_id, a.subtask_id, a.plan_id, a.type, a.title, a.content, a.status, a.created_at, a.updated_at \
+         FROM artifacts a JOIN conversations c ON a.conversation_id = c.id \
+         WHERE c.project_key = ?1 AND a.created_at > ?2 AND a.created_at <= ?3 \
+           AND a.type IN ({}) \
+         ORDER BY a.created_at ASC",
+        placeholders
+    );
+    let mut params_vec: Vec<&dyn rusqlite::ToSql> = vec![&project_key, &since_ts, &until_ts];
+    for k in ARTIFACT_TYPE_ORDER {
+        params_vec.push(k);
+    }
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt
+        .query_map(rusqlite::params_from_iter(params_vec.iter()), |row| {
+            Ok(Artifact {
+                id: row.get(0)?,
+                conversation_id: row.get(1)?,
+                branch_id: row.get(2)?,
+                subtask_id: row.get(3)?,
+                plan_id: row.get(4)?,
+                artifact_type: row.get(5)?,
+                title: row.get(6)?,
+                content: row.get(7)?,
+                status: row.get(8)?,
+                created_at: row.get(9)?,
+                updated_at: row.get(10)?,
+            })
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(rows)
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn artifact(id: &str, typ: &str, title: &str, content: &str, ts: i64) -> Artifact {
+        Artifact {
+            id: id.into(),
+            conversation_id: Some("c1".into()),
+            branch_id: None,
+            subtask_id: None,
+            plan_id: None,
+            artifact_type: typ.into(),
+            title: title.into(),
+            content: content.into(),
+            status: "draft".into(),
+            created_at: ts,
+            updated_at: ts,
+        }
+    }
+
+    #[test]
+    fn prompt_template_contains_required_rules() {
+        assert!(IDENTITY_PROMPT_TEMPLATE.contains("Do not narrate"));
+        assert!(IDENTITY_PROMPT_TEMPLATE.contains("Total budget: 1,350 ~ 2,050 tokens"));
+        assert!(IDENTITY_PROMPT_TEMPLATE.contains("### Project identity"));
+        assert!(IDENTITY_PROMPT_TEMPLATE.contains("### Do / Avoid"));
+    }
+
+    #[test]
+    fn serialize_groups_by_type_in_fixed_order() {
+        let artifacts = vec![
+            artifact("a1", "finding_failure", "f1", "{}", 30),
+            artifact("a2", "decision", "d1", "{}", 10),
+            artifact("a3", "decision", "d2", "{}", 20),
+            artifact("a4", "workflow_milestone", "m1", "{}", 40),
+        ];
+        let out = serialize_artifacts_for_prompt(&artifacts);
+        let decision_idx = out.find("### decision").unwrap();
+        let failure_idx = out.find("### finding_failure").unwrap();
+        let milestone_idx = out.find("### workflow_milestone").unwrap();
+        // order: decision < finding_failure < workflow_milestone (per ARTIFACT_TYPE_ORDER)
+        assert!(decision_idx < failure_idx);
+        assert!(failure_idx < milestone_idx);
+        // 정렬 확인 — d1 (ts=10) 이 d2 (ts=20) 앞
+        let d1_idx = out.find("[a2]").unwrap();
+        let d2_idx = out.find("[a3]").unwrap();
+        assert!(d1_idx < d2_idx);
+    }
+
+    #[test]
+    fn summarize_content_caps_length() {
+        let long = "a".repeat(500);
+        let summary = summarize_content(&long, 50);
+        assert!(summary.len() <= 53); // 50 + "..."
+        assert!(summary.ends_with("..."));
+    }
+
+    #[test]
+    fn summarize_content_noop_when_short() {
+        let short = "hello";
+        assert_eq!(summarize_content(short, 100), "hello");
+    }
+
+    fn valid_summary_body() -> String {
+        let section_body = "word ".repeat(200);
+        // section 당 token 추정 = 200 * 1.3 = 260. 각 section 의 예산 범위에 들어오도록
+        // 섹션별로 단어 수 조정.
+        format!(
+            "### Project identity\n{}\n\n### User working preference\n{}\n\n### Agent operating preference\n{}\n\n### Recent inflection points\n{}\n\n### Do / Avoid\n{}\n",
+            "word ".repeat(150),  // ~195 tokens (150-250 OK)
+            "word ".repeat(300),  // ~390 tokens (300-500 OK)
+            "word ".repeat(300),  // ~390 tokens (300-500 OK)
+            section_body,         // ~260 tokens (300-450 OK with tolerance)
+            "word ".repeat(200),  // ~260 tokens (200-300 OK)
+        )
+    }
+
+    #[test]
+    fn validate_accepts_well_formed_summary() {
+        let body = valid_summary_body();
+        let v = validate_identity_summary_sections(&body);
+        assert!(v.has_all_sections, "missing={:?}", v.missing);
+        assert!(v.budget_ok, "offending={:?}", v.offending_sections);
+        assert!(v.is_ok());
+    }
+
+    #[test]
+    fn validate_detects_missing_sections() {
+        let partial = "### Project identity\n\
+                       Some content.\n\n\
+                       ### User working preference\n\
+                       More content.\n";
+        let v = validate_identity_summary_sections(partial);
+        assert!(!v.has_all_sections);
+        assert!(v.missing.contains(&"### Agent operating preference".to_string()));
+        assert!(v.missing.contains(&"### Recent inflection points".to_string()));
+        assert!(v.missing.contains(&"### Do / Avoid".to_string()));
+    }
+
+    #[test]
+    fn validate_detects_budget_overflow() {
+        let mut content = String::new();
+        for (header, _) in REQUIRED_SECTIONS {
+            content.push_str(header);
+            content.push('\n');
+            // 각 섹션 매우 짧게 (under budget)
+            content.push_str("one\n\n");
+        }
+        let v = validate_identity_summary_sections(&content);
+        assert!(v.has_all_sections);
+        assert!(!v.budget_ok, "너무 짧으면 offending 이어야");
+    }
+
+    #[test]
+    fn frontmatter_builds_expected_yaml() {
+        let fm = build_frontmatter("proj-x", 100, 200, &["a1", "a2"], Some("prev-id"));
+        assert!(fm.starts_with("---\n"));
+        assert!(fm.contains("project_key: proj-x"));
+        assert!(fm.contains("period_start: 100"));
+        assert!(fm.contains("period_end: 200"));
+        assert!(fm.contains("artifact_refs: [a1,a2]"));
+        assert!(fm.contains("supersedes: prev-id"));
+    }
+
+    #[test]
+    fn strip_frontmatter_removes_yaml_block() {
+        let full = "---\nproject_key: p\nperiod_start: 0\n---\n\n### Project identity\nbody";
+        let stripped = strip_frontmatter(full);
+        assert!(stripped.starts_with("### Project identity"));
+    }
+
+    #[test]
+    fn strip_frontmatter_noop_when_no_yaml() {
+        let plain = "### Project identity\nbody";
+        assert_eq!(strip_frontmatter(plain), plain);
+    }
+
+    // run_identity_analysis_inner 의 retry 로직은 DB 연동이 필요 — 별도 integration
+    // 테스트로 상위 모듈 (commands) 쪽에서 테스트. 본 파일에서는 Stub invoker 의
+    // 동작만 단위 테스트.
+
+    #[test]
+    fn stub_sequence_returns_responses_in_order() {
+        let inv = InvokeAnalyzer::StubSequence {
+            responses: std::sync::Mutex::new(vec!["first".into(), "second".into()]),
+        };
+        assert_eq!(inv.call("x").unwrap(), "first");
+        assert_eq!(inv.call("x").unwrap(), "second");
+        assert!(inv.call("x").is_err());
+    }
+}

--- a/src-tauri/src/agents/mod.rs
+++ b/src-tauri/src/agents/mod.rs
@@ -8,6 +8,7 @@ pub mod crg;
 pub mod embedder;
 pub mod gemini;
 pub mod gemini_sdk;
+pub mod identity_analyzer;
 pub mod loader;
 pub mod openai_compat;
 pub mod openai_sdk;

--- a/src-tauri/src/commands/agents_helpers/send_common/context_loading.rs
+++ b/src-tauri/src/commands/agents_helpers/send_common/context_loading.rs
@@ -103,6 +103,11 @@ pub struct ContextData {
     /// 가지고 있어 tunaFlow prepend 가 오염원이 되기 때문. 에이전트는 필요 시
     /// `tool-request:recent_turns:N` 으로 명시 조회. False 면 정상 Full + anchor.
     pub is_session_continuation: bool,
+
+    /// projectIdentityAnalysisPlan subtask-03: project 별 최신 `identity_summary`
+    /// artifact 의 body (frontmatter strip 후). ContextPack 주입 시 worldview 뒤 /
+    /// identity 앞 위치. 없으면 None.
+    pub identity_summary_fragment: Option<String>,
 }
 
 /// Phase A: Load all data needed for ContextPack assembly from DB.
@@ -493,6 +498,17 @@ pub fn load_context_data(
         .map(|pk| crate::commands::conventions_sync::is_conventions_sync_enabled(conn, pk))
         .unwrap_or(false);
 
+    // projectIdentityAnalysisPlan subtask-03: 최신 identity_summary 를 pre-load 해
+    // ContextPack 주입에 사용. frontmatter 는 strip 후 저장.
+    let identity_summary_fragment: Option<String> = project_key
+        .as_deref()
+        .and_then(|pk| {
+            crate::commands::artifacts::fetch_latest_identity_summary(conn, pk)
+                .ok()
+                .flatten()
+        })
+        .map(|a| crate::agents::identity_analyzer::strip_frontmatter(&a.content).to_string());
+
     ContextData {
         conversation_id: conversation_id.to_string(),
         project_path: project_path.map(|s| s.to_string()),
@@ -521,6 +537,7 @@ pub fn load_context_data(
         user_profile: user_profile_json.map(|s| s.to_string()),
         conventions_synced,
         is_session_continuation: false, // persistence.rs 에서 필요시 true 로 override
+        identity_summary_fragment,
     }
 }
 

--- a/src-tauri/src/commands/agents_helpers/send_common/mod.rs
+++ b/src-tauri/src/commands/agents_helpers/send_common/mod.rs
@@ -51,6 +51,7 @@ mod tests {
             user_profile: None,
             conventions_synced: false,
             is_session_continuation: false,
+            identity_summary_fragment: None,
         }
     }
 

--- a/src-tauri/src/commands/agents_helpers/send_common/prompt_assembly.rs
+++ b/src-tauri/src/commands/agents_helpers/send_common/prompt_assembly.rs
@@ -167,6 +167,14 @@ pub fn assemble_prompt(
         included_sections.push("worldview".into());
     }
 
+    // Project identity summary — 최근 분석 결과 (projectIdentityAnalysisPlan subtask-03).
+    // worldview 뒤, identity 앞에 삽입. context_loading 에서 pre-load 해 둔 fragment
+    // 만 참조하므로 여기서 DB 접근 없음. frontmatter 는 이미 strip 된 상태.
+    if let Some(identity_text) = &data.identity_summary_fragment {
+        sections.push(format!("## Project Identity\n\n{}", identity_text));
+        included_sections.push("project-identity".into());
+    }
+
     // Identity + Persona section
     {
         let (identity_block, persona_block) = parse_identity_and_persona(identity_fragment);
@@ -704,6 +712,7 @@ mod tests {
             user_profile: None,
             conventions_synced: false,
             is_session_continuation: false,
+            identity_summary_fragment: None,
         }
     }
 
@@ -737,6 +746,38 @@ mod tests {
         if let Some(p) = idx_platform {
             assert!(p < idx_worldview.unwrap(), "platform 은 worldview 앞");
         }
+    }
+
+    #[test]
+    fn identity_summary_injected_between_worldview_and_identity() {
+        // subtask-03 INV: project_identity 는 worldview 뒤, identity 앞.
+        let tmp = TempDir::new().unwrap();
+        let project_dir = tmp.path().to_path_buf();
+        let wv_path = project_dir.join(".tunaflow").join("user_worldview.md");
+        fs::create_dir_all(wv_path.parent().unwrap()).unwrap();
+        fs::write(&wv_path, "# worldview body").unwrap();
+
+        let mut data = empty_context_data(Some(project_dir.to_string_lossy().to_string()));
+        data.identity_summary_fragment = Some("### Project identity\nsummary body".into());
+
+        let (_a, _s, meta) = assemble_prompt(&data, Some("## Identity\n\ntest"));
+        let idx_wv = meta.sections.iter().position(|s| s == "worldview").unwrap();
+        let idx_id = meta.sections.iter().position(|s| s == "identity").unwrap();
+        let idx_pi = meta
+            .sections
+            .iter()
+            .position(|s| s == "project-identity")
+            .expect("project-identity 섹션이 존재해야");
+        assert!(idx_wv < idx_pi, "project-identity 는 worldview 뒤");
+        assert!(idx_pi < idx_id, "project-identity 는 identity 앞");
+    }
+
+    #[test]
+    fn identity_summary_absent_when_fragment_is_none() {
+        let tmp = TempDir::new().unwrap();
+        let data = empty_context_data(Some(tmp.path().to_string_lossy().to_string()));
+        let (_a, _s, meta) = assemble_prompt(&data, Some("## Identity\n\ntest"));
+        assert!(!meta.sections.iter().any(|s| s == "project-identity"));
     }
 
     #[test]

--- a/src-tauri/src/commands/artifacts.rs
+++ b/src-tauri/src/commands/artifacts.rs
@@ -179,6 +179,48 @@ pub fn delete_artifact(id: String, state: State<DbState>) -> Result<(), AppError
     Ok(())
 }
 
+// ─── Identity summary (subtask-03, analyzer 전용 경로) ────────────────────
+
+/// 분석 output artifact 를 저장하는 analyzer 전용 헬퍼. `create_identity_input_artifact`
+/// 의 INV-1 enforcement (IdentitySummary kind 거부) 를 우회한다.
+/// 호출 site 는 `agents::identity_analyzer` 모듈에 한정 (crate-private).
+pub(crate) fn create_identity_summary(
+    conn: &Connection,
+    project_key: &str,
+    title: &str,
+    content: &str,
+) -> Result<String, AppError> {
+    let id = format!("identity-{}-{}", project_key, now_epoch_ms());
+    let now = now_epoch_ms();
+    conn.execute(
+        "INSERT INTO artifacts (id, conversation_id, branch_id, subtask_id, plan_id, type, title, content, status, created_at, updated_at) \
+         VALUES (?1, NULL, NULL, NULL, NULL, 'identity_summary', ?2, ?3, 'final', ?4, ?4)",
+        params![id, title, content, now],
+    )?;
+    Ok(id)
+}
+
+/// ContextPack 주입 용 — project 별 최신 `identity_summary` artifact 를 가져온다.
+/// frontmatter 의 `project_key: <key>` 를 LIKE 매칭. subtask 당 월 수개 수준이라
+/// 풀스캔 허용.
+pub(crate) fn fetch_latest_identity_summary(
+    conn: &Connection,
+    project_key: &str,
+) -> Result<Option<Artifact>, AppError> {
+    let pattern = format!("%project_key: {}\n%", project_key);
+    let row = conn
+        .query_row(
+            "SELECT id, conversation_id, branch_id, subtask_id, plan_id, type, title, content, status, created_at, updated_at \
+             FROM artifacts \
+             WHERE type = 'identity_summary' AND content LIKE ?1 \
+             ORDER BY created_at DESC LIMIT 1",
+            [&pattern],
+            map_row,
+        )
+        .ok();
+    Ok(row)
+}
+
 // ─── Identity input artifacts (projectIdentityAnalysisPlan subtask-01) ───────
 
 /// Dedup window (ms) — 같은 `(conversation_id, type, content-hash)` 튜플이 이 이내
@@ -401,6 +443,62 @@ mod tests {
         )
         .unwrap();
         assert!(second.is_some(), "content 가 다르면 새 row 생성되어야");
+    }
+
+    #[test]
+    fn create_identity_summary_persists_with_final_status() {
+        let conn = test_conn();
+        let id = create_identity_summary(
+            &conn,
+            "proj-x",
+            "Identity — proj-x",
+            "---\nproject_key: proj-x\n---\n\n### Project identity\nbody",
+        )
+        .unwrap();
+        assert!(id.starts_with("identity-proj-x-"));
+        let (typ, status): (String, String) = conn
+            .query_row(
+                "SELECT type, status FROM artifacts WHERE id = ?1",
+                [&id],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(typ, "identity_summary");
+        assert_eq!(status, "final");
+    }
+
+    #[test]
+    fn fetch_latest_identity_summary_returns_most_recent_for_project() {
+        let conn = test_conn();
+        // 두 project 혼재
+        create_identity_summary(
+            &conn, "proj-a", "a1",
+            "---\nproject_key: proj-a\n---\n\n### Project identity\nv1",
+        )
+        .unwrap();
+        // 살짝 시간차
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        let id2 = create_identity_summary(
+            &conn, "proj-a", "a2",
+            "---\nproject_key: proj-a\n---\n\n### Project identity\nv2",
+        )
+        .unwrap();
+        create_identity_summary(
+            &conn, "proj-b", "b1",
+            "---\nproject_key: proj-b\n---\n\n### Project identity\nother",
+        )
+        .unwrap();
+
+        let found = fetch_latest_identity_summary(&conn, "proj-a").unwrap().unwrap();
+        assert_eq!(found.id, id2, "proj-a 의 가장 최근 summary");
+        assert!(found.content.contains("v2"));
+    }
+
+    #[test]
+    fn fetch_latest_identity_summary_returns_none_when_absent() {
+        let conn = test_conn();
+        let found = fetch_latest_identity_summary(&conn, "missing-proj").unwrap();
+        assert!(found.is_none());
     }
 
     #[test]

--- a/src-tauri/src/commands/meta_agent/background_worker.rs
+++ b/src-tauri/src/commands/meta_agent/background_worker.rs
@@ -76,8 +76,8 @@ async fn worker_tick(app: &AppHandle, db: &DbState) -> Result<(), AppError> {
         );
     }
 
-    // Dispatcher — 현재 skeleton. 실제 핸들러는 subtask-03 / metaAgent Phase 3 이후 추가.
-    let result = dispatch(&job).await;
+    // Dispatcher — identity_analysis 는 subtask-03 에서 실제 핸들러 연결됨.
+    let result = dispatch(&job, db).await;
 
     let status = match &result {
         Ok(_) => "done",
@@ -103,24 +103,109 @@ async fn worker_tick(app: &AppHandle, db: &DbState) -> Result<(), AppError> {
     Ok(())
 }
 
-/// Kind 별 dispatcher. 현재 모든 kind 는 "not implemented" 로 실패 처리되도록 둬,
-/// skeleton 임을 운영 시 명확히 드러낸다. 실 핸들러가 붙으면 match arm 으로 교체.
-async fn dispatch(job: &BackgroundJob) -> Result<(), AppError> {
+/// Kind 별 dispatcher. `identity_analysis` 는 subtask-03 에서 실 핸들러 연결됨.
+/// `insight_background` 는 userWorldview 잔여 경로로 현재 no-op (후속 plan).
+async fn dispatch(job: &BackgroundJob, db: &DbState) -> Result<(), AppError> {
     match job.kind.as_str() {
-        "identity_analysis" | "insight_background" => {
-            // metaAgent Phase 3 / subtask-03 에서 실제 핸들러 추가 예정.
+        "identity_analysis" => run_identity_analysis_dispatch(job, db).await,
+        "insight_background" => {
             eprintln!(
-                "[bg-worker] dispatch stub kind={} job={} — handler not yet implemented",
-                job.kind, job.id
+                "[bg-worker] insight_background kind={} — no handler registered yet",
+                job.id
             );
-            Err(AppError::Agent(format!(
-                "background kind '{}' handler not implemented (Phase 4 skeleton)",
-                job.kind
-            )))
+            Err(AppError::Agent(
+                "insight_background kind handler not implemented".into(),
+            ))
         }
         other => Err(AppError::BadRequest(format!(
             "unknown background kind: {}",
             other
         ))),
+    }
+}
+
+/// identity_analysis 실행. sync 경로 (`identity_analyzer::run_identity_analysis_inner`)
+/// 를 `spawn_blocking` 으로 감싸 Tokio 워커 스레드에서 실행.
+///
+/// dedupe_key 포맷 `identity-analysis-{project_key}-{done_count}` 에서 project_key
+/// 를 추출. parse 실패 시 job 실패 처리.
+async fn run_identity_analysis_dispatch(
+    job: &BackgroundJob,
+    db: &DbState,
+) -> Result<(), AppError> {
+    let Some(dedupe_key) = &job.dedupe_key else {
+        return Err(AppError::BadRequest(
+            "identity_analysis job missing dedupe_key — cannot resolve project_key".into(),
+        ));
+    };
+    // 포맷: "identity-analysis-{project}-{count}". count 이전의 '-' 분리 기반 역추출.
+    let project_key = parse_project_key_from_dedupe(dedupe_key).ok_or_else(|| {
+        AppError::BadRequest(format!(
+            "identity_analysis: cannot parse project_key from dedupe_key '{}'",
+            dedupe_key
+        ))
+    })?;
+    let project_key = project_key.to_string();
+    let db_write = db.write.clone();
+    tauri::async_runtime::spawn_blocking(move || -> Result<(), AppError> {
+        let conn = db_write.lock().map_err(|_| AppError::Lock)?;
+        let outcome = crate::agents::identity_analyzer::run_identity_analysis_inner(
+            &conn,
+            &project_key,
+            &crate::agents::identity_analyzer::InvokeAnalyzer::Real { model: None },
+        )?;
+        eprintln!(
+            "[identity-analyzer] job done artifact_id={} regenerated={}",
+            outcome.artifact_id, outcome.regenerated
+        );
+        Ok(())
+    })
+    .await
+    .map_err(|e| AppError::Agent(format!("spawn_blocking join error: {}", e)))?
+}
+
+/// `identity-analysis-{project_key}-{count}` 에서 project_key 부분 추출. prefix 고정
+/// 길이 + trailing `-{digits}` 제거. project_key 에 '-' 가 포함돼도 된다.
+fn parse_project_key_from_dedupe(dedupe_key: &str) -> Option<&str> {
+    const PREFIX: &str = "identity-analysis-";
+    let rest = dedupe_key.strip_prefix(PREFIX)?;
+    // trailing "-<digits>" 제거
+    let trailing_dash = rest.rfind('-')?;
+    let (project, tail) = rest.split_at(trailing_dash);
+    if tail.len() >= 2 && tail[1..].chars().all(|c| c.is_ascii_digit()) {
+        Some(project)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod dispatch_tests {
+    use super::parse_project_key_from_dedupe;
+
+    #[test]
+    fn parse_simple_project_key() {
+        assert_eq!(
+            parse_project_key_from_dedupe("identity-analysis-myproj-3"),
+            Some("myproj")
+        );
+    }
+
+    #[test]
+    fn parse_project_key_with_dashes() {
+        assert_eq!(
+            parse_project_key_from_dedupe("identity-analysis-my-cool-proj-9"),
+            Some("my-cool-proj")
+        );
+    }
+
+    #[test]
+    fn parse_rejects_unknown_prefix() {
+        assert_eq!(parse_project_key_from_dedupe("wrong-prefix-p-3"), None);
+    }
+
+    #[test]
+    fn parse_rejects_non_numeric_suffix() {
+        assert_eq!(parse_project_key_from_dedupe("identity-analysis-proj-x"), None);
     }
 }


### PR DESCRIPTION
## Summary

projectIdentityAnalysisPlan **subtask-03** 완성. Phase 3 가 enqueue 한 \`identity_analysis\` background job 을 worker 가 dispatch → 본 모듈이 분석 실행 → \`identity_summary\` artifact 저장 → 이후 요청의 ContextPack 에 주입.

## \`agents/identity_analyzer.rs\` (신규)
- **IDENTITY_PROMPT_TEMPLATE** — "Do not narrate" / 고정 5 섹션 / 예산 (1,350~2,050 tokens)
- **serialize_artifacts_for_prompt** — 6 타입 순서 + type 별 timestamp 정렬 + content 100 chars 축약
- **validate_identity_summary_sections** — 헤더 존재 + word-count×1.3 token 추정 + ±20% 예산 허용
- **build_frontmatter / strip_frontmatter** — YAML (project_key / period / artifact_refs / supersedes)
- **InvokeAnalyzer** enum — \`Real\` (claude::run 호출) / \`Stub\` / \`StubSequence\` (test)
- **run_identity_analysis_inner(conn, project_key, invoker)** — pipeline:
  1. period + eligible artifact 수집
  2. prompt build + LLM 호출
  3. validate → 실패 시 hint 추가해 1회 재생성 → 재실패 시 err
  4. frontmatter + \`create_identity_summary\` 저장
  5. 입력 artifact 들을 \`status='analyzed'\` 로 mark (best-effort)

## \`commands/artifacts.rs\`
- \`create_identity_summary\` — analyzer 전용 (INV-1 bypass: IdentitySummary kind 저장 가능). \`crate-private\`.
- \`fetch_latest_identity_summary\` — frontmatter \`project_key: <key>\` LIKE 매칭, project 별 최신 1건

## ContextPack 주입
- \`ContextData\` 에 \`identity_summary_fragment: Option<String>\` 필드 추가
- \`load_context_data\` → project_key 로 fetch → strip_frontmatter → pre-load
- \`prompt_assembly\` → worldview 뒤 / identity 앞 \`## Project Identity\` 섹션 삽입
- \`ctx_sections\` 에 \`"project-identity"\` 추가 (trace 관찰 가능)

## Worker dispatcher wire
- \`dispatch(job, db)\` 로 시그니처 확장
- \`identity_analysis\` kind → \`spawn_blocking\` + \`run_identity_analysis_inner(Real)\`
- dedupe_key \`identity-analysis-{project}-{count}\` 에서 project_key parse (dash 포함 허용)
- \`insight_background\` 는 여전히 stub (userWorldview 잔여, 후속 plan)

## 테스트 (+20)
- \`agents::identity_analyzer\` **+11**: 템플릿 필수 키워드 / 타입별 정렬·그룹 / content 축약 / 검증(all-OK · 누락 · 예산 초과) / frontmatter · strip · stub_sequence
- \`commands::artifacts\` **+3**: create_identity_summary / fetch_latest 최신 / none
- \`send_common::prompt_assembly\` **+2**: identity_summary 주입 위치 (wv < pi < id) / 없을 때 부재
- \`meta_agent::background_worker::dispatch_tests\` **+4**: project_key parse (basic / dash 포함 / 잘못된 prefix / 비-숫자 suffix)

**Rust 454 → 474** tests, Frontend 305 유지, \`tsc --noEmit\` 통과.

## 동작 flow (end-to-end)
1. Plan 3개 done + eligible artifact 10개 누적 (#149 #150 Phase A+B)
2. \`updatePlanStatus(id, 'done')\` → Phase 3 trigger 평가 → \`identity_analysis\` job enqueue
3. 30s 내 worker tick (#151 Phase 4) → pick + mark running + emit \`background_insight_progress\`
4. **본 PR**: dispatcher → spawn_blocking → run_identity_analysis_inner (Real = claude CLI)
5. 프롬프트 + LLM + 검증 + 재생성 → \`identity_summary\` artifact 생성
6. 이후 요청에서 ContextPack 조립 시 자동 주입 (worldview 뒤 / identity 앞)

## INV 준수
- **INV-1** (자동 생성 surveillance 금지): identity_summary 는 \`create_identity_input_artifact\` 가 여전히 거부. analyzer 전용 \`create_identity_summary\` (crate-private) 로만 저장.
- **INV-3** (Settings OFF): Phase 4 worker loop 에서 BACKGROUND_INSIGHT_ENABLED 확인 → dispatch 도달 전 skip
- **INV-6** (trace 투명): worker 가 pending→running→done/failed 전이 + \`background_insight_progress\` 이벤트 emit. 분석기 자체도 \`[identity-analyzer] job done ...\` 로깅
- **Token Policy 준수**: summary 1,350~2,050 tokens (외부 README 의 Quality over token thrift 정합)

## 다음 단계 (별도 PR)
- **subtask-04 — Insight 탭 UI**: identity_summary 렌더 + "지금 실행" 버튼 + 상태 배지
- **IdentityAnalysisSettings**: threshold 튜닝 슬라이더 + BACKGROUND_INSIGHT_ENABLED 토글
- **StatusBar UI (P4-4)**: pending/running bg job 수 표시

## Test plan
- [x] \`cargo test --lib agents::identity_analyzer\` (11 통과)
- [x] \`cargo test --lib commands::artifacts\` (13 통과, +3 신규)
- [x] \`cargo test --lib\` (474 통과)
- [x] \`npx vitest run\` (305 유지)
- [x] \`npx tsc --noEmit\`
- [ ] 실제 Plan 3개 done + eligible ≥10 상태에서 trigger → 30s~1min 내 identity_summary artifact 생성 확인 (수동 E2E, claude CLI 필요)
- [ ] 이후 chat 요청의 trace_log \`ctx_sections\` 에 \`"project-identity"\` 포함 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)