### PR TITLE
feat(i18n): PR A2-D — MessageItem + sidebar 하위 컴포넌트 전환

### DIFF
--- a/src/components/tunaflow/MessageItem.tsx
+++ b/src/components/tunaflow/MessageItem.tsx
@@ -1,4 +1,5 @@
 import { memo, useMemo, useState, useEffect } from "react";
+import { useTranslation } from "react-i18next";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { invoke } from "@tauri-apps/api/core";
@@ -21,6 +22,7 @@ import { ChevronRight } from "lucide-react";
 
 /** Collapsible display for tool-request follow-up results (auto-injected by tunaFlow). */
 function ToolResultCollapsible({ content, conversationId }: { content: string; conversationId?: string }) {
+  const { t } = useTranslation("chat");
   const [open, setOpen] = useState(false);
   const lineCount = content.split("\n").length;
   return (
@@ -30,8 +32,8 @@ function ToolResultCollapsible({ content, conversationId }: { content: string; c
         className="flex items-center gap-1.5 w-full px-3 py-1.5 text-muted-foreground/70 hover:text-foreground hover:bg-accent/30 transition-colors"
       >
         <ChevronRight className={cn("w-3 h-3 transition-transform", open && "rotate-90")} />
-        <span className="font-medium">도구 호출 결과</span>
-        <span className="text-muted-foreground/40 ml-1">({lineCount}줄)</span>
+        <span className="font-medium">{t("message.tool_result_label")}</span>
+        <span className="text-muted-foreground/40 ml-1">{t("message.tool_result_lines", { count: lineCount })}</span>
       </button>
       {open && (
         <div className="px-3 py-2 border-t border-border/20 text-xs">
@@ -126,6 +128,7 @@ interface MessageItemProps {
 }
 
 export const MessageItem = memo(function MessageItem({ message, onBranch, onBranchRT, onMemo, onFollowup, onDeletePair, onSaveArtifact, threadBranches, onOpenThread, showActions = true, variant = "default", grouped = false }: MessageItemProps) {
+  const { t } = useTranslation("chat");
   const isUser = message.role === "user";
   const isSystem = message.role === "system";
   const isStreaming = message.status === "streaming";
@@ -169,7 +172,7 @@ export const MessageItem = memo(function MessageItem({ message, onBranch, onBran
       onFollowup={onFollowup ? () => onFollowup("claude", message.content) : undefined}
       onDelete={onDeletePair ? async () => {
         const { ask } = await import("@tauri-apps/plugin-dialog");
-        if (await ask("이 메시지를 삭제하시겠습니까?", { title: "메시지 삭제", kind: "warning" })) onDeletePair(message.id);
+        if (await ask(t("message.delete_confirm_body"), { title: t("message.delete_confirm_title"), kind: "warning" })) onDeletePair(message.id);
       } : undefined}
     >
       <div

--- a/src/components/tunaflow/sidebar/AddProjectForm.tsx
+++ b/src/components/tunaflow/sidebar/AddProjectForm.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { cn, errorMessage } from "@/lib/utils";
 import { invoke } from "@tauri-apps/api/core";
 import { open } from "@tauri-apps/plugin-dialog";
@@ -12,22 +13,23 @@ interface AddProjectFormProps {
 }
 
 export function AddProjectForm({ showAddProject, setShowAddProject, createProject, selectProject }: AddProjectFormProps) {
+  const { t } = useTranslation("sidebar");
   const [newProjectPath, setNewProjectPath] = useState("");
   const [newProjectName, setNewProjectName] = useState("");
   const [addingProject, setAddingProject] = useState(false);
   const [pathError, setPathError] = useState<string | null>(null);
 
   const handlePickFolder = async () => {
-    try { const s = await open({ directory: true, multiple: false, title: "프로젝트 폴더 선택" }); if (s && typeof s === "string") { setNewProjectPath(s); setPathError(null); if (!newProjectName.trim()) setNewProjectName(s.split(/[\\/]/).pop() || ""); } } catch { /**/ }
+    try { const s = await open({ directory: true, multiple: false, title: t("dialog.pick_project_folder") }); if (s && typeof s === "string") { setNewProjectPath(s); setPathError(null); if (!newProjectName.trim()) setNewProjectName(s.split(/[\\/]/).pop() || ""); } } catch { /**/ }
   };
 
   const handleAddProject = async () => {
     const path = newProjectPath.trim();
-    if (!path) { setPathError("경로를 입력하세요"); return; }
+    if (!path) { setPathError(t("error.path_required")); return; }
     setAddingProject(true); setPathError(null);
     try {
       const v = await invoke<{ valid: boolean; normalizedPath: string; error?: string }>("validate_project_path", { path });
-      if (!v.valid) { setPathError(v.error || "유효하지 않은 경로"); setAddingProject(false); return; }
+      if (!v.valid) { setPathError(v.error || t("error.invalid_path")); setAddingProject(false); return; }
       const name = newProjectName.trim() || v.normalizedPath.split(/[\\/]/).pop() || "Project";
       const key = name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "") || `proj-${Date.now()}`;
       await createProject({ key, name, path: v.normalizedPath, type: "project", source: "configured" });
@@ -41,7 +43,7 @@ export function AddProjectForm({ showAddProject, setShowAddProject, createProjec
     return (
       <button onClick={() => setShowAddProject(true)}
         className="w-full flex items-center gap-1.5 px-1 h-[22px] text-[10px] text-sidebar-foreground/35 hover:text-sidebar-foreground hover:bg-white/[0.04] rounded transition-colors">
-        <FolderPlus className="w-3 h-3" /> Add project
+        <FolderPlus className="w-3 h-3" /> {t("action.new_project")}
       </button>
     );
   }
@@ -49,23 +51,23 @@ export function AddProjectForm({ showAddProject, setShowAddProject, createProjec
   return (
     <div className="space-y-1 pl-1">
       <div className="flex gap-1">
-        <input placeholder="경로" value={newProjectPath} onChange={(e) => { setNewProjectPath(e.target.value); setPathError(null); }}
+        <input placeholder={t("placeholder.project_path")} value={newProjectPath} onChange={(e) => { setNewProjectPath(e.target.value); setPathError(null); }}
           className={cn("flex-1 bg-white/[0.04] rounded px-1.5 py-0.5 text-[10px] outline-none placeholder:text-sidebar-foreground/25 border focus:border-ring/30",
             pathError ? "border-destructive/40" : "border-white/[0.06]")} autoFocus />
-        <button onClick={handlePickFolder} className="shrink-0 p-1 rounded bg-white/[0.04] text-sidebar-foreground/50 hover:text-sidebar-foreground transition-colors" title="폴더 선택">
+        <button onClick={handlePickFolder} className="shrink-0 p-1 rounded bg-white/[0.04] text-sidebar-foreground/50 hover:text-sidebar-foreground transition-colors" title={t("action.pick_folder")}>
           <FolderPlus className="w-3 h-3" />
         </button>
       </div>
       {pathError && <p className="text-[8px] text-destructive px-0.5">{pathError}</p>}
-      <input placeholder="이름 (선택)" value={newProjectName} onChange={(e) => setNewProjectName(e.target.value)}
+      <input placeholder={t("placeholder.project_name_optional")} value={newProjectName} onChange={(e) => setNewProjectName(e.target.value)}
         onKeyDown={(e) => { if (e.key === "Enter") handleAddProject(); }}
         className="w-full bg-white/[0.04] rounded px-1.5 py-0.5 text-[10px] outline-none placeholder:text-sidebar-foreground/25 border border-white/[0.06] focus:border-ring/30" />
       <div className="flex gap-1">
         <button onClick={handleAddProject} disabled={!newProjectPath.trim() || addingProject}
           className="flex-1 px-2 py-0.5 rounded bg-primary/15 text-primary text-[10px] font-medium hover:bg-primary/25 transition-colors disabled:opacity-40">
-          {addingProject ? "…" : "추가"}</button>
+          {addingProject ? "…" : t("action.add")}</button>
         <button onClick={() => { setShowAddProject(false); setPathError(null); }}
-          className="px-2 py-0.5 rounded text-sidebar-foreground/40 text-[10px] hover:bg-white/[0.04] transition-colors">취소</button>
+          className="px-2 py-0.5 rounded text-sidebar-foreground/40 text-[10px] hover:bg-white/[0.04] transition-colors">{t("action.cancel")}</button>
       </div>
     </div>
   );

--- a/src/components/tunaflow/sidebar/DocsSection.tsx
+++ b/src/components/tunaflow/sidebar/DocsSection.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
+import { useTranslation } from "react-i18next";
 import { invoke } from "@tauri-apps/api/core";
 import { FileText, ChevronRight, ChevronDown, Folder, FolderOpen, Copy } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -78,6 +79,7 @@ interface DocsSectionProps {
 }
 
 export function DocsSection({ projectPath }: DocsSectionProps) {
+  const { t } = useTranslation("sidebar");
   const [docs, setDocs] = useState<DocEntry[]>([]);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [ctxMenu, setCtxMenu] = useState<ContextMenuState | null>(null);
@@ -104,12 +106,12 @@ export function DocsSection({ projectPath }: DocsSectionProps) {
       y: e.clientY,
       items: [
         {
-          label: "Finder에서 보기",
+          label: t("action.show_in_finder"),
           icon: <FolderOpen className="w-3.5 h-3.5" />,
           onClick: () => revealInFinder(entry.path),
         },
         {
-          label: "경로 복사",
+          label: t("action.copy_path"),
           icon: <Copy className="w-3.5 h-3.5" />,
           onClick: () => copyToClipboard(entry.path),
         },
@@ -157,7 +159,7 @@ export function DocsSection({ projectPath }: DocsSectionProps) {
   return (
     <div className="py-1">
       {docs.length === 0 ? (
-        <p className="px-3 text-[10px] text-sidebar-foreground/25 italic">No docs found</p>
+        <p className="px-3 text-[10px] text-sidebar-foreground/25 italic">{t("empty.no_docs")}</p>
       ) : (
         docs.map((entry) => renderEntry(entry, 0))
       )}

--- a/src/components/tunaflow/sidebar/ScratchpadSection.tsx
+++ b/src/components/tunaflow/sidebar/ScratchpadSection.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
 import { Lightbulb, Plus, Trash2, ChevronRight, Pencil } from "lucide-react";
 import { useChatStore } from "@/stores/chatStore";
@@ -19,6 +20,7 @@ export function ScratchpadSection({
   selectConversation,
   renameConversation,
 }: ScratchpadSectionProps) {
+  const { t } = useTranslation("sidebar");
   const [expanded, setExpanded] = useState(true);
   const createConversation = useChatStore((s) => s.createConversation);
   const deleteConversation = useChatStore((s) => s.deleteConversation);
@@ -40,7 +42,7 @@ export function ScratchpadSection({
   };
 
   const handleDelete = async (id: string) => {
-    const ok = await ask("Delete this scratchpad?", { kind: "warning", title: "Delete" });
+    const ok = await ask(t("confirm.scratchpad_delete_body"), { kind: "warning", title: t("confirm.scratchpad_delete_title") });
     if (ok) await deleteConversation(id);
   };
 
@@ -52,16 +54,16 @@ export function ScratchpadSection({
       y: e.clientY,
       items: [
         {
-          label: "이름 변경",
+          label: t("action.rename"),
           icon: <Pencil className="w-3.5 h-3.5" />,
           onClick: () => {
-            const val = window.prompt("새 이름을 입력하세요", sp.label ?? "");
+            const val = window.prompt(t("prompt.rename_new_name"), sp.label ?? "");
             if (val) renameConversation(sp.id, val);
           },
         },
         { separator: true, label: "", onClick: () => {} },
         {
-          label: "삭제",
+          label: t("action.delete"),
           icon: <Trash2 className="w-3.5 h-3.5" />,
           danger: true,
           onClick: () => handleDelete(sp.id),
@@ -80,12 +82,12 @@ export function ScratchpadSection({
         >
           <ChevronRight className={cn("w-3 h-3 transition-transform", expanded && "rotate-90")} />
           <Lightbulb className="w-3 h-3" />
-          Scratchpad
+          {t("section.scratchpad")}
         </button>
         <button
           onClick={handleAdd}
           className="p-0.5 rounded text-muted-foreground/30 hover:text-foreground hover:bg-accent/40 transition-colors"
-          title="New scratchpad"
+          title={t("action.new_scratchpad")}
         >
           <Plus className="w-3 h-3" />
         </button>
@@ -95,7 +97,7 @@ export function ScratchpadSection({
       {expanded && (
         <div className="space-y-0.5 mt-0.5">
           {scratchpads.length === 0 && (
-            <p className="text-[10px] text-muted-foreground/30 px-3 py-1">No scratchpads yet</p>
+            <p className="text-[10px] text-muted-foreground/30 px-3 py-1">{t("empty.no_scratchpads")}</p>
           )}
           {scratchpads.map((sp) => {
             const isSelected = sp.id === selectedConversationId;

--- a/src/locales/en/chat.json
+++ b/src/locales/en/chat.json
@@ -23,7 +23,11 @@
     "retry": "Retry",
     "delete_pair": "Delete pair",
     "created_branch": "Create branch",
-    "streaming_hint": "Streaming..."
+    "streaming_hint": "Streaming...",
+    "tool_result_label": "Tool call result",
+    "tool_result_lines": "({{count}} lines)",
+    "delete_confirm_title": "Delete message",
+    "delete_confirm_body": "Delete this message?"
   },
   "branch": {
     "create": "Create branch",

--- a/src/locales/en/sidebar.json
+++ b/src/locales/en/sidebar.json
@@ -19,19 +19,35 @@
     "unarchive": "Unarchive",
     "pin": "Pin",
     "unpin": "Unpin",
-    "open_folder": "Open folder"
+    "open_folder": "Open folder",
+    "show_in_finder": "Show in Finder",
+    "copy_path": "Copy path",
+    "add": "Add",
+    "cancel": "Cancel",
+    "pick_folder": "Pick folder"
   },
   "prompt": {
     "rename_new_name": "Enter a new name"
   },
   "placeholder": {
     "search_chats": "Search chats...",
-    "new_project_path": "Project path or name"
+    "new_project_path": "Project path or name",
+    "project_path": "Path",
+    "project_name_optional": "Name (optional)"
   },
   "empty": {
     "no_chats": "No chats yet",
     "no_branches": "No branches",
-    "no_projects": "No registered projects"
+    "no_projects": "No registered projects",
+    "no_scratchpads": "No scratchpads yet",
+    "no_docs": "No docs found"
+  },
+  "error": {
+    "path_required": "Enter a path",
+    "invalid_path": "Invalid path"
+  },
+  "dialog": {
+    "pick_project_folder": "Pick project folder"
   },
   "confirm": {
     "project_delete_title": "Delete project",
@@ -43,6 +59,8 @@
     "rt_delete_title": "Delete roundtable",
     "rt_delete_body": "Delete this roundtable?",
     "archive_delete_title": "Delete archive",
-    "archive_delete_body": "Delete this archive?"
+    "archive_delete_body": "Delete this archive?",
+    "scratchpad_delete_title": "Delete scratchpad",
+    "scratchpad_delete_body": "Delete this scratchpad?"
   }
 }

--- a/src/locales/ko/chat.json
+++ b/src/locales/ko/chat.json
@@ -23,7 +23,11 @@
     "retry": "재시도",
     "delete_pair": "쌍 삭제",
     "created_branch": "브랜치 생성",
-    "streaming_hint": "스트리밍 중..."
+    "streaming_hint": "스트리밍 중...",
+    "tool_result_label": "도구 호출 결과",
+    "tool_result_lines": "({{count}}줄)",
+    "delete_confirm_title": "메시지 삭제",
+    "delete_confirm_body": "이 메시지를 삭제하시겠습니까?"
   },
   "branch": {
     "create": "브랜치 만들기",

--- a/src/locales/ko/sidebar.json
+++ b/src/locales/ko/sidebar.json
@@ -19,19 +19,35 @@
     "unarchive": "복원",
     "pin": "고정",
     "unpin": "고정 해제",
-    "open_folder": "폴더 열기"
+    "open_folder": "폴더 열기",
+    "show_in_finder": "Finder에서 보기",
+    "copy_path": "경로 복사",
+    "add": "추가",
+    "cancel": "취소",
+    "pick_folder": "폴더 선택"
   },
   "prompt": {
     "rename_new_name": "새 이름을 입력하세요"
   },
   "placeholder": {
     "search_chats": "대화 검색...",
-    "new_project_path": "프로젝트 경로 또는 이름"
+    "new_project_path": "프로젝트 경로 또는 이름",
+    "project_path": "경로",
+    "project_name_optional": "이름 (선택)"
   },
   "empty": {
     "no_chats": "대화 없음",
     "no_branches": "브랜치 없음",
-    "no_projects": "등록된 프로젝트 없음"
+    "no_projects": "등록된 프로젝트 없음",
+    "no_scratchpads": "스크래치패드 없음",
+    "no_docs": "문서 없음"
+  },
+  "error": {
+    "path_required": "경로를 입력하세요",
+    "invalid_path": "유효하지 않은 경로"
+  },
+  "dialog": {
+    "pick_project_folder": "프로젝트 폴더 선택"
   },
   "confirm": {
     "project_delete_title": "프로젝트 삭제",
@@ -43,6 +59,8 @@
     "rt_delete_title": "RT 삭제",
     "rt_delete_body": "이 Roundtable을 삭제하시겠습니까?",
     "archive_delete_title": "아카이브 삭제",
-    "archive_delete_body": "이 아카이브를 삭제하시겠습니까?"
+    "archive_delete_body": "이 아카이브를 삭제하시겠습니까?",
+    "scratchpad_delete_title": "스크래치패드 삭제",
+    "scratchpad_delete_body": "이 스크래치패드를 삭제하시겠습니까?"
   }
 }


### PR DESCRIPTION
## Summary

i18n PR A 의 A2-D 슬라이스. `MessageItem.tsx` + sidebar 하위 4개 컴포넌트의 한국어·영어 하드코딩을 namespace 키로 이관.

### 파일 변경

- `src/components/tunaflow/MessageItem.tsx` — `chat.message.*` (tool-result label/lines, delete confirm)
- `src/components/tunaflow/sidebar/ScratchpadSection.tsx` — `sidebar.*` (rename/delete/section/new_scratchpad/empty/delete-confirm)
- `src/components/tunaflow/sidebar/DocsSection.tsx` — `sidebar.*` (show_in_finder/copy_path/empty)
- `src/components/tunaflow/sidebar/AddProjectForm.tsx` — `sidebar.*` (placeholder/error/dialog/action/new_project)
- `src/locales/{ko,en}/sidebar.json` — action(+5), placeholder(+2), empty(+2), error(+2), dialog(+1), confirm(+2) 확장
- `src/locales/{ko,en}/chat.json` — `message.tool_result_label`, `message.tool_result_lines`, `message.delete_confirm_{title,body}` 추가

### 범위 외 (scope 명시)

- **TreeRow / ChatsSection / FilesSection / SidebarContextMenu** — 한국어 문자열 없음. 변경 없음 (이미 순수 구조/아이콘 중심).
- `AddProjectForm` L36 `msg.includes("이미")` — Rust 에러 메시지 matching. A3 (Rust 에러 코드화) scope 이므로 본 PR 건드리지 않음.
- `MessageItem` L206 `"### 🛠️ 도구 호출 결과"` — 백엔드에서 주입하는 content 마커 문자열. i18n 대상 아님.

## Test plan

- [x] `npx tsc --noEmit` 통과
- [x] `npx vitest run` 322 통과 (기존 유지)
- [ ] 수동 확인: Settings > Language ko/en 토글 후 Scratchpad 추가/삭제/이름변경 · AddProject 폼 · Docs 우클릭 메뉴 · 메시지 삭제 컨펌 각각 정상 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)