### PR TITLE
feat(i18n): PR A2-E — workflow namespace + plans UI 전환 (agent prompts 제외)

### DIFF
--- a/src/components/tunaflow/chat/PlanProposalCard.tsx
+++ b/src/components/tunaflow/chat/PlanProposalCard.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
 import { invoke } from "@tauri-apps/api/core";
 import { ClipboardList, Check, RotateCcw, Merge, X } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -15,6 +16,7 @@ interface PlanProposalCardProps {
 }
 
 export function PlanProposalCard({ proposal, conversationId }: PlanProposalCardProps) {
+  const { t } = useTranslation("workflow");
   const [status, setStatus] = useState<"loading" | "idle" | "promoting" | "promoted" | "merged" | "revising" | "warn-empty" | "dismissed">("loading");
   const [revisionInput, setRevisionInput] = useState("");
   const [revisionTarget, setRevisionTarget] = useState<Plan | null>(null);
@@ -139,18 +141,12 @@ export function PlanProposalCard({ proposal, conversationId }: PlanProposalCardP
   const handleOverwrite = async () => {
     if (!overwriteCandidate) return;
     const isResumingDone = overwriteCandidate.status === "done" || overwriteCandidate.status === "abandoned";
-    // 명시적 사용자 confirm — 기존 subtasks/메타가 교체되고 branches 가 archive 됨을 경고.
+    const statusLabel = overwriteCandidate.status === "done"
+      ? t("proposal.confirm.status_done")
+      : t("proposal.confirm.status_abandoned");
     const confirmMsg = isResumingDone
-      ? `완료된 Plan "${overwriteCandidate.title}" 을 이 제안으로 재개하시겠습니까?\n\n` +
-        `- 이미 ${overwriteCandidate.status === "done" ? "완료" : "폐기"} 된 Plan 을 active 로 되돌려 Dev 단계로 진입시킵니다\n` +
-        `- 기존 subtasks 는 모두 제안 내용으로 교체됩니다\n` +
-        `- 이미 archive 된 impl/review branches 는 그대로 (재사용하지 않음 — 신규 Dev 시작 시 새 브랜치)\n` +
-        `- 이미 수정된 파일은 자동 revert 되지 않습니다`
-      : `기존 Plan "${overwriteCandidate.title}" 을 이 제안으로 덮어쓰시겠습니까?\n\n` +
-        `- 기존 subtasks 는 모두 교체됩니다\n` +
-        `- 진행 중인 implementation/review branches 는 archive 됩니다\n` +
-        `- Phase 가 Approval 로 리셋되어 Dev 시작 가능 상태가 됩니다\n` +
-        `- 이미 수정된 파일은 자동 revert 되지 않습니다 (필요 시 수동 처리)`;
+      ? t("proposal.confirm.reopen_body", { title: overwriteCandidate.title, statusLabel })
+      : t("proposal.confirm.overwrite_body", { title: overwriteCandidate.title });
     const ok = window.confirm(confirmMsg);
     if (!ok) return;
 
@@ -208,12 +204,14 @@ export function PlanProposalCard({ proposal, conversationId }: PlanProposalCardP
           disp.revert.length > 0 ? `Revert ${disp.revert.length}` : null,
         ].filter(Boolean).join(" · ");
         if (disp.revert.length > 0) {
+          const items = disp.revert.slice(0, 6).map((f) => `• ${f}`).join("\n");
+          const more = disp.revert.length > 6 ? `\n… +${disp.revert.length - 6}` : "";
           toast.warning(
-            `파일 처리 방침: ${summary}\n\nRevert 대상 (수동 처리 필요):\n${disp.revert.slice(0, 6).map((f) => `• ${f}`).join("\n")}${disp.revert.length > 6 ? `\n… +${disp.revert.length - 6}` : ""}`,
+            t("proposal.toast.disposition_revert_warning", { summary, items, more }),
             { duration: 12000 },
           );
         } else {
-          toast.info(`파일 처리 방침: ${summary}`, { duration: 5000 });
+          toast.info(t("proposal.toast.disposition_summary", { summary }), { duration: 5000 });
         }
       }
     } catch (e) {
@@ -287,7 +285,7 @@ export function PlanProposalCard({ proposal, conversationId }: PlanProposalCardP
     // no main conversation was selected when the card mounted.
     if (planConvId.startsWith("branch:")) {
       import("sonner")
-        .then(({ toast }) => toast.error("Plan 등록 실패: 부모 대화를 선택한 뒤 다시 시도해주세요."))
+        .then(({ toast }) => toast.error(t("proposal.toast.promote_branch_error")))
         .catch(() => {});
       setStatus("idle");
       return;
@@ -377,29 +375,25 @@ export function PlanProposalCard({ proposal, conversationId }: PlanProposalCardP
     return (
       <div className="my-2 rounded-lg border border-primary/30 bg-primary/5 px-4 py-2.5 text-xs text-primary flex items-center gap-2">
         <Merge className="w-3.5 h-3.5" />
-        <span>Plan &quot;{proposal.title}&quot; rev.{rev} — 수정 반영 완료 (재승인 필요)</span>
+        <span>{t("proposal.status.merged_label", { title: proposal.title, rev })}</span>
       </div>
     );
   }
 
   if (status === "promoted") {
     const isDone = overwriteCandidate?.status === "done" || overwriteCandidate?.status === "abandoned";
-    const locationHint = isDone ? " (워크플로우 탭 → Done)" : "";
+    const locationHint = isDone ? t("proposal.status.location_done_hint") : "";
     return (
       <div className="my-2 rounded-lg border border-status-approved/30 bg-status-approved/5 px-4 py-2.5 text-xs text-status-approved flex items-center gap-2 flex-wrap">
         <Check className="w-3.5 h-3.5 shrink-0" />
-        <span className="flex-1 min-w-0">Plan &quot;{proposal.title}&quot; — Plan 탭에 등록됨{locationHint}</span>
+        <span className="flex-1 min-w-0">{t("proposal.status.promoted_label", { title: proposal.title, locationHint })}</span>
         {overwriteCandidate && (
           <button
             onClick={handleOverwrite}
             className="shrink-0 px-2 py-0.5 rounded text-[11px] font-medium bg-primary/10 text-primary hover:bg-primary/20 transition-colors"
-            title={
-              isDone
-                ? "완료된 Plan 을 이 제안으로 재개 (active + Approval)"
-                : "이 제안으로 기존 Plan 덮어쓰기 (Approval 로 리셋 + branches archive)"
-            }
+            title={isDone ? t("proposal.status.overwrite_done_tooltip") : t("proposal.status.overwrite_active_tooltip")}
           >
-            {isDone ? "완료 Plan 재개" : "rev 로 덮어쓰기"}
+            {isDone ? t("proposal.status.overwrite_done_button") : t("proposal.status.overwrite_active_button")}
           </button>
         )}
       </div>
@@ -409,39 +403,36 @@ export function PlanProposalCard({ proposal, conversationId }: PlanProposalCardP
   if (status === "warn-empty") {
     return (
       <div className="my-2 rounded-lg border border-amber-500/30 bg-amber-500/5 px-4 py-3 text-xs space-y-2">
-        <p className="text-amber-400 font-medium">서브태스크를 인식하지 못했습니다</p>
-        <p className="text-muted-foreground text-[11px]">
-          에이전트가 서브태스크를 잘못된 형식으로 작성했을 수 있습니다.
-          파서가 인식하는 형식:
-        </p>
+        <p className="text-amber-400 font-medium">{t("proposal.warn_empty.title")}</p>
+        <p className="text-muted-foreground text-[11px]">{t("proposal.warn_empty.body")}</p>
         <pre className="text-[10px] text-muted-foreground/70 bg-black/20 rounded px-2 py-1.5 font-mono leading-relaxed">
 {`### Subtasks        ← 삼중 # 필수
 1. 첫 번째 작업 — 설명
 2. 두 번째 작업 — 설명`}
         </pre>
         <p className="text-muted-foreground/60 text-[10px]">
-          ❌ <code className="font-mono">## Subtasks</code> (이중 #) &nbsp;·&nbsp;
-          ❌ 마크다운 테이블 <code className="font-mono">| # | 제목 |</code> &nbsp;·&nbsp;
-          ❌ 마커 밖 작성
+          {t("proposal.warn_empty.counter_example_double_hash")} &nbsp;·&nbsp;
+          {t("proposal.warn_empty.counter_example_table")} &nbsp;·&nbsp;
+          {t("proposal.warn_empty.counter_example_outside_marker")}
         </p>
         <div className="flex gap-1.5 pt-0.5">
           <button
             onClick={() => setStatus("revising")}
             className="px-2.5 py-1 rounded-md text-xs font-medium bg-primary/10 text-primary hover:bg-primary/20 transition-colors"
           >
-            수정 요청
+            {t("proposal.warn_empty.revise_button")}
           </button>
           <button
             onClick={() => { void handlePromote(true); }}
             className="px-2.5 py-1 rounded-md text-xs font-medium bg-amber-500/15 text-amber-400 hover:bg-amber-500/25 transition-colors"
           >
-            그래도 승격
+            {t("proposal.warn_empty.promote_anyway_button")}
           </button>
           <button
             onClick={() => setStatus("idle")}
             className="px-2.5 py-1 rounded-md text-xs text-muted-foreground hover:text-foreground transition-colors"
           >
-            취소
+            {t("proposal.warn_empty.cancel_button")}
           </button>
         </div>
       </div>
@@ -532,7 +523,7 @@ export function PlanProposalCard({ proposal, conversationId }: PlanProposalCardP
           <textarea
             value={revisionInput}
             onChange={(e) => setRevisionInput(e.target.value)}
-            placeholder="수정 요청 내용을 입력하세요..."
+            placeholder={t("proposal.revise.placeholder")}
             rows={2}
             className="w-full bg-input rounded-md px-2.5 py-1.5 text-xs outline-none text-foreground placeholder:text-muted-foreground border border-border focus:border-ring/50 resize-none"
             autoFocus
@@ -548,13 +539,13 @@ export function PlanProposalCard({ proposal, conversationId }: PlanProposalCardP
               }}
               className="px-2.5 py-1 rounded-md text-xs font-medium bg-primary/10 text-primary hover:bg-primary/20 transition-colors"
             >
-              전송
+              {t("proposal.revise.send_button")}
             </button>
             <button
               onClick={() => { setStatus("idle"); setRevisionInput(""); }}
               className="px-2.5 py-1 rounded-md text-xs text-muted-foreground hover:text-foreground transition-colors"
             >
-              취소
+              {t("proposal.revise.cancel_button")}
             </button>
           </div>
         </div>
@@ -573,22 +564,22 @@ export function PlanProposalCard({ proposal, conversationId }: PlanProposalCardP
             )}
           >
             <Check className="w-3 h-3" />
-            {status === "promoting" ? "처리 중..." : "Plan으로 승격"}
+            {status === "promoting" ? t("proposal.action.promote_busy") : t("proposal.action.promote_button")}
           </button>
           <button
             onClick={() => setStatus("revising")}
             className="flex items-center gap-1.5 px-3 py-1 rounded-md text-xs text-muted-foreground hover:text-foreground hover:bg-accent/30 transition-colors"
           >
             <RotateCcw className="w-3 h-3" />
-            수정 요청
+            {t("proposal.action.revise_button")}
           </button>
           <button
             onClick={() => setStatus("dismissed")}
             className="ml-auto flex items-center gap-1 px-2 py-1 rounded-md text-xs text-muted-foreground/50 hover:text-muted-foreground hover:bg-accent/20 transition-colors"
-            title="이 제안 닫기"
+            title={t("proposal.action.dismiss_tooltip")}
           >
             <X className="w-3 h-3" />
-            닫기
+            {t("proposal.action.dismiss_button")}
           </button>
         </div>
       )}

--- a/src/components/tunaflow/context-panel/DevProgressView.tsx
+++ b/src/components/tunaflow/context-panel/DevProgressView.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { invoke } from "@tauri-apps/api/core";
 import { cn } from "@/lib/utils";
 import { useChatStore } from "@/stores/chatStore";
@@ -18,6 +19,7 @@ interface DevProgressViewProps {
 }
 
 export function DevProgressView({ plan, onPlanUpdate }: DevProgressViewProps) {
+  const { t } = useTranslation("workflow");
   const { openThread, sendThreadMessage, sendThreadRoundtable, loadBranches, saveConversationEngine } = useChatStore();
   const profiles = useChatStore((s) => s.agentProfiles);
   const runningThreadIds = useChatStore((s) => s.runningThreadIds);
@@ -283,7 +285,7 @@ export function DevProgressView({ plan, onPlanUpdate }: DevProgressViewProps) {
   };
 
   if (loading) {
-    return <p className="text-xs text-muted-foreground px-2">Loading...</p>;
+    return <p className="text-xs text-muted-foreground px-2">{t("progress.header.loading")}</p>;
   }
 
   // Approval phase: show the gate UI before implementation starts
@@ -294,7 +296,7 @@ export function DevProgressView({ plan, onPlanUpdate }: DevProgressViewProps) {
           <ClipboardList className="w-4 h-4 text-primary/60" />
           <span className="text-xs font-medium text-foreground flex-1">{plan.title}</span>
           <button onClick={() => setShowDoc(true)} className="flex items-center gap-1 text-[9px] text-muted-foreground/50 hover:text-primary/60 transition-colors">
-            <FileText className="w-3 h-3" />문서
+            <FileText className="w-3 h-3" />{t("progress.header.doc_button")}
           </button>
         </div>
         <ApprovalGate
@@ -320,14 +322,14 @@ export function DevProgressView({ plan, onPlanUpdate }: DevProgressViewProps) {
             : <ClipboardList className="w-4 h-4 text-primary/60" />}
           <span className="text-xs font-medium text-foreground flex-1">{plan.title}</span>
           {branchRunning && (
-            <span className="text-[9px] text-primary/60">구현 중...</span>
+            <span className="text-[9px] text-primary/60">{t("progress.header.implementing")}</span>
           )}
           <button onClick={() => setShowDoc(true)} className="flex items-center gap-1 text-[9px] text-muted-foreground/50 hover:text-primary/60 transition-colors">
-            <FileText className="w-3 h-3" />문서
+            <FileText className="w-3 h-3" />{t("progress.header.doc_button")}
           </button>
           {plan.implementationBranchId && (
             <button onClick={handleOpenBranch} className="flex items-center gap-1 text-[9px] text-primary/60 hover:text-primary transition-colors">
-              <GitBranch className="w-3 h-3" />Branch 열기
+              <GitBranch className="w-3 h-3" />{t("progress.header.branch_open")}
             </button>
           )}
         </div>
@@ -358,11 +360,11 @@ export function DevProgressView({ plan, onPlanUpdate }: DevProgressViewProps) {
                   <p className="text-[10px] text-muted-foreground/60 leading-snug mt-0.5 line-clamp-2">{st.details}</p>
                 )}
                 <div className="flex items-center gap-2 mt-1.5">
-                  {isDone && <span className="text-[9px] text-status-approved/60">완료</span>}
+                  {isDone && <span className="text-[9px] text-status-approved/60">{t("progress.subtask.done_label")}</span>}
                   {!isDone && (
                     <button onClick={() => handleRerunSubtask(st, i)} disabled={busy}
                       className="flex items-center gap-0.5 text-[9px] text-primary/60 hover:text-primary disabled:opacity-40 transition-colors">
-                      <RotateCcw className="w-2.5 h-2.5" />재수행
+                      <RotateCcw className="w-2.5 h-2.5" />{t("progress.subtask.rerun_button")}
                     </button>
                   )}
                   <button onClick={() => handleCreateSubPlan(st, i)} disabled={busy}
@@ -388,35 +390,26 @@ export function DevProgressView({ plan, onPlanUpdate }: DevProgressViewProps) {
             <>
               {failCount === 0 ? (
                 <>
-                  <p className="font-semibold">⚠️ 설계 재검토 필요 — Architect 재설계 진행 중</p>
-                  <p className="text-[9px] text-foreground/60">
-                    이전 싸이클에서 Review 5회 이상 실패로 에스컬레이션 되었습니다.
-                    Architect 의 rev 제안을 검토/승인한 뒤 Dev 를 다시 시작하세요.
-                  </p>
+                  <p className="font-semibold">{t("progress.rework.design_review_required_title")}</p>
+                  <p className="text-[9px] text-foreground/60">{t("progress.rework.design_review_required_body")}</p>
                 </>
               ) : failCount === 1 ? (
                 <>
-                  <p className="font-semibold">⚠️ Review 1회 실패 — 이전 싸이클 설계 재검토 이력 있음</p>
-                  <p className="text-[9px] text-foreground/60">
-                    동일 패턴이 반복되면 설계 재검토가 또 필요할 수 있습니다.
-                    Rework 으로 해소되지 않으면 Architect 재설계를 요청하세요.
-                  </p>
+                  <p className="font-semibold">{t("progress.rework.review_failed_once_title")}</p>
+                  <p className="text-[9px] text-foreground/60">{t("progress.rework.review_failed_once_body")}</p>
                 </>
               ) : (
                 <>
-                  <p className="font-semibold">⚠️ Review {failCount}회 연속 실패 — 설계 재검토가 필요합니다</p>
-                  <p className="text-[9px] text-foreground/60">
-                    동일한 문제가 반복되고 있어 Rework 으로 해결되지 않습니다.
-                    Subtask 설계를 재검토하고 Architect 에게 수정을 요청하세요.
-                  </p>
+                  <p className="font-semibold">{t("progress.rework.review_failed_many_title", { count: failCount })}</p>
+                  <p className="text-[9px] text-foreground/60">{t("progress.rework.review_failed_many_body")}</p>
                 </>
               )}
             </>
           ) : (
-            <p className="font-medium">Rework 필요 — Review에서 다음 사항이 지적되었습니다.</p>
+            <p className="font-medium">{t("progress.rework.rework_needed")}</p>
           )}
           {designReviewSuggested && !doomLoopEscalated && (
-            <p className="text-amber-500 font-medium">⚠️ 동일 파일에서 반복 실패 — Rework 대신 설계 재검토를 권장합니다.</p>
+            <p className="text-amber-500 font-medium">{t("progress.rework.design_review_suggested")}</p>
           )}
           {reviewVerdict && reviewVerdict.findings.length > 0 && (
             <ul className="space-y-0.5 text-[9px] text-foreground/60 pl-2">
@@ -432,7 +425,7 @@ export function DevProgressView({ plan, onPlanUpdate }: DevProgressViewProps) {
             {!doomLoopEscalated && (
               <button onClick={handleRework} disabled={busy}
                 className="px-2.5 py-1 rounded-md text-[10px] font-medium bg-primary/10 text-primary hover:bg-primary/20 disabled:opacity-50 transition-colors">
-                {busy ? "전달 중..." : "Developer에게 전달 + Rework"}
+                {busy ? t("progress.rework.deliver_busy") : t("progress.rework.deliver_button")}
               </button>
             )}
             <button
@@ -452,7 +445,7 @@ export function DevProgressView({ plan, onPlanUpdate }: DevProgressViewProps) {
                   ? "bg-amber-500/20 text-amber-600 hover:bg-amber-500/30"
                   : "bg-accent text-muted-foreground hover:text-foreground"
               )}>
-              {doomLoopEscalated ? "설계 재검토 시작 →" : "설계 변경 → Subtask"}
+              {doomLoopEscalated ? t("progress.rework.design_review_button") : t("progress.rework.design_change_button")}
             </button>
           </div>
         </div>
@@ -461,7 +454,7 @@ export function DevProgressView({ plan, onPlanUpdate }: DevProgressViewProps) {
       {/* Test results */}
       {testRunning && (
         <div className="rounded-md border border-primary/20 bg-primary/5 p-2.5 text-[10px] text-primary flex items-center gap-2">
-          <Loader2 className="w-3.5 h-3.5 animate-spin" />테스트 실행 중...
+          <Loader2 className="w-3.5 h-3.5 animate-spin" />{t("progress.test.running")}
         </div>
       )}
       {testResult && !testRunning && (
@@ -469,16 +462,16 @@ export function DevProgressView({ plan, onPlanUpdate }: DevProgressViewProps) {
           "rounded-md border p-2.5 text-[10px] space-y-1",
           testResult.success ? "border-status-approved/30 bg-status-approved/5 text-status-approved" : "border-status-rejected/30 bg-status-rejected/5 text-status-rejected"
         )}>
-          <div className="font-medium">{testResult.testType} 테스트: {testResult.success ? "PASS" : "FAIL"}</div>
+          <div className="font-medium">{t("progress.test.result_label", { type: testResult.testType, status: testResult.success ? t("progress.test.result_pass") : t("progress.test.result_fail") })}</div>
           <div className="flex gap-3 text-[9px]">
-            <span>통과: {testResult.passed}</span>
-            <span>실패: {testResult.failed}</span>
-            {testResult.skipped > 0 && <span>건너뜀: {testResult.skipped}</span>}
+            <span>{t("progress.test.passed_label")} {testResult.passed}</span>
+            <span>{t("progress.test.failed_label")} {testResult.failed}</span>
+            {testResult.skipped > 0 && <span>{t("progress.test.skipped_label")} {testResult.skipped}</span>}
             <span>{testResult.durationMs >= 60000 ? `${Math.floor(testResult.durationMs / 60000)}m ${Math.round((testResult.durationMs % 60000) / 1000)}s` : `${Math.round(testResult.durationMs / 1000)}s`}</span>
           </div>
           {!testResult.success && testResult.output && (
             <details className="mt-1">
-              <summary className="text-[9px] cursor-pointer text-muted-foreground/60 hover:text-foreground">출력 보기</summary>
+              <summary className="text-[9px] cursor-pointer text-muted-foreground/60 hover:text-foreground">{t("progress.test.output_toggle")}</summary>
               <pre className="text-[8px] mt-1 max-h-32 overflow-auto bg-card/50 rounded p-1.5 whitespace-pre-wrap">{testResult.output.slice(0, 2000)}</pre>
             </details>
           )}
@@ -488,25 +481,25 @@ export function DevProgressView({ plan, onPlanUpdate }: DevProgressViewProps) {
       {/* Re-review findings summary */}
       {implComplete && plan.phase !== "rework" && reviewVerdict && (
         <div className="rounded-md border border-amber-500/20 bg-amber-500/5 p-2.5 text-[10px] space-y-1.5">
-          <div className="font-medium text-amber-600">이전 Review Findings (Re-review #{(plan.versionMinor || 0) + 1})</div>
+          <div className="font-medium text-amber-600">{t("progress.rereview.findings_header", { round: (plan.versionMinor || 0) + 1 })}</div>
           <ul className="space-y-0.5 text-[9px] text-foreground/60 pl-2">
             {reviewVerdict.findings.slice(0, 5).map((f, i) => <li key={i}>□ {f.slice(0, 150)}</li>)}
           </ul>
-          <p className="text-[9px] text-muted-foreground/50">위 사항이 수정되었는지 중심으로 재검증됩니다.</p>
+          <p className="text-[9px] text-muted-foreground/50">{t("progress.rereview.reverify_note")}</p>
         </div>
       )}
 
       {/* Summary + actions */}
       <div className="pt-2 border-t border-border/30 space-y-1.5">
         <div className="flex items-center gap-2">
-          <span className="text-[10px] text-muted-foreground/50">{completedNums.size}/{subtasks.length} 완료</span>
+          <span className="text-[10px] text-muted-foreground/50">{t("progress.summary.completed_count", { done: completedNums.size, total: subtasks.length })}</span>
         </div>
         {implComplete && plan.phase !== "rework" && (
           <div className="space-y-1.5">
             {/* Re-review scope indicator */}
             {reviewVerdict && reviewVerdict.failedSubtaskIds.length > 0 && (
               <div className="flex items-center gap-1.5 text-[9px] text-amber-600/70 flex-wrap">
-                <span>리뷰 대상:</span>
+                <span>{t("progress.summary.scope_label")}</span>
                 {reviewVerdict.failedSubtaskIds.map((id) => {
                   const st = subtasks[id - 1];
                   return (
@@ -515,7 +508,7 @@ export function DevProgressView({ plan, onPlanUpdate }: DevProgressViewProps) {
                     </span>
                   );
                 })}
-                <span className="text-muted-foreground/40">나머지는 이전 pass</span>
+                <span className="text-muted-foreground/40">{t("progress.summary.rest_pass")}</span>
               </div>
             )}
             {/* Track selector: Quick = single reviewer chat / Deep = RT with ≥2 engines */}
@@ -523,18 +516,18 @@ export function DevProgressView({ plan, onPlanUpdate }: DevProgressViewProps) {
               <label className="flex items-center gap-1 cursor-pointer">
                 <input type="radio" name="review-track" checked={reviewTrack === "quick"}
                   onChange={() => setReviewTrack("quick")} className="accent-primary" />
-                <span>Quick <span className="text-muted-foreground/60">(단일)</span></span>
+                <span>Quick <span className="text-muted-foreground/60">{t("progress.track.quick_suffix")}</span></span>
               </label>
               <label className="flex items-center gap-1 cursor-pointer">
                 <input type="radio" name="review-track" checked={reviewTrack === "deep"}
                   onChange={() => setReviewTrack("deep")} className="accent-primary" />
-                <span>Deep RT <span className="text-muted-foreground/60">(다명 합의)</span></span>
+                <span>Deep RT <span className="text-muted-foreground/60">{t("progress.track.deep_suffix")}</span></span>
               </label>
             </div>
 
             {reviewTrack === "quick" ? (
               <div className="flex items-center gap-2">
-                <span className="text-[10px] text-muted-foreground shrink-0">Reviewer:</span>
+                <span className="text-[10px] text-muted-foreground shrink-0">{t("progress.reviewer.single_label")}</span>
                 <select value={selectedReviewerId} onChange={(e) => setSelectedReviewerId(e.target.value)}
                   disabled={busy}
                   className="flex-1 text-[10px] bg-input border border-border rounded px-1.5 py-0.5 outline-none disabled:opacity-40">
@@ -546,13 +539,13 @@ export function DevProgressView({ plan, onPlanUpdate }: DevProgressViewProps) {
                   className={cn("flex items-center gap-1 px-2.5 py-1 rounded-md text-[10px] font-medium disabled:opacity-50 transition-colors",
                     reviewVerdict ? "bg-amber-500/10 text-amber-600 hover:bg-amber-500/20" : "bg-status-approved/10 text-status-approved hover:bg-status-approved/20",
                   )}>
-                  <Check className="w-3 h-3" />{busy ? "시작 중..." : reviewVerdict ? "Re-review 시작" : "Review 시작"}
+                  <Check className="w-3 h-3" />{busy ? t("progress.reviewer.start_busy") : reviewVerdict ? t("progress.reviewer.re_review_start") : t("progress.reviewer.review_start")}
                 </button>
               </div>
             ) : (
               <div className="space-y-1.5">
                 <div className="flex items-center gap-2 flex-wrap">
-                  <span className="text-[10px] text-muted-foreground shrink-0">Reviewers:</span>
+                  <span className="text-[10px] text-muted-foreground shrink-0">{t("progress.reviewer.multi_label")}</span>
                   {profiles.map((p) => (
                     <label key={p.id} className={cn(
                       "flex items-center gap-1 px-1.5 py-0.5 rounded border cursor-pointer text-[10px]",
@@ -566,13 +559,13 @@ export function DevProgressView({ plan, onPlanUpdate }: DevProgressViewProps) {
                 </div>
                 <div className="flex items-center gap-2">
                   <span className="text-[9px] text-muted-foreground/60">
-                    {selectedDeepIds.size}명 선택{selectedDeepIds.size < 2 ? " — 최소 2명 필요" : ""}
+                    {t("progress.reviewer.selection_count", { count: selectedDeepIds.size, suffix: selectedDeepIds.size < 2 ? t("progress.reviewer.min_required_suffix") : "" })}
                   </span>
                   <button onClick={handleStartReviewRT} disabled={busy || selectedDeepIds.size < 2}
                     className={cn("ml-auto flex items-center gap-1 px-2.5 py-1 rounded-md text-[10px] font-medium disabled:opacity-40 disabled:cursor-not-allowed transition-colors",
                       reviewVerdict ? "bg-amber-500/10 text-amber-600 hover:bg-amber-500/20" : "bg-status-approved/10 text-status-approved hover:bg-status-approved/20",
                     )}>
-                    <Check className="w-3 h-3" />{busy ? "시작 중..." : reviewVerdict ? "Re-review RT 시작" : "Review RT 시작"}
+                    <Check className="w-3 h-3" />{busy ? t("progress.reviewer.start_busy") : reviewVerdict ? t("progress.reviewer.re_review_rt_start") : t("progress.reviewer.review_rt_start")}
                   </button>
                 </div>
               </div>

--- a/src/components/tunaflow/context-panel/plans/ApprovalGate.tsx
+++ b/src/components/tunaflow/context-panel/plans/ApprovalGate.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { useChatStore } from "@/stores/chatStore";
 import { invoke } from "@tauri-apps/api/core";
 import { Check, Pause } from "lucide-react";
@@ -19,6 +20,7 @@ export function ApprovalGate({
   subtasks: PlanSubtask[] | null;
   onPlanUpdate: (update: Partial<Plan>) => void;
 }) {
+  const { t } = useTranslation("workflow");
   const { openThread, loadBranches, sendThreadMessage, saveConversationEngine } = useChatStore();
   const profiles = useChatStore((s) => s.agentProfiles);
   const [mode, setMode] = useState<"idle" | "agent-select" | "busy">("idle");
@@ -36,7 +38,7 @@ export function ApprovalGate({
       if (projectKey) {
         const activePlans = await invoke<number>("count_active_plans", { projectKey }).catch(() => 0);
         if (activePlans >= 5) {
-          toast.warning(`동시 진행 Plan ${activePlans}개 — 리뷰 병목 주의. WIP 줄이기 권장.`);
+          toast.warning(t("approval.wip_warning", { count: activePlans }));
         }
       }
       const engine = selectedProfile?.engine ?? "claude";
@@ -51,7 +53,7 @@ export function ApprovalGate({
       await sendThreadMessage(prompt, engine, selectedProfile?.model);
     } catch (e) {
       console.error("[ApprovalGate] dev start failed:", e);
-      toast.error("Dev 시작 실패: " + errorMessage(e));
+      toast.error(t("approval.dev_start_error", { error: errorMessage(e) }));
       setMode("idle");
     }
   };
@@ -64,7 +66,7 @@ export function ApprovalGate({
       onPlanUpdate({ phase: "subtask_review" as PlanPhase });
     } catch (e) {
       console.error("[ApprovalGate] revert failed:", e);
-      toast.error("되돌리기 실패: " + errorMessage(e));
+      toast.error(t("approval.revert_error", { error: errorMessage(e) }));
       setMode("idle");
     }
   };
@@ -75,7 +77,7 @@ export function ApprovalGate({
   return (
     <div className="mt-2 pt-2 border-t border-border/20 space-y-1.5">
       <div className="flex items-center gap-2">
-        <span className="text-[10px] text-muted-foreground shrink-0">Developer:</span>
+        <span className="text-[10px] text-muted-foreground shrink-0">{t("approval.developer_label")}</span>
         <select
           value={selectedProfileId}
           onChange={(e) => setSelectedProfileId(e.target.value)}
@@ -93,16 +95,16 @@ export function ApprovalGate({
           onClick={handleDevStart}
           disabled={mode === "busy" || !selectedProfile}
           className="flex items-center gap-1 px-2.5 py-1 rounded-md text-[10px] font-medium bg-status-approved/10 text-status-approved hover:bg-status-approved/20 disabled:opacity-50 transition-colors"
-          title="선택된 Developer 에이전트로 즉시 구현 시작"
+          title={t("approval.dev_start_tooltip")}
         >
-          <Check className="w-3 h-3" />Dev 시작
+          <Check className="w-3 h-3" />{mode === "busy" ? t("approval.dev_start_busy") : t("approval.dev_start_button")}
         </button>
         <button
           onClick={handleRevert}
           disabled={mode === "busy"}
           className="flex items-center gap-1 px-2.5 py-1 rounded-md text-[10px] font-medium bg-accent text-muted-foreground hover:text-foreground disabled:opacity-50 transition-colors"
         >
-          <Pause className="w-3 h-3" />되돌리기
+          <Pause className="w-3 h-3" />{t("approval.revert_button")}
         </button>
       </div>
     </div>

--- a/src/components/tunaflow/context-panel/plans/DraftingActions.tsx
+++ b/src/components/tunaflow/context-panel/plans/DraftingActions.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { invoke } from "@tauri-apps/api/core";
 import { useChatStore } from "@/stores/chatStore";
 import { FileText, Search, RefreshCw, Loader2 } from "lucide-react";
@@ -19,6 +20,7 @@ export function DraftingActions({
   onPlanUpdate: (update: Partial<Plan>) => void;
   onSwitchToChat?: () => void;
 }) {
+  const { t } = useTranslation("workflow");
   const { sendWithEngine, selectedConversationId, getConversationEngine, projects, selectedProjectKey } = useChatStore();
   const runningThreadIds = useChatStore((s) => s.runningThreadIds);
   const [busy, setBusy] = useState(false);
@@ -38,26 +40,17 @@ export function DraftingActions({
     setBusy(true);
     try {
       const list = subtasks.map((s, i) => {
-        const detail = s.details?.trim() ? ` — ${s.details}` : " — (상세 설계 없음)";
+        const detail = s.details?.trim() ? ` — ${s.details}` : t("drafting.no_details_suffix");
         return `${i + 1}. ${s.title}${detail}`;
       }).join("\n");
       const planContext = `## Plan: ${plan.title}\n${plan.description ?? ""}\n\n### Subtasks\n${list}`;
-      const prompt = [
-        `[상세 설계 요청] "${plan.title}"`,
-        "",
-        `아래 Plan의 각 subtask에 **구현 방법(how)**을 추가해주세요.`,
-        `각 subtask별로: 수정/생성할 파일, 접근 방법, 주의사항을 details에 작성하세요.`,
-        "",
-        planContext,
-        "",
-        `\`<!-- tunaflow:plan-proposal -->\` 형식으로 상세 설계가 포함된 수정 Plan을 제안하세요.`,
-      ].join("\n");
+      const prompt = t("drafting.detail_design_prompt", { title: plan.title, planContext });
       await sendWithEngine(mainEngine, prompt);
       await planApi.createPlanEvent(plan.id, "detail_design_requested", "user");
       onSwitchToChat?.();
     } catch (e) {
       console.error("[DraftingActions] detail design request failed:", e);
-      toast.error("상세 설계 요청 실패: " + errorMessage(e));
+      toast.error(t("drafting.detail_design_error", { error: errorMessage(e) }));
     }
     setBusy(false);
   };
@@ -65,7 +58,7 @@ export function DraftingActions({
   /** Read task docs and populate subtask details from file content summaries. */
   const handleSyncFromDocs = async () => {
     const project = projects.find((p) => p.key === selectedProjectKey);
-    if (!project?.path) { toast.error("프로젝트 경로를 찾을 수 없습니다."); return; }
+    if (!project?.path) { toast.error(t("drafting.no_project_path_error")); return; }
     setSyncing(true);
     try {
       const slug = getPlanSlug(plan);
@@ -78,7 +71,7 @@ export function DraftingActions({
         .sort((a, b) => a.name.localeCompare(b.name));
 
       if (taskFiles.length === 0) {
-        toast.error(`docs/plans/${slug}-task-*.md 파일을 찾지 못했습니다.`);
+        toast.error(t("drafting.no_task_files_error", { slug }));
         setSyncing(false);
         return;
       }
@@ -95,12 +88,12 @@ export function DraftingActions({
 
       await planApi.replacePlanSubtasks(plan.id, updatedSubtasks);
       await planApi.createPlanEvent(plan.id, "review_merged", "system", `Synced details from ${taskFiles.length} task docs`);
-      toast.success(`${taskFiles.length}개 subtask 상세 설계 동기화 완료`);
+      toast.success(t("drafting.sync_success", { count: taskFiles.length }));
       // Reload the plan card
       onPlanUpdate({ phase: plan.phase });
     } catch (e) {
       console.error("[DraftingActions] sync from docs failed:", e);
-      toast.error("문서 동기화 실패: " + errorMessage(e));
+      toast.error(t("drafting.sync_error", { error: errorMessage(e) }));
     }
     setSyncing(false);
   };
@@ -113,7 +106,7 @@ export function DraftingActions({
       onPlanUpdate({ phase: "subtask_review" as PlanPhase });
     } catch (e) {
       console.error("[DraftingActions] start review failed:", e);
-      toast.error("Subtask 검토 전환 실패: " + errorMessage(e));
+      toast.error(t("drafting.review_transition_error", { error: errorMessage(e) }));
     }
     setBusy(false);
   };
@@ -121,36 +114,33 @@ export function DraftingActions({
   return (
     <div className="mt-2 pt-2 border-t border-border/20 space-y-1.5">
       {hasEmptyDetails && hasSubtasks && !isArchitectWriting && (
-        <p className="text-[9px] text-amber-600/60">일부 subtask에 상세 설계가 없습니다.</p>
+        <p className="text-[9px] text-amber-600/60">{t("drafting.empty_details_warning")}</p>
       )}
       <div className="flex items-center gap-2 flex-wrap">
         {hasEmptyDetails && hasSubtasks && (
           <>
             <button onClick={handleDetailDesign} disabled={busy || syncing || isArchitectWriting} className="flex items-center gap-1 px-2.5 py-1 rounded-md text-[10px] font-medium bg-amber-500/10 text-amber-600 hover:bg-amber-500/20 disabled:opacity-50 transition-colors">
-              <FileText className="w-3 h-3" />{busy ? "요청 중..." : "상세 설계 요청"}
+              <FileText className="w-3 h-3" />{busy ? t("drafting.detail_design_busy") : t("drafting.detail_design_button")}
             </button>
             <button onClick={handleSyncFromDocs} disabled={busy || syncing || isArchitectWriting} className="flex items-center gap-1 px-2.5 py-1 rounded-md text-[10px] font-medium bg-primary/10 text-primary hover:bg-primary/20 disabled:opacity-50 transition-colors">
               {syncing ? <Loader2 className="w-3 h-3 animate-spin" /> : <RefreshCw className="w-3 h-3" />}
-              {syncing ? "동기화 중..." : "docs에서 동기화"}
+              {syncing ? t("drafting.sync_docs_busy") : t("drafting.sync_docs_button")}
             </button>
           </>
         )}
-        {/* Subtask 검토 버튼: 상세 설계가 모두 채워졌을 때만 노출. 문서 작성 완료 전에는
-            Dev 로 올라가는 관문이 아예 보이지 않음 — 사용자가 미완성 문서로 진행하는 사고 방지. */}
         {hasSubtasks && !hasEmptyDetails && (
           <button onClick={handleStartReview} disabled={busy || syncing} className="flex items-center gap-1 px-2.5 py-1 rounded-md text-[10px] font-medium bg-primary/10 text-primary hover:bg-primary/20 disabled:opacity-50 transition-colors">
-            <Search className="w-3 h-3" />{busy ? "이동 중..." : "Subtask 검토"}
+            <Search className="w-3 h-3" />{busy ? t("drafting.subtask_review_busy") : t("drafting.subtask_review_button")}
           </button>
         )}
         {!hasSubtasks && (
-          <p className="text-[9px] text-muted-foreground/50">Subtask가 없습니다. Chat에서 Architect에게 Plan 수정을 요청하세요.</p>
+          <p className="text-[9px] text-muted-foreground/50">{t("drafting.no_subtasks_hint")}</p>
         )}
       </div>
-      {/* 아키텍트 문서 작성 중 표시 — agent 가 해당 conv 에서 실행 중이고 아직 details 비어있을 때 */}
       {isArchitectWriting && (
         <div className="flex items-center gap-1.5 pt-1 text-[10px] text-muted-foreground">
           <Loader2 className="w-3 h-3 animate-spin text-primary" />
-          <span>아키텍트 문서 작성 중...</span>
+          <span>{t("drafting.architect_writing")}</span>
         </div>
       )}
     </div>

--- a/src/components/tunaflow/context-panel/plans/MergeBranchButton.tsx
+++ b/src/components/tunaflow/context-panel/plans/MergeBranchButton.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { invoke } from "@tauri-apps/api/core";
 import { useChatStore } from "@/stores/chatStore";
 import { Merge } from "lucide-react";
@@ -20,6 +21,7 @@ export function MergeBranchButton({
   branchType: "review" | "implementation";
   onPlanUpdate: (update: Partial<Plan>) => void;
 }) {
+  const { t } = useTranslation("workflow");
   const { closeThread, loadBranches } = useChatStore();
   const [busy, setBusy] = useState(false);
 
@@ -57,14 +59,14 @@ export function MergeBranchButton({
       }
     } catch (e) {
       console.error("[MergeBranchButton] merge failed:", e);
-      toast.error("Plan 병합 실패: " + errorMessage(e));
+      toast.error(t("merge.error", { error: errorMessage(e) }));
     }
     setBusy(false);
   };
 
   return (
     <button onClick={handleMerge} disabled={busy} className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-[9px] font-medium text-primary/70 hover:text-primary hover:bg-primary/10 disabled:opacity-50 transition-colors">
-      <Merge className="w-3 h-3" />{busy ? "병합 중..." : "Plan에 병합"}
+      <Merge className="w-3 h-3" />{busy ? t("merge.busy") : t("merge.button")}
     </button>
   );
 }

--- a/src/components/tunaflow/context-panel/plans/PlanCard.tsx
+++ b/src/components/tunaflow/context-panel/plans/PlanCard.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
 import { invoke } from "@tauri-apps/api/core";
 import * as ContextMenu from "@radix-ui/react-context-menu";
 import { cn } from "@/lib/utils";
@@ -37,6 +38,7 @@ export function PlanCard({
   onSwitchToChat?: () => void;
   defaultExpanded?: boolean;
 }) {
+  const { t } = useTranslation("workflow");
   const { sendFollowup, setHandoffSource, branches, openThread, sendThreadRoundtable, loadBranches, runningThreadIds } = useChatStore();
   const [plan, setPlan] = useState(initialPlan);
   // Sync local plan state when parent re-renders with updated plan (e.g., auto-detect verdict)
@@ -127,10 +129,10 @@ export function PlanCard({
   ];
 
   const allStatusActions: { status: PlanStatus; label: string; icon: React.ReactNode; destructive?: boolean }[] = [
-    { status: "active", label: "Active로 변경", icon: <Play className={ctxMenuIcon} /> },
-    { status: "done", label: "완료 처리", icon: <CheckCircle className={ctxMenuIcon} /> },
-    { status: "draft", label: "Draft로 되돌리기", icon: <RotateCcw className={ctxMenuIcon} /> },
-    { status: "abandoned", label: "Abandon", icon: <Ban className={ctxMenuIcon} />, destructive: true },
+    { status: "active", label: t("plan.context_menu.status_active"), icon: <Play className={ctxMenuIcon} /> },
+    { status: "done", label: t("plan.context_menu.status_done"), icon: <CheckCircle className={ctxMenuIcon} /> },
+    { status: "draft", label: t("plan.context_menu.status_draft"), icon: <RotateCcw className={ctxMenuIcon} /> },
+    { status: "abandoned", label: t("plan.context_menu.status_abandoned"), icon: <Ban className={ctxMenuIcon} />, destructive: true },
   ];
   const statusActions = allStatusActions.filter((a) => a.status !== plan.status);
 
@@ -148,7 +150,7 @@ export function PlanCard({
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-1.5">
             <p className="text-xs font-medium text-foreground leading-snug">{plan.title}</p>
-            <button onClick={(e) => { e.stopPropagation(); setShowDoc(true); }} title="문서 보기" className="shrink-0 text-muted-foreground/30 hover:text-primary/60 transition-colors">
+            <button onClick={(e) => { e.stopPropagation(); setShowDoc(true); }} title={t("plan.header.doc_tooltip")} className="shrink-0 text-muted-foreground/30 hover:text-primary/60 transition-colors">
               <FileText className="w-3 h-3" />
             </button>
             {plan.phase !== "drafting" && (
@@ -234,7 +236,7 @@ export function PlanCard({
                   }}
                   className="flex items-center gap-1 px-2.5 py-1 rounded-md text-[10px] font-medium bg-status-approved/10 text-status-approved hover:bg-status-approved/20 transition-colors"
                 >
-                  <Check className="w-3 h-3" />검토 완료 → Dev 승인
+                  <Check className="w-3 h-3" />{t("plan.subtask_review.approve_button")}
                 </button>
                 <button
                   onClick={async () => {
@@ -244,7 +246,7 @@ export function PlanCard({
                   }}
                   className="flex items-center gap-1 px-2.5 py-1 rounded-md text-[10px] font-medium bg-accent text-muted-foreground hover:text-foreground transition-colors"
                 >
-                  수정 필요 → Drafting
+                  {t("plan.subtask_review.revert_button")}
                 </button>
               </div>
             )}
@@ -258,7 +260,7 @@ export function PlanCard({
             {plan.phase === "approval" && plan.reviewBranchId && (
               <div className="mt-1.5 flex items-center gap-2">
                 <button onClick={() => openThread(plan.reviewBranchId!)} className="text-[9px] text-primary/60 hover:text-primary hover:underline flex items-center gap-0.5">
-                  <GitBranch className="w-2.5 h-2.5" />Review Branch 열기
+                  <GitBranch className="w-2.5 h-2.5" />{t("plan.branch_links.review_open")}
                 </button>
                 <MergeBranchButton plan={plan} branchId={plan.reviewBranchId} branchType="review" onPlanUpdate={handlePlanUpdate} />
               </div>
@@ -269,12 +271,12 @@ export function PlanCard({
               <>
                 <div className="mt-1.5 flex items-center gap-2">
                   <button onClick={() => openThread(plan.implementationBranchId!)} className="text-[9px] text-primary/60 hover:text-primary hover:underline flex items-center gap-0.5">
-                    <GitBranch className="w-2.5 h-2.5" />Implementation Branch 열기
+                    <GitBranch className="w-2.5 h-2.5" />{t("plan.branch_links.impl_open")}
                   </button>
                 </div>
                 {implComplete && !runningThreadIds.includes(`branch:${plan.implementationBranchId}`) && (
                   <div className="mt-2 rounded-md border border-status-approved/30 bg-status-approved/5 p-2 text-tf-xs text-status-approved flex items-center gap-1.5">
-                    <Check className="w-3 h-3" />구현 완료 — Review 단계로 전환 가능
+                    <Check className="w-3 h-3" />{t("plan.review_ready.impl_complete_label")}
                     <button
                       onClick={async () => {
                         // 진입 게이트 + roleAssignments 해석으로 model 포함 전달
@@ -309,7 +311,7 @@ export function PlanCard({
                       }}
                       className="ml-auto px-2 py-0.5 rounded text-[9px] font-medium bg-status-approved/20 hover:bg-status-approved/30 transition-colors"
                     >
-                      Review RT 시작
+                      {t("plan.review_ready.review_rt_button")}
                     </button>
                   </div>
                 )}
@@ -322,7 +324,7 @@ export function PlanCard({
                 {plan.reviewBranchId && (
                   <div className="mt-1.5">
                     <button onClick={() => openThread(plan.reviewBranchId!)} className="text-[9px] text-primary/60 hover:text-primary hover:underline flex items-center gap-0.5">
-                      <GitBranch className="w-2.5 h-2.5" />Review Branch 열기
+                      <GitBranch className="w-2.5 h-2.5" />{t("plan.branch_links.review_open")}
                     </button>
                   </div>
                 )}
@@ -332,27 +334,24 @@ export function PlanCard({
                 {/* Fallback: no verdict marker detected — let user manually decide */}
                 {!reviewVerdict && !runningThreadIds.includes(`branch:${plan.reviewBranchId}`) && (
                   <div className="mt-2 rounded-md border border-muted/40 bg-muted/5 p-2.5 space-y-1.5">
-                    <p className="text-[9px] text-muted-foreground/60">리뷰어 마커가 감지되지 않았습니다. 수동으로 판단하세요.</p>
+                    <p className="text-[9px] text-muted-foreground/60">{t("plan.review_fallback.no_verdict_hint")}</p>
                     <div className="flex items-center gap-2 flex-wrap">
                       <button
                         onClick={async () => {
-                          // Review 진입 자체가 실패한 경우 — 한 단계 전(dev 완료 상태)으로 되돌려
-                          // 사용자가 Review RT 를 다시 시작할 수 있게 한다. 기존 review 브랜치는
-                          // archive (재사용되지 않고 다음 시작 시 새 브랜치 생성됨). s37
                           if (plan.reviewBranchId) {
                             await invoke("archive_branch", { id: plan.reviewBranchId }).catch(() => {});
                           }
                           await planApi.updatePlanPhase(plan.id, "implementation");
                           await planApi.createPlanEvent(
                             plan.id, "review_rolled_back", "user",
-                            "Review 진입 실패로 Dev 단계 복귀",
+                            t("plan.review_fallback.back_to_dev_event_reason"),
                           );
                           handlePlanUpdate({ phase: "implementation" });
                         }}
                         className="px-2.5 py-1 rounded-md text-[10px] font-medium bg-primary/10 text-primary hover:bg-primary/20 transition-colors"
-                        title="Review RT 진입이 실패했을 때 Dev 완료 상태로 되돌립니다. 기존 review 브랜치는 archive."
+                        title={t("plan.review_fallback.back_to_dev_tooltip")}
                       >
-                        ← Dev 단계로 복귀 (Review 재시도)
+                        {t("plan.review_fallback.back_to_dev_button")}
                       </button>
                       <button
                         onClick={async () => {
@@ -362,7 +361,7 @@ export function PlanCard({
                         }}
                         className="px-2.5 py-1 rounded-md text-[10px] font-medium bg-status-rejected/10 text-status-rejected hover:bg-status-rejected/20 transition-colors"
                       >
-                        수정 필요 (Rework)
+                        {t("plan.review_fallback.mark_rework_button")}
                       </button>
                       <button
                         onClick={async () => {
@@ -373,7 +372,7 @@ export function PlanCard({
                         }}
                         className="px-2.5 py-1 rounded-md text-[10px] font-medium bg-status-approved/10 text-status-approved hover:bg-status-approved/20 transition-colors"
                       >
-                        통과 처리 (Done)
+                        {t("plan.review_fallback.mark_done_button")}
                       </button>
                     </div>
                   </div>
@@ -384,12 +383,15 @@ export function PlanCard({
             {/* Rework phase — send findings to Developer or return to Subtask */}
             {plan.phase === "rework" && plan.implementationBranchId && (
               <div className="mt-2 rounded-md border border-status-rejected/30 bg-status-rejected/5 p-2.5 text-tf-xs text-status-rejected space-y-2">
-                <p>Rework 필요 — Review findings를 Developer에게 전달합니다.</p>
+                <p>{t("plan.rework_notice.heading")}</p>
                 {(() => {
                   const failCount = events.filter((e) => e.eventType === "review_failed").length;
                   return failCount >= 2 ? (
                     <p className="text-[9px] font-medium text-amber-500">
-                      ⚠ Review 실패 {failCount}회 — {failCount >= 3 ? "설계 재검토가 필요합니다." : "다음 실패 시 설계 재검토로 에스컬레이션됩니다."}
+                      {t("plan.rework_notice.fail_count_warning", {
+                        count: failCount,
+                        hint: failCount >= 3 ? t("plan.rework_notice.fail_hint_final") : t("plan.rework_notice.fail_hint_next"),
+                      })}
                     </p>
                   ) : null;
                 })()}
@@ -405,26 +407,23 @@ export function PlanCard({
                       await planApi.createPlanEvent(plan.id, "rework_requested", "user");
                       handlePlanUpdate({ phase: "implementation" });
                       await openThread(plan.implementationBranchId!);
-                      // Send review findings to Developer with budget pressure
-                      const findings = reviewVerdict?.findings.join("\n- ") ?? "";
+                      const findingsRaw = reviewVerdict?.findings.join("\n- ") ?? "";
                       const failCount = events.filter((e) => e.eventType === "review_failed").length;
+                      const findings = findingsRaw ? `- ${findingsRaw}` : t("plan.rework_notice.rework_findings_empty");
                       const pressure = failCount >= 2
-                        ? `\n> ⚠️ 이전 ${failCount}회 Review 실패. ${failCount >= 3 ? "이번이 마지막 기회입니다." : "다음 실패 시 설계 재검토로 에스컬레이션됩니다."}`
+                        ? t("plan.rework_notice.rework_pressure", {
+                            count: failCount,
+                            hint: failCount >= 3 ? t("plan.rework_notice.fail_hint_final") : t("plan.rework_notice.fail_hint_next"),
+                          })
                         : "";
-                      const reworkPrompt = [
-                        `[Rework] Review에서 다음 사항이 지적되었습니다:`,
-                        findings ? `- ${findings}` : "(findings 없음)",
-                        "",
-                        `위 사항을 수정하고 완료되면 알려주세요.`,
-                        pressure,
-                      ].filter(Boolean).join("\n");
+                      const reworkPrompt = t("plan.rework_notice.rework_prompt", { findings, pressure });
                       const shadowConvId = `branch:${plan.implementationBranchId}`;
                       const saved = useChatStore.getState().getConversationEngine(shadowConvId);
                       await useChatStore.getState().sendThreadMessage(reworkPrompt, saved?.engine ?? "claude", saved?.model ?? undefined);
                     }}
                     className="px-2.5 py-1 rounded-md text-tf-xs font-medium bg-primary/10 text-primary hover:bg-primary/20 transition-colors"
                   >
-                    Developer에게 전달 + Rework
+                    {t("plan.rework_notice.deliver_rework_button")}
                   </button>
                   <button
                     onClick={async () => {
@@ -434,7 +433,7 @@ export function PlanCard({
                     }}
                     className="px-2.5 py-1 rounded-md text-tf-xs font-medium bg-accent text-muted-foreground hover:text-foreground transition-colors"
                   >
-                    설계 변경 → Subtask
+                    {t("plan.rework_notice.redesign_subtask_button")}
                   </button>
                 </div>
               </div>
@@ -462,11 +461,11 @@ export function PlanCard({
       <ContextMenu.Portal>
         <ContextMenu.Content className={ctxMenuContent}>
           <ContextMenu.Item className={ctxMenuItem} onSelect={() => setShowDoc(true)}>
-            <FileText className={ctxMenuIcon} /> 문서 보기
+            <FileText className={ctxMenuIcon} /> {t("plan.context_menu.doc_view")}
           </ContextMenu.Item>
           <ContextMenu.Item className={ctxMenuItem} onSelect={handleToggle}>
             {expanded ? <ChevronDown className={ctxMenuIcon} /> : <ChevronRight className={ctxMenuIcon} />}
-            {expanded ? "접기" : "펼치기"}
+            {expanded ? t("plan.context_menu.collapse") : t("plan.context_menu.expand")}
           </ContextMenu.Item>
           <ContextMenu.Separator className={ctxMenuSeparator} />
           {statusActions.map((a) => (
@@ -482,7 +481,7 @@ export function PlanCard({
             </ContextMenu.Item>
           ))}
           <ContextMenu.Separator className={ctxMenuSeparator} />
-          <ContextMenu.Label className="px-2.5 py-1 text-[9px] text-muted-foreground/40 font-medium">Phase 전환</ContextMenu.Label>
+          <ContextMenu.Label className="px-2.5 py-1 text-[9px] text-muted-foreground/40 font-medium">{t("plan.context_menu.phase_section_label")}</ContextMenu.Label>
           {(["drafting", "approval", "implementation", "review", "done"] as PlanPhase[])
             .filter((p) => p !== plan.phase)
             .map((phase) => (
@@ -518,6 +517,7 @@ function extractHeading(md: string): string | null {
 }
 
 function AddSubtasksInline({ plan, onAdded }: { plan: Plan; onAdded: (tasks: PlanSubtask[]) => void }) {
+  const { t } = useTranslation("workflow");
   const [open, setOpen] = useState(false);
   const [text, setText] = useState("");
   const [saving, setSaving] = useState(false);
@@ -584,7 +584,7 @@ function AddSubtasksInline({ plan, onAdded }: { plan: Plan; onAdded: (tasks: Pla
         onClick={() => { setOpen(true); setTimeout(() => textareaRef.current?.focus(), 50); }}
         className="flex items-center gap-1 text-tf-xs text-muted-foreground/40 hover:text-primary/60 transition-colors py-0.5"
       >
-        <Plus className="w-3 h-3" /> 서브태스크 추가
+        <Plus className="w-3 h-3" /> {t("plan.add_subtasks.add_button")}
       </button>
     );
   }
@@ -592,7 +592,7 @@ function AddSubtasksInline({ plan, onAdded }: { plan: Plan; onAdded: (tasks: Pla
   return (
     <div className="space-y-1.5 mt-1">
       <div className="flex items-center justify-between">
-        <p className="text-tf-xs text-muted-foreground/50">한 줄에 하나씩 (마크다운 리스트 형식 OK)</p>
+        <p className="text-tf-xs text-muted-foreground/50">{t("plan.add_subtasks.line_hint")}</p>
         {plan.slug && (
           <button
             onClick={handleParseFromDocs}
@@ -600,7 +600,7 @@ function AddSubtasksInline({ plan, onAdded }: { plan: Plan; onAdded: (tasks: Pla
             className="flex items-center gap-1 text-tf-xs text-primary/50 hover:text-primary transition-colors disabled:opacity-40"
           >
             {parsing ? <Loader2 className="w-3 h-3 animate-spin" /> : <FolderOpen className="w-3 h-3" />}
-            docs에서 가져오기
+            {t("plan.add_subtasks.from_docs_button")}
           </button>
         )}
       </div>
@@ -608,7 +608,7 @@ function AddSubtasksInline({ plan, onAdded }: { plan: Plan; onAdded: (tasks: Pla
         ref={textareaRef}
         value={text}
         onChange={(e) => setText(e.target.value)}
-        placeholder={"1. 첫 번째 작업\n2. 두 번째 작업\n3. 세 번째 작업"}
+        placeholder={t("plan.add_subtasks.textarea_placeholder")}
         rows={5}
         className="w-full bg-input rounded-md px-2.5 py-1.5 text-tf-sm outline-none text-foreground placeholder:text-muted-foreground/30 border border-border/30 focus:border-ring/40 resize-none font-mono"
       />
@@ -619,13 +619,13 @@ function AddSubtasksInline({ plan, onAdded }: { plan: Plan; onAdded: (tasks: Pla
           className="flex items-center gap-1 px-2.5 py-1 rounded-md text-tf-xs font-medium bg-primary/10 text-primary hover:bg-primary/20 disabled:opacity-40 transition-colors"
         >
           {saving ? <Loader2 className="w-3 h-3 animate-spin" /> : <Check className="w-3 h-3" />}
-          저장
+          {t("plan.add_subtasks.save_button")}
         </button>
         <button
           onClick={() => { setOpen(false); setText(""); }}
           className="px-2 py-1 rounded-md text-tf-xs text-muted-foreground hover:text-foreground transition-colors"
         >
-          취소
+          {t("plan.add_subtasks.cancel_button")}
         </button>
       </div>
     </div>

--- a/src/components/tunaflow/context-panel/plans/ReviewVerdictCard.tsx
+++ b/src/components/tunaflow/context-panel/plans/ReviewVerdictCard.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { cn, errorMessage } from "@/lib/utils";
 import { useChatStore } from "@/stores/chatStore";
 import type { Plan, PlanPhase, PlanStatus } from "@/types";
@@ -17,6 +18,7 @@ export function ReviewVerdictCard({
   plan: Plan;
   onPlanUpdate: (update: Partial<Plan>) => void;
 }) {
+  const { t } = useTranslation("workflow");
   const [busy, setBusy] = useState(false);
   // Done 확인 단계 — fail/conditional 판정일 때 한 번 더 확인
   const [doneConfirm, setDoneConfirm] = useState(false);
@@ -28,7 +30,7 @@ export function ReviewVerdictCard({
       onPlanUpdate({ phase: "done" as PlanPhase, status: "done" as PlanStatus });
     } catch (e) {
       console.error("[ReviewVerdictCard] approve failed:", e);
-      toast.error("완료 처리 실패: " + errorMessage(e));
+      toast.error(t("review.verdict.approve_error", { error: errorMessage(e) }));
     }
     setBusy(false);
   };
@@ -40,7 +42,7 @@ export function ReviewVerdictCard({
       onPlanUpdate({ phase: "rework" as PlanPhase });
     } catch (e) {
       console.error("[ReviewVerdictCard] rework failed:", e);
-      toast.error("Rework 처리 실패: " + errorMessage(e));
+      toast.error(t("review.verdict.rework_error", { error: errorMessage(e) }));
     }
     setBusy(false);
   };
@@ -59,21 +61,17 @@ export function ReviewVerdictCard({
       const { openThread, sendThreadMessage, getConversationEngine } = useChatStore.getState();
       await openThread(plan.implementationBranchId);
       const saved = getConversationEngine(`branch:${plan.implementationBranchId}`);
-      const findings = verdict.findings.length > 0 ? `\n- ${verdict.findings.join("\n- ")}` : " (세부 findings 없음 — Review Branch를 직접 확인하세요)";
+      const findings = verdict.findings.length > 0
+        ? `\n- ${verdict.findings.join("\n- ")}`
+        : t("review.verdict.findings_empty_conditional");
       const recs = verdict.recommendations.length > 0 ? `\n- ${verdict.recommendations.join("\n- ")}` : "";
-      const prompt = [
-        `[Conditional Review] 리뷰어가 일부 수정을 요청했습니다.`,
-        ``,
-        `**Findings (수정 필요):${findings}`,
-        recs ? `**Recommendations:${recs}` : "",
-        ``,
-        `수정 후 impl-complete 마커를 출력해 주세요.`,
-      ].filter(Boolean).join("\n");
+      const recsBlock = recs ? t("review.verdict.conditional_recs_block", { recs }) : "";
+      const prompt = t("review.verdict.conditional_prompt", { findings, recsBlock });
       await sendThreadMessage(prompt, saved?.engine ?? "claude", saved?.model ?? undefined);
-      toast.success("DEV에게 conditional findings를 전달했습니다");
+      toast.success(t("review.verdict.dev_delivery_success"));
     } catch (e) {
       console.error("[ReviewVerdictCard] sendToDevDirect failed:", e);
-      toast.error("DEV 전달 실패: " + errorMessage(e));
+      toast.error(t("review.verdict.dev_delivery_error", { error: errorMessage(e) }));
     }
     setBusy(false);
   };
@@ -88,7 +86,7 @@ export function ReviewVerdictCard({
       // 2. 현재 플랜 폐기 (원안 abandoned)
       await planApi.updatePlanPhase(plan.id, "done");
       await planApi.updatePlanStatus(plan.id, "abandoned");
-      await planApi.createPlanEvent(plan.id, "abandoned", "user", "리뷰 실패 — 원안 폐기, 재설계 요청");
+      await planApi.createPlanEvent(plan.id, "abandoned", "user", t("review.verdict.redesign_event_reason"));
 
       // 3. 서브태스크 전부 pending 리셋
       const subtasks = await invoke<{ id: string }[]>("list_subtasks", { planId: plan.id });
@@ -102,33 +100,29 @@ export function ReviewVerdictCard({
       const saved = getConversationEngine(convId);
       const engine = saved?.engine ?? "claude";
 
-      const findingsText = verdict.findings.length > 0
+      const findings = verdict.findings.length > 0
         ? verdict.findings.map((f) => `- ${f}`).join("\n")
-        : "- (세부 findings 없음 — Review Branch를 참고하세요)";
-      const recsText = verdict.recommendations.length > 0
+        : t("review.verdict.findings_empty_redesign");
+      const recs = verdict.recommendations.length > 0
         ? verdict.recommendations.map((r) => `- ${r}`).join("\n")
         : "";
-
-      const prompt = [
-        `[Plan 개정 요청] "${plan.title}" (rev.${plan.revision})이 리뷰 실패로 폐기되었습니다.`,
-        ``,
-        `**리뷰어 판정**: ${verdict.verdict.toUpperCase()}`,
-        ``,
-        `**Findings (실패 원인)**:`,
-        findingsText,
-        recsText ? `\n**Recommendations**:\n${recsText}` : "",
-        ``,
-        `위 findings를 분석하여 실패한 서브태스크를 수정한 rev.${(plan.revision ?? 1) + 1} Plan을 \`<!-- tunaflow:plan-proposal -->\` 형식으로 제안해 주세요.`,
-        `성공한 서브태스크는 유지하고, 실패 원인이 된 부분만 수정하세요.`,
-      ].filter(Boolean).join("\n");
+      const recsBlock = recs ? t("review.verdict.redesign_recs_block", { recs }) : "";
+      const prompt = t("review.verdict.redesign_prompt", {
+        title: plan.title,
+        revision: plan.revision,
+        verdict: verdict.verdict.toUpperCase(),
+        findings,
+        recsBlock,
+        nextRevision: (plan.revision ?? 1) + 1,
+      });
 
       await sendWithEngine(engine, prompt);
 
       onPlanUpdate({ phase: "done" as PlanPhase, status: "abandoned" as PlanStatus });
-      toast.success("원안이 폐기되었습니다. Architect가 재설계를 시작합니다.");
+      toast.success(t("review.verdict.redesign_success"));
     } catch (e) {
       console.error("[ReviewVerdictCard] redesign failed:", e);
-      toast.error("재설계 전환 실패: " + errorMessage(e));
+      toast.error(t("review.verdict.redesign_error", { error: errorMessage(e) }));
     }
     setBusy(false);
   };
@@ -196,51 +190,50 @@ export function ReviewVerdictCard({
       {plan.phase !== "done" && (
         <div className="pt-1 border-t border-current/10">
           {doneConfirm ? (
-            /* 완료 확인 단계 — 다른 버튼 없이 단독 표시 */
             <div className="space-y-1.5">
               <p className="text-[9px] text-status-rejected/80 leading-snug">
-                리뷰어 판정이 <strong>{verdict.verdict === "fail" ? "실패" : "조건부"}</strong>입니다.
-                이대로 완료 시 기대 동작을 하지 않을 수 있습니다.
+                {t("review.verdict.done_confirm_prefix")}
+                <strong>{verdict.verdict === "fail" ? t("review.verdict.verdict_fail_label") : t("review.verdict.verdict_conditional_label")}</strong>
+                {t("review.verdict.done_confirm_suffix")}
               </p>
               <div className="flex items-center gap-1.5">
                 <button onClick={handleApprove} disabled={busy}
                   className="px-2 py-1 rounded text-[10px] font-medium bg-status-approved/10 text-status-approved hover:bg-status-approved/20 disabled:opacity-50 transition-colors">
-                  그래도 완료
+                  {t("review.verdict.approve_anyway_button")}
                 </button>
                 <button onClick={() => setDoneConfirm(false)} disabled={busy}
                   className="px-2 py-1 rounded text-[10px] text-muted-foreground hover:text-foreground disabled:opacity-50 transition-colors">
-                  돌아가기
+                  {t("review.verdict.back_button")}
                 </button>
               </div>
             </div>
           ) : (
-            /* 기본 액션 */
             <div className="flex items-center justify-between gap-1.5 flex-wrap">
               <div className="flex items-center gap-1.5 flex-wrap">
-                <span className="text-[9px] text-muted-foreground/50">수정:</span>
+                <span className="text-[9px] text-muted-foreground/50">{t("review.verdict.edit_label")}</span>
                 {verdict.verdict === "conditional" && plan.implementationBranchId ? (
                   <button onClick={handleSendToDevDirect} disabled={busy}
                     className="px-2 py-1 rounded text-[10px] font-medium bg-muted/40 text-muted-foreground hover:bg-muted/60 disabled:opacity-50 transition-colors"
-                    title="Findings를 DEV에 전달하고 바로 구현 단계로 전환">
-                    코드 재작성
+                    title={t("review.verdict.code_rewrite_tooltip")}>
+                    {t("review.verdict.code_rewrite_button")}
                   </button>
                 ) : (
                   <button onClick={handleRework} disabled={busy}
                     className="px-2 py-1 rounded text-[10px] font-medium bg-muted/40 text-muted-foreground hover:bg-muted/60 disabled:opacity-50 transition-colors">
-                    코드 재작성
+                    {t("review.verdict.code_rewrite_button")}
                   </button>
                 )}
                 <button onClick={handleRedesign} disabled={busy}
                   className="px-2 py-1 rounded text-[10px] font-medium bg-muted/40 text-muted-foreground hover:bg-muted/60 disabled:opacity-50 transition-colors"
-                  title="Plan 단계로 복귀 — Architect가 처음부터 재설계">
-                  처음부터 재설계
+                  title={t("review.verdict.redesign_tooltip")}>
+                  {t("review.verdict.redesign_button")}
                 </button>
               </div>
               <button
                 onClick={verdict.verdict === "pass" ? handleApprove : () => setDoneConfirm(true)}
                 disabled={busy}
                 className="px-2.5 py-1 rounded text-[10px] font-medium bg-status-approved/10 text-status-approved hover:bg-status-approved/20 disabled:opacity-50 transition-colors">
-                완료-{">"} Done
+                {t("review.verdict.done_button")}
               </button>
             </div>
           )}
@@ -248,7 +241,7 @@ export function ReviewVerdictCard({
       )}
       {plan.phase === "done" && (
         <div className="pt-1 border-t border-current/10 text-[9px] text-muted-foreground/50">
-          자동 처리 완료
+          {t("review.verdict.auto_completed")}
         </div>
       )}
     </div>

--- a/src/components/tunaflow/context-panel/plans/SubtaskRow.tsx
+++ b/src/components/tunaflow/context-panel/plans/SubtaskRow.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
 import { Forward, GitBranch } from "lucide-react";
 import type { PlanSubtask, SubtaskStatus } from "@/types";
@@ -24,6 +25,7 @@ export function SubtaskRow({
   linkedBranch?: { id: string; label: string; customLabel?: string; status: string } | null;
   onOpenThread?: (branchId: string) => void;
 }) {
+  const { t } = useTranslation("workflow");
   const profiles = useChatStore((s) => s.agentProfiles);
   const cfg = SUBTASK_STATUS_CFG[subtask.status];
   const owner = subtask.ownerAgent;
@@ -38,7 +40,7 @@ export function SubtaskRow({
     if (owner) lines.push(`Owner: ${owner}`);
     if (subtask.details) lines.push(`\nDetails:\n${subtask.details}`);
     if (linkedBranch) lines.push(`\nLinked branch: ${linkedBranch.customLabel ?? linkedBranch.label} (${linkedBranch.status})`);
-    lines.push("\n위 작업을 진행해주세요.");
+    lines.push(t("subtask.follow_up_suffix"));
     return lines.join("\n");
   };
 
@@ -71,7 +73,7 @@ export function SubtaskRow({
         {subtask.details ? (
           <p className="text-[10px] text-muted-foreground leading-snug mt-0.5 line-clamp-2">{subtask.details}</p>
         ) : (
-          <p className="text-[10px] text-amber-600/40 italic mt-0.5">상세 설계 없음</p>
+          <p className="text-[10px] text-amber-600/40 italic mt-0.5">{t("subtask.empty_details_row")}</p>
         )}
         {/* Linked branch — if any */}
         {linkedBranch && (

--- a/src/locales/en/workflow.json
+++ b/src/locales/en/workflow.json
@@ -91,6 +91,110 @@
       "cancel_button": "Cancel"
     }
   },
+  "progress": {
+    "header": {
+      "implementing": "Implementing...",
+      "branch_open": "Open Branch",
+      "doc_button": "Doc",
+      "loading": "Loading..."
+    },
+    "subtask": {
+      "done_label": "Done",
+      "rerun_button": "Rerun"
+    },
+    "rework": {
+      "design_review_required_title": "⚠️ Design review required — Architect redesign in progress",
+      "design_review_required_body": "Escalated after 5+ Review failures in the previous cycle. Review/approve the Architect's rev proposal, then restart Dev.",
+      "review_failed_once_title": "⚠️ Review failed once — prior cycle had a design review",
+      "review_failed_once_body": "If the same pattern repeats, another design review may be needed. If Rework doesn't resolve it, request an Architect redesign.",
+      "review_failed_many_title": "⚠️ Review failed {{count}} times in a row — design review required",
+      "review_failed_many_body": "The same issue keeps recurring and Rework is not resolving it. Review the Subtask design and ask the Architect for revisions.",
+      "rework_needed": "Rework needed — Review pointed out the following items.",
+      "design_review_suggested": "⚠️ Repeated failures on the same file — design review is recommended instead of Rework.",
+      "deliver_button": "Deliver to Developer + Rework",
+      "deliver_busy": "Delivering...",
+      "design_review_button": "Start design review →",
+      "design_change_button": "Design change → Subtask"
+    },
+    "test": {
+      "running": "Running tests...",
+      "result_pass": "PASS",
+      "result_fail": "FAIL",
+      "result_label": "{{type}} test: {{status}}",
+      "passed_label": "Passed:",
+      "failed_label": "Failed:",
+      "skipped_label": "Skipped:",
+      "output_toggle": "View output"
+    },
+    "rereview": {
+      "findings_header": "Previous Review Findings (Re-review #{{round}})",
+      "reverify_note": "Re-verified with focus on whether the items above were fixed."
+    },
+    "summary": {
+      "completed_count": "{{done}}/{{total}} done",
+      "scope_label": "Review scope:",
+      "rest_pass": "others previously passed"
+    },
+    "track": {
+      "quick_suffix": "(single)",
+      "deep_suffix": "(multi consensus)"
+    },
+    "reviewer": {
+      "single_label": "Reviewer:",
+      "multi_label": "Reviewers:",
+      "selection_count": "{{count}} selected{{suffix}}",
+      "min_required_suffix": " — at least 2 required",
+      "start_busy": "Starting...",
+      "review_start": "Start Review",
+      "re_review_start": "Start Re-review",
+      "review_rt_start": "Start Review RT",
+      "re_review_rt_start": "Start Re-review RT"
+    }
+  },
+  "proposal": {
+    "status": {
+      "merged_label": "Plan \"{{title}}\" rev.{{rev}} — revision merged (re-approval needed)",
+      "promoted_label": "Plan \"{{title}}\" — registered in the Plan tab{{locationHint}}",
+      "location_done_hint": " (Workflow tab → Done)",
+      "overwrite_done_button": "Reopen completed Plan",
+      "overwrite_active_button": "Overwrite with rev",
+      "overwrite_done_tooltip": "Reopen the completed Plan with this proposal (active + Approval)",
+      "overwrite_active_tooltip": "Overwrite the existing Plan with this proposal (reset to Approval + archive branches)"
+    },
+    "warn_empty": {
+      "title": "Subtasks not recognized",
+      "body": "The agent may have written subtasks in an invalid format. The parser accepts:",
+      "counter_example_double_hash": "❌ `## Subtasks` (double #)",
+      "counter_example_table": "❌ Markdown table `| # | title |`",
+      "counter_example_outside_marker": "❌ Written outside the marker",
+      "revise_button": "Request revision",
+      "promote_anyway_button": "Promote anyway",
+      "cancel_button": "Cancel"
+    },
+    "action": {
+      "promote_button": "Promote to Plan",
+      "promote_busy": "Processing...",
+      "revise_button": "Request revision",
+      "dismiss_button": "Dismiss",
+      "dismiss_tooltip": "Dismiss this proposal"
+    },
+    "revise": {
+      "placeholder": "Enter revision request...",
+      "send_button": "Send",
+      "cancel_button": "Cancel"
+    },
+    "confirm": {
+      "status_done": "done",
+      "status_abandoned": "abandoned",
+      "reopen_body": "Reopen the completed Plan \"{{title}}\" with this proposal?\n\n- The {{statusLabel}} Plan will be restored to active and enter the Dev phase\n- Existing subtasks will all be replaced with the proposal\n- Archived impl/review branches remain archived (not reused — a new branch is created on next Dev start)\n- Already modified files are not auto-reverted",
+      "overwrite_body": "Overwrite the existing Plan \"{{title}}\" with this proposal?\n\n- Existing subtasks will all be replaced\n- Running implementation/review branches will be archived\n- Phase resets to Approval so Dev can start\n- Already modified files are not auto-reverted (handle manually if needed)"
+    },
+    "toast": {
+      "promote_branch_error": "Plan registration failed: select the parent conversation and try again.",
+      "disposition_summary": "File disposition: {{summary}}",
+      "disposition_revert_warning": "File disposition: {{summary}}\n\nRevert targets (manual):\n{{items}}{{more}}"
+    }
+  },
   "review": {
     "verdict": {
       "verdict_fail_label": "Fail",

--- a/src/locales/en/workflow.json
+++ b/src/locales/en/workflow.json
@@ -1,0 +1,40 @@
+{
+  "approval": {
+    "developer_label": "Developer:",
+    "dev_start_button": "Start Dev",
+    "dev_start_tooltip": "Start implementation immediately with the selected Developer agent",
+    "dev_start_busy": "Starting...",
+    "revert_button": "Revert",
+    "dev_start_error": "Failed to start Dev: {{error}}",
+    "revert_error": "Failed to revert: {{error}}",
+    "wip_warning": "{{count}} active plans — review bottleneck risk. Reducing WIP is recommended."
+  },
+  "drafting": {
+    "empty_details_warning": "Some subtasks are missing detailed design.",
+    "detail_design_button": "Request detailed design",
+    "detail_design_busy": "Requesting...",
+    "sync_docs_button": "Sync from docs",
+    "sync_docs_busy": "Syncing...",
+    "subtask_review_button": "Review subtasks",
+    "subtask_review_busy": "Switching...",
+    "no_subtasks_hint": "No subtasks. Ask Architect in Chat to revise the Plan.",
+    "architect_writing": "Architect is writing docs...",
+    "detail_design_error": "Detailed design request failed: {{error}}",
+    "no_project_path_error": "Project path not found.",
+    "no_task_files_error": "Could not find docs/plans/{{slug}}-task-*.md files.",
+    "sync_success": "Synced {{count}} subtask details",
+    "sync_error": "Doc sync failed: {{error}}",
+    "review_transition_error": "Subtask review switch failed: {{error}}",
+    "detail_design_prompt": "[Detailed design request] \"{{title}}\"\n\nPlease add **implementation method (how)** to each subtask in the Plan below.\nFor each subtask, write to details: files to modify/create, approach, and caveats.\n\n{{planContext}}\n\nPropose the revised Plan with detailed design in `<!-- tunaflow:plan-proposal -->` format.",
+    "no_details_suffix": " — (no detailed design)"
+  },
+  "subtask": {
+    "empty_details_row": "No detailed design",
+    "follow_up_suffix": "\nPlease proceed with the task above."
+  },
+  "merge": {
+    "busy": "Merging...",
+    "button": "Merge into Plan",
+    "error": "Plan merge failed: {{error}}"
+  }
+}

--- a/src/locales/en/workflow.json
+++ b/src/locales/en/workflow.json
@@ -37,6 +37,60 @@
     "button": "Merge into Plan",
     "error": "Plan merge failed: {{error}}"
   },
+  "plan": {
+    "header": {
+      "doc_tooltip": "View document"
+    },
+    "context_menu": {
+      "status_active": "Set to Active",
+      "status_done": "Mark as Done",
+      "status_draft": "Revert to Draft",
+      "status_abandoned": "Abandon",
+      "doc_view": "View document",
+      "collapse": "Collapse",
+      "expand": "Expand",
+      "phase_section_label": "Phase transition"
+    },
+    "subtask_review": {
+      "approve_button": "Review done → Approve Dev",
+      "revert_button": "Needs revision → Drafting"
+    },
+    "branch_links": {
+      "review_open": "Open Review Branch",
+      "impl_open": "Open Implementation Branch"
+    },
+    "review_ready": {
+      "impl_complete_label": "Implementation complete — ready for Review phase",
+      "review_rt_button": "Start Review RT"
+    },
+    "review_fallback": {
+      "no_verdict_hint": "Reviewer marker not detected. Decide manually.",
+      "back_to_dev_button": "← Back to Dev (retry Review)",
+      "back_to_dev_tooltip": "If Review RT entry failed, revert to Dev-complete state. The existing review branch is archived.",
+      "back_to_dev_event_reason": "Back to Dev — Review entry failed",
+      "mark_rework_button": "Needs revision (Rework)",
+      "mark_done_button": "Pass (Done)"
+    },
+    "rework_notice": {
+      "heading": "Rework needed — sending Review findings to Developer.",
+      "fail_count_warning": "⚠ Review failed {{count}} times — {{hint}}",
+      "fail_hint_final": "Design review is required.",
+      "fail_hint_next": "Another failure will escalate to design review.",
+      "deliver_rework_button": "Deliver to Developer + Rework",
+      "redesign_subtask_button": "Redesign → Subtask",
+      "rework_prompt": "[Rework] The Review pointed out the following:\n{{findings}}\n\nPlease fix the items above and report when complete.{{pressure}}",
+      "rework_findings_empty": "(no findings)",
+      "rework_pressure": "\n> ⚠️ {{count}} previous Review failures. {{hint}}"
+    },
+    "add_subtasks": {
+      "add_button": "Add subtasks",
+      "line_hint": "One per line (markdown list format OK)",
+      "from_docs_button": "Import from docs",
+      "textarea_placeholder": "1. First task\n2. Second task\n3. Third task",
+      "save_button": "Save",
+      "cancel_button": "Cancel"
+    }
+  },
   "review": {
     "verdict": {
       "verdict_fail_label": "Fail",

--- a/src/locales/en/workflow.json
+++ b/src/locales/en/workflow.json
@@ -36,5 +36,35 @@
     "busy": "Merging...",
     "button": "Merge into Plan",
     "error": "Plan merge failed: {{error}}"
+  },
+  "review": {
+    "verdict": {
+      "verdict_fail_label": "Fail",
+      "verdict_conditional_label": "Conditional",
+      "edit_label": "Edit:",
+      "code_rewrite_button": "Rewrite code",
+      "code_rewrite_tooltip": "Send findings to DEV and switch straight to implementation",
+      "redesign_button": "Redesign from scratch",
+      "redesign_tooltip": "Return to Plan phase — Architect redesigns from the start",
+      "done_button": "Complete → Done",
+      "approve_anyway_button": "Complete anyway",
+      "back_button": "Back",
+      "done_confirm_prefix": "Reviewer verdict is ",
+      "done_confirm_suffix": ". Completing as-is may not produce expected behavior.",
+      "auto_completed": "Auto-completed",
+      "approve_error": "Failed to mark done: {{error}}",
+      "rework_error": "Rework failed: {{error}}",
+      "dev_delivery_success": "Sent conditional findings to DEV",
+      "dev_delivery_error": "Failed to deliver to DEV: {{error}}",
+      "redesign_success": "Original plan abandoned. Architect is starting a redesign.",
+      "redesign_error": "Redesign transition failed: {{error}}",
+      "redesign_event_reason": "Review failed — original abandoned, redesign requested",
+      "findings_empty_conditional": " (No detailed findings — check the Review Branch directly)",
+      "findings_empty_redesign": "- (No detailed findings — refer to the Review Branch)",
+      "conditional_prompt": "[Conditional Review] The reviewer requested partial revisions.\n\n**Findings (must fix):{{findings}}\n{{recsBlock}}\n\nAfter fixing, emit the impl-complete marker.",
+      "conditional_recs_block": "**Recommendations:{{recs}}",
+      "redesign_prompt": "[Plan revision request] \"{{title}}\" (rev.{{revision}}) was abandoned after review failure.\n\n**Reviewer verdict**: {{verdict}}\n\n**Findings (failure causes)**:\n{{findings}}\n{{recsBlock}}\n\nAnalyze the findings above and propose a revised rev.{{nextRevision}} Plan that fixes the failed subtasks, in `<!-- tunaflow:plan-proposal -->` format.\nKeep successful subtasks as-is; only revise the parts that caused the failure.",
+      "redesign_recs_block": "\n**Recommendations**:\n{{recs}}"
+    }
   }
 }

--- a/src/locales/index.ts
+++ b/src/locales/index.ts
@@ -8,12 +8,14 @@ import koSettings from "./ko/settings.json";
 import koSidebar from "./ko/sidebar.json";
 import koChat from "./ko/chat.json";
 import koDialog from "./ko/dialog.json";
+import koWorkflow from "./ko/workflow.json";
 import enCommon from "./en/common.json";
 import enError from "./en/error.json";
 import enSettings from "./en/settings.json";
 import enSidebar from "./en/sidebar.json";
 import enChat from "./en/chat.json";
 import enDialog from "./en/dialog.json";
+import enWorkflow from "./en/workflow.json";
 
 /** Supported locales. Add 'ja', 'zh', etc. in later PRs. */
 export type SupportedLocale = "ko" | "en";
@@ -31,6 +33,7 @@ export const resources = {
     sidebar: koSidebar,
     chat: koChat,
     dialog: koDialog,
+    workflow: koWorkflow,
   },
   en: {
     common: enCommon,
@@ -39,6 +42,7 @@ export const resources = {
     sidebar: enSidebar,
     chat: enChat,
     dialog: enDialog,
+    workflow: enWorkflow,
   },
 } as const;
 
@@ -52,7 +56,7 @@ i18n
     // 누락 키는 빈 문자열 대신 키 그대로 표시 → 누락 즉시 인지.
     returnEmptyString: false,
     defaultNS: "common",
-    ns: ["common", "error", "settings", "sidebar", "chat", "dialog"],
+    ns: ["common", "error", "settings", "sidebar", "chat", "dialog", "workflow"],
     detection: {
       // appStore (IndexedDB) 우선, 그 다음 localStorage/navigator.
       order: ["localStorage", "navigator"],

--- a/src/locales/ko/workflow.json
+++ b/src/locales/ko/workflow.json
@@ -1,0 +1,40 @@
+{
+  "approval": {
+    "developer_label": "Developer:",
+    "dev_start_button": "Dev 시작",
+    "dev_start_tooltip": "선택된 Developer 에이전트로 즉시 구현 시작",
+    "dev_start_busy": "시작 중...",
+    "revert_button": "되돌리기",
+    "dev_start_error": "Dev 시작 실패: {{error}}",
+    "revert_error": "되돌리기 실패: {{error}}",
+    "wip_warning": "동시 진행 Plan {{count}}개 — 리뷰 병목 주의. WIP 줄이기 권장."
+  },
+  "drafting": {
+    "empty_details_warning": "일부 subtask에 상세 설계가 없습니다.",
+    "detail_design_button": "상세 설계 요청",
+    "detail_design_busy": "요청 중...",
+    "sync_docs_button": "docs에서 동기화",
+    "sync_docs_busy": "동기화 중...",
+    "subtask_review_button": "Subtask 검토",
+    "subtask_review_busy": "이동 중...",
+    "no_subtasks_hint": "Subtask가 없습니다. Chat에서 Architect에게 Plan 수정을 요청하세요.",
+    "architect_writing": "아키텍트 문서 작성 중...",
+    "detail_design_error": "상세 설계 요청 실패: {{error}}",
+    "no_project_path_error": "프로젝트 경로를 찾을 수 없습니다.",
+    "no_task_files_error": "docs/plans/{{slug}}-task-*.md 파일을 찾지 못했습니다.",
+    "sync_success": "{{count}}개 subtask 상세 설계 동기화 완료",
+    "sync_error": "문서 동기화 실패: {{error}}",
+    "review_transition_error": "Subtask 검토 전환 실패: {{error}}",
+    "detail_design_prompt": "[상세 설계 요청] \"{{title}}\"\n\n아래 Plan의 각 subtask에 **구현 방법(how)**을 추가해주세요.\n각 subtask별로: 수정/생성할 파일, 접근 방법, 주의사항을 details에 작성하세요.\n\n{{planContext}}\n\n`<!-- tunaflow:plan-proposal -->` 형식으로 상세 설계가 포함된 수정 Plan을 제안하세요.",
+    "no_details_suffix": " — (상세 설계 없음)"
+  },
+  "subtask": {
+    "empty_details_row": "상세 설계 없음",
+    "follow_up_suffix": "\n위 작업을 진행해주세요."
+  },
+  "merge": {
+    "busy": "병합 중...",
+    "button": "Plan에 병합",
+    "error": "Plan 병합 실패: {{error}}"
+  }
+}

--- a/src/locales/ko/workflow.json
+++ b/src/locales/ko/workflow.json
@@ -36,5 +36,35 @@
     "busy": "병합 중...",
     "button": "Plan에 병합",
     "error": "Plan 병합 실패: {{error}}"
+  },
+  "review": {
+    "verdict": {
+      "verdict_fail_label": "실패",
+      "verdict_conditional_label": "조건부",
+      "edit_label": "수정:",
+      "code_rewrite_button": "코드 재작성",
+      "code_rewrite_tooltip": "Findings를 DEV에 전달하고 바로 구현 단계로 전환",
+      "redesign_button": "처음부터 재설계",
+      "redesign_tooltip": "Plan 단계로 복귀 — Architect가 처음부터 재설계",
+      "done_button": "완료-> Done",
+      "approve_anyway_button": "그래도 완료",
+      "back_button": "돌아가기",
+      "done_confirm_prefix": "리뷰어 판정이 ",
+      "done_confirm_suffix": "입니다. 이대로 완료 시 기대 동작을 하지 않을 수 있습니다.",
+      "auto_completed": "자동 처리 완료",
+      "approve_error": "완료 처리 실패: {{error}}",
+      "rework_error": "Rework 처리 실패: {{error}}",
+      "dev_delivery_success": "DEV에게 conditional findings를 전달했습니다",
+      "dev_delivery_error": "DEV 전달 실패: {{error}}",
+      "redesign_success": "원안이 폐기되었습니다. Architect가 재설계를 시작합니다.",
+      "redesign_error": "재설계 전환 실패: {{error}}",
+      "redesign_event_reason": "리뷰 실패 — 원안 폐기, 재설계 요청",
+      "findings_empty_conditional": " (세부 findings 없음 — Review Branch를 직접 확인하세요)",
+      "findings_empty_redesign": "- (세부 findings 없음 — Review Branch를 참고하세요)",
+      "conditional_prompt": "[Conditional Review] 리뷰어가 일부 수정을 요청했습니다.\n\n**Findings (수정 필요):{{findings}}\n{{recsBlock}}\n\n수정 후 impl-complete 마커를 출력해 주세요.",
+      "conditional_recs_block": "**Recommendations:{{recs}}",
+      "redesign_prompt": "[Plan 개정 요청] \"{{title}}\" (rev.{{revision}})이 리뷰 실패로 폐기되었습니다.\n\n**리뷰어 판정**: {{verdict}}\n\n**Findings (실패 원인)**:\n{{findings}}\n{{recsBlock}}\n\n위 findings를 분석하여 실패한 서브태스크를 수정한 rev.{{nextRevision}} Plan을 `<!-- tunaflow:plan-proposal -->` 형식으로 제안해 주세요.\n성공한 서브태스크는 유지하고, 실패 원인이 된 부분만 수정하세요.",
+      "redesign_recs_block": "\n**Recommendations**:\n{{recs}}"
+    }
   }
 }

--- a/src/locales/ko/workflow.json
+++ b/src/locales/ko/workflow.json
@@ -91,6 +91,110 @@
       "cancel_button": "취소"
     }
   },
+  "progress": {
+    "header": {
+      "implementing": "구현 중...",
+      "branch_open": "Branch 열기",
+      "doc_button": "문서",
+      "loading": "Loading..."
+    },
+    "subtask": {
+      "done_label": "완료",
+      "rerun_button": "재수행"
+    },
+    "rework": {
+      "design_review_required_title": "⚠️ 설계 재검토 필요 — Architect 재설계 진행 중",
+      "design_review_required_body": "이전 싸이클에서 Review 5회 이상 실패로 에스컬레이션 되었습니다. Architect 의 rev 제안을 검토/승인한 뒤 Dev 를 다시 시작하세요.",
+      "review_failed_once_title": "⚠️ Review 1회 실패 — 이전 싸이클 설계 재검토 이력 있음",
+      "review_failed_once_body": "동일 패턴이 반복되면 설계 재검토가 또 필요할 수 있습니다. Rework 으로 해소되지 않으면 Architect 재설계를 요청하세요.",
+      "review_failed_many_title": "⚠️ Review {{count}}회 연속 실패 — 설계 재검토가 필요합니다",
+      "review_failed_many_body": "동일한 문제가 반복되고 있어 Rework 으로 해결되지 않습니다. Subtask 설계를 재검토하고 Architect 에게 수정을 요청하세요.",
+      "rework_needed": "Rework 필요 — Review에서 다음 사항이 지적되었습니다.",
+      "design_review_suggested": "⚠️ 동일 파일에서 반복 실패 — Rework 대신 설계 재검토를 권장합니다.",
+      "deliver_button": "Developer에게 전달 + Rework",
+      "deliver_busy": "전달 중...",
+      "design_review_button": "설계 재검토 시작 →",
+      "design_change_button": "설계 변경 → Subtask"
+    },
+    "test": {
+      "running": "테스트 실행 중...",
+      "result_pass": "PASS",
+      "result_fail": "FAIL",
+      "result_label": "{{type}} 테스트: {{status}}",
+      "passed_label": "통과:",
+      "failed_label": "실패:",
+      "skipped_label": "건너뜀:",
+      "output_toggle": "출력 보기"
+    },
+    "rereview": {
+      "findings_header": "이전 Review Findings (Re-review #{{round}})",
+      "reverify_note": "위 사항이 수정되었는지 중심으로 재검증됩니다."
+    },
+    "summary": {
+      "completed_count": "{{done}}/{{total}} 완료",
+      "scope_label": "리뷰 대상:",
+      "rest_pass": "나머지는 이전 pass"
+    },
+    "track": {
+      "quick_suffix": "(단일)",
+      "deep_suffix": "(다명 합의)"
+    },
+    "reviewer": {
+      "single_label": "Reviewer:",
+      "multi_label": "Reviewers:",
+      "selection_count": "{{count}}명 선택{{suffix}}",
+      "min_required_suffix": " — 최소 2명 필요",
+      "start_busy": "시작 중...",
+      "review_start": "Review 시작",
+      "re_review_start": "Re-review 시작",
+      "review_rt_start": "Review RT 시작",
+      "re_review_rt_start": "Re-review RT 시작"
+    }
+  },
+  "proposal": {
+    "status": {
+      "merged_label": "Plan \"{{title}}\" rev.{{rev}} — 수정 반영 완료 (재승인 필요)",
+      "promoted_label": "Plan \"{{title}}\" — Plan 탭에 등록됨{{locationHint}}",
+      "location_done_hint": " (워크플로우 탭 → Done)",
+      "overwrite_done_button": "완료 Plan 재개",
+      "overwrite_active_button": "rev 로 덮어쓰기",
+      "overwrite_done_tooltip": "완료된 Plan 을 이 제안으로 재개 (active + Approval)",
+      "overwrite_active_tooltip": "이 제안으로 기존 Plan 덮어쓰기 (Approval 로 리셋 + branches archive)"
+    },
+    "warn_empty": {
+      "title": "서브태스크를 인식하지 못했습니다",
+      "body": "에이전트가 서브태스크를 잘못된 형식으로 작성했을 수 있습니다. 파서가 인식하는 형식:",
+      "counter_example_double_hash": "❌ `## Subtasks` (이중 #)",
+      "counter_example_table": "❌ 마크다운 테이블 `| # | 제목 |`",
+      "counter_example_outside_marker": "❌ 마커 밖 작성",
+      "revise_button": "수정 요청",
+      "promote_anyway_button": "그래도 승격",
+      "cancel_button": "취소"
+    },
+    "action": {
+      "promote_button": "Plan으로 승격",
+      "promote_busy": "처리 중...",
+      "revise_button": "수정 요청",
+      "dismiss_button": "닫기",
+      "dismiss_tooltip": "이 제안 닫기"
+    },
+    "revise": {
+      "placeholder": "수정 요청 내용을 입력하세요...",
+      "send_button": "전송",
+      "cancel_button": "취소"
+    },
+    "confirm": {
+      "status_done": "완료",
+      "status_abandoned": "폐기",
+      "reopen_body": "완료된 Plan \"{{title}}\" 을 이 제안으로 재개하시겠습니까?\n\n- 이미 {{statusLabel}} 된 Plan 을 active 로 되돌려 Dev 단계로 진입시킵니다\n- 기존 subtasks 는 모두 제안 내용으로 교체됩니다\n- 이미 archive 된 impl/review branches 는 그대로 (재사용하지 않음 — 신규 Dev 시작 시 새 브랜치)\n- 이미 수정된 파일은 자동 revert 되지 않습니다",
+      "overwrite_body": "기존 Plan \"{{title}}\" 을 이 제안으로 덮어쓰시겠습니까?\n\n- 기존 subtasks 는 모두 교체됩니다\n- 진행 중인 implementation/review branches 는 archive 됩니다\n- Phase 가 Approval 로 리셋되어 Dev 시작 가능 상태가 됩니다\n- 이미 수정된 파일은 자동 revert 되지 않습니다 (필요 시 수동 처리)"
+    },
+    "toast": {
+      "promote_branch_error": "Plan 등록 실패: 부모 대화를 선택한 뒤 다시 시도해주세요.",
+      "disposition_summary": "파일 처리 방침: {{summary}}",
+      "disposition_revert_warning": "파일 처리 방침: {{summary}}\n\nRevert 대상 (수동 처리 필요):\n{{items}}{{more}}"
+    }
+  },
   "review": {
     "verdict": {
       "verdict_fail_label": "실패",

--- a/src/locales/ko/workflow.json
+++ b/src/locales/ko/workflow.json
@@ -37,6 +37,60 @@
     "button": "Plan에 병합",
     "error": "Plan 병합 실패: {{error}}"
   },
+  "plan": {
+    "header": {
+      "doc_tooltip": "문서 보기"
+    },
+    "context_menu": {
+      "status_active": "Active로 변경",
+      "status_done": "완료 처리",
+      "status_draft": "Draft로 되돌리기",
+      "status_abandoned": "Abandon",
+      "doc_view": "문서 보기",
+      "collapse": "접기",
+      "expand": "펼치기",
+      "phase_section_label": "Phase 전환"
+    },
+    "subtask_review": {
+      "approve_button": "검토 완료 → Dev 승인",
+      "revert_button": "수정 필요 → Drafting"
+    },
+    "branch_links": {
+      "review_open": "Review Branch 열기",
+      "impl_open": "Implementation Branch 열기"
+    },
+    "review_ready": {
+      "impl_complete_label": "구현 완료 — Review 단계로 전환 가능",
+      "review_rt_button": "Review RT 시작"
+    },
+    "review_fallback": {
+      "no_verdict_hint": "리뷰어 마커가 감지되지 않았습니다. 수동으로 판단하세요.",
+      "back_to_dev_button": "← Dev 단계로 복귀 (Review 재시도)",
+      "back_to_dev_tooltip": "Review RT 진입이 실패했을 때 Dev 완료 상태로 되돌립니다. 기존 review 브랜치는 archive.",
+      "back_to_dev_event_reason": "Review 진입 실패로 Dev 단계 복귀",
+      "mark_rework_button": "수정 필요 (Rework)",
+      "mark_done_button": "통과 처리 (Done)"
+    },
+    "rework_notice": {
+      "heading": "Rework 필요 — Review findings를 Developer에게 전달합니다.",
+      "fail_count_warning": "⚠ Review 실패 {{count}}회 — {{hint}}",
+      "fail_hint_final": "설계 재검토가 필요합니다.",
+      "fail_hint_next": "다음 실패 시 설계 재검토로 에스컬레이션됩니다.",
+      "deliver_rework_button": "Developer에게 전달 + Rework",
+      "redesign_subtask_button": "설계 변경 → Subtask",
+      "rework_prompt": "[Rework] Review에서 다음 사항이 지적되었습니다:\n{{findings}}\n\n위 사항을 수정하고 완료되면 알려주세요.{{pressure}}",
+      "rework_findings_empty": "(findings 없음)",
+      "rework_pressure": "\n> ⚠️ 이전 {{count}}회 Review 실패. {{hint}}"
+    },
+    "add_subtasks": {
+      "add_button": "서브태스크 추가",
+      "line_hint": "한 줄에 하나씩 (마크다운 리스트 형식 OK)",
+      "from_docs_button": "docs에서 가져오기",
+      "textarea_placeholder": "1. 첫 번째 작업\n2. 두 번째 작업\n3. 세 번째 작업",
+      "save_button": "저장",
+      "cancel_button": "취소"
+    }
+  },
   "review": {
     "verdict": {
       "verdict_fail_label": "실패",

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -12,6 +12,7 @@ import type koSettings from "../locales/ko/settings.json";
 import type koSidebar from "../locales/ko/sidebar.json";
 import type koChat from "../locales/ko/chat.json";
 import type koDialog from "../locales/ko/dialog.json";
+import type koWorkflow from "../locales/ko/workflow.json";
 
 declare module "i18next" {
   interface CustomTypeOptions {
@@ -23,6 +24,7 @@ declare module "i18next" {
       sidebar: typeof koSidebar;
       chat: typeof koChat;
       dialog: typeof koDialog;
+      workflow: typeof koWorkflow;
     };
   }
 }


### PR DESCRIPTION
## Summary

i18n PR A 의 A2-E 슬라이스. `workflow` namespace 신설 + 8개 워크플로우 컴포넌트의 UI 라벨/토스트/confirm 다이얼로그 전환.

대형 agent prompt body (multiline 템플릿) 는 본 PR 범위 외로 분리 — 다음 슬라이스 **A2-E-msg** 에서 처리 (i18n 후 번역 품질 및 마커 의존성 별도 검토).

### 전환된 컴포넌트 (UI part)

| 파일 | 범위 |
|---|---|
| `locales/{ko,en}/workflow.json` | 신규 — approval/drafting/subtask/merge/plan/progress/proposal/review.verdict 섹션 |
| `locales/index.ts` / `types/i18next.d.ts` | workflow namespace 등록 |
| `plans/ApprovalGate.tsx` | Dev 시작/되돌리기/WIP 경고/토스트 |
| `plans/SubtaskRow.tsx` | empty_details_row + follow_up suffix |
| `plans/MergeBranchButton.tsx` | 병합 버튼/토스트 |
| `plans/DraftingActions.tsx` | 상세설계·docs동기화·Subtask검토 버튼/토스트 + detail_design_prompt 템플릿 (INV-6) |
| `plans/ReviewVerdictCard.tsx` | verdict 버튼/토스트/conditional·redesign prompt 템플릿 (INV-6) |
| `plans/PlanCard.tsx` | context menu/subtask_review/branch links/review_fallback/rework_notice/AddSubtasksInline + rework_prompt 템플릿 (INV-6) |
| `context-panel/DevProgressView.tsx` | header/subtask/rework(doom_loop 3종)/test/rereview/summary/track/reviewer UI |
| `chat/PlanProposalCard.tsx` | status/warn_empty/action/revise/confirm 다이얼로그/토스트 |

### 범위 외 (A2-E-msg 로 분리)

1. **DevProgressView agent prompt 4종**: `handleRerunSubtask` (L69), `handleStartReview` (L113-138), `handleCreateSubPlan` (L204-210), `handleRework` (L223-275) — 복잡한 multiline 템플릿, 마커 의존성 별도 검토 필요
2. **PlanProposalCard agent prompt 2종**: `docPrompt` (L316-332 — Architect 에게 문서 작성 요청), revision feedback (L535)
3. **PlanProposalCard pre 예시 블록**: `### Subtasks ← 삼중 # 필수 …` (L409-411, parser 문법 설명용 예시)

### INV-6 적용 (user locale 기반 agent prompt)

본 PR 에서 이미 적용된 agent prompt 템플릿:
- `workflow.drafting.detail_design_prompt`
- `workflow.review.verdict.conditional_prompt` / `redesign_prompt`
- `workflow.plan.rework_notice.rework_prompt`
- `workflow.subtask.follow_up_suffix`

마커 (`<!-- tunaflow:plan-proposal -->` 등) 는 번역 내 유지.

### 커밋 구성

| commit | 내용 |
|---|---|
| part 1 | workflow namespace + ApprovalGate/SubtaskRow/MergeBranchButton/DraftingActions |
| part 2 | ReviewVerdictCard + review.verdict 확장 |
| part 3 | PlanCard + plan.* 확장 |
| part 4 | DevProgressView UI + progress.* 확장 |
| part 5 | PlanProposalCard UI + proposal.* 확장 |

## Test plan

- [x] `npx tsc --noEmit` 통과 (각 part 별 확인)
- [x] `npx vitest run` 322 통과 (각 part 별 확인)
- [ ] 수동 확인: Settings → Language ko/en 토글 후
  - Drafting phase: 상세 설계 요청 버튼 + Subtask 검토 버튼
  - Approval phase: Dev 시작 / 되돌리기
  - Implementation phase: Branch 열기 / Re-review scope label / test result
  - Review phase: verdict 버튼 (코드 재작성 / 처음부터 재설계 / 완료 → Done)
  - Review fallback (no verdict): ← Dev 복귀 / Rework / Done 버튼
  - Rework phase: doom_loop 3종 경고 / Developer 전달 / 설계 변경
  - PlanProposalCard: 승격 / rev 덮어쓰기 / warn_empty 상태 / revise dialog / 닫기

## 후속 작업

- **A2-E-msg**: 남은 agent prompt 4+2 종 + pre 예시 블록 i18n. Architect INV-6 해석 확정 후 착수.
- **A2-F**: branch + roundtable namespace (BranchThreadPanel, CreateRoundtableDialog)
- **A2-G**: insight namespace (InsightPanel, IdentityView)
- **A3**: Rust 페르소나 + 도구 영어화

🤖 Generated with [Claude Code](https://claude.com/claude-code)