### PR TITLE
feat(i18n): PR A2-E-msg — DevProgressView/PlanProposalCard agent prompt 템플릿 전환

### DIFF
--- a/src/components/tunaflow/chat/PlanProposalCard.tsx
+++ b/src/components/tunaflow/chat/PlanProposalCard.tsx
@@ -310,27 +310,17 @@ export function PlanProposalCard({ proposal, conversationId }: PlanProposalCardP
       ).join("\n");
 
       const taskFiles = proposal.subtasks.map((s, i) =>
-        `- \`docs/plans/${slug}-task-${String(i + 1).padStart(2, "0")}.md\` — ${s.title}`
-      );
-      const docPrompt = [
-        `### 📋 문서 작성 요청`,
-        ``,
-        `**Plan**: "${proposal.title}"`,
-        ``,
-        `**작성할 문서**:`,
-        `- \`docs/plans/${slug}.md\` — 전체 계획서`,
-        ...taskFiles,
-        ``,
-        `**각 작업 지시서 포함 내용**:`,
-        `- **Changed files** — 대상 파일 경로 (가능하면 줄번호까지)`,
-        `- **Change description** — 구현 접근법 (단계별)`,
-        `- **Dependencies** — 의존성 (패키지, 다른 subtask)`,
-        `- **Verification** — 완료를 증명하는 **실행 가능한 셸 명령** (예: \`cargo test\`, \`npx tsc --noEmit\`)`,
-        `- **Risks** — 리스크 및 주의사항`,
-        `- **Scope boundary** — 수정 금지 파일 목록 (다른 task 영역 침범 방지)`,
-        ``,
-        `> 완료 조건: 모든 문서 작성 후 알려주세요`,
-      ].join("\n");
+        t("proposal.doc_prompt.task_line", {
+          slug,
+          num: String(i + 1).padStart(2, "0"),
+          title: s.title,
+        })
+      ).join("\n");
+      const docPrompt = t("proposal.doc_prompt.body", {
+        title: proposal.title,
+        slug,
+        taskFiles,
+      });
 
       await sendWithEngine(
         useChatStore.getState().getConversationEngine(conversationId)?.engine ?? "claude",
@@ -406,9 +396,7 @@ export function PlanProposalCard({ proposal, conversationId }: PlanProposalCardP
         <p className="text-amber-400 font-medium">{t("proposal.warn_empty.title")}</p>
         <p className="text-muted-foreground text-[11px]">{t("proposal.warn_empty.body")}</p>
         <pre className="text-[10px] text-muted-foreground/70 bg-black/20 rounded px-2 py-1.5 font-mono leading-relaxed">
-{`### Subtasks        ← 삼중 # 필수
-1. 첫 번째 작업 — 설명
-2. 두 번째 작업 — 설명`}
+          {t("proposal.example_subtasks_markdown")}
         </pre>
         <p className="text-muted-foreground/60 text-[10px]">
           {t("proposal.warn_empty.counter_example_double_hash")} &nbsp;·&nbsp;
@@ -532,7 +520,10 @@ export function PlanProposalCard({ proposal, conversationId }: PlanProposalCardP
             <button
               onClick={async () => {
                 if (!revisionInput.trim()) return;
-                const feedback = `[Plan 수정 요청: ${proposal.title}]\n\n${revisionInput.trim()}\n\n위 피드백을 반영하여 Plan을 수정하고 \`<!-- tunaflow:plan-proposal -->\` 형식으로 다시 제안하세요.`;
+                const feedback = t("proposal.revision_feedback_prompt", {
+                  title: proposal.title,
+                  feedback: revisionInput.trim(),
+                });
                 setStatus("idle");
                 setRevisionInput("");
                 await sendWithEngine("claude", feedback);

--- a/src/components/tunaflow/context-panel/DevProgressView.tsx
+++ b/src/components/tunaflow/context-panel/DevProgressView.tsx
@@ -68,7 +68,11 @@ export function DevProgressView({ plan, onPlanUpdate }: DevProgressViewProps) {
     setBusy(true);
     try {
       await openThread(plan.implementationBranchId);
-      const prompt = `Subtask ${index + 1} "${subtask.title}"을(를) 다시 구현해주세요.\n\n상세 설계:\n${subtask.details ?? "(없음)"}`;
+      const prompt = t("progress.rerun_prompt", {
+        num: index + 1,
+        title: subtask.title,
+        details: subtask.details ?? t("progress.rerun_details_empty"),
+      });
       const shadowConvId = `branch:${plan.implementationBranchId}`;
       const saved = useChatStore.getState().getConversationEngine(shadowConvId);
       await sendThreadMessage(prompt, saved?.engine ?? "claude", saved?.model ?? undefined);
@@ -112,32 +116,27 @@ export function DevProgressView({ plan, onPlanUpdate }: DevProgressViewProps) {
       const isScoped = failedIds.length > 0 && reviewVerdict;
 
       const prevFindingsBlock = reviewVerdict && reviewVerdict.findings.length > 0
-        ? [``, `**이전 Review Findings (중점 확인 대상)**:`,
-           ...reviewVerdict.findings.map((f, i) => `${i + 1}. ${f.slice(0, 500)}`),
-           ``, `> 위 사항이 해결되었는지 확인하세요.`]
-        : [];
+        ? "\n\n" + t("progress.review_prompt.prev_findings_header") + "\n"
+          + reviewVerdict.findings.map((f, i) => `${i + 1}. ${f.slice(0, 500)}`).join("\n")
+          + "\n\n" + t("progress.review_prompt.prev_findings_footer")
+        : "";
 
       const taskScope = isScoped
-        ? failedIds.map((id) => `- \`docs/plans/${slug}-task-${String(id).padStart(2, "0")}.md\``)
-        : [`- \`docs/plans/${slug}-task-*.md\``];
+        ? "\n" + failedIds.map((id) => `- \`docs/plans/${slug}-task-${String(id).padStart(2, "0")}.md\``).join("\n")
+        : `\n- \`docs/plans/${slug}-task-*.md\``;
 
       const scopeNote = isScoped
-        ? [``, `**리뷰 범위**: Task ${failedIds.join(", ")}번만 검토하세요. 나머지 subtask는 이전 리뷰에서 pass되었습니다.`]
-        : [];
+        ? "\n\n" + t("progress.review_prompt.scope_note", { ids: failedIds.join(", ") })
+        : "";
 
-      const prompt = [
-        `### 🔍 ${roundLabel} 요청`, ``,
-        `**Plan**: "${plan.title}"`, ``,
-        `**검증 문서**:`,
-        `- Plan: \`docs/plans/${slug}.md\``,
-        `- 결과: \`docs/plans/${slug}-result.md\``,
-        ...taskScope,
-        ...scopeNote,
-        ...prevFindingsBlock, ``,
-        `각 task 파일의 **변경 내용**과 **검증 조건**을 기준으로 구현 결과를 검증하세요.`,
-        `Plan에 명시되지 않은 코드 스타일이나 범위 밖 파일의 기존 문제는 fail 사유가 아닙니다.`, ``,
-        `> 완료 후 리뷰 verdict를 제출하세요.`,
-      ].join("\n");
+      const prompt = t("progress.review_prompt.body", {
+        roundLabel,
+        title: plan.title,
+        slug,
+        taskScope,
+        scopeNote,
+        prevFindings: prevFindingsBlock,
+      });
 
       // 자동 생성 프롬프트 → role="system" 으로 persist 후 sendThreadMessage 에 pre-existing
       // id 로 전달. UI 는 사용자 말풍선이 아닌 접힘 시스템 블록으로 렌더 (s37 원칙).
@@ -203,12 +202,17 @@ export function DevProgressView({ plan, onPlanUpdate }: DevProgressViewProps) {
     const { sendWithEngine } = useChatStore.getState();
     setBusy(true);
     try {
+      const existingDesign = subtask.details
+        ? t("progress.sub_plan_prompt.existing_design_block", { details: subtask.details })
+        : "";
       const prompt = [
-        `[Sub-plan 요청] Plan "${plan.title}" → Subtask ${index + 1} "${subtask.title}"`, "",
-        `이 subtask의 구현이 복잡하여 별도 Plan이 필요합니다.`,
-        subtask.details ? `\n### 기존 상세 설계\n${subtask.details}` : "", "",
-        `이 subtask를 위한 별도 Plan을 \`<!-- tunaflow:plan-proposal -->\` 형식으로 제안하세요.`,
-        `부모 Plan: ${plan.title}`,
+        t("progress.sub_plan_prompt.header", { plan: plan.title, num: index + 1, title: subtask.title }),
+        "",
+        t("progress.sub_plan_prompt.body"),
+        existingDesign,
+        "",
+        t("progress.sub_plan_prompt.instruction"),
+        t("progress.sub_plan_prompt.parent_label", { plan: plan.title }),
       ].filter(Boolean).join("\n");
       await sendWithEngine("claude", prompt);
     } catch (e) { console.warn("[tunaflow]", e); }
@@ -226,7 +230,9 @@ export function DevProgressView({ plan, onPlanUpdate }: DevProgressViewProps) {
         const fileMatch = f.match(/([a-zA-Z0-9_./-]+\.[a-zA-Z]+(?:[:#]L?\d+)?)/);
         const file = fileMatch ? fileMatch[1] : "";
         const summary = f.slice(0, 500);
-        return file ? `□ ${i + 1}. ${summary}\n  파일: ${file}` : `□ ${i + 1}. ${summary}`;
+        return file
+          ? t("progress.rework_prompt.finding_with_file", { n: i + 1, summary, file })
+          : t("progress.rework_prompt.finding_without_file", { n: i + 1, summary });
       }) ?? [];
       const recItems = reviewVerdict?.recommendations.map((r) => `• ${r.slice(0, 300)}`) ?? [];
 
@@ -240,7 +246,12 @@ export function DevProgressView({ plan, onPlanUpdate }: DevProgressViewProps) {
       const failEvents = sinceReset.filter((e) => e.eventType === "review_failed");
       const failCount = failEvents.length;
       const pressureWarning = failCount >= 2
-        ? `\n> ⚠️ 이전 ${failCount}회 Review 실패. ${failCount >= 3 ? "이번이 마지막 기회입니다." : "다음 실패 시 설계 재검토로 에스컬레이션됩니다."}`
+        ? t("progress.rework_prompt.pressure", {
+            count: failCount,
+            hint: failCount >= 3
+              ? t("progress.rework_prompt.pressure_final")
+              : t("progress.rework_prompt.pressure_next"),
+          })
         : "";
 
       let historySection = "";
@@ -250,10 +261,17 @@ export function DevProgressView({ plan, onPlanUpdate }: DevProgressViewProps) {
           try {
             const d = JSON.parse(ev.detail ?? "{}");
             const findings = (d.findings as string[] ?? []).slice(0, 3).map((f: string) => f.slice(0, 200));
-            return `- ${i + 1}차: ${findings.join("; ") || "상세 없음"} → ❌`;
-          } catch { return `- ${i + 1}차: (파싱 불가) → ❌`; }
+            const findingsStr = findings.join("; ") || t("progress.rework_prompt.history_empty");
+            return t("progress.rework_prompt.history_entry", { n: i + 1, findings: findingsStr });
+          } catch {
+            return t("progress.rework_prompt.history_entry_parse_error", { n: i + 1 });
+          }
         });
-        historySection = [`**이전 시도 이력** (${previousFails.length}회 실패):`, ...historyItems, ``].join("\n");
+        historySection = [
+          t("progress.rework_prompt.history_header", { count: previousFails.length }),
+          ...historyItems,
+          ``,
+        ].join("\n");
       }
 
       const failedIds = reviewVerdict?.failedSubtaskIds ?? [];
@@ -264,16 +282,22 @@ export function DevProgressView({ plan, onPlanUpdate }: DevProgressViewProps) {
           .map((id) => { const st = subtasks.find((s) => s.idx === id); return st ? `Task ${String(id).padStart(2, "0")} (${st.title})` : `Task ${String(id).padStart(2, "0")}`; })
           .join(", ");
         const otherCount = subtasks.length - failedIds.length;
-        targetSection = [`**대상 서브태스크**: ${targetNames}`,
-          otherCount > 0 ? `**나머지 ${otherCount}개 태스크**: 이미 완료됨 — 수정하지 마세요.` : "", ``].filter(Boolean).join("\n");
+        targetSection = [
+          t("progress.rework_prompt.target_header", { names: targetNames }),
+          otherCount > 0 ? t("progress.rework_prompt.target_other_note", { count: otherCount }) : "",
+          ``,
+        ].filter(Boolean).join("\n");
       }
 
+      const scopeRestrictionSuffix = failedIds.length > 0
+        ? t("progress.rework_prompt.scope_restriction_suffix")
+        : "";
       const reworkPrompt = [
-        `### 🔄 Rework`, ``, historySection, targetSection,
-        `**수정 항목** (${findingItems.length}건):`,
+        t("progress.rework_prompt.heading"), ``, historySection, targetSection,
+        t("progress.rework_prompt.items_header", { count: findingItems.length }),
         ...findingItems.map((f) => `- ${f}`),
         ...(recItems.length > 0 ? [``, `**Recommendations**:`, ...recItems.map((r) => `- ${r}`)] : []),
-        ``, `> 완료 조건: 위 항목 모두 해결 후 완료를 알려주세요.${failedIds.length > 0 ? " 다른 태스크의 코드를 변경하지 마세요." : ""}`,
+        ``, t("progress.rework_prompt.completion_condition") + scopeRestrictionSuffix,
         pressureWarning,
       ].filter(Boolean).join("\n");
       const shadowConvId = `branch:${plan.implementationBranchId}`;

--- a/src/locales/en/workflow.json
+++ b/src/locales/en/workflow.json
@@ -149,6 +149,38 @@
       "re_review_start": "Start Re-review",
       "review_rt_start": "Start Review RT",
       "re_review_rt_start": "Start Re-review RT"
+    },
+    "rerun_prompt": "Please re-implement Subtask {{num}} \"{{title}}\".\n\nDetailed design:\n{{details}}",
+    "rerun_details_empty": "(none)",
+    "review_prompt": {
+      "prev_findings_header": "**Previous Review Findings (focus area)**:",
+      "prev_findings_footer": "> Verify whether the items above were resolved.",
+      "scope_note": "**Review scope**: review only Task {{ids}}. The other subtasks passed in the previous review.",
+      "body": "### 🔍 {{roundLabel}} request\n\n**Plan**: \"{{title}}\"\n\n**Verification documents**:\n- Plan: `docs/plans/{{slug}}.md`\n- Result: `docs/plans/{{slug}}-result.md`\n{{taskScope}}{{scopeNote}}{{prevFindings}}\n\nValidate the implementation against each task file's **Change description** and **Verification**.\nCode style not specified in the Plan, or existing issues in files outside scope, are not fail reasons.\n\n> Submit the review verdict when done."
+    },
+    "sub_plan_prompt": {
+      "header": "[Sub-plan request] Plan \"{{plan}}\" → Subtask {{num}} \"{{title}}\"",
+      "body": "This subtask is complex enough to require its own Plan.",
+      "existing_design_block": "\n### Existing detailed design\n{{details}}",
+      "instruction": "Propose a separate Plan for this subtask in `<!-- tunaflow:plan-proposal -->` format.",
+      "parent_label": "Parent Plan: {{plan}}"
+    },
+    "rework_prompt": {
+      "heading": "### 🔄 Rework",
+      "finding_with_file": "□ {{n}}. {{summary}}\n  file: {{file}}",
+      "finding_without_file": "□ {{n}}. {{summary}}",
+      "pressure": "\n> ⚠️ {{count}} previous Review failures. {{hint}}",
+      "pressure_final": "This is the last chance.",
+      "pressure_next": "Another failure will escalate to design review.",
+      "history_entry": "- Attempt {{n}}: {{findings}} → ❌",
+      "history_entry_parse_error": "- Attempt {{n}}: (parse failed) → ❌",
+      "history_empty": "no details",
+      "history_header": "**Previous attempts** ({{count}} failures):",
+      "target_header": "**Target subtasks**: {{names}}",
+      "target_other_note": "**Other {{count}} tasks**: already done — do not modify.",
+      "items_header": "**Items to fix** ({{count}}):",
+      "completion_condition": "> Completion: resolve all items above and notify.",
+      "scope_restriction_suffix": " Do not modify code in other tasks."
     }
   },
   "proposal": {
@@ -193,7 +225,13 @@
       "promote_branch_error": "Plan registration failed: select the parent conversation and try again.",
       "disposition_summary": "File disposition: {{summary}}",
       "disposition_revert_warning": "File disposition: {{summary}}\n\nRevert targets (manual):\n{{items}}{{more}}"
-    }
+    },
+    "doc_prompt": {
+      "body": "### 📋 Document writing request\n\n**Plan**: \"{{title}}\"\n\n**Documents to write**:\n- `docs/plans/{{slug}}.md` — full plan\n{{taskFiles}}\n\n**Contents for each task spec**:\n- **Changed files** — target file paths (with line numbers if possible)\n- **Change description** — implementation approach (step by step)\n- **Dependencies** — dependencies (packages, other subtasks)\n- **Verification** — **executable shell commands** that prove completion (e.g. `cargo test`, `npx tsc --noEmit`)\n- **Risks** — risks and caveats\n- **Scope boundary** — list of files NOT to modify (prevents invading other tasks)\n\n> Completion: notify when all documents are written",
+      "task_line": "- `docs/plans/{{slug}}-task-{{num}}.md` — {{title}}"
+    },
+    "revision_feedback_prompt": "[Plan revision request: {{title}}]\n\n{{feedback}}\n\nRevise the Plan incorporating the feedback above and propose it again in `<!-- tunaflow:plan-proposal -->` format.",
+    "example_subtasks_markdown": "### Subtasks        ← triple # required\n1. First task — description\n2. Second task — description"
   },
   "review": {
     "verdict": {

--- a/src/locales/ko/workflow.json
+++ b/src/locales/ko/workflow.json
@@ -149,6 +149,38 @@
       "re_review_start": "Re-review 시작",
       "review_rt_start": "Review RT 시작",
       "re_review_rt_start": "Re-review RT 시작"
+    },
+    "rerun_prompt": "Subtask {{num}} \"{{title}}\"을(를) 다시 구현해주세요.\n\n상세 설계:\n{{details}}",
+    "rerun_details_empty": "(없음)",
+    "review_prompt": {
+      "prev_findings_header": "**이전 Review Findings (중점 확인 대상)**:",
+      "prev_findings_footer": "> 위 사항이 해결되었는지 확인하세요.",
+      "scope_note": "**리뷰 범위**: Task {{ids}}번만 검토하세요. 나머지 subtask는 이전 리뷰에서 pass되었습니다.",
+      "body": "### 🔍 {{roundLabel}} 요청\n\n**Plan**: \"{{title}}\"\n\n**검증 문서**:\n- Plan: `docs/plans/{{slug}}.md`\n- 결과: `docs/plans/{{slug}}-result.md`\n{{taskScope}}{{scopeNote}}{{prevFindings}}\n\n각 task 파일의 **변경 내용**과 **검증 조건**을 기준으로 구현 결과를 검증하세요.\nPlan에 명시되지 않은 코드 스타일이나 범위 밖 파일의 기존 문제는 fail 사유가 아닙니다.\n\n> 완료 후 리뷰 verdict를 제출하세요."
+    },
+    "sub_plan_prompt": {
+      "header": "[Sub-plan 요청] Plan \"{{plan}}\" → Subtask {{num}} \"{{title}}\"",
+      "body": "이 subtask의 구현이 복잡하여 별도 Plan이 필요합니다.",
+      "existing_design_block": "\n### 기존 상세 설계\n{{details}}",
+      "instruction": "이 subtask를 위한 별도 Plan을 `<!-- tunaflow:plan-proposal -->` 형식으로 제안하세요.",
+      "parent_label": "부모 Plan: {{plan}}"
+    },
+    "rework_prompt": {
+      "heading": "### 🔄 Rework",
+      "finding_with_file": "□ {{n}}. {{summary}}\n  파일: {{file}}",
+      "finding_without_file": "□ {{n}}. {{summary}}",
+      "pressure": "\n> ⚠️ 이전 {{count}}회 Review 실패. {{hint}}",
+      "pressure_final": "이번이 마지막 기회입니다.",
+      "pressure_next": "다음 실패 시 설계 재검토로 에스컬레이션됩니다.",
+      "history_entry": "- {{n}}차: {{findings}} → ❌",
+      "history_entry_parse_error": "- {{n}}차: (파싱 불가) → ❌",
+      "history_empty": "상세 없음",
+      "history_header": "**이전 시도 이력** ({{count}}회 실패):",
+      "target_header": "**대상 서브태스크**: {{names}}",
+      "target_other_note": "**나머지 {{count}}개 태스크**: 이미 완료됨 — 수정하지 마세요.",
+      "items_header": "**수정 항목** ({{count}}건):",
+      "completion_condition": "> 완료 조건: 위 항목 모두 해결 후 완료를 알려주세요.",
+      "scope_restriction_suffix": " 다른 태스크의 코드를 변경하지 마세요."
     }
   },
   "proposal": {
@@ -193,7 +225,13 @@
       "promote_branch_error": "Plan 등록 실패: 부모 대화를 선택한 뒤 다시 시도해주세요.",
       "disposition_summary": "파일 처리 방침: {{summary}}",
       "disposition_revert_warning": "파일 처리 방침: {{summary}}\n\nRevert 대상 (수동 처리 필요):\n{{items}}{{more}}"
-    }
+    },
+    "doc_prompt": {
+      "body": "### 📋 문서 작성 요청\n\n**Plan**: \"{{title}}\"\n\n**작성할 문서**:\n- `docs/plans/{{slug}}.md` — 전체 계획서\n{{taskFiles}}\n\n**각 작업 지시서 포함 내용**:\n- **Changed files** — 대상 파일 경로 (가능하면 줄번호까지)\n- **Change description** — 구현 접근법 (단계별)\n- **Dependencies** — 의존성 (패키지, 다른 subtask)\n- **Verification** — 완료를 증명하는 **실행 가능한 셸 명령** (예: `cargo test`, `npx tsc --noEmit`)\n- **Risks** — 리스크 및 주의사항\n- **Scope boundary** — 수정 금지 파일 목록 (다른 task 영역 침범 방지)\n\n> 완료 조건: 모든 문서 작성 후 알려주세요",
+      "task_line": "- `docs/plans/{{slug}}-task-{{num}}.md` — {{title}}"
+    },
+    "revision_feedback_prompt": "[Plan 수정 요청: {{title}}]\n\n{{feedback}}\n\n위 피드백을 반영하여 Plan을 수정하고 `<!-- tunaflow:plan-proposal -->` 형식으로 다시 제안하세요.",
+    "example_subtasks_markdown": "### Subtasks        ← 삼중 # 필수\n1. 첫 번째 작업 — 설명\n2. 두 번째 작업 — 설명"
   },
   "review": {
     "verdict": {


### PR DESCRIPTION
## Summary

A2-E 에서 분리된 남은 agent prompt 템플릿을 i18n 화. A2 시리즈 UI+prompt 전체 완결.

### 대상 (INV-6 — user locale 기반 agent prompt)

**DevProgressView.tsx** (4 prompts):
- `progress.rerun_prompt` — Subtask 재수행
- `progress.review_prompt.body` + prev_findings_header/footer + scope_note — Review 진입
- `progress.sub_plan_prompt.*` — Sub-plan 분리 요청 (header/body/existing_design/instruction/parent_label)
- `progress.rework_prompt.*` — Rework 프롬프트 (~14 subkeys: heading / finding_with_file / finding_without_file / pressure / pressure_final / pressure_next / history_entry / history_entry_parse_error / history_empty / history_header / target_header / target_other_note / items_header / completion_condition / scope_restriction_suffix)

**PlanProposalCard.tsx** (2 prompts + 1 example):
- `proposal.doc_prompt.body` + task_line — Architect 에게 plan 문서 작성 요청
- `proposal.revision_feedback_prompt` — Plan 수정 피드백 전송
- `proposal.example_subtasks_markdown` — warn-empty UI 의 parser 형식 예시 블록

### workflow.json 확장

- `progress` 섹션: rerun/review/sub_plan/rework 템플릿 (~20 키)
- `proposal` 섹션: doc_prompt / revision_feedback_prompt / example (~5 키)

## 마커 보존

모든 템플릿에서 parser 마커 (`<!-- tunaflow:plan-proposal -->`, `docs/plans/{slug}-task-*.md` 경로 패턴, `### 🔍`, `### 🔄 Rework`, `### 📋 문서 작성 요청` 이모지 등) 유지. en 번역에서도 구조 동일.

## Test plan

- [x] `npx tsc --noEmit` 통과
- [x] `npx vitest run` 322 통과
- [ ] 수동 확인: Settings → Language ko/en 토글 후
  - Implementation phase → subtask rerun (DevProgressView)
  - Review phase 진입 (handleStartReview) — roundLabel / taskScope / prev findings / scope note
  - Subtask → Sub-plan 요청 (handleCreateSubPlan)
  - Rework phase → Developer 전달 (handleRework) — history / target / findings / recommendations / pressure
  - Chat → plan-proposal 마커 생성 → "Plan으로 승격" → doc_prompt 자동 발송
  - warn-empty 상태에서 parser 형식 예시 pre 블록
  - 수정 요청 dialog → 피드백 입력 → 전송

## A2 시리즈 완결

| PR | 내용 | 상태 |
|---|---|---|
| #158 | A1 infra + error contract | ✅ |
| #159 | A2 partial (settings + 4 namespace) | ✅ |
| #160 | A2-B (NewMessageInput/ChatPanel) | ✅ |
| #161 | A2-C (Sidebar.tsx) | ✅ |
| #164 | A2-D (MessageItem + sidebar 하위) | ✅ |
| #165 | A2-E (workflow namespace + plans UI) | ✅ |
| #166 | A2-F (branch namespace) | ✅ |
| #167 | A2-G (insight namespace) | ✅ |
| **this** | **A2-E-msg (agent prompts)** | 🟢 |

남은 범위: **A3** (Rust 페르소나 + 도구 영어 고정 — INV-1 마지막 조각), **Phase 5** (베타 공개 — README 보류 섹션 + v0.1.0-beta 태그).

🤖 Generated with [Claude Code](https://claude.com/claude-code)