### PR TITLE
feat(i18n): PR A2-B partial — NewMessageInput / ChatPanel chat namespace migration

### DIFF
--- a/src/components/tunaflow/ChatPanel.tsx
+++ b/src/components/tunaflow/ChatPanel.tsx
@@ -1,6 +1,7 @@
 import { useRef, useEffect, useState, useCallback } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { Virtuoso, VirtuosoHandle } from "react-virtuoso";
+import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
 import type { Message, Branch } from "@/types";
 import { useChatStore } from "@/stores/chatStore";
@@ -11,6 +12,7 @@ import { CreateRoundtableDialog } from "./CreateRoundtableDialog";
 import { SaveArtifactDialog } from "./SaveArtifactDialog";
 
 export function ChatPanel() {
+  const { t: chatT } = useTranslation("chat");
   // Selective subscriptions — only re-render when these specific fields change
   const messages = useChatStore((s) => s.messages);
   const branches = useChatStore((s) => s.branches);
@@ -291,7 +293,7 @@ export function ChatPanel() {
               <button
                 onClick={scrollToBottom}
                 className="pointer-events-auto w-8 h-8 rounded-full bg-background/90 hover:bg-accent border border-border text-muted-foreground hover:text-foreground flex items-center justify-center shadow-lg backdrop-blur-sm transition-all"
-                aria-label="최신 메시지로"
+                aria-label={chatT("input.scroll_to_latest")}
               >
                 <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
                   <polyline points="6 9 12 15 18 9" />

--- a/src/components/tunaflow/NewMessageInput.tsx
+++ b/src/components/tunaflow/NewMessageInput.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect, useMemo } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
 import { useChatStore } from "@/stores/chatStore";
 import { getSetting, setSetting } from "@/lib/appStore";
@@ -26,6 +27,7 @@ interface NewMessageInputProps {
 }
 
 export function NewMessageInput({ threadMode = false, onCreateRT }: NewMessageInputProps) {
+  const { t } = useTranslation("chat");
   const selectedConversationId = useChatStore((s) => s.selectedConversationId);
   const conversations = useChatStore((s) => s.conversations);
   const activeBranchId = useChatStore((s) => s.activeBranchId);
@@ -236,7 +238,7 @@ export function NewMessageInput({ threadMode = false, onCreateRT }: NewMessageIn
     const projectPath = await resolveProjectPath();
     if (!projectPath) {
       const { toast } = await import("sonner");
-      toast.error("프로젝트가 선택되지 않아 첨부할 수 없습니다");
+      toast.error(t("input.attach_no_project"));
       return;
     }
     setAttachBusy(true);
@@ -246,7 +248,7 @@ export function NewMessageInput({ threadMode = false, onCreateRT }: NewMessageIn
           const bytes = await readFsFile(path);
           if (bytes.byteLength > MAX_ATTACHMENT_SIZE) {
             const { toast } = await import("sonner");
-            toast.error(`${path.split("/").pop()}: 20MB 초과 — 건너뜀`);
+            toast.error(t("input.attach_too_large", { name: path.split("/").pop() ?? "" }));
             continue;
           }
           const name = path.split("/").pop() ?? "file";
@@ -256,7 +258,7 @@ export function NewMessageInput({ threadMode = false, onCreateRT }: NewMessageIn
         } catch (e) {
           console.warn("[attach]", path, e);
           const { toast } = await import("sonner");
-          toast.error(`첨부 실패: ${formatError(e)}`);
+          toast.error(t("input.attach_failed", { error: formatError(e) }));
         }
       }
     } finally {
@@ -268,7 +270,7 @@ export function NewMessageInput({ threadMode = false, onCreateRT }: NewMessageIn
     const projectPath = await resolveProjectPath();
     if (!projectPath) {
       const { toast } = await import("sonner");
-      toast.error("프로젝트가 선택되지 않아 첨부할 수 없습니다");
+      toast.error(t("input.attach_no_project"));
       return;
     }
     setAttachBusy(true);
@@ -276,7 +278,7 @@ export function NewMessageInput({ threadMode = false, onCreateRT }: NewMessageIn
       for (const f of Array.from(files)) {
         if (f.size > MAX_ATTACHMENT_SIZE) {
           const { toast } = await import("sonner");
-          toast.error(`${f.name}: 20MB 초과 — 건너뜀`);
+          toast.error(t("input.attach_too_large", { name: f.name }));
           continue;
         }
         try {
@@ -286,7 +288,7 @@ export function NewMessageInput({ threadMode = false, onCreateRT }: NewMessageIn
         } catch (e) {
           console.warn("[attach]", f.name, e);
           const { toast } = await import("sonner");
-          toast.error(`첨부 실패: ${formatError(e)}`);
+          toast.error(t("input.attach_failed", { error: formatError(e) }));
         }
       }
     } finally {
@@ -508,12 +510,12 @@ export function NewMessageInput({ threadMode = false, onCreateRT }: NewMessageIn
           onDrop={handleDrop}
           placeholder={
             !selectedConversationId
-              ? "Select a conversation first"
+              ? t("input.placeholder_no_conversation")
               : isRoundtable
               ? hasRtMessages
-                ? "/follow codex,claude <prompt> or type…  ↵ send · ⇧↵ newline"
-                : "Start roundtable…  ↵ send · ⇧↵ newline"
-              : "Ask anything…  ↵ send · ⇧↵ newline · 이미지/파일 드래그·붙여넣기 가능"
+                ? t("input.placeholder_rt_follow")
+                : t("input.placeholder_rt_empty")
+              : t("input.placeholder_chat")
           }
           disabled={!selectedConversationId}
           rows={1}

--- a/src/locales/en/chat.json
+++ b/src/locales/en/chat.json
@@ -2,9 +2,17 @@
   "input": {
     "placeholder": "Type a message... (Shift+Enter for newline)",
     "placeholder_empty_project": "Select a project first",
+    "placeholder_no_conversation": "Select a conversation first",
+    "placeholder_rt_empty": "Start roundtable…  ↵ send · ⇧↵ newline",
+    "placeholder_rt_follow": "/follow codex,claude <prompt> or type…  ↵ send · ⇧↵ newline",
+    "placeholder_chat": "Ask anything…  ↵ send · ⇧↵ newline · drag/paste images/files",
     "send_button": "Send",
     "stop_button": "Stop",
-    "attach_button": "Attach file"
+    "attach_button": "Attach file",
+    "attach_no_project": "No project selected — cannot attach",
+    "attach_too_large": "{{name}}: exceeds 20MB — skipped",
+    "attach_failed": "Attach failed: {{error}}",
+    "scroll_to_latest": "Scroll to latest message"
   },
   "message": {
     "role_user": "You",

--- a/src/locales/ko/chat.json
+++ b/src/locales/ko/chat.json
@@ -2,9 +2,17 @@
   "input": {
     "placeholder": "메시지를 입력하세요... (Shift+Enter 줄바꿈)",
     "placeholder_empty_project": "먼저 프로젝트를 선택하세요",
+    "placeholder_no_conversation": "먼저 대화를 선택하세요",
+    "placeholder_rt_empty": "라운드테이블 시작...  ↵ 전송 · ⇧↵ 줄바꿈",
+    "placeholder_rt_follow": "/follow codex,claude <프롬프트> 또는 직접 입력...  ↵ 전송 · ⇧↵ 줄바꿈",
+    "placeholder_chat": "무엇이든 물어보세요...  ↵ 전송 · ⇧↵ 줄바꿈 · 이미지/파일 드래그·붙여넣기 가능",
     "send_button": "보내기",
     "stop_button": "중지",
-    "attach_button": "파일 첨부"
+    "attach_button": "파일 첨부",
+    "attach_no_project": "프로젝트가 선택되지 않아 첨부할 수 없습니다",
+    "attach_too_large": "{{name}}: 20MB 초과 — 건너뜀",
+    "attach_failed": "첨부 실패: {{error}}",
+    "scroll_to_latest": "최신 메시지로"
   },
   "message": {
     "role_user": "사용자",


### PR DESCRIPTION
## Summary

i18nPlan PR A 세 번째 슬라이스 (A2-B partial). chat.json 확장 + 2 주요 컴포넌트 t() 전환. Sidebar / MessageItem 등 나머지 chat 경로는 후속 세션.

## chat.json 확장 (+8 keys)
- \`input.placeholder_no_conversation\` / \`placeholder_rt_empty\` / \`placeholder_rt_follow\` / \`placeholder_chat\` — 4 상태 placeholder
- \`input.attach_no_project\` / \`attach_too_large\` / \`attach_failed\` — 첨부 오류 3종 (interpolation 지원)
- \`input.scroll_to_latest\` — ChatPanel aria-label

## 컴포넌트 migration

**NewMessageInput.tsx**:
- 7 하드코딩 Korean toast + 4 placeholder 분기 → \`t('input.*')\`
- \`useTranslation("chat")\` hook 추가

**ChatPanel.tsx**:
- "최신 메시지로" aria-label → \`t('input.scroll_to_latest')\`
- \`useTranslation("chat")\` hook 추가

## 후속 세션으로 이관
- **A2-C**: Sidebar.tsx (context menus / ask dialogs / aria-label — 대량 인라인 Korean), MessageItem.tsx, TreeRow.tsx, 기타 chat 컴포넌트 본문
- **A2-D**: WorkflowCard / DevProgressView / PlanCard / PlanProposalCard (workflow 네임스페이스 필요)
- **A2-E**: Branch 드로어 / CreateRoundtableDialog (branch 네임스페이스 필요)
- **A2-F**: InsightPanel / IdentityView 본문 (insight 네임스페이스 필요)

## 결과
- Frontend **322** tests 유지
- \`npx tsc --noEmit\` 통과
- 입력창 첨부 흐름의 주요 에러 + placeholder 가 언어 전환으로 반응

## Test plan
- [x] tsc + vitest
- [ ] Settings > Language 전환 → 입력창 placeholder 영문 변환 확인
- [ ] 첨부 오류 시 영문 toast 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)