### PR TITLE
feat(i18n): PR A2-G — insight namespace + InsightPanel / IdentityView 전환

### DIFF
--- a/src/components/tunaflow/context-panel/IdentityView.tsx
+++ b/src/components/tunaflow/context-panel/IdentityView.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { RefreshCw, Clock, AlertTriangle, Check } from "lucide-react";
@@ -25,6 +26,7 @@ import type { Artifact } from "@/types";
  *  - Empty state — summary 없을 때 조건 안내
  */
 export function IdentityView() {
+  const { t } = useTranslation("insight");
   const projectKey = useChatStore((s) => s.selectedProjectKey);
   const [summaries, setSummaries] = useState<Artifact[]>([]);
   const [selected, setSelected] = useState<Artifact | null>(null);
@@ -83,7 +85,7 @@ export function IdentityView() {
   };
 
   if (!projectKey) {
-    return <div className="p-4 text-[11px] text-muted-foreground">프로젝트를 선택하세요.</div>;
+    return <div className="p-4 text-[11px] text-muted-foreground">{t("identity.empty_project")}</div>;
   }
 
   return (
@@ -121,6 +123,7 @@ function Toolbar({
   onRun: (force: boolean) => void;
   busy: boolean;
 }) {
+  const { t } = useTranslation("insight");
   return (
     <div className="flex items-center gap-2 px-3 py-2 border-b border-border/20 shrink-0">
       <button
@@ -134,7 +137,7 @@ function Toolbar({
         )}
       >
         {busy ? <RefreshCw className="w-3 h-3 animate-spin" /> : <Check className="w-3 h-3" />}
-        {busy ? "enqueue 중..." : "강제 실행"}
+        {busy ? t("identity.force_busy") : t("identity.force_button")}
       </button>
       {summaries.length > 0 && (
         <select
@@ -194,16 +197,20 @@ function EmptyState({
   onForce: () => void;
   busy: boolean;
 }) {
+  const { t } = useTranslation("insight");
   return (
     <div className="flex flex-col items-center justify-center h-full p-6 gap-3 text-center">
-      <p className="text-[12px] text-foreground">아직 정체성 분석 결과가 없습니다.</p>
+      <p className="text-[12px] text-foreground">{t("identity.empty_title")}</p>
       <p className="text-[10px] text-muted-foreground max-w-[360px] leading-relaxed">
-        Plan 3개 완료 + eligible artifact 10개 누적 시 자동 실행됩니다.
+        {t("identity.empty_hint")}
         {status && (
           <>
             {" "}
-            현재 Plans done {status.donePlanCount}개, Eligible {status.eligibleArtifactCount}/
-            {status.threshold}.
+            {t("identity.status_summary", {
+              done: status.donePlanCount,
+              eligible: status.eligibleArtifactCount,
+              required: status.threshold,
+            })}
           </>
         )}
       </p>
@@ -212,7 +219,7 @@ function EmptyState({
         disabled={busy}
         className="text-[10px] px-2.5 py-1 rounded bg-accent text-accent-foreground hover:bg-accent/80 disabled:opacity-50"
       >
-        강제 실행 (threshold 무시)
+        {t("identity.force_tooltip")}
       </button>
     </div>
   );
@@ -249,11 +256,12 @@ function SummaryBody({ summary, parsed }: { summary: Artifact; parsed: ParsedIde
 }
 
 function Section({ title, content }: { title: string; content: string }) {
+  const { t } = useTranslation("insight");
   if (!content.trim()) {
     return (
       <div>
         <h4 className="text-[11px] font-semibold text-foreground/80 mb-1">{title}</h4>
-        <p className="text-[10px] text-muted-foreground italic">(데이터 없음)</p>
+        <p className="text-[10px] text-muted-foreground italic">{t("identity.no_data")}</p>
       </div>
     );
   }
@@ -268,13 +276,14 @@ function Section({ title, content }: { title: string; content: string }) {
 }
 
 function InflectionTimeline({ points }: { points: InflectionPoint[] }) {
+  const { t } = useTranslation("insight");
   if (points.length === 0) {
     return (
       <div>
         <h4 className="text-[11px] font-semibold text-foreground/80 mb-1">
           Recent inflection points
         </h4>
-        <p className="text-[10px] text-muted-foreground italic">(데이터 없음)</p>
+        <p className="text-[10px] text-muted-foreground italic">{t("identity.no_data")}</p>
       </div>
     );
   }
@@ -300,11 +309,12 @@ function InflectionTimeline({ points }: { points: InflectionPoint[] }) {
 }
 
 function DoAvoidLists({ items }: { items: { do: string[]; avoid: string[] } }) {
+  const { t } = useTranslation("insight");
   if (items.do.length === 0 && items.avoid.length === 0) {
     return (
       <div>
         <h4 className="text-[11px] font-semibold text-foreground/80 mb-1">Do / Avoid</h4>
-        <p className="text-[10px] text-muted-foreground italic">(데이터 없음)</p>
+        <p className="text-[10px] text-muted-foreground italic">{t("identity.no_data")}</p>
       </div>
     );
   }

--- a/src/components/tunaflow/context-panel/InsightPanel.tsx
+++ b/src/components/tunaflow/context-panel/InsightPanel.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from "react";
+import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
 import { useChatStore } from "@/stores/chatStore";
 import {
@@ -61,6 +62,7 @@ function InsightTabsBar({
 }
 
 function InsightFindingsTab() {
+  const { t } = useTranslation("insight");
   const selectedProjectKey = useChatStore((s) => s.selectedProjectKey);
   const projects = useChatStore((s) => s.projects);
   // Running-analysis state lives in the store so a tab switch (which
@@ -116,7 +118,7 @@ function InsightFindingsTab() {
     if (!selectedProjectKey || running) return;
     const project = projects.find((p) => p.key === selectedProjectKey);
     if (!project?.path) {
-      toast.error("프로젝트 경로 없음");
+      toast.error(t("toast.no_project_path"));
       return;
     }
 
@@ -134,14 +136,14 @@ function InsightFindingsTab() {
       setActiveSession(session);
       setFindings(newFindings);
       setSessions((prev) => [session, ...prev.filter((s) => s.id !== session.id)]);
-      useChatStore.getState().insightAppendProgress(`✓ 완료: ${newFindings.length}건 발견`);
+      useChatStore.getState().insightAppendProgress(t("toast.progress_completed", { count: newFindings.length }));
       useChatStore.getState().insightFinishRun(session.id);
-      toast.success(`분석 완료: ${newFindings.length}건 발견`);
+      toast.success(t("toast.analysis_success", { count: newFindings.length }));
     } catch (err) {
       useChatStore.getState().insightFailRun(String(err));
-      toast.error(`분석 실패: ${formatError(err)}`);
+      toast.error(t("toast.analysis_error", { error: formatError(err) }));
     }
-  }, [selectedProjectKey, projects, categoryFilter, running]);
+  }, [selectedProjectKey, projects, categoryFilter, running, t]);
 
   // Toggle selection
   const handleToggle = useCallback((id: string) => {
@@ -172,11 +174,11 @@ function InsightFindingsTab() {
       setSessions((prev) => prev.filter((s) => s.id !== sessionId));
       setSessionFindings((prev) => { const next = { ...prev }; delete next[sessionId]; return next; });
       setExpandedSessionIds((prev) => { const next = new Set(prev); next.delete(sessionId); return next; });
-      toast.success("이전 분석 삭제됨");
+      toast.success(t("toast.delete_success"));
     } catch (err) {
-      toast.error(`삭제 실패: ${formatError(err)}`);
+      toast.error(t("toast.delete_error", { error: formatError(err) }));
     }
-  }, []);
+  }, [t]);
 
   // Toggle accordion for previous session
   const handleToggleSession = useCallback(async (sessionId: string) => {
@@ -206,53 +208,55 @@ function InsightFindingsTab() {
   const handleExportToFiles = useCallback(async () => {
     if (!activeSession || !selectedProjectKey) return;
     const project = projects.find((p) => p.key === selectedProjectKey);
-    if (!project?.path) { toast.error("프로젝트 경로 없음"); return; }
+    if (!project?.path) { toast.error(t("toast.no_project_path")); return; }
     try {
       const count = await insightApi.exportInsightToFiles(activeSession.id, project.path);
-      toast.success(`${count}개 파일 저장 완료 (docs/insight/)`);
+      toast.success(t("toast.save_success", { count }));
     } catch (err) {
-      toast.error(`파일 저장 실패: ${formatError(err)}`);
+      toast.error(t("toast.save_error", { error: formatError(err) }));
     }
-  }, [activeSession, selectedProjectKey, projects]);
+  }, [activeSession, selectedProjectKey, projects, t]);
 
   // Send findings to Architect via a new Review Branch (B안)
   const handleSendToArchitect = useCallback(async (targetFindings: InsightFinding[]) => {
     if (targetFindings.length === 0) return;
     const store = useChatStore.getState();
     const convId = store.selectedConversationId;
-    if (!convId) { toast.error("대화를 먼저 선택해주세요"); return; }
+    if (!convId) { toast.error(t("toast.select_conversation_first")); return; }
 
     const lines = targetFindings.map((f) => {
-      let entry = `### ${f.title}\n- **카테고리**: ${f.category} | **심각도**: ${f.severity} | **난이도**: ${f.fixDifficulty}`;
-      if (f.filePath) entry += `\n- **위치**: \`${f.filePath}${f.lineNumber ? `:${f.lineNumber}` : ""}\``;
-      entry += `\n- **설명**: ${f.description}`;
+      const location = f.filePath
+        ? t("review_prompt.entry_location", {
+            path: f.filePath,
+            line: f.lineNumber ? `:${f.lineNumber}` : "",
+          })
+        : "";
+      let entry = t("review_prompt.entry", {
+        title: f.title,
+        category: f.category,
+        severity: f.severity,
+        difficulty: f.fixDifficulty,
+        location,
+        description: f.description,
+      });
       if (f.snippet) entry += `\n\`\`\`\n${f.snippet.slice(0, 300)}\n\`\`\``;
       return entry;
     });
 
-    const prompt = `## Insight 분석 결과 검토 요청
-
-다음 ${targetFindings.length}건의 코드 품질 이슈를 검토해주세요.
-
-각 항목에 대해 **자율적으로 판단**해주세요:
-- 관련 파일을 직접 읽고 현재 상태 확인
-- Plan으로 승격할지, 단순 메모로 처리할지, 이미 해결됐는지 판단
-- Plan이 필요하다면 여러 항목을 묶어 하나의 plan-proposal로 작성 (불필요한 Plan 낭비 방지)
-- Plan 없이 처리 가능한 것들은 처리 방법을 간략히 설명
-
----
-
-${lines.join("\n\n")}`;
+    const prompt = t("review_prompt.body", {
+      count: targetFindings.length,
+      findings: lines.join("\n\n"),
+    });
 
     try {
       // Create Architect Review Branch
-      await store.createBranch(convId, undefined, `Insight Review (${targetFindings.length}건)`, "chat");
+      await store.createBranch(convId, undefined, t("review_prompt.branch_label", { count: targetFindings.length }), "chat");
       // Branch is now at top of list — find it
       const newBranch = useChatStore.getState().branches
         .filter((b) => b.conversationId === convId && b.mode !== "roundtable")
         .sort((a, b) => b.createdAt - a.createdAt)[0];
 
-      if (!newBranch) { toast.error("브랜치 생성 실패"); return; }
+      if (!newBranch) { toast.error(t("toast.branch_creation_failed")); return; }
 
       // Handoff to Architect = findings done from Insight's perspective. Mark
       // them resolved immediately so the user's "needs action" queue stays
@@ -276,11 +280,11 @@ ${lines.join("\n\n")}`;
         store.sendThreadMessage(prompt);
       }, 300);
 
-      toast.success(`Architect Review Branch 생성 → ${targetFindings.length}건 전달`);
+      toast.success(t("toast.branch_send_success", { count: targetFindings.length }));
     } catch (err) {
-      toast.error(`브랜치 생성 실패: ${formatError(err)}`);
+      toast.error(t("toast.branch_creation_error", { error: formatError(err) }));
     }
-  }, []);
+  }, [t]);
 
   // Revalidate open findings against current codebase. Routes the same
   // store-backed progress path as handleRunAnalysis so revalidation
@@ -288,11 +292,11 @@ ${lines.join("\n\n")}`;
   const handleRevalidate = useCallback(async () => {
     if (running || !selectedProjectKey) return;
     const openCount = findings.filter((f) => f.status === "open").length;
-    if (openCount === 0) { toast.info("재검토할 open findings가 없습니다"); return; }
+    if (openCount === 0) { toast.info(t("toast.rerun_no_open")); return; }
 
     const store = useChatStore.getState();
     store.insightStartRun();
-    store.insightAppendProgress(`${openCount}건 재검토 중...`);
+    store.insightAppendProgress(t("toast.rerun_progress", { count: openCount }));
     try {
       const results = await revalidateFindings(
         findings,
@@ -314,15 +318,18 @@ ${lines.join("\n\n")}`;
       }
 
       const msg = resolved.length > 0
-        ? `재검토 완료: ${resolved.length}건 해결됨으로 업데이트${uncertain.length > 0 ? `, ${uncertain.length}건 불확실` : ""}`
-        : `재검토 완료: 모든 findings가 여전히 유효합니다`;
+        ? t("toast.rerun_done_resolved", {
+            count: resolved.length,
+            suffix: uncertain.length > 0 ? t("toast.rerun_uncertain_suffix", { count: uncertain.length }) : "",
+          })
+        : t("toast.rerun_done_all_valid");
       useChatStore.getState().insightFinishRun();
       toast.success(msg);
     } catch (err) {
       useChatStore.getState().insightFailRun(String(err));
-      toast.error(`재검토 실패: ${formatError(err)}`);
+      toast.error(t("toast.rerun_error", { error: formatError(err) }));
     }
-  }, [running, findings, selectedProjectKey]);
+  }, [running, findings, selectedProjectKey, t]);
 
   // Auto fix — disabled, pending meta-agent (see docs/ideas/onboardingMetaAgentIdea.md §8)
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -354,7 +361,7 @@ ${lines.join("\n\n")}`;
       : activeFinding ? "finding" : "none";
 
   if (!selectedProjectKey) {
-    return <div className="p-4 text-center text-muted-foreground/50 text-xs">프로젝트를 선택하세요</div>;
+    return <div className="p-4 text-center text-muted-foreground/50 text-xs">{t("panel.empty_project")}</div>;
   }
 
   return (
@@ -372,7 +379,7 @@ ${lines.join("\n\n")}`;
           )}
         >
           {running ? <Loader2 className="w-3 h-3 animate-spin" /> : <Play className="w-3 h-3" />}
-          {running ? "분석 중..." : "분석 실행"}
+          {running ? t("action.run_analysis_busy") : t("action.run_analysis")}
         </button>
 
         {activeSession && findings.length > 0 && (
@@ -380,10 +387,10 @@ ${lines.join("\n\n")}`;
             onClick={handleRevalidate}
             disabled={running}
             className="flex items-center gap-0.5 text-[10px] px-1.5 py-0.5 rounded text-prose-muted hover:text-foreground hover:bg-muted/30 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
-            title="현재 코드 기반으로 open findings 재검토"
+            title={t("action.rerun_tooltip")}
           >
             <RefreshCw className="w-3 h-3" />
-            재검토
+            {t("action.rerun_button")}
           </button>
         )}
 
@@ -391,10 +398,10 @@ ${lines.join("\n\n")}`;
           <button
             onClick={handleExportToFiles}
             className="flex items-center gap-0.5 text-[10px] px-1.5 py-0.5 rounded text-prose-muted hover:text-foreground hover:bg-muted/30 transition-colors"
-            title="docs/insight/ 에 파일 저장"
+            title={t("action.save_tooltip")}
           >
             <Download className="w-3 h-3" />
-            저장
+            {t("action.save_button")}
           </button>
         )}
 
@@ -405,9 +412,9 @@ ${lines.join("\n\n")}`;
           onChange={(e) => setCategoryFilter(e.target.value as InsightCategory | "all")}
           className="text-[10px] bg-transparent border border-border/30 rounded px-1.5 py-0.5 text-foreground"
         >
-          <option value="all">전체 카테고리</option>
-          {Object.entries(CATEGORY_META).map(([k, v]) => (
-            <option key={k} value={k}>{v.label}</option>
+          <option value="all">{t("panel.all_categories")}</option>
+          {Object.keys(CATEGORY_META).map((k) => (
+            <option key={k} value={k}>{t(`category.${k}` as "category.stability")}</option>
           ))}
         </select>
 
@@ -453,8 +460,8 @@ ${lines.join("\n\n")}`;
             <span className="w-px h-2.5 bg-border/30" />
             <span className="text-prose-disabled">
               {open > 0 && <span className="text-foreground/50">{open} open</span>}
-              {inProgress > 0 && <span className="ml-1.5 text-primary/50">{inProgress} 진행 중</span>}
-              {resolved > 0 && <span className="ml-1.5 text-status-approved/60">{resolved}/{total} 해결</span>}
+              {inProgress > 0 && <span className="ml-1.5 text-primary/50">{t("panel.progress_in_progress", { count: inProgress })}</span>}
+              {resolved > 0 && <span className="ml-1.5 text-status-approved/60">{t("panel.progress_resolved", { resolved, total })}</span>}
             </span>
             {resolved > 0 && (
               <div className="ml-auto w-20 h-1 bg-muted/40 rounded-full overflow-hidden">
@@ -487,11 +494,11 @@ ${lines.join("\n\n")}`;
                     {allSelected
                       ? <CheckSquare className="w-3 h-3 text-accent" />
                       : <Square className="w-3 h-3 text-muted-foreground/40" />}
-                    전체 선택
+                    {t("action.select_all")}
                   </button>
                   {selectedIds.size > 0 && (
                     <>
-                      <span className="text-[10px] text-prose-disabled">{selectedIds.size}개 선택됨</span>
+                      <span className="text-[10px] text-prose-disabled">{t("action.selected_count", { count: selectedIds.size })}</span>
                       <button
                         onClick={() => {
                           const selected = findings.filter((f) => selectedIds.has(f.id));
@@ -500,13 +507,13 @@ ${lines.join("\n\n")}`;
                         className="flex items-center gap-0.5 text-[10px] text-primary hover:text-primary/80 px-1.5 py-0.5 rounded border border-primary/30"
                       >
                         <GitBranch className="w-2.5 h-2.5" />
-                        Architect 검토
+                        {t("action.architect_review_button")}
                       </button>
                       <button
                         onClick={handleDismiss}
                         className="text-[10px] text-prose-faint hover:text-foreground px-1.5 py-0.5 rounded border border-border/30"
                       >
-                        무시
+                        {t("action.dismiss_button")}
                       </button>
                     </>
                   )}
@@ -520,19 +527,19 @@ ${lines.join("\n\n")}`;
             </>
           ) : activeSession ? (
             <div className="text-center text-prose-faint text-tf-sm py-8">
-              {activeSession.status === "completed" ? "발견 사항 없음" : activeSession.summary || "세션 로드 중..."}
+              {activeSession.status === "completed" ? t("panel.no_findings") : activeSession.summary || t("panel.session_loading")}
             </div>
           ) : (
             <div className="text-center text-prose-faint text-tf-sm py-8">
-              <p>아직 분석을 실행하지 않았습니다.</p>
-              <p className="mt-1">"분석 실행" 버튼으로 프로젝트 품질을 분석하세요.</p>
+              <p>{t("panel.no_analysis_yet")}</p>
+              <p className="mt-1">{t("panel.no_analysis_hint")}</p>
             </div>
           )}
 
           {/* Previous sessions — accordion */}
           {sessions.length > 1 && (
             <div className="pt-3 border-t border-border/20 space-y-1">
-              <p className="text-[10px] font-semibold text-prose-disabled uppercase tracking-wider mb-2">이전 분석</p>
+              <p className="text-[10px] font-semibold text-prose-disabled uppercase tracking-wider mb-2">{t("panel.previous_analysis")}</p>
               {sessions.slice(1).map((s) => {
                 const expanded = expandedSessionIds.has(s.id);
                 const sFindings = sessionFindings[s.id];
@@ -557,7 +564,7 @@ ${lines.join("\n\n")}`;
                       <button
                         onClick={() => handleDeleteSession(s.id)}
                         className="shrink-0 p-0.5 rounded text-prose-disabled hover:text-destructive hover:bg-destructive/10 transition-colors"
-                        title="삭제"
+                        title={t("action.delete_tooltip")}
                       >
                         <Trash2 className="w-3 h-3" />
                       </button>
@@ -567,10 +574,10 @@ ${lines.join("\n\n")}`;
                       <div className="border-t border-border/10 px-2 py-1.5 space-y-1">
                         {sFindings === undefined ? (
                           <div className="flex items-center gap-1 text-[9px] text-prose-disabled py-1">
-                            <Loader2 className="w-2.5 h-2.5 animate-spin" /> 로드 중...
+                            <Loader2 className="w-2.5 h-2.5 animate-spin" /> {t("panel.loading")}
                           </div>
                         ) : sFindings.length === 0 ? (
-                          <p className="text-[9px] text-prose-faint py-1">발견 사항 없음</p>
+                          <p className="text-[9px] text-prose-faint py-1">{t("panel.no_findings")}</p>
                         ) : (
                           sFindings.map((f) => (
                             <button
@@ -615,7 +622,7 @@ ${lines.join("\n\n")}`;
               /* Progress log — streaming style */
               <div className="flex-1 overflow-y-auto p-3">
                 <p className="text-[9px] font-semibold uppercase tracking-wider text-prose-disabled mb-2">
-                  {running ? "분석 진행 중..." : "마지막 분석 로그"}
+                  {running ? t("panel.running_log") : t("panel.last_log")}
                 </p>
                 <div className="space-y-0.5 font-mono">
                   {progressLines.map((line, i) => (
@@ -623,7 +630,7 @@ ${lines.join("\n\n")}`;
                       "text-[10px] leading-relaxed",
                       line.startsWith("✓") ? "text-status-approved/80" :
                       line.startsWith("✗") ? "text-destructive/80" :
-                      line.includes("실패") || line.includes("없음") ? "text-prose-disabled" :
+                      line.includes(t("log_hint.failure")) || line.includes(t("log_hint.empty")) ? "text-prose-disabled" :
                       "text-prose-muted",
                     )}>
                       {line}
@@ -631,7 +638,7 @@ ${lines.join("\n\n")}`;
                   ))}
                   {running && (
                     <div className="flex items-center gap-1 text-[10px] text-primary/60 animate-pulse mt-1">
-                      <Loader2 className="w-2.5 h-2.5 animate-spin" /> 처리 중...
+                      <Loader2 className="w-2.5 h-2.5 animate-spin" /> {t("panel.processing")}
                     </div>
                   )}
                   <div ref={progressEndRef} />

--- a/src/components/tunaflow/context-panel/insight/InsightFindingCards.tsx
+++ b/src/components/tunaflow/context-panel/insight/InsightFindingCards.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
 import { CheckSquare, Square, CheckCircle2, Clock, GitBranch } from "lucide-react";
 import type { InsightFinding, InsightSeverity } from "@/types";
@@ -90,6 +91,7 @@ export function FindingRow({
 // ── Detail panel ─────────────────────────────────────────────
 
 export function FindingDetail({ finding, onSendToArchitect }: { finding: InsightFinding; onSendToArchitect?: (f: InsightFinding) => void }) {
+  const { t } = useTranslation("insight");
   const catMeta = CATEGORY_META[finding.category];
   const sevMeta = SEVERITY_META[finding.severity];
 
@@ -127,7 +129,7 @@ export function FindingDetail({ finding, onSendToArchitect }: { finding: Insight
       {/* Code snippet */}
       {finding.snippet && (
         <div>
-          <p className="text-tf-xs text-prose-faint mb-1">코드</p>
+          <p className="text-tf-xs text-prose-faint mb-1">{t("finding_card.code_label")}</p>
           <pre className="text-tf-sm bg-[#1e1e1e] text-[#d4d4d4] rounded-md p-3 overflow-x-auto font-mono leading-relaxed">
             {finding.snippet}
           </pre>
@@ -137,7 +139,7 @@ export function FindingDetail({ finding, onSendToArchitect }: { finding: Insight
       {/* Resolution (resolved/done findings) */}
       {finding.resolution && (
         <div>
-          <p className="text-tf-xs text-status-approved/70 mb-1 font-medium">해결 방법</p>
+          <p className="text-tf-xs text-status-approved/70 mb-1 font-medium">{t("finding_card.solution_label")}</p>
           <div className="text-tf-sm text-prose-base bg-status-approved/5 border border-status-approved/20 rounded-md p-3 whitespace-pre-wrap">
             {finding.resolution}
           </div>
@@ -147,7 +149,7 @@ export function FindingDetail({ finding, onSendToArchitect }: { finding: Insight
       {/* Meta */}
       {finding.estimatedFiles && finding.estimatedFiles > 1 && (
         <p className="text-tf-xs text-prose-disabled">
-          예상 수정 파일: {finding.estimatedFiles}개
+          {t("finding_card.estimated_files", { count: finding.estimatedFiles })}
         </p>
       )}
 
@@ -158,7 +160,7 @@ export function FindingDetail({ finding, onSendToArchitect }: { finding: Insight
           className="flex items-center gap-1 text-tf-xs px-2 py-1 rounded font-medium bg-primary/10 text-primary hover:bg-primary/20 transition-colors"
         >
           <GitBranch className="w-3 h-3" />
-          Architect 검토
+          {t("finding_card.architect_review_button")}
         </button>
       )}
     </div>

--- a/src/components/tunaflow/context-panel/insight/InsightQuadrant.tsx
+++ b/src/components/tunaflow/context-panel/insight/InsightQuadrant.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import type { InsightFinding } from "@/types";
 import type { QuadrantKey } from "./insightConstants";
@@ -28,6 +29,7 @@ export function QuadrantSection({
   onSelect: (f: InsightFinding) => void;
   onAutoFix?: () => void;
 }) {
+  const { t } = useTranslation("insight");
   const [collapsed, setCollapsed] = useState(quadrant === "deprioritize");
   const meta = QUADRANT_META[quadrant];
   const open = findings.filter((f) => f.status !== "resolved" && f.status !== "dismissed");
@@ -47,10 +49,10 @@ export function QuadrantSection({
         </button>
         {quadrant === "quick-wins" && open.length > 0 && (
           <span
-            title="메타에이전트 도입 후 활성화 예정"
+            title={t("quadrant.auto_fix_tooltip")}
             className="text-tf-micro px-1.5 py-0.5 rounded bg-muted/30 text-prose-disabled cursor-not-allowed"
           >
-            Auto Fix (준비 중)
+            {t("quadrant.auto_fix_label")}
           </span>
         )}
       </div>

--- a/src/locales/en/insight.json
+++ b/src/locales/en/insight.json
@@ -1,0 +1,88 @@
+{
+  "category": {
+    "stability": "Stability",
+    "test": "Test",
+    "architecture": "Architecture",
+    "performance": "Performance",
+    "security": "Security",
+    "debt": "Tech debt"
+  },
+  "quadrant": {
+    "auto_fix_tooltip": "Will be enabled after meta-agent introduction",
+    "auto_fix_label": "Auto Fix (coming)"
+  },
+  "finding_card": {
+    "code_label": "Code",
+    "solution_label": "Solution",
+    "estimated_files": "Estimated files: {{count}}",
+    "architect_review_button": "Architect review"
+  },
+  "panel": {
+    "empty_project": "Select a project",
+    "all_categories": "All categories",
+    "no_findings": "No findings",
+    "no_analysis_yet": "No analysis has been run yet.",
+    "no_analysis_hint": "Click \"Run analysis\" to analyze project quality.",
+    "session_loading": "Loading session...",
+    "previous_analysis": "Previous analyses",
+    "last_log": "Last analysis log",
+    "running_log": "Analysis in progress...",
+    "processing": "Processing...",
+    "loading": "Loading...",
+    "progress_in_progress": "{{count}} in progress",
+    "progress_resolved": "{{resolved}}/{{total}} resolved"
+  },
+  "action": {
+    "run_analysis": "Run analysis",
+    "run_analysis_busy": "Analyzing...",
+    "rerun_button": "Re-check",
+    "rerun_tooltip": "Revalidate open findings against current code",
+    "save_button": "Save",
+    "save_tooltip": "Save files under docs/insight/",
+    "select_all": "Select all",
+    "selected_count": "{{count}} selected",
+    "architect_review_button": "Architect review",
+    "dismiss_button": "Dismiss",
+    "delete_tooltip": "Delete"
+  },
+  "toast": {
+    "no_project_path": "Project path not found",
+    "progress_completed": "✓ Done: {{count}} findings",
+    "analysis_success": "Analysis complete: {{count}} findings",
+    "analysis_error": "Analysis failed: {{error}}",
+    "delete_success": "Previous analysis deleted",
+    "delete_error": "Delete failed: {{error}}",
+    "save_success": "Saved {{count}} files (docs/insight/)",
+    "save_error": "File save failed: {{error}}",
+    "select_conversation_first": "Select a conversation first",
+    "branch_send_success": "Architect Review Branch created → {{count}} sent",
+    "branch_creation_failed": "Branch creation failed",
+    "branch_creation_error": "Branch creation failed: {{error}}",
+    "rerun_no_open": "No open findings to re-check",
+    "rerun_progress": "Re-checking {{count}} findings...",
+    "rerun_done_resolved": "Re-check done: {{count}} updated to resolved{{suffix}}",
+    "rerun_uncertain_suffix": ", {{count}} uncertain",
+    "rerun_done_all_valid": "Re-check done: all findings still valid",
+    "rerun_error": "Re-check failed: {{error}}"
+  },
+  "log_hint": {
+    "failure": "fail",
+    "empty": "none"
+  },
+  "review_prompt": {
+    "body": "## Insight analysis review request\n\nPlease review the following {{count}} code quality issues.\n\nFor each item, use **autonomous judgment**:\n- Read the relevant files and verify the current state\n- Decide whether to promote as Plan, record as memo, or mark already-resolved\n- If a Plan is needed, bundle multiple items into one plan-proposal (avoid unnecessary Plans)\n- For items that don't need a Plan, briefly describe the handling\n\n---\n\n{{findings}}",
+    "entry": "### {{title}}\n- **Category**: {{category}} | **Severity**: {{severity}} | **Difficulty**: {{difficulty}}{{location}}\n- **Description**: {{description}}",
+    "entry_location": "\n- **Location**: `{{path}}{{line}}`",
+    "branch_label": "Insight Review ({{count}})"
+  },
+  "identity": {
+    "empty_project": "Select a project.",
+    "force_button": "Force run",
+    "force_tooltip": "Force run (ignore threshold)",
+    "force_busy": "Enqueuing...",
+    "empty_title": "No identity analysis yet.",
+    "empty_hint": "Runs automatically after 3 completed Plans + 10 eligible artifacts accumulated.",
+    "status_summary": "Current Plans done {{done}}, Eligible {{eligible}}/{{required}}",
+    "no_data": "(no data)"
+  }
+}

--- a/src/locales/index.ts
+++ b/src/locales/index.ts
@@ -10,6 +10,7 @@ import koChat from "./ko/chat.json";
 import koDialog from "./ko/dialog.json";
 import koWorkflow from "./ko/workflow.json";
 import koBranch from "./ko/branch.json";
+import koInsight from "./ko/insight.json";
 import enCommon from "./en/common.json";
 import enError from "./en/error.json";
 import enSettings from "./en/settings.json";
@@ -18,6 +19,7 @@ import enChat from "./en/chat.json";
 import enDialog from "./en/dialog.json";
 import enWorkflow from "./en/workflow.json";
 import enBranch from "./en/branch.json";
+import enInsight from "./en/insight.json";
 
 /** Supported locales. Add 'ja', 'zh', etc. in later PRs. */
 export type SupportedLocale = "ko" | "en";
@@ -37,6 +39,7 @@ export const resources = {
     dialog: koDialog,
     workflow: koWorkflow,
     branch: koBranch,
+    insight: koInsight,
   },
   en: {
     common: enCommon,
@@ -47,6 +50,7 @@ export const resources = {
     dialog: enDialog,
     workflow: enWorkflow,
     branch: enBranch,
+    insight: enInsight,
   },
 } as const;
 
@@ -60,7 +64,7 @@ i18n
     // 누락 키는 빈 문자열 대신 키 그대로 표시 → 누락 즉시 인지.
     returnEmptyString: false,
     defaultNS: "common",
-    ns: ["common", "error", "settings", "sidebar", "chat", "dialog", "workflow", "branch"],
+    ns: ["common", "error", "settings", "sidebar", "chat", "dialog", "workflow", "branch", "insight"],
     detection: {
       // appStore (IndexedDB) 우선, 그 다음 localStorage/navigator.
       order: ["localStorage", "navigator"],

--- a/src/locales/ko/insight.json
+++ b/src/locales/ko/insight.json
@@ -1,0 +1,88 @@
+{
+  "category": {
+    "stability": "안정성",
+    "test": "테스트",
+    "architecture": "아키텍처",
+    "performance": "성능",
+    "security": "보안",
+    "debt": "기술 부채"
+  },
+  "quadrant": {
+    "auto_fix_tooltip": "메타에이전트 도입 후 활성화 예정",
+    "auto_fix_label": "Auto Fix (준비 중)"
+  },
+  "finding_card": {
+    "code_label": "코드",
+    "solution_label": "해결 방법",
+    "estimated_files": "예상 수정 파일: {{count}}개",
+    "architect_review_button": "Architect 검토"
+  },
+  "panel": {
+    "empty_project": "프로젝트를 선택하세요",
+    "all_categories": "전체 카테고리",
+    "no_findings": "발견 사항 없음",
+    "no_analysis_yet": "아직 분석을 실행하지 않았습니다.",
+    "no_analysis_hint": "\"분석 실행\" 버튼으로 프로젝트 품질을 분석하세요.",
+    "session_loading": "세션 로드 중...",
+    "previous_analysis": "이전 분석",
+    "last_log": "마지막 분석 로그",
+    "running_log": "분석 진행 중...",
+    "processing": "처리 중...",
+    "loading": "로드 중...",
+    "progress_in_progress": "{{count}} 진행 중",
+    "progress_resolved": "{{resolved}}/{{total}} 해결"
+  },
+  "action": {
+    "run_analysis": "분석 실행",
+    "run_analysis_busy": "분석 중...",
+    "rerun_button": "재검토",
+    "rerun_tooltip": "현재 코드 기반으로 open findings 재검토",
+    "save_button": "저장",
+    "save_tooltip": "docs/insight/ 에 파일 저장",
+    "select_all": "전체 선택",
+    "selected_count": "{{count}}개 선택됨",
+    "architect_review_button": "Architect 검토",
+    "dismiss_button": "무시",
+    "delete_tooltip": "삭제"
+  },
+  "toast": {
+    "no_project_path": "프로젝트 경로 없음",
+    "progress_completed": "✓ 완료: {{count}}건 발견",
+    "analysis_success": "분석 완료: {{count}}건 발견",
+    "analysis_error": "분석 실패: {{error}}",
+    "delete_success": "이전 분석 삭제됨",
+    "delete_error": "삭제 실패: {{error}}",
+    "save_success": "{{count}}개 파일 저장 완료 (docs/insight/)",
+    "save_error": "파일 저장 실패: {{error}}",
+    "select_conversation_first": "대화를 먼저 선택해주세요",
+    "branch_send_success": "Architect Review Branch 생성 → {{count}}건 전달",
+    "branch_creation_failed": "브랜치 생성 실패",
+    "branch_creation_error": "브랜치 생성 실패: {{error}}",
+    "rerun_no_open": "재검토할 open findings가 없습니다",
+    "rerun_progress": "{{count}}건 재검토 중...",
+    "rerun_done_resolved": "재검토 완료: {{count}}건 해결됨으로 업데이트{{suffix}}",
+    "rerun_uncertain_suffix": ", {{count}}건 불확실",
+    "rerun_done_all_valid": "재검토 완료: 모든 findings가 여전히 유효합니다",
+    "rerun_error": "재검토 실패: {{error}}"
+  },
+  "log_hint": {
+    "failure": "실패",
+    "empty": "없음"
+  },
+  "review_prompt": {
+    "body": "## Insight 분석 결과 검토 요청\n\n다음 {{count}}건의 코드 품질 이슈를 검토해주세요.\n\n각 항목에 대해 **자율적으로 판단**해주세요:\n- 관련 파일을 직접 읽고 현재 상태 확인\n- Plan으로 승격할지, 단순 메모로 처리할지, 이미 해결됐는지 판단\n- Plan이 필요하다면 여러 항목을 묶어 하나의 plan-proposal로 작성 (불필요한 Plan 낭비 방지)\n- Plan 없이 처리 가능한 것들은 처리 방법을 간략히 설명\n\n---\n\n{{findings}}",
+    "entry": "### {{title}}\n- **카테고리**: {{category}} | **심각도**: {{severity}} | **난이도**: {{difficulty}}{{location}}\n- **설명**: {{description}}",
+    "entry_location": "\n- **위치**: `{{path}}{{line}}`",
+    "branch_label": "Insight Review ({{count}}건)"
+  },
+  "identity": {
+    "empty_project": "프로젝트를 선택하세요.",
+    "force_button": "강제 실행",
+    "force_tooltip": "강제 실행 (threshold 무시)",
+    "force_busy": "enqueue 중...",
+    "empty_title": "아직 정체성 분석 결과가 없습니다.",
+    "empty_hint": "Plan 3개 완료 + eligible artifact 10개 누적 시 자동 실행됩니다.",
+    "status_summary": "현재 Plans done {{done}}개, Eligible {{eligible}}/{{required}}",
+    "no_data": "(데이터 없음)"
+  }
+}

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -14,6 +14,7 @@ import type koChat from "../locales/ko/chat.json";
 import type koDialog from "../locales/ko/dialog.json";
 import type koWorkflow from "../locales/ko/workflow.json";
 import type koBranch from "../locales/ko/branch.json";
+import type koInsight from "../locales/ko/insight.json";
 
 declare module "i18next" {
   interface CustomTypeOptions {
@@ -27,6 +28,7 @@ declare module "i18next" {
       dialog: typeof koDialog;
       workflow: typeof koWorkflow;
       branch: typeof koBranch;
+      insight: typeof koInsight;
     };
   }
 }


### PR DESCRIPTION
## Summary

i18n PR A 의 A2-G 슬라이스. `insight` namespace 신설 + Insight 탭 전체 UI 전환.

### 전환된 파일

| 파일 | 범위 |
|---|---|
| `locales/{ko,en}/insight.json` | 신규 — category/quadrant/finding_card/panel/action/toast/log_hint/review_prompt/identity (~50 키) |
| `locales/index.ts` / `types/i18next.d.ts` | insight namespace 등록 |
| `InsightPanel.tsx` | 분석 실행·재검토·저장 버튼 / 카테고리 필터 / findings 목록 / progress 로그 / 이전 분석 accordion / 모든 토스트 |
| `IdentityView.tsx` | empty 상태 / 강제 실행 버튼 / status summary / `(데이터 없음)` placeholder (Section / InflectionTimeline / DoAvoidLists) |
| `insight/InsightFindingCards.tsx` | FindingDetail: 코드 / 해결 방법 / 예상 수정 파일 / Architect 검토 |
| `insight/InsightQuadrant.tsx` | Auto Fix (준비 중) tooltip + label |

### INV-6 적용 (user locale 기반 agent prompt)

- `insight.review_prompt.body` — Architect Review Branch 로 전달되는 Insight 검토 요청 템플릿
- `insight.review_prompt.entry` / `entry_location` — finding 항목 포맷
- `insight.review_prompt.branch_label` — `Insight Review (N건)` 브랜치 라벨

### 범위 외 (유지)

- `insightConstants.tsx` 의 `CATEGORY_META.label` 필드 자체 (breaking change 피함). 실사용처 (InsightPanel 필터 option / InsightFindingCards) 에서는 `t(\`category.\${k}\`)` 로 override.
- `QUADRANT_META` 는 영어 고정 (Quick Wins / Strategic / Fill-ins / Deprioritize — 제품 용어).

## Test plan

- [x] `npx tsc --noEmit` 통과
- [x] `npx vitest run` 322 통과
- [ ] 수동 확인: Settings → Language ko/en 토글 후
  - Insight 탭: 분석 실행 / 재검토 / 저장 버튼
  - 카테고리 필터 드롭다운 (안정성/테스트/… ↔ Stability/Test/…)
  - 발견 사항 선택 → Architect 검토 → 토스트 `Architect Review Branch 생성 → N건 전달`
  - 재검토 결과 토스트 (resolved 일부 + uncertain 포함/미포함)
  - Identity 탭: empty state + 강제 실행 버튼 + status summary
  - Finding detail: 코드 / 해결 방법 / 예상 수정 파일 / Architect 검토 버튼

## 후속 작업 (남은 범위)

- **A2-E-msg**: DevProgressView 4 agent prompts + PlanProposalCard 2 agent prompts + pre 예시
- **A3**: Rust 페르소나 + 도구 영어화 (defaultPersonas / tool_handler / roundtable_helpers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)