### PR TITLE
feat(i18n): PR A2-F — branch namespace + BranchThreadPanel / CreateRoundtableDialog

### DIFF
--- a/src/components/tunaflow/BranchThreadPanel.tsx
+++ b/src/components/tunaflow/BranchThreadPanel.tsx
@@ -1,4 +1,5 @@
 import { useRef, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { invoke } from "@tauri-apps/api/core";
 import { X, Check, GitBranch, Users, Trash2, ChevronsLeft, ChevronsRight, ChevronRight, AlertTriangle, Pin, PinOff } from "lucide-react";
 import { ask } from "@tauri-apps/plugin-dialog";
@@ -16,6 +17,7 @@ import * as planApi from "@/lib/api/plans";
 import { useNavigationChain } from "./useNavigationChain";
 
 export function BranchThreadPanel() {
+  const { t } = useTranslation("branch");
   const {
     threadBranchId,
     threadBranchConvId,
@@ -120,7 +122,7 @@ export function BranchThreadPanel() {
   return (
     <div
       role="complementary"
-      aria-label="브랜치/라운드테이블 패널"
+      aria-label={t("panel.aria_label")}
       className="flex flex-col w-full h-full bg-background"
     >
       {/* Header — navigator + actions */}
@@ -216,9 +218,9 @@ export function BranchThreadPanel() {
                 closeThread();
               }}
               className="flex items-center gap-0.5 px-1.5 py-0.5 rounded text-[9px] font-medium text-status-approved/70 hover:bg-status-approved/8 transition-colors"
-              title="대화 완료 → Branch 아카이브"
+              title={t("action.complete_tooltip")}
             >
-              <Check className="w-2.5 h-2.5" />완료
+              <Check className="w-2.5 h-2.5" />{t("action.complete_button")}
             </button>
           )}
           {!isReadOnly && threadBranch?.checkpointId && (
@@ -238,9 +240,9 @@ export function BranchThreadPanel() {
               }
               const hasAdopted = branches.some((b) => descendants.includes(b.id) && (b.status === "adopted" || b.status === "archived"));
               const message = hasAdopted
-                ? `"${threadBranchLabel}" 브랜치에 채택된 결과가 포함되어 있습니다.\n하위 브랜치와 이력이 모두 삭제됩니다. 계속하시겠습니까?`
-                : `"${threadBranchLabel}" 브랜치를 삭제하시겠습니까?`;
-              const yes = await ask(message, { title: "브랜치 삭제", kind: "warning" });
+                ? t("confirm.delete_with_adopted_body", { label: threadBranchLabel })
+                : t("confirm.delete_body", { label: threadBranchLabel });
+              const yes = await ask(message, { title: t("confirm.delete_title"), kind: "warning" });
               if (yes) {
                 closeThread();
                 deleteBranch(threadBranchId);
@@ -372,6 +374,7 @@ export function BranchThreadPanel() {
  * Appears after 15s of spinning with no streaming activity.
  */
 function StuckRecoveryButton({ convId }: { convId: string | null }) {
+  const { t } = useTranslation("branch");
   const [visible, setVisible] = useState(false);
   const [recovering, setRecovering] = useState(false);
 
@@ -400,9 +403,9 @@ function StuckRecoveryButton({ convId }: { convId: string | null }) {
       onClick={handleRecover}
       disabled={recovering}
       className="ml-2 text-[9px] text-muted-foreground/40 hover:text-muted-foreground transition-colors disabled:opacity-30"
-      title="PTY가 완료되었는데 스피너가 멈추지 않을 때 클릭"
+      title={t("recovery.tooltip")}
     >
-      {recovering ? "불러오는 중..." : "응답 불러오기"}
+      {recovering ? t("recovery.busy") : t("recovery.button")}
     </button>
   );
 }
@@ -412,10 +415,11 @@ function StuckRecoveryButton({ convId }: { convId: string | null }) {
 function PlanRevisionActions({ plan, threadMessages, threadBranchConvId }: {
   plan: Plan; threadMessages: Message[]; threadBranchConvId: string | null;
 }) {
+  const { t } = useTranslation("branch");
   const [mode, setMode] = useState<"idle" | "select" | "busy">("idle");
   const [engine, setEngine] = useState("claude");
 
-  if (mode === "busy") return <span className="text-[9px] text-amber-600/50">전송 중...</span>;
+  if (mode === "busy") return <span className="text-[9px] text-amber-600/50">{t("plan_revision.sending")}</span>;
 
   if (mode === "select") return (
     <div className="flex items-center gap-1">
@@ -435,18 +439,18 @@ function PlanRevisionActions({ plan, threadMessages, threadBranchConvId }: {
           setMode("idle");
         }}
         className="text-[9px] px-1.5 py-0.5 rounded bg-amber-500/10 text-amber-600 hover:bg-amber-500/20 transition-colors"
-      >전송</button>
-      <button onClick={() => setMode("idle")} className="text-[9px] text-muted-foreground hover:text-foreground">취소</button>
+      >{t("plan_revision.send_button")}</button>
+      <button onClick={() => setMode("idle")} className="text-[9px] text-muted-foreground hover:text-foreground">{t("plan_revision.cancel_button")}</button>
     </div>
   );
 
   return (
     <button
       onClick={() => setMode("select")}
-      title="계획 수정 요청 — Architect에게 전달"
+      title={t("plan_revision.tooltip")}
       className="flex items-center gap-0.5 px-1.5 py-0.5 rounded text-[9px] font-medium text-amber-600/60 hover:text-amber-600 hover:bg-amber-500/10 transition-colors"
     >
-      <AlertTriangle className="w-2.5 h-2.5" />계획 수정
+      <AlertTriangle className="w-2.5 h-2.5" />{t("plan_revision.button")}
     </button>
   );
 }

--- a/src/components/tunaflow/CreateRoundtableDialog.tsx
+++ b/src/components/tunaflow/CreateRoundtableDialog.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useEffect } from "react";
+import { useTranslation } from "react-i18next";
 import { invoke } from "@tauri-apps/api/core";
 import { cn } from "@/lib/utils";
 import { useChatStore } from "@/stores/chatStore";
@@ -23,6 +24,7 @@ interface CreateRoundtableDialogProps {
 }
 
 export function CreateRoundtableDialog({ open, onClose, checkpointId }: CreateRoundtableDialogProps) {
+  const { t } = useTranslation("branch");
   const { selectedConversationId, conversations, createBranch, selectConversation, engineModels } = useChatStore();
 
   // Non-shadow, non-RT conversations for parent selection
@@ -202,13 +204,13 @@ export function CreateRoundtableDialog({ open, onClose, checkpointId }: CreateRo
           {/* Parent conversation selector — shown when creating from sidebar with multiple chats */}
           {!checkpointId && chatConvs.length > 1 && (
             <div>
-              <label className="text-[11px] text-sidebar-foreground/60 mb-1 block">상위 채팅</label>
+              <label className="text-[11px] text-sidebar-foreground/60 mb-1 block">{t("roundtable.labels.parent_chat")}</label>
               <select
                 value={effectiveParentConvId ?? ""}
                 onChange={(e) => setParentConvId(e.target.value || null)}
                 className="w-full bg-input rounded-md px-3 py-1.5 text-[12px] outline-none text-foreground border border-border/30 focus:border-ring/40 cursor-pointer"
               >
-                <option value="">채팅을 선택하세요</option>
+                <option value="">{t("roundtable.placeholder.select_chat")}</option>
                 {chatConvs.map((c) => (
                   <option key={c.id} value={c.id}>{c.customLabel ?? c.label}</option>
                 ))}
@@ -217,7 +219,7 @@ export function CreateRoundtableDialog({ open, onClose, checkpointId }: CreateRo
           )}
           {!checkpointId && chatConvs.length === 0 && (
             <div className="text-[10px] text-destructive/70 bg-destructive/5 rounded px-2.5 py-1.5">
-              채팅이 없습니다. 먼저 채팅을 생성하세요.
+              {t("roundtable.empty.no_chats")}
             </div>
           )}
 
@@ -293,7 +295,7 @@ export function CreateRoundtableDialog({ open, onClose, checkpointId }: CreateRo
           {/* Validation warnings */}
           {noModelParticipants.length > 0 && (
             <div className="text-[10px] text-amber-500/70 bg-amber-500/5 rounded px-2.5 py-1.5">
-              {noModelParticipants.map((p) => p.name).join(", ")} — 모델 미선택 (엔진 기본값 사용)
+              {t("roundtable.warning.no_models", { names: noModelParticipants.map((p) => p.name).join(", ") })}
             </div>
           )}
 

--- a/src/locales/en/branch.json
+++ b/src/locales/en/branch.json
@@ -1,0 +1,40 @@
+{
+  "panel": {
+    "aria_label": "Branch / Roundtable panel"
+  },
+  "action": {
+    "complete_button": "Done",
+    "complete_tooltip": "Complete conversation → Archive branch"
+  },
+  "confirm": {
+    "delete_title": "Delete branch",
+    "delete_body": "Delete branch \"{{label}}\"?",
+    "delete_with_adopted_body": "Branch \"{{label}}\" contains adopted results.\nAll child branches and history will be deleted. Continue?"
+  },
+  "recovery": {
+    "tooltip": "Click when PTY finished but the spinner keeps running",
+    "busy": "Loading...",
+    "button": "Load response"
+  },
+  "plan_revision": {
+    "sending": "Sending...",
+    "send_button": "Send",
+    "cancel_button": "Cancel",
+    "button": "Revise plan",
+    "tooltip": "Request plan revision — delivered to Architect"
+  },
+  "roundtable": {
+    "labels": {
+      "parent_chat": "Parent chat"
+    },
+    "placeholder": {
+      "select_chat": "Select a chat"
+    },
+    "empty": {
+      "no_chats": "No chats yet. Create a chat first."
+    },
+    "warning": {
+      "no_models": "{{names}} — no model selected (using engine default)"
+    }
+  }
+}

--- a/src/locales/index.ts
+++ b/src/locales/index.ts
@@ -9,6 +9,7 @@ import koSidebar from "./ko/sidebar.json";
 import koChat from "./ko/chat.json";
 import koDialog from "./ko/dialog.json";
 import koWorkflow from "./ko/workflow.json";
+import koBranch from "./ko/branch.json";
 import enCommon from "./en/common.json";
 import enError from "./en/error.json";
 import enSettings from "./en/settings.json";
@@ -16,6 +17,7 @@ import enSidebar from "./en/sidebar.json";
 import enChat from "./en/chat.json";
 import enDialog from "./en/dialog.json";
 import enWorkflow from "./en/workflow.json";
+import enBranch from "./en/branch.json";
 
 /** Supported locales. Add 'ja', 'zh', etc. in later PRs. */
 export type SupportedLocale = "ko" | "en";
@@ -34,6 +36,7 @@ export const resources = {
     chat: koChat,
     dialog: koDialog,
     workflow: koWorkflow,
+    branch: koBranch,
   },
   en: {
     common: enCommon,
@@ -43,6 +46,7 @@ export const resources = {
     chat: enChat,
     dialog: enDialog,
     workflow: enWorkflow,
+    branch: enBranch,
   },
 } as const;
 
@@ -56,7 +60,7 @@ i18n
     // 누락 키는 빈 문자열 대신 키 그대로 표시 → 누락 즉시 인지.
     returnEmptyString: false,
     defaultNS: "common",
-    ns: ["common", "error", "settings", "sidebar", "chat", "dialog", "workflow"],
+    ns: ["common", "error", "settings", "sidebar", "chat", "dialog", "workflow", "branch"],
     detection: {
       // appStore (IndexedDB) 우선, 그 다음 localStorage/navigator.
       order: ["localStorage", "navigator"],

--- a/src/locales/ko/branch.json
+++ b/src/locales/ko/branch.json
@@ -1,0 +1,40 @@
+{
+  "panel": {
+    "aria_label": "브랜치/라운드테이블 패널"
+  },
+  "action": {
+    "complete_button": "완료",
+    "complete_tooltip": "대화 완료 → Branch 아카이브"
+  },
+  "confirm": {
+    "delete_title": "브랜치 삭제",
+    "delete_body": "\"{{label}}\" 브랜치를 삭제하시겠습니까?",
+    "delete_with_adopted_body": "\"{{label}}\" 브랜치에 채택된 결과가 포함되어 있습니다.\n하위 브랜치와 이력이 모두 삭제됩니다. 계속하시겠습니까?"
+  },
+  "recovery": {
+    "tooltip": "PTY가 완료되었는데 스피너가 멈추지 않을 때 클릭",
+    "busy": "불러오는 중...",
+    "button": "응답 불러오기"
+  },
+  "plan_revision": {
+    "sending": "전송 중...",
+    "send_button": "전송",
+    "cancel_button": "취소",
+    "button": "계획 수정",
+    "tooltip": "계획 수정 요청 — Architect에게 전달"
+  },
+  "roundtable": {
+    "labels": {
+      "parent_chat": "상위 채팅"
+    },
+    "placeholder": {
+      "select_chat": "채팅을 선택하세요"
+    },
+    "empty": {
+      "no_chats": "채팅이 없습니다. 먼저 채팅을 생성하세요."
+    },
+    "warning": {
+      "no_models": "{{names}} — 모델 미선택 (엔진 기본값 사용)"
+    }
+  }
+}

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -13,6 +13,7 @@ import type koSidebar from "../locales/ko/sidebar.json";
 import type koChat from "../locales/ko/chat.json";
 import type koDialog from "../locales/ko/dialog.json";
 import type koWorkflow from "../locales/ko/workflow.json";
+import type koBranch from "../locales/ko/branch.json";
 
 declare module "i18next" {
   interface CustomTypeOptions {
@@ -25,6 +26,7 @@ declare module "i18next" {
       chat: typeof koChat;
       dialog: typeof koDialog;
       workflow: typeof koWorkflow;
+      branch: typeof koBranch;
     };
   }
 }


### PR DESCRIPTION
## Summary

i18n PR A 의 A2-F 슬라이스. `branch` namespace 신설 + branch 드로어 관련 2 컴포넌트 UI 전환.

### 전환된 파일

| 파일 | 범위 |
|---|---|
| `locales/{ko,en}/branch.json` | 신규 — panel/action/confirm/recovery/plan_revision/roundtable 섹션 (~15 키) |
| `locales/index.ts` / `types/i18next.d.ts` | branch namespace 등록 |
| `BranchThreadPanel.tsx` | aria_label / 완료 버튼·tooltip / 삭제 확인 다이얼로그 (adopted 변형) / StuckRecoveryButton (PTY 복구) / PlanRevisionActions (계획 수정 요청) |
| `CreateRoundtableDialog.tsx` | 상위 채팅 label / select_chat placeholder / no_chats 경고 / no_models 경고 |

### 범위 외 (유지)

- `threadBranch.label.startsWith("검토"|"작업지시"|"Subtask")` — 에이전트가 생성하는 branch label prefix matching 로직. UI 표시 아님.
- `RoundtableView` / `roundtable/*` — 한국어 문자열 없음 (주석만).

## Test plan

- [x] `npx tsc --noEmit` 통과
- [x] `npx vitest run` 322 통과
- [ ] 수동 확인: Settings → Language ko/en 토글 후
  - Branch 드로어 열기/닫기 (aria-label)
  - Subtask discussion branch 의 "완료" 버튼 (archive)
  - 브랜치 삭제 dialog (채택된 하위 존재 여부에 따라 body 달라짐)
  - PTY 복구 버튼 (15초 이상 spinner 지속 시 노출)
  - PlanRevisionActions — 계획 수정 버튼 / 전송/취소
  - CreateRoundtableDialog: 상위 채팅 선택 라벨 / 채팅 없음 경고 / 모델 미선택 경고

## 후속 작업

- **A2-G**: insight namespace (InsightPanel, IdentityView)
- **A2-E-msg**: A2-E 남은 agent prompt body (DevProgressView 4종 + PlanProposalCard 2종 + pre 예시)
- **A3**: Rust 페르소나 + 도구 영어화

🤖 Generated with [Claude Code](https://claude.com/claude-code)