### PR TITLE
chore: post-handoff cleanup — i18nPlan §12 + .gitignore + drop ja/zh README drafts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ screenshot-*.png
 # External tool clones / scratch (not part of tunaFlow source)
 _util/
 _stash_recovery/
+
+# Eval run artifacts (results emitted at runtime; suite README preserved)
+evals/results/

--- a/docs/plans/i18nPlan.md
+++ b/docs/plans/i18nPlan.md
@@ -378,10 +378,37 @@ Phase 4B (반나절):  insightOrchestration 영어 전환 + A/B 검증          
 
 ---
 
-## 9. 참고
+## 11. 참고
 
 - react-i18next 공식 문서: https://react.i18next.com/
 - 현재 프론트 문자열 조사: 88파일, ~1,300+ 문자열
 - ContextPack user_profile: `preferredLanguages` 필드 — prompt_assembly.rs:153,180에서 이미 per-request로 읽는 중
 - 프로젝트 규칙: projects.rs:481-512에서 "사용자 언어에 맞춰 응답" 이미 명시
 - 디자인 시스템: 텍스트 길이 변화에 따른 레이아웃 대응 필요 (EN이 KR보다 보통 20-30% 김)
+
+---
+
+## 12. Developer 핸드오프 — PR B (베타 공개 이후)
+
+> 베타 공개 후 안정기에 처리. PR A 머지 + 실사용 검증 완료 후 착수.
+
+```
+[작업] i18n PR B — insightOrchestration.ts 영어 전환 + A/B 검증
+
+[전제]
+- PR A 머지 완료 상태.
+- tunaInsight (또는 동급 테스트 프로젝트) 에서 Insight 분석 실행 가능 환경.
+
+[범위]
+- Phase 4B-1: src/lib/insightOrchestration.ts 시스템 프롬프트 / 카테고리 라벨 / severity 기준 / evidence 설명 / JSON 예시 모두 영어 재작성.
+- Phase 4B-2: 동일 프로젝트에서 한국어 프롬프트 버전 vs 영어 프롬프트 버전 각 1회 분석 → finding 수 / severity 분포 / JSON 파싱 성공률 / finding 설명 구체성 비교.
+- Phase 4B-3: ContextPack 응답 언어 지시 (user_profile.preferredLanguages → assemble_prompt()) 실제 동작 확인, 미동작 시 "Respond in {lang}." 한 줄 추가.
+
+[INV]
+- [INV-3] A/B 검증 통과 후에만 merge. 영어 버전이 한국어 버전 대비 동등 이상일 때 확정.
+- 품질 하락 시 한국어 유지 (기능 > 일관성). 롤백은 git revert 로 단일 커밋.
+
+[PR 설명 필수 항목]
+- A/B 비교 수치 표 (finding 수 / severity / JSON 파싱률 / 대표 finding 예시 2~3건).
+- 결정: 영어 전환 확정 / 한국어 유지 중 어느 쪽인지 명시.
+```


### PR DESCRIPTION
## Summary

세션 40 핸드오프 직후 정리 3건:

1. **docs/plans/i18nPlan.md** — outdated §12 (PR A 핸드오프) 삭제, §13 (PR B — insightOrchestration 영어 전환) 을 §12 로 재번호. SSOT 는 이제 `docs/prompts/nextSessionHandoff_2026-04-24.md`.
2. **.gitignore** — `evals/results/` 추가. 수트 README/스크립트는 유지하고 실행 결과물만 무시.
3. **README.ja.md / README.zh.md 로컬 삭제** (untracked) — Gemini 초안은 품질 미검증. i18nPlan §7 공식 scope (한/영) 외라 베타 공개에 노출하지 않음. 정식 번역 착수 시 재생성.

## Test plan

- [x] grep 결과 §0~§12 연속 확인
- [x] `git status` 클린 (`.claude/scheduled_tasks.lock` 제외 — harness lock)
- CI 는 `paths-ignore` (`docs/**`, `**.md`) 및 `.gitignore` 만 수정이라 스킵 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)