### PR TITLE
feat(i18n): PR A2-C — Sidebar.tsx 15 strings migrated + sidebar.json 확장

### DIFF
--- a/src/components/tunaflow/Sidebar.tsx
+++ b/src/components/tunaflow/Sidebar.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { useTranslation } from "react-i18next";
 import { useChatStore } from "@/stores/chatStore";
 import { ChevronDown, ChevronRight, FolderOpen, Folder, Trash2, Loader2, GitBranch, Archive, Users, Plus, Pencil } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -105,6 +106,7 @@ function SectionResizeHandle({ onDrag, onDragEnd }: { onDrag: (delta: number) =>
 // ─── Sidebar ──────────────────────────────────────────────────────────────────
 
 export function Sidebar() {
+  const { t } = useTranslation("sidebar");
   const projects = useChatStore((s) => s.projects);
   const selectedProjectKey = useChatStore((s) => s.selectedProjectKey);
   const selectProject = useChatStore((s) => s.selectProject);
@@ -264,7 +266,7 @@ export function Sidebar() {
       y: e.clientY,
       items: [
         {
-          label: "새 Scratchpad",
+          label: t("action.new_scratchpad"),
           icon: <Plus className="w-3.5 h-3.5" />,
           onClick: async () => {
             const scratchCount = conversations.filter((c) => c.type === "scratchpad").length;
@@ -286,7 +288,7 @@ export function Sidebar() {
     <aside
       data-testid="sidebar"
       role="navigation"
-      aria-label="프로젝트 사이드바"
+      aria-label={t("aria_label")}
       className="flex flex-col w-full bg-sidebar h-full overflow-hidden text-sidebar-foreground"
       onContextMenu={handleSidebarCtx}
     >
@@ -342,7 +344,7 @@ export function Sidebar() {
                     <button
                       onClick={async (e) => {
                         e.stopPropagation();
-                        const yes = await ask(`"${p.name}" 프로젝트를 삭제하시겠습니까?\n(프로젝트 데이터는 보존되며, 같은 경로로 다시 추가할 수 있습니다)`, { title: "프로젝트 삭제", kind: "warning" });
+                        const yes = await ask(t("confirm.project_delete_body", { name: p.name }), { title: t("confirm.project_delete_title"), kind: "warning" });
                         if (yes) {
                           hideProject(p.key);
                           if (projects.length <= 1) setProjectDropdownOpen(false);
@@ -395,17 +397,17 @@ export function Sidebar() {
                 activeChatBranches.map((b) => (
                   <button key={b.id} onClick={() => openThread(b.id)}
                     onContextMenu={(e) => openCtx(e, [
-                      { label: "이름 변경", icon: <Pencil className="w-3.5 h-3.5" />, onClick: () => {
-                        const val = window.prompt("새 이름을 입력하세요", b.customLabel ?? b.label ?? "");
+                      { label: t("action.rename"), icon: <Pencil className="w-3.5 h-3.5" />, onClick: () => {
+                        const val = window.prompt(t("prompt.rename_new_name"), b.customLabel ?? b.label ?? "");
                         if (val) renameBranch(b.id, val);
                       }},
                       { separator: true, label: "", onClick: () => {} },
-                      { label: "아카이브", icon: <Archive className="w-3.5 h-3.5" />, onClick: async () => {
-                        const yes = await ask("이 브랜치를 아카이브하시겠습니까?", { title: "브랜치 아카이브", kind: "warning" });
+                      { label: t("action.archive"), icon: <Archive className="w-3.5 h-3.5" />, onClick: async () => {
+                        const yes = await ask(t("confirm.branch_archive_body"), { title: t("confirm.branch_archive_title"), kind: "warning" });
                         if (yes) invoke("archive_branch", { id: b.id }).catch(console.error);
                       }},
-                      { label: "삭제", icon: <Trash2 className="w-3.5 h-3.5" />, danger: true, onClick: async () => {
-                        const yes = await ask("이 브랜치를 삭제하시겠습니까?", { title: "브랜치 삭제", kind: "warning" });
+                      { label: t("action.delete"), icon: <Trash2 className="w-3.5 h-3.5" />, danger: true, onClick: async () => {
+                        const yes = await ask(t("confirm.branch_delete_body"), { title: t("confirm.branch_delete_title"), kind: "warning" });
                         if (yes) deleteBranch(b.id);
                       }},
                     ])}
@@ -450,13 +452,13 @@ export function Sidebar() {
                 activeRTBranches.map((b) => (
                   <button key={b.id} onClick={() => openThread(b.id)}
                     onContextMenu={(e) => openCtx(e, [
-                      { label: "이름 변경", icon: <Pencil className="w-3.5 h-3.5" />, onClick: () => {
-                        const val = window.prompt("새 이름을 입력하세요", b.customLabel ?? b.label ?? "");
+                      { label: t("action.rename"), icon: <Pencil className="w-3.5 h-3.5" />, onClick: () => {
+                        const val = window.prompt(t("prompt.rename_new_name"), b.customLabel ?? b.label ?? "");
                         if (val) renameBranch(b.id, val);
                       }},
                       { separator: true, label: "", onClick: () => {} },
-                      { label: "삭제", icon: <Trash2 className="w-3.5 h-3.5" />, danger: true, onClick: async () => {
-                        const yes = await ask("이 Roundtable을 삭제하시겠습니까?", { title: "RT 삭제", kind: "warning" });
+                      { label: t("action.delete"), icon: <Trash2 className="w-3.5 h-3.5" />, danger: true, onClick: async () => {
+                        const yes = await ask(t("confirm.rt_delete_body"), { title: t("confirm.rt_delete_title"), kind: "warning" });
                         if (yes) deleteBranch(b.id);
                       }},
                     ])}
@@ -556,8 +558,8 @@ export function Sidebar() {
                   archivedBranches.map((b) => (
                     <button key={b.id} onClick={() => openThread(b.id)}
                       onContextMenu={(e) => openCtx(e, [
-                        { label: "삭제", icon: <Trash2 className="w-3.5 h-3.5" />, danger: true, onClick: async () => {
-                          const yes = await ask("이 아카이브를 삭제하시겠습니까?", { title: "아카이브 삭제", kind: "warning" });
+                        { label: t("action.delete"), icon: <Trash2 className="w-3.5 h-3.5" />, danger: true, onClick: async () => {
+                          const yes = await ask(t("confirm.archive_delete_body"), { title: t("confirm.archive_delete_title"), kind: "warning" });
                           if (yes) deleteBranch(b.id);
                         }},
                       ])}

--- a/src/locales/en/sidebar.json
+++ b/src/locales/en/sidebar.json
@@ -1,4 +1,5 @@
 {
+  "aria_label": "Project sidebar",
   "section": {
     "chats": "Chats",
     "branches": "Branches",
@@ -10,6 +11,7 @@
   },
   "action": {
     "new_chat": "New chat",
+    "new_scratchpad": "New scratchpad",
     "new_project": "Add project",
     "rename": "Rename",
     "delete": "Delete",
@@ -19,6 +21,9 @@
     "unpin": "Unpin",
     "open_folder": "Open folder"
   },
+  "prompt": {
+    "rename_new_name": "Enter a new name"
+  },
   "placeholder": {
     "search_chats": "Search chats...",
     "new_project_path": "Project path or name"
@@ -27,5 +32,17 @@
     "no_chats": "No chats yet",
     "no_branches": "No branches",
     "no_projects": "No registered projects"
+  },
+  "confirm": {
+    "project_delete_title": "Delete project",
+    "project_delete_body": "Delete project \"{{name}}\"?\n(Project data is preserved; you can re-add it later with the same path.)",
+    "branch_archive_title": "Archive branch",
+    "branch_archive_body": "Archive this branch?",
+    "branch_delete_title": "Delete branch",
+    "branch_delete_body": "Delete this branch?",
+    "rt_delete_title": "Delete roundtable",
+    "rt_delete_body": "Delete this roundtable?",
+    "archive_delete_title": "Delete archive",
+    "archive_delete_body": "Delete this archive?"
   }
 }

--- a/src/locales/ko/sidebar.json
+++ b/src/locales/ko/sidebar.json
@@ -1,4 +1,5 @@
 {
+  "aria_label": "프로젝트 사이드바",
   "section": {
     "chats": "대화",
     "branches": "브랜치",
@@ -10,6 +11,7 @@
   },
   "action": {
     "new_chat": "새 대화",
+    "new_scratchpad": "새 Scratchpad",
     "new_project": "프로젝트 추가",
     "rename": "이름 변경",
     "delete": "삭제",
@@ -19,6 +21,9 @@
     "unpin": "고정 해제",
     "open_folder": "폴더 열기"
   },
+  "prompt": {
+    "rename_new_name": "새 이름을 입력하세요"
+  },
   "placeholder": {
     "search_chats": "대화 검색...",
     "new_project_path": "프로젝트 경로 또는 이름"
@@ -27,5 +32,17 @@
     "no_chats": "대화 없음",
     "no_branches": "브랜치 없음",
     "no_projects": "등록된 프로젝트 없음"
+  },
+  "confirm": {
+    "project_delete_title": "프로젝트 삭제",
+    "project_delete_body": "\"{{name}}\" 프로젝트를 삭제하시겠습니까?\n(프로젝트 데이터는 보존되며, 같은 경로로 다시 추가할 수 있습니다)",
+    "branch_archive_title": "브랜치 아카이브",
+    "branch_archive_body": "이 브랜치를 아카이브하시겠습니까?",
+    "branch_delete_title": "브랜치 삭제",
+    "branch_delete_body": "이 브랜치를 삭제하시겠습니까?",
+    "rt_delete_title": "RT 삭제",
+    "rt_delete_body": "이 Roundtable을 삭제하시겠습니까?",
+    "archive_delete_title": "아카이브 삭제",
+    "archive_delete_body": "이 아카이브를 삭제하시겠습니까?"
   }
 }


### PR DESCRIPTION
## Summary

i18nPlan PR A 네 번째 슬라이스 (A2-C). Sidebar 본체 **15 하드코딩 Korean 전부** 이관 + sidebar.json 에 confirm 네임스페이스 추가.

## sidebar.json 확장
- \`aria_label\` — 프로젝트 사이드바
- \`action.new_scratchpad\`
- \`prompt.rename_new_name\`
- \`confirm.*\` **10 키**: project_delete_title/body (interpolation), branch_archive_title/body, branch_delete_title/body, rt_delete_title/body, archive_delete_title/body
- en/sidebar.json 완전 번역 동기화

## Sidebar.tsx 전환 (15 → 0)
- aria-label
- \`새 Scratchpad\` action
- 프로젝트 삭제 \`ask()\` title + body (name interpolation)
- \`이름 변경\` / \`삭제\` / \`아카이브\` context menu × 3 그룹
- \`window.prompt("새 이름을 입력하세요")\` × 3
- 브랜치 archive + delete \`ask()\`
- RT delete \`ask()\`
- 아카이브 delete \`ask()\`

**Korean 인라인 문자열 검출 0건** (grep 검증).

## 결과
- Frontend **322** tests 유지
- \`tsc --noEmit\` 통과
- 3 files +51/-15

## 후속 A2 경로
- **A2-D**: MessageItem / TreeRow / ChatsSection / 기타 sidebar 하위 컴포넌트 (아직 Korean 잔존)
- **A2-E**: WorkflowCard / DevProgressView / PlanCard / PlanProposalCard (workflow.json 네임스페이스 필요)
- **A2-F**: BranchPanel / CreateRoundtableDialog (branch.json)
- **A2-G**: InsightPanel / IdentityView 본문 (insight.json)
- **A3**: Phase 4A-2/3 — defaultPersonas.ts + tool_handler.rs 영어 전환 (Rust)

## Test plan
- [x] tsc + vitest
- [ ] Settings > Language 전환 → 사이드바 프로젝트 삭제 / 브랜치 아카이브 다이얼로그 영문 확인
- [ ] 이름 변경 prompt 영문 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)