### PR TITLE
fix(insight): stabilize 4-bug chain (rawq clamp / skip strict / usage parser / timeout propagation)

### DIFF
--- a/src-tauri/src/agents/claude.rs
+++ b/src-tauri/src/agents/claude.rs
@@ -34,7 +34,21 @@ struct StreamLine {
     total_cost_usd: Option<f64>,
     total_input_tokens: Option<i64>,
     total_output_tokens: Option<i64>,
+    /// claude CLI 최신 스키마 — usage 가 nested. top-level total_*_tokens 는 일부
+    /// 버전에서 부재하므로 `.or_else()` fallback 으로 양쪽 모두 지원.
+    /// insightStabilityPlan Subtask 03 (INV-3).
+    usage: Option<StreamUsage>,
     session_id: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct StreamUsage {
+    input_tokens: Option<i64>,
+    output_tokens: Option<i64>,
+    #[allow(dead_code)]
+    cache_creation_input_tokens: Option<i64>,
+    #[allow(dead_code)]
+    cache_read_input_tokens: Option<i64>,
 }
 
 #[derive(Deserialize)]
@@ -88,7 +102,19 @@ pub struct ClaudeJsonOutput {
     pub cost_usd: Option<f64>,
     pub total_input_tokens: Option<i64>,
     pub total_output_tokens: Option<i64>,
+    /// 최신 스키마 — usage nested. StreamLine 와 동일 fallback (INV-3).
+    pub usage: Option<ClaudeUsage>,
     pub session_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ClaudeUsage {
+    pub input_tokens: Option<i64>,
+    pub output_tokens: Option<i64>,
+    #[allow(dead_code)]
+    pub cache_creation_input_tokens: Option<i64>,
+    #[allow(dead_code)]
+    pub cache_read_input_tokens: Option<i64>,
 }
 
 pub struct RunInput {
@@ -185,20 +211,33 @@ where
     let mut final_output: Option<RunOutput> = None;
     let mut unparsed_lines: Vec<String> = Vec::new();
 
-    // Idle timeout: kill process if no output for 10 minutes
+    // Idle timeout: kill process if no output for 10 minutes.
+    // insightStabilityPlan Subtask 04 (INV-4): watchdog 가 `timed_out` 플래그를 set
+    // 하면 reader 루프 exit 후 distinct 에러 반환 → 상위 (run_insight_analysis) 가
+    // insight_sessions.status = 'failed' 로 전이할 때 원인 구분 가능.
     let idle_timeout = std::time::Duration::from_secs(600);
     let last_activity = std::sync::Arc::new(parking_lot::Mutex::new(std::time::Instant::now()));
+    let timed_out = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
     let child_id = child.id();
     {
         let last_act = std::sync::Arc::clone(&last_activity);
+        let timed_out_flag = std::sync::Arc::clone(&timed_out);
         thread::spawn(move || {
             loop {
                 thread::sleep(std::time::Duration::from_secs(30));
                 let elapsed = last_act.lock().elapsed();
                 if elapsed > idle_timeout {
-                    eprintln!("[agent-timeout] No output for {}s, killing pid {}", elapsed.as_secs(), child_id);
+                    eprintln!(
+                        "[agent-timeout] No output for {}s, killing pid {}",
+                        elapsed.as_secs(),
+                        child_id
+                    );
+                    timed_out_flag.store(true, std::sync::atomic::Ordering::SeqCst);
                     // Best-effort kill via system command
-                    let _ = std::process::Command::new("kill").arg("-9").arg(child_id.to_string()).output();
+                    let _ = std::process::Command::new("kill")
+                        .arg("-9")
+                        .arg(child_id.to_string())
+                        .output();
                     break;
                 }
             }
@@ -287,8 +326,16 @@ where
                 final_output = Some(RunOutput {
                     content: parsed.result.unwrap_or_default(),
                     cost_usd: parsed.total_cost_usd.or(parsed.cost_usd).unwrap_or(0.0),
-                    input_tokens: parsed.total_input_tokens.unwrap_or(0),
-                    output_tokens: parsed.total_output_tokens.unwrap_or(0),
+                    // INV-3: top-level total_*_tokens 우선, 최신 스키마의 nested
+                    // usage.*_tokens 로 fallback. 양쪽 None 이면 0.
+                    input_tokens: parsed
+                        .total_input_tokens
+                        .or_else(|| parsed.usage.as_ref().and_then(|u| u.input_tokens))
+                        .unwrap_or(0),
+                    output_tokens: parsed
+                        .total_output_tokens
+                        .or_else(|| parsed.usage.as_ref().and_then(|u| u.output_tokens))
+                        .unwrap_or(0),
                     session_id: parsed.session_id,
                 });
             }
@@ -298,6 +345,14 @@ where
 
     child.wait()?;
     let stderr_content = stderr_handle.join().unwrap_or_default();
+
+    // Watchdog 가 kill 했으면 원인 구분된 에러로 반환 (INV-4).
+    if timed_out.load(std::sync::atomic::Ordering::SeqCst) {
+        return Err(AppError::Agent(format!(
+            "agent timeout after {}s: claude subprocess killed by watchdog (no output within idle window)",
+            idle_timeout.as_secs()
+        )));
+    }
 
     final_output.ok_or_else(|| {
         // Build a diagnostic message using stderr, then unparsed stdout lines as fallback
@@ -378,8 +433,119 @@ pub fn run(input: RunInput) -> Result<RunOutput, AppError> {
     Ok(RunOutput {
         content: parsed.result.unwrap_or_default(),
         cost_usd: parsed.cost_usd.unwrap_or(0.0),
-        input_tokens: parsed.total_input_tokens.unwrap_or(0),
-        output_tokens: parsed.total_output_tokens.unwrap_or(0),
+        // INV-3: nested usage.*_tokens fallback (최신 schema 지원)
+        input_tokens: parsed
+            .total_input_tokens
+            .or_else(|| parsed.usage.as_ref().and_then(|u| u.input_tokens))
+            .unwrap_or(0),
+        output_tokens: parsed
+            .total_output_tokens
+            .or_else(|| parsed.usage.as_ref().and_then(|u| u.output_tokens))
+            .unwrap_or(0),
         session_id: parsed.session_id,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// insightStabilityPlan Subtask 03 — INV-3 검증.
+    /// old schema (top-level total_*_tokens) 와 new schema (nested usage.*_tokens)
+    /// 양쪽 모두 parse 하여 non-zero tokens 반환.
+    #[test]
+    fn claude_json_output_parses_top_level_tokens_old_schema() {
+        let json = r#"{
+            "type": "result",
+            "result": "hi",
+            "is_error": false,
+            "cost_usd": 0.01,
+            "total_input_tokens": 100,
+            "total_output_tokens": 50,
+            "session_id": "s1"
+        }"#;
+        let parsed: ClaudeJsonOutput = serde_json::from_str(json).unwrap();
+        let input = parsed
+            .total_input_tokens
+            .or_else(|| parsed.usage.as_ref().and_then(|u| u.input_tokens))
+            .unwrap_or(0);
+        let output = parsed
+            .total_output_tokens
+            .or_else(|| parsed.usage.as_ref().and_then(|u| u.output_tokens))
+            .unwrap_or(0);
+        assert_eq!(input, 100);
+        assert_eq!(output, 50);
+    }
+
+    #[test]
+    fn claude_json_output_parses_nested_usage_new_schema() {
+        // 실제 claude CLI 2.1.x `result` 이벤트 구조 재현
+        let json = r#"{
+            "type": "result",
+            "result": "hi",
+            "is_error": false,
+            "total_cost_usd": 0.132644,
+            "usage": {
+                "input_tokens": 6,
+                "output_tokens": 12,
+                "cache_creation_input_tokens": 19878,
+                "cache_read_input_tokens": 16153
+            },
+            "session_id": "s1"
+        }"#;
+        let parsed: ClaudeJsonOutput = serde_json::from_str(json).unwrap();
+        // top-level 없음
+        assert!(parsed.total_input_tokens.is_none());
+        assert!(parsed.total_output_tokens.is_none());
+        // fallback 체인이 usage 에서 찾음
+        let input = parsed
+            .total_input_tokens
+            .or_else(|| parsed.usage.as_ref().and_then(|u| u.input_tokens))
+            .unwrap_or(0);
+        let output = parsed
+            .total_output_tokens
+            .or_else(|| parsed.usage.as_ref().and_then(|u| u.output_tokens))
+            .unwrap_or(0);
+        assert_eq!(input, 6);
+        assert_eq!(output, 12);
+    }
+
+    #[test]
+    fn stream_line_parses_nested_usage_new_schema() {
+        let json = r#"{
+            "type": "result",
+            "result": "hi",
+            "is_error": false,
+            "total_cost_usd": 0.13,
+            "usage": {
+                "input_tokens": 6,
+                "output_tokens": 12,
+                "cache_creation_input_tokens": 100,
+                "cache_read_input_tokens": 50
+            },
+            "session_id": "s1"
+        }"#;
+        let parsed: StreamLine = serde_json::from_str(json).unwrap();
+        let input = parsed
+            .total_input_tokens
+            .or_else(|| parsed.usage.as_ref().and_then(|u| u.input_tokens))
+            .unwrap_or(0);
+        let output = parsed
+            .total_output_tokens
+            .or_else(|| parsed.usage.as_ref().and_then(|u| u.output_tokens))
+            .unwrap_or(0);
+        assert_eq!(input, 6);
+        assert_eq!(output, 12);
+    }
+
+    #[test]
+    fn both_schemas_absent_returns_zero() {
+        let json = r#"{"type":"result","result":"hi","is_error":false,"cost_usd":0.01,"session_id":"s1"}"#;
+        let parsed: ClaudeJsonOutput = serde_json::from_str(json).unwrap();
+        let input = parsed
+            .total_input_tokens
+            .or_else(|| parsed.usage.as_ref().and_then(|u| u.input_tokens))
+            .unwrap_or(0);
+        assert_eq!(input, 0);
+    }
 }

--- a/src-tauri/src/commands/insight_extract.rs
+++ b/src-tauri/src/commands/insight_extract.rs
@@ -399,49 +399,63 @@ pub async fn run_insight_analysis(
     };
 
     let engine_name = engine.unwrap_or_else(|| "claude".to_string());
+    let engine_for_log = engine_name.clone();
     eprintln!("[insight] run_insight_analysis: engine={}, model={:?}, prompt_len={}, project_path={:?}",
         engine_name, input.model, input.prompt.len(), input.project_path);
 
-    // Run synchronously in a blocking thread — dispatch by engine
-    let result: RunOutput = match engine_name.as_str() {
-        "gemini" => {
-            tokio::task::spawn_blocking(move || {
-                crate::agents::gemini::stream_run(
-                    input,
-                    |_| {}, |_| {}, || false,
-                )
-            })
-            .await
-            .map_err(|e| AppError::Agent(format!("spawn_blocking failed: {}", e)))?
-            .map_err(|e| AppError::Agent(format!("gemini analysis failed: {}", e)))?
-        }
-        "codex" => {
-            tokio::task::spawn_blocking(move || {
-                crate::agents::codex::stream_run(
-                    input,
-                    |_| {}, |_| {},
-                )
-            })
-            .await
-            .map_err(|e| AppError::Agent(format!("spawn_blocking failed: {}", e)))?
-            .map_err(|e| AppError::Agent(format!("codex analysis failed: {}", e)))?
-        }
-        _ => {
-            // Default: claude
-            tokio::task::spawn_blocking(move || {
-                crate::agents::claude::stream_run(
-                    input,
-                    |_| {}, |_| {}, || false,
-                )
-            })
-            .await
-            .map_err(|e| AppError::Agent(format!("spawn_blocking failed: {}", e)))?
-            .map_err(|e| AppError::Agent(format!("claude analysis failed: {}", e)))?
+    // insightStabilityPlan Subtask 04 (INV-4): Wall-clock timeout 12분 (agent idle
+    // watchdog 10분 + 2분 buffer). Agent 내부 watchdog 이 hang 되는 edge case 에서도
+    // Tauri 커맨드가 반드시 에러로 반환되어 FE 의 catch 가 session status='failed'
+    // 로 전이 → spinner off.
+    let wall_clock_timeout = std::time::Duration::from_secs(12 * 60);
+
+    let run_fut = async move {
+        let result: Result<RunOutput, AppError> = match engine_name.as_str() {
+            "gemini" => {
+                tokio::task::spawn_blocking(move || {
+                    crate::agents::gemini::stream_run(input, |_| {}, |_| {}, || false)
+                })
+                .await
+                .map_err(|e| AppError::Agent(format!("spawn_blocking failed: {}", e)))?
+                .map_err(|e| AppError::Agent(format!("gemini analysis failed: {}", e)))
+            }
+            "codex" => {
+                tokio::task::spawn_blocking(move || {
+                    crate::agents::codex::stream_run(input, |_| {}, |_| {})
+                })
+                .await
+                .map_err(|e| AppError::Agent(format!("spawn_blocking failed: {}", e)))?
+                .map_err(|e| AppError::Agent(format!("codex analysis failed: {}", e)))
+            }
+            _ => {
+                tokio::task::spawn_blocking(move || {
+                    crate::agents::claude::stream_run(input, |_| {}, |_| {}, || false)
+                })
+                .await
+                .map_err(|e| AppError::Agent(format!("spawn_blocking failed: {}", e)))?
+                .map_err(|e| AppError::Agent(format!("claude analysis failed: {}", e)))
+            }
+        };
+        result
+    };
+
+    let result: RunOutput = match tokio::time::timeout(wall_clock_timeout, run_fut).await {
+        Ok(Ok(r)) => r,
+        Ok(Err(e)) => return Err(e),
+        Err(_elapsed) => {
+            eprintln!(
+                "[insight] run_insight_analysis: wall-clock timeout after {}s",
+                wall_clock_timeout.as_secs()
+            );
+            return Err(AppError::Agent(format!(
+                "insight analysis wall-clock timeout after {}s (agent watchdog likely hung)",
+                wall_clock_timeout.as_secs()
+            )));
         }
     };
 
     eprintln!("[insight] analysis done: engine={}, input_tokens={}, output_tokens={}, cost=${:.4}",
-        engine_name, result.input_tokens, result.output_tokens, result.cost_usd);
+        engine_for_log, result.input_tokens, result.output_tokens, result.cost_usd);
 
     // Return content + usage as JSON
     let response = serde_json::json!({

--- a/src/lib/insightOrchestration.ts
+++ b/src/lib/insightOrchestration.ts
@@ -216,10 +216,16 @@ export async function runInsightAnalysis(
     for (const catExtraction of extraction.categories) {
       const cat = catExtraction.category as InsightCategory;
       const catLabel = CATEGORY_LABELS[cat] || cat;
-      const hasData = catExtraction.snippets.length > 0 || catExtraction.extraContext.length > 0;
+      // insightStabilityPlan Subtask 02 (INV-2): 증거 기반 분석 원칙 — snippets 가
+      // 없으면 extraContext 만으로는 LLM 이 "아래 스니펫에서 확인할 수 있는 문제만
+      // 보고" 시스템 규칙과 모순되어 extended thinking 폭주 + hallucination 위험.
+      // OR 였던 기존 조건을 AND-equivalent (스니펫 필수) 로 강화.
+      const hasData = catExtraction.snippets.length > 0;
 
       if (!hasData) {
-        onProgress?.(`${catLabel}: 사전 추출 데이터 없음, 건너뜀`);
+        onProgress?.(
+          `${catLabel}: 스니펫 없음, 건너뜀 (extraContext=${catExtraction.extraContext.length})`,
+        );
         continue;
       }
 


### PR DESCRIPTION
## Summary

insightStabilityPlan 4 Subtask 순차 수정. tunaReader 에서 **\$0.8+ 비용 + 613초 무응답 + UI 스피너 무한** 현상을 직렬 원인 따라 해소. 베타 공개 blocker.

## 직렬 연관도
\`\`\`
① rawq engine.rs:998 OOB panic (stale chunk)
   └→ rawq daemon 크래시 → 특정 카테고리 snippets=0
② insightOrchestration.ts:219 skip 조건 너무 관대 (OR)
   └→ snippets=0 + extraContext≥1 에서 분석 실행 → LLM 폭주
③ claude.rs StreamLine schema drift
   └→ top-level total_*_tokens 파싱 항상 None → input/output=0 표시
④ agent-timeout(613s) pid kill 후 status 전이 누락
   └→ 스피너 무한
\`\`\`

## Subtask 01 — rawq ctx_before / chunk_start clamp (로컬 patch)
- \`_research/_util/rawq\` + \`tunaDish/vendor/rawq\` 양쪽 동기화 (upstream PR 생략, 사용자 지시)
- \`ctx_before_start/end\` + \`chunk_start\` 에 \`.min(lines.len())\` — stale chunk 의 out-of-bounds panic 방지
- Regression test: chunk.lines=[98,105] + 44-line source → panic 없이 empty context
- \`./scripts/build-rawq.sh\` 로 sidecar 재빌드 완료

## Subtask 02 — insight skip 엄격화 (INV-2)
- \`src/lib/insightOrchestration.ts:219\`: hasData OR → **snippets.length > 0 필수**
- buildAnalysisPrompt 의 "증거 기반" 시스템 규칙과 모순 방지 — LLM hallucination 차단

## Subtask 03 — claude usage nested 파서 (INV-3)
- 실측: claude CLI 2.1.117 → nested usage, top-level 부재 (케이스 B 확정)
- \`StreamLine\` / \`ClaudeJsonOutput\` 양쪽에 \`usage: Option<*Usage>\` 필드
- final_output 두 지점 (stream-json 316 / one-shot 415) 에 \`.or_else()\` fallback
- 단위 테스트 **4건**: old / new / both-schemas / absent-both

## Subtask 04 — agent-timeout propagation (INV-4)
- \`claude::stream_run\`: watchdog \`timed_out: Arc<AtomicBool>\` → reader exit 후 distinct AppError
- \`insight_extract::run_insight_analysis\`: **tokio::time::timeout 12분 wall-clock** wrapper — agent 내부 watchdog 이 hang 되는 edge case 에서도 Tauri 커맨드가 반드시 에러 반환 → FE catch → session.status='failed' → spinner off

## 테스트
- **Rust 478 → 482** (+4 schema parser)
- **Frontend 316** 유지
- rawq 두 repo **40 tests 각각** 통과
- tsc \`--noEmit\` 통과

## INV 준수
- INV-1 rawq slice clamp — regression test 로 입증
- INV-2 evidence-based skip — snippets 없으면 invoke 0회
- INV-3 usage schema fallback — old/new 양쪽 non-zero tokens 반환
- INV-4 timeout propagation — watchdog flag + wall-clock guard 이중 안전장치

## 재현 전/후 기대값
| 지표 | before | after |
|---|---|---|
| 카테고리 1회 max 비용 | \$0.9+ (extended thinking) | \~\$0.1 |
| 카테고리 1회 max 시간 | 613s → hang | 12min 강제 timeout |
| UI 스피너 | 무한 | 에러 toast + spinner off |
| input/output 토큰 표시 | 0 (top-level 부재) | 실제 값 |

## Test plan
- [x] rawq \`cargo test --lib\` (40 tests 양쪽 repo)
- [x] tunaFlow \`cargo test --lib\` (482 통과)
- [x] \`npx vitest run\` (316 유지)
- [x] \`npx tsc --noEmit\`
- [ ] 수동 E2E: tunaReader 에서 Insight 분석 → 아키텍처/테스트 카테고리 스피너 정상 종료 + 비용 합리적 (카테고리당 \$0.1 미만)
- [ ] Insight 로그 \`input_tokens/output_tokens\` 0 아닌 실제값 표시

## 후속 (별도 작업, public release 경로 계속)
- publicReadiness Phase 0~4 (cleanup + OSS hygiene + README 보강)
- i18n PR A (Phase 1+2+3+4A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)