### PR TITLE
feat(i18n): PR A2 partial — 4 신규 namespace + Settings 3 컴포넌트 migration

### DIFF
--- a/src/components/tunaflow/SettingsPanel.tsx
+++ b/src/components/tunaflow/SettingsPanel.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
 import { X, Bot, UserCircle, Zap, Cpu, Terminal, Smartphone, User, HelpCircle, Globe, Brain } from "lucide-react";
 import { SkillsPanel } from "./context-panel/SkillsPanel";
@@ -14,17 +15,19 @@ import { IdentityAnalysisSettings } from "./settings/IdentityAnalysisSettings";
 
 type SettingsSection = "profile" | "worldview" | "identity" | "agents" | "personas" | "skills" | "runtime" | "terminal" | "mobile" | "help";
 
-const SECTIONS: { id: SettingsSection; label: string; icon: React.ReactNode }[] = [
-  { id: "profile", label: "Profile", icon: <User className="w-4 h-4" /> },
-  { id: "worldview", label: "Worldview", icon: <Globe className="w-4 h-4" /> },
-  { id: "identity", label: "Identity", icon: <Brain className="w-4 h-4" /> },
-  { id: "agents", label: "Agents", icon: <Bot className="w-4 h-4" /> },
-  { id: "personas", label: "Personas", icon: <UserCircle className="w-4 h-4" /> },
-  { id: "skills", label: "Skills", icon: <Zap className="w-4 h-4" /> },
-  { id: "runtime", label: "Runtime", icon: <Cpu className="w-4 h-4" /> },
-  { id: "terminal", label: "Terminal", icon: <Terminal className="w-4 h-4" /> },
-  { id: "mobile", label: "Mobile", icon: <Smartphone className="w-4 h-4" /> },
-  { id: "help", label: "Help", icon: <HelpCircle className="w-4 h-4" /> },
+/** Section labels come from `settings.section.*` i18n keys. The order is visual
+ *  layout, not config — 새 섹션 추가 시 JSON 키 + 이 배열 양쪽에 등록. */
+const SECTION_CONFIG: { id: SettingsSection; icon: React.ReactNode }[] = [
+  { id: "profile", icon: <User className="w-4 h-4" /> },
+  { id: "worldview", icon: <Globe className="w-4 h-4" /> },
+  { id: "identity", icon: <Brain className="w-4 h-4" /> },
+  { id: "agents", icon: <Bot className="w-4 h-4" /> },
+  { id: "personas", icon: <UserCircle className="w-4 h-4" /> },
+  { id: "skills", icon: <Zap className="w-4 h-4" /> },
+  { id: "runtime", icon: <Cpu className="w-4 h-4" /> },
+  { id: "terminal", icon: <Terminal className="w-4 h-4" /> },
+  { id: "mobile", icon: <Smartphone className="w-4 h-4" /> },
+  { id: "help", icon: <HelpCircle className="w-4 h-4" /> },
 ];
 
 interface SettingsPanelProps {
@@ -38,6 +41,7 @@ export function SettingsPanel({ onClose, initialSection }: SettingsPanelProps) {
     ? (initialSection as SettingsSection)
     : "profile";
   const [activeSection, setActiveSection] = useState<SettingsSection>(initial);
+  const { t } = useTranslation("settings");
 
   return (
     <div className="fixed inset-0 z-[80] flex items-center justify-center">
@@ -45,7 +49,7 @@ export function SettingsPanel({ onClose, initialSection }: SettingsPanelProps) {
 
       <div className="relative bg-sidebar border border-border/40 rounded-xl shadow-2xl w-[80vw] max-w-[900px] h-[70vh] max-h-[600px] overflow-hidden flex flex-col">
         <div className="flex items-center px-5 h-12 shrink-0">
-          <span className="text-[14px] font-[550] text-foreground flex-1">Settings</span>
+          <span className="text-[14px] font-[550] text-foreground flex-1">{t("title")}</span>
           <button onClick={onClose} className="p-1.5 rounded-md hover:bg-accent text-muted-foreground hover:text-foreground transition-colors">
             <X className="w-4 h-4" />
           </button>
@@ -53,7 +57,7 @@ export function SettingsPanel({ onClose, initialSection }: SettingsPanelProps) {
 
         <div className="flex flex-1 min-h-0">
           <nav className="w-[180px] shrink-0 px-3 py-2 space-y-0.5">
-            {SECTIONS.map((section) => (
+            {SECTION_CONFIG.map((section) => (
               <button
                 key={section.id}
                 onClick={() => setActiveSection(section.id)}
@@ -65,7 +69,7 @@ export function SettingsPanel({ onClose, initialSection }: SettingsPanelProps) {
                 )}
               >
                 {section.icon}
-                {section.label}
+                {t(`section.${section.id}`)}
               </button>
             ))}
           </nav>

--- a/src/components/tunaflow/settings/IdentityAnalysisSettings.tsx
+++ b/src/components/tunaflow/settings/IdentityAnalysisSettings.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
+import { useTranslation } from "react-i18next";
 import { Brain, Play } from "lucide-react";
 import { useChatStore } from "@/stores/chatStore";
 import {
@@ -20,6 +21,7 @@ import {
  *  - TriggerStatus 배지 (Plans done / Eligible / reason)
  */
 export function IdentityAnalysisSettings() {
+  const { t } = useTranslation("settings");
   const projectKey = useChatStore((s) => s.selectedProjectKey);
   const [enabled, setEnabled] = useState(true);
   const [threshold, setThreshold] = useState(10);
@@ -59,9 +61,9 @@ export function IdentityAnalysisSettings() {
     try {
       await setBackgroundInsightEnabled(next);
       setEnabled(next);
-      toast.success(next ? "Background insight 활성화" : "Background insight 비활성화 (큐 보존)");
+      toast.success(t(next ? "identity.toast.toggle_on" : "identity.toast.toggle_off"));
     } catch (e) {
-      toast.error(`토글 실패: ${e}`);
+      toast.error(t("identity.toast.toggle_failed", { error: String(e) }));
     }
   };
 
@@ -70,7 +72,7 @@ export function IdentityAnalysisSettings() {
     try {
       await setIdentityAnalysisThreshold(next);
     } catch (e) {
-      toast.error(`threshold 저장 실패: ${e}`);
+      toast.error(t("identity.toast.threshold_save_failed", { error: String(e) }));
     }
   };
 
@@ -82,11 +84,11 @@ export function IdentityAnalysisSettings() {
       setStatus(decision);
       toast.success(
         decision.shouldRun
-          ? "분석 job enqueue — 30s 내 worker 가 실행"
-          : `skip — ${decision.reason}`,
+          ? t("identity.toast.enqueued")
+          : t("identity.toast.skipped", { reason: decision.reason }),
       );
     } catch (e) {
-      toast.error(`실행 실패: ${e}`);
+      toast.error(t("identity.toast.run_failed", { error: String(e) }));
     } finally {
       setBusy(false);
     }
@@ -97,11 +99,10 @@ export function IdentityAnalysisSettings() {
       <div>
         <h2 className="text-[14px] font-[550] text-foreground mb-1 flex items-center gap-2">
           <Brain className="w-4 h-4" />
-          Identity Analysis
+          {t("identity.heading")}
         </h2>
         <p className="text-[12px] text-muted-foreground leading-relaxed">
-          Plan 완료 artifact 를 주기적으로 분석해 프로젝트 정체성 요약을 생성합니다.
-          ContextPack 에 자동 주입되어 이후 agent 응답의 정합성을 높입니다.
+          {t("identity.description")}
         </p>
       </div>
 
@@ -114,13 +115,13 @@ export function IdentityAnalysisSettings() {
           onChange={(e) => handleToggle(e.target.checked)}
           className="accent-primary"
         />
-        Background 분석 활성화 (OFF 시 worker 는 pending job 을 pick 하지 않음)
+        {t("identity.toggle_label")}
       </label>
 
       {/* Threshold slider */}
       <div className="space-y-1">
         <label className="text-[12px] font-medium text-foreground/80 flex items-center justify-between">
-          <span>Eligible artifact threshold</span>
+          <span>{t("identity.threshold_label")}</span>
           <span className="text-[11px] text-muted-foreground font-mono">{threshold}</span>
         </label>
         <input
@@ -134,20 +135,19 @@ export function IdentityAnalysisSettings() {
           className="w-full accent-primary"
         />
         <p className="text-[11px] text-muted-foreground/70">
-          Plan done 이 3의 배수이고, 이전 분석 이후 누적된 eligible artifact 수가 이 값 이상이면 자동 실행됩니다.
-          기본 10 (범위 3~50).
+          {t("identity.threshold_hint")}
         </p>
       </div>
 
       {/* TriggerStatus */}
       {projectKey && status && (
         <div className="text-[11px] bg-muted/30 rounded-md p-3 space-y-1">
-          <div className="text-[10px] text-muted-foreground uppercase tracking-wide">현재 상태</div>
-          <div>Plans done: <span className="font-mono">{status.donePlanCount}</span></div>
-          <div>Eligible artifacts: <span className="font-mono">{status.eligibleArtifactCount} / {status.threshold}</span></div>
-          <div className="text-muted-foreground">reason: <span className="font-mono">{status.reason}</span></div>
+          <div className="text-[10px] text-muted-foreground uppercase tracking-wide">{t("identity.status.heading")}</div>
+          <div>{t("identity.status.plans_done")} <span className="font-mono">{status.donePlanCount}</span></div>
+          <div>{t("identity.status.eligible")} <span className="font-mono">{status.eligibleArtifactCount} / {status.threshold}</span></div>
+          <div className="text-muted-foreground">{t("identity.status.reason")} <span className="font-mono">{status.reason}</span></div>
           <div className="text-muted-foreground/80">
-            {status.shouldRun ? "✓ 다음 Plan 완료 시 자동 실행" : "⏸ 조건 미충족"}
+            {status.shouldRun ? t("identity.status.will_run") : t("identity.status.wont_run")}
           </div>
         </div>
       )}
@@ -160,10 +160,10 @@ export function IdentityAnalysisSettings() {
           className="flex items-center gap-1.5 px-3 py-1.5 text-[12px] font-medium rounded-md bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
         >
           <Play className="w-3 h-3" />
-          {busy ? "enqueue 중..." : "지금 실행 (threshold 무시)"}
+          {busy ? t("identity.button.enqueuing") : t("identity.button.run_now")}
         </button>
         <span className="text-[11px] text-muted-foreground">
-          plan done %3 조건은 유지됩니다 (partial period 분석 품질 저하 방지)
+          {t("identity.force_hint")}
         </span>
       </div>
     </div>

--- a/src/components/tunaflow/settings/WorldviewSettings.tsx
+++ b/src/components/tunaflow/settings/WorldviewSettings.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { toast } from "sonner";
+import { useTranslation } from "react-i18next";
 import { Globe, FileText } from "lucide-react";
 
 const WORLDVIEW_MAX_TOKENS = 500;
@@ -31,6 +32,7 @@ function estimateTokens(text: string): number {
 }
 
 export function WorldviewSettings() {
+  const { t } = useTranslation("settings");
   const [content, setContent] = useState<string>("");
   const [saved, setSaved] = useState<boolean>(true);
   const [loading, setLoading] = useState<boolean>(true);
@@ -51,12 +53,12 @@ export function WorldviewSettings() {
         setSaved(true);
       } catch (err) {
         console.error("[worldview] load failed", err);
-        toast.error("Worldview 로드 실패");
+        toast.error(t("worldview.toast.load_failed"));
       } finally {
         setLoading(false);
       }
     })();
-  }, []);
+  }, [t]);
 
   const tokens = estimateTokens(content);
   const overLimit = tokens > WORLDVIEW_MAX_TOKENS;
@@ -69,10 +71,10 @@ export function WorldviewSettings() {
         input: { projectPath: null },
       });
       setAppliedPath(newPath);
-      toast.success("Worldview 저장됨 — 다음 요청부터 적용");
+      toast.success(t("worldview.toast.saved"));
     } catch (err) {
       console.error("[worldview] save failed", err);
-      toast.error(`저장 실패: ${err}`);
+      toast.error(t("worldview.toast.save_failed", { error: String(err) }));
     }
   };
 
@@ -85,10 +87,10 @@ export function WorldviewSettings() {
     try {
       await invoke("set_worldview_enabled", { input: { enabled: next } });
       setEnabled(next);
-      toast.success(next ? "Worldview 주입 활성화" : "Worldview 주입 비활성화");
+      toast.success(t(next ? "worldview.toast.toggle_on" : "worldview.toast.toggle_off"));
     } catch (err) {
       console.error("[worldview] toggle failed", err);
-      toast.error(`토글 실패: ${err}`);
+      toast.error(t("worldview.toast.save_failed", { error: String(err) }));
     }
   };
 
@@ -97,11 +99,10 @@ export function WorldviewSettings() {
       <div>
         <h2 className="text-[14px] font-[550] text-foreground mb-1 flex items-center gap-2">
           <Globe className="w-4 h-4" />
-          User Worldview
+          {t("worldview.heading")}
         </h2>
         <p className="text-[12px] text-muted-foreground leading-relaxed">
-          에이전트가 매 요청 시 ContextPack 의 identity 바로 앞에서 참조하는 사용자 stance 문서입니다.
-          최대 {WORLDVIEW_MAX_TOKENS} tokens.
+          {t("worldview.description", { max: WORLDVIEW_MAX_TOKENS })}
         </p>
       </div>
 
@@ -113,7 +114,7 @@ export function WorldviewSettings() {
           onChange={(e) => handleToggleEnabled(e.target.checked)}
           className="accent-primary"
         />
-        Worldview 주입 활성화
+        {t("worldview.toggle_label")}
       </label>
 
       {/* Editor */}
@@ -125,13 +126,13 @@ export function WorldviewSettings() {
             setContent(e.target.value);
             setSaved(false);
           }}
-          placeholder="(비어있음 — 기본 문구 로드 또는 직접 작성)"
+          placeholder={t("worldview.placeholder")}
           className="w-full h-72 font-mono text-[12px] bg-background border border-border/40 rounded-md px-3 py-2 text-foreground placeholder:text-muted-foreground/40 focus:outline-none focus:border-ring/50 resize-none"
         />
         <div className="flex items-center justify-between text-[11px]">
           <span className={overLimit ? "text-red-500 font-medium" : "text-muted-foreground/70"}>
-            {tokens} / {WORLDVIEW_MAX_TOKENS} tokens
-            {overLimit ? " — 앞부분만 주입됨" : ""}
+            {t("worldview.token_counter", { current: tokens, max: WORLDVIEW_MAX_TOKENS })}
+            {overLimit ? t("worldview.over_limit_note") : ""}
           </span>
           {appliedPath && (
             <span className="text-muted-foreground/60 inline-flex items-center gap-1 truncate max-w-[60%]">
@@ -149,14 +150,14 @@ export function WorldviewSettings() {
           disabled={saved || loading}
           className="px-3 py-1.5 text-[12px] font-medium rounded-md bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
         >
-          저장
+          {t("worldview.button.save")}
         </button>
         <button
           onClick={handleLoadDefault}
           disabled={loading}
           className="px-3 py-1.5 text-[12px] font-medium rounded-md text-foreground/70 hover:text-foreground hover:bg-accent transition-colors"
         >
-          기본 문구 로드
+          {t("worldview.button.load_default")}
         </button>
       </div>
     </div>

--- a/src/locales/en/chat.json
+++ b/src/locales/en/chat.json
@@ -1,0 +1,36 @@
+{
+  "input": {
+    "placeholder": "Type a message... (Shift+Enter for newline)",
+    "placeholder_empty_project": "Select a project first",
+    "send_button": "Send",
+    "stop_button": "Stop",
+    "attach_button": "Attach file"
+  },
+  "message": {
+    "role_user": "You",
+    "role_assistant": "Agent",
+    "role_system": "System",
+    "copy": "Copy",
+    "copied": "Copied",
+    "retry": "Retry",
+    "delete_pair": "Delete pair",
+    "created_branch": "Create branch",
+    "streaming_hint": "Streaming..."
+  },
+  "branch": {
+    "create": "Create branch",
+    "default_label": "New branch",
+    "from_here": "Branch from here"
+  },
+  "error": {
+    "send_failed": "Send failed",
+    "empty_response": "Agent returned an empty response",
+    "engine_not_available": "Engine is not available"
+  },
+  "status": {
+    "sending": "Sending...",
+    "waiting_agent": "Waiting for agent response...",
+    "tool_call": "Tool call: {{name}}",
+    "thinking": "Thinking..."
+  }
+}

--- a/src/locales/en/dialog.json
+++ b/src/locales/en/dialog.json
@@ -1,0 +1,30 @@
+{
+  "delete": {
+    "title": "Confirm delete",
+    "message": "Are you sure you want to delete {{name}}?",
+    "message_generic": "Are you sure you want to delete this item?",
+    "confirm": "Delete",
+    "cancel": "Cancel",
+    "irreversible_hint": "This action cannot be undone."
+  },
+  "rename": {
+    "title": "Rename",
+    "label": "New name",
+    "confirm": "Rename",
+    "cancel": "Cancel"
+  },
+  "confirm": {
+    "title": "Confirm",
+    "default_message": "Continue?",
+    "yes": "Yes",
+    "no": "No"
+  },
+  "save_artifact": {
+    "title": "Save artifact",
+    "name_label": "Name",
+    "type_label": "Type",
+    "description_label": "Description",
+    "save": "Save",
+    "cancel": "Cancel"
+  }
+}

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -1,0 +1,86 @@
+{
+  "title": "Settings",
+  "section": {
+    "profile": "Profile",
+    "worldview": "Worldview",
+    "identity": "Identity",
+    "agents": "Agents",
+    "personas": "Personas",
+    "skills": "Skills",
+    "runtime": "Runtime",
+    "terminal": "Terminal",
+    "mobile": "Mobile",
+    "help": "Help"
+  },
+  "profile": {
+    "description": "Configure your agent context and developer information.",
+    "group": {
+      "basic": "Basic info",
+      "agent_context": "Agent context",
+      "dev_info": "Developer info",
+      "advanced": "Advanced"
+    },
+    "field": {
+      "name": "Name",
+      "title": "Title",
+      "github_username": "GitHub username",
+      "bio": "Bio",
+      "preferred_languages": "Preferred languages",
+      "git_name": "Git name",
+      "git_email": "Git email",
+      "github_org": "GitHub org",
+      "github_token": "GitHub token"
+    },
+    "toast": {
+      "saved": "Profile saved"
+    }
+  },
+  "worldview": {
+    "heading": "User Worldview",
+    "description": "A user-stance document referenced by the agent on every request, placed right before the identity section of the ContextPack. Max {{max}} tokens.",
+    "toggle_label": "Enable worldview injection",
+    "token_counter": "{{current}} / {{max}} tokens",
+    "over_limit_note": " — only the first portion will be injected",
+    "button": {
+      "save": "Save",
+      "load_default": "Load default"
+    },
+    "toast": {
+      "saved": "Worldview saved — will apply from the next request",
+      "load_failed": "Failed to load worldview",
+      "save_failed": "Save failed: {{error}}",
+      "toggle_on": "Worldview injection enabled",
+      "toggle_off": "Worldview injection disabled"
+    },
+    "placeholder": "(Empty — load default or write your own)"
+  },
+  "identity": {
+    "heading": "Identity Analysis",
+    "description": "Periodically analyzes completed-plan artifacts to generate a project identity summary. The summary is auto-injected into ContextPack to improve consistency of future agent responses.",
+    "toggle_label": "Enable background analysis (when OFF, the worker will not pick pending jobs)",
+    "threshold_label": "Eligible artifact threshold",
+    "threshold_hint": "Runs automatically when Plan done count is a multiple of 3 AND eligible artifacts since the last summary reach this value. Default 10 (range 3-50).",
+    "status": {
+      "heading": "Current status",
+      "plans_done": "Plans done:",
+      "eligible": "Eligible artifacts:",
+      "reason": "reason:",
+      "will_run": "✓ Will run on next plan completion",
+      "wont_run": "⏸ Conditions not met"
+    },
+    "button": {
+      "run_now": "Run now (bypass threshold)",
+      "enqueuing": "Enqueueing..."
+    },
+    "force_hint": "Plan done %3 condition is still enforced (partial-period analysis degrades quality)",
+    "toast": {
+      "toggle_on": "Background insight enabled",
+      "toggle_off": "Background insight disabled (queue preserved)",
+      "toggle_failed": "Toggle failed: {{error}}",
+      "threshold_save_failed": "Failed to save threshold: {{error}}",
+      "enqueued": "Analysis job enqueued — worker will run within 30s",
+      "skipped": "Skip — {{reason}}",
+      "run_failed": "Run failed: {{error}}"
+    }
+  }
+}

--- a/src/locales/en/sidebar.json
+++ b/src/locales/en/sidebar.json
@@ -1,0 +1,31 @@
+{
+  "section": {
+    "chats": "Chats",
+    "branches": "Branches",
+    "roundtables": "Roundtables",
+    "scratchpad": "Scratchpad",
+    "docs": "Docs",
+    "archive": "Archive",
+    "projects": "Projects"
+  },
+  "action": {
+    "new_chat": "New chat",
+    "new_project": "Add project",
+    "rename": "Rename",
+    "delete": "Delete",
+    "archive": "Archive",
+    "unarchive": "Unarchive",
+    "pin": "Pin",
+    "unpin": "Unpin",
+    "open_folder": "Open folder"
+  },
+  "placeholder": {
+    "search_chats": "Search chats...",
+    "new_project_path": "Project path or name"
+  },
+  "empty": {
+    "no_chats": "No chats yet",
+    "no_branches": "No branches",
+    "no_projects": "No registered projects"
+  }
+}

--- a/src/locales/index.ts
+++ b/src/locales/index.ts
@@ -4,8 +4,16 @@ import LanguageDetector from "i18next-browser-languagedetector";
 
 import koCommon from "./ko/common.json";
 import koError from "./ko/error.json";
+import koSettings from "./ko/settings.json";
+import koSidebar from "./ko/sidebar.json";
+import koChat from "./ko/chat.json";
+import koDialog from "./ko/dialog.json";
 import enCommon from "./en/common.json";
 import enError from "./en/error.json";
+import enSettings from "./en/settings.json";
+import enSidebar from "./en/sidebar.json";
+import enChat from "./en/chat.json";
+import enDialog from "./en/dialog.json";
 
 /** Supported locales. Add 'ja', 'zh', etc. in later PRs. */
 export type SupportedLocale = "ko" | "en";
@@ -19,10 +27,18 @@ export const resources = {
   ko: {
     common: koCommon,
     error: koError,
+    settings: koSettings,
+    sidebar: koSidebar,
+    chat: koChat,
+    dialog: koDialog,
   },
   en: {
     common: enCommon,
     error: enError,
+    settings: enSettings,
+    sidebar: enSidebar,
+    chat: enChat,
+    dialog: enDialog,
   },
 } as const;
 
@@ -36,7 +52,7 @@ i18n
     // 누락 키는 빈 문자열 대신 키 그대로 표시 → 누락 즉시 인지.
     returnEmptyString: false,
     defaultNS: "common",
-    ns: ["common", "error"],
+    ns: ["common", "error", "settings", "sidebar", "chat", "dialog"],
     detection: {
       // appStore (IndexedDB) 우선, 그 다음 localStorage/navigator.
       order: ["localStorage", "navigator"],

--- a/src/locales/ko/chat.json
+++ b/src/locales/ko/chat.json
@@ -1,0 +1,36 @@
+{
+  "input": {
+    "placeholder": "메시지를 입력하세요... (Shift+Enter 줄바꿈)",
+    "placeholder_empty_project": "먼저 프로젝트를 선택하세요",
+    "send_button": "보내기",
+    "stop_button": "중지",
+    "attach_button": "파일 첨부"
+  },
+  "message": {
+    "role_user": "사용자",
+    "role_assistant": "에이전트",
+    "role_system": "시스템",
+    "copy": "복사",
+    "copied": "복사됨",
+    "retry": "재시도",
+    "delete_pair": "쌍 삭제",
+    "created_branch": "브랜치 생성",
+    "streaming_hint": "스트리밍 중..."
+  },
+  "branch": {
+    "create": "브랜치 만들기",
+    "default_label": "새 브랜치",
+    "from_here": "여기서 분기"
+  },
+  "error": {
+    "send_failed": "전송 실패",
+    "empty_response": "에이전트가 빈 응답을 반환했습니다",
+    "engine_not_available": "엔진을 사용할 수 없습니다"
+  },
+  "status": {
+    "sending": "전송 중...",
+    "waiting_agent": "에이전트 응답 대기 중...",
+    "tool_call": "도구 호출: {{name}}",
+    "thinking": "생각 중..."
+  }
+}

--- a/src/locales/ko/dialog.json
+++ b/src/locales/ko/dialog.json
@@ -1,0 +1,30 @@
+{
+  "delete": {
+    "title": "삭제 확인",
+    "message": "정말 {{name}}을(를) 삭제하시겠습니까?",
+    "message_generic": "이 항목을 정말 삭제하시겠습니까?",
+    "confirm": "삭제",
+    "cancel": "취소",
+    "irreversible_hint": "이 작업은 되돌릴 수 없습니다."
+  },
+  "rename": {
+    "title": "이름 변경",
+    "label": "새 이름",
+    "confirm": "변경",
+    "cancel": "취소"
+  },
+  "confirm": {
+    "title": "확인",
+    "default_message": "계속 진행하시겠습니까?",
+    "yes": "예",
+    "no": "아니오"
+  },
+  "save_artifact": {
+    "title": "Artifact 저장",
+    "name_label": "이름",
+    "type_label": "종류",
+    "description_label": "설명",
+    "save": "저장",
+    "cancel": "취소"
+  }
+}

--- a/src/locales/ko/settings.json
+++ b/src/locales/ko/settings.json
@@ -1,0 +1,86 @@
+{
+  "title": "Settings",
+  "section": {
+    "profile": "Profile",
+    "worldview": "Worldview",
+    "identity": "Identity",
+    "agents": "Agents",
+    "personas": "Personas",
+    "skills": "Skills",
+    "runtime": "Runtime",
+    "terminal": "Terminal",
+    "mobile": "Mobile",
+    "help": "Help"
+  },
+  "profile": {
+    "description": "에이전트 컨텍스트와 개발자 정보를 설정합니다.",
+    "group": {
+      "basic": "기본 정보",
+      "agent_context": "에이전트 맥락",
+      "dev_info": "개발자 정보",
+      "advanced": "고급"
+    },
+    "field": {
+      "name": "이름",
+      "title": "직함",
+      "github_username": "GitHub 사용자명",
+      "bio": "Bio",
+      "preferred_languages": "선호 언어",
+      "git_name": "Git 사용자명",
+      "git_email": "Git 이메일",
+      "github_org": "GitHub 조직",
+      "github_token": "GitHub 토큰"
+    },
+    "toast": {
+      "saved": "프로필 저장됨"
+    }
+  },
+  "worldview": {
+    "heading": "User Worldview",
+    "description": "에이전트가 매 요청 시 ContextPack 의 identity 바로 앞에서 참조하는 사용자 stance 문서입니다. 최대 {{max}} tokens.",
+    "toggle_label": "Worldview 주입 활성화",
+    "token_counter": "{{current}} / {{max}} tokens",
+    "over_limit_note": " — 앞부분만 주입됨",
+    "button": {
+      "save": "저장",
+      "load_default": "기본 문구 로드"
+    },
+    "toast": {
+      "saved": "Worldview 저장됨 — 다음 요청부터 적용",
+      "load_failed": "Worldview 로드 실패",
+      "save_failed": "저장 실패: {{error}}",
+      "toggle_on": "Worldview 주입 활성화",
+      "toggle_off": "Worldview 주입 비활성화"
+    },
+    "placeholder": "(비어있음 — 기본 문구 로드 또는 직접 작성)"
+  },
+  "identity": {
+    "heading": "Identity Analysis",
+    "description": "Plan 완료 artifact 를 주기적으로 분석해 프로젝트 정체성 요약을 생성합니다. ContextPack 에 자동 주입되어 이후 agent 응답의 정합성을 높입니다.",
+    "toggle_label": "Background 분석 활성화 (OFF 시 worker 는 pending job 을 pick 하지 않음)",
+    "threshold_label": "Eligible artifact threshold",
+    "threshold_hint": "Plan done 이 3의 배수이고, 이전 분석 이후 누적된 eligible artifact 수가 이 값 이상이면 자동 실행됩니다. 기본 10 (범위 3~50).",
+    "status": {
+      "heading": "현재 상태",
+      "plans_done": "Plans done:",
+      "eligible": "Eligible artifacts:",
+      "reason": "reason:",
+      "will_run": "✓ 다음 Plan 완료 시 자동 실행",
+      "wont_run": "⏸ 조건 미충족"
+    },
+    "button": {
+      "run_now": "지금 실행 (threshold 무시)",
+      "enqueuing": "enqueue 중..."
+    },
+    "force_hint": "plan done %3 조건은 유지됩니다 (partial period 분석 품질 저하 방지)",
+    "toast": {
+      "toggle_on": "Background insight 활성화",
+      "toggle_off": "Background insight 비활성화 (큐 보존)",
+      "toggle_failed": "토글 실패: {{error}}",
+      "threshold_save_failed": "threshold 저장 실패: {{error}}",
+      "enqueued": "분석 job enqueue — 30s 내 worker 가 실행",
+      "skipped": "skip — {{reason}}",
+      "run_failed": "실행 실패: {{error}}"
+    }
+  }
+}

--- a/src/locales/ko/sidebar.json
+++ b/src/locales/ko/sidebar.json
@@ -1,0 +1,31 @@
+{
+  "section": {
+    "chats": "대화",
+    "branches": "브랜치",
+    "roundtables": "라운드테이블",
+    "scratchpad": "스크래치패드",
+    "docs": "문서",
+    "archive": "아카이브",
+    "projects": "프로젝트"
+  },
+  "action": {
+    "new_chat": "새 대화",
+    "new_project": "프로젝트 추가",
+    "rename": "이름 변경",
+    "delete": "삭제",
+    "archive": "아카이브",
+    "unarchive": "복원",
+    "pin": "고정",
+    "unpin": "고정 해제",
+    "open_folder": "폴더 열기"
+  },
+  "placeholder": {
+    "search_chats": "대화 검색...",
+    "new_project_path": "프로젝트 경로 또는 이름"
+  },
+  "empty": {
+    "no_chats": "대화 없음",
+    "no_branches": "브랜치 없음",
+    "no_projects": "등록된 프로젝트 없음"
+  }
+}

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -8,6 +8,10 @@
 import "i18next";
 import type koCommon from "../locales/ko/common.json";
 import type koError from "../locales/ko/error.json";
+import type koSettings from "../locales/ko/settings.json";
+import type koSidebar from "../locales/ko/sidebar.json";
+import type koChat from "../locales/ko/chat.json";
+import type koDialog from "../locales/ko/dialog.json";
 
 declare module "i18next" {
   interface CustomTypeOptions {
@@ -15,6 +19,10 @@ declare module "i18next" {
     resources: {
       common: typeof koCommon;
       error: typeof koError;
+      settings: typeof koSettings;
+      sidebar: typeof koSidebar;
+      chat: typeof koChat;
+      dialog: typeof koDialog;
     };
   }
 }


### PR DESCRIPTION
## Summary

i18nPlan PR A 의 **두 번째 슬라이스 (A2 partial)**. 4 신규 namespace (settings / sidebar / chat / dialog) ko/en JSON 작성 + Settings 경로 3 컴포넌트 t() 전환. 나머지 UI 는 후속 세션으로 분할.

## 신규 namespace (총 4)
| Namespace | 키 수 | 내용 |
|---|---|---|
| \`settings\` | ~52 | title + 10 section labels + profile/worldview/identity 본문 |
| \`sidebar\` | ~22 | section / action / placeholder / empty |
| \`chat\` | ~20 | input / message / branch / error / status |
| \`dialog\` | ~21 | delete / rename / confirm / save_artifact |

각 namespace: ko (SSOT) + en 완전 번역 = **8 신규 JSON 파일**.

## 인프라 업데이트
- \`locales/index.ts\`: ns 목록 확장 + resources 에 4 신규 namespace 등록
- \`types/i18next.d.ts\`: 신규 JSON 타입 선언 — compile-time 키 자동완성 유지

## 컴포넌트 migration (3건)
- **SettingsPanel**: title + 10 section nav labels
- **WorldviewSettings**: heading / description / toggle / token counter / buttons + 5 toast
- **IdentityAnalysisSettings**: heading / description / toggle / threshold label + hint / status 카드 5 필드 / button + force_hint / 4 toast

## 나머지 하드코딩 유지 (후속 세션 이관 대기)
- \`ProfileSection\` 본문 필드 라벨
- \`ChatPanel\` / \`MessageItem\` / \`InputBar\`
- \`Sidebar\` / \`TreeRow\` / \`ProjectOnboardingModal\`
- \`WorkflowCard\` / \`DevProgressView\` / \`PlanCard\` / \`PlanProposalCard\`
- Branch 드로어 / \`CreateRoundtableDialog\`
- \`InsightPanel\` / \`IdentityView\` (content 본문)
- 기타 dialog 계열

**본 PR 은 plan Phase 2 의 약 20-30% 이관 분량**. 전체 완결까지 A2-B/C 세션 추가 필요. 본 PR 머지로 **i18n 인프라 확장 + 패턴 정착 완료** → 후속 세션에서 기계적으로 동일 패턴 반복 가능.

## 패턴 정착
\`\`\`tsx
const { t } = useTranslation("settings");
// 텍스트 블록
<h2>{t("worldview.heading")}</h2>
// Interpolation
<p>{t("worldview.description", { max: 500 })}</p>
// Toast 조건부
toast.success(t(next ? "toast.on" : "toast.off"));
// 동적 키
<span>{t(\`section.\${id}\`)}</span>
\`\`\`

## 검증
- Frontend **322** tests 유지
- \`npx tsc --noEmit\` 통과
- 타입 선언 덕분에 잘못된 키 사용 시 compile-time 에러

## 후속 세션 로드맵
- **A2-B**: chat / sidebar 컴포넌트 이관 (ChatPanel / InputBar / MessageItem / Sidebar / TreeRow)
- **A2-C**: workflow / branch / insight 컴포넌트 이관 (PlanCard / DevProgressView / BranchPanel / InsightPanel 등)
- **A3**: Phase 4A-2/3 — defaultPersonas.ts + tool_handler.rs 영어 전환
- **PR B**: insightOrchestration.ts 영어 전환 + A/B 검증 (베타 후)

## Test plan
- [x] \`npx tsc --noEmit\`
- [x] \`npx vitest run\` (322 통과)
- [ ] Settings > Profile > Language 드롭다운으로 ko↔en 전환
- [ ] Settings nav 10 섹션 라벨 영문/한국어 렌더 확인
- [ ] Settings > Worldview / Identity 패널 전체 영문/한국어 렌더 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)