### PR TITLE
docs(i18n): 3 세션 병렬용 Developer prompt 분리

### DIFF
--- a/docs/prompts/i18n-session-track1-a2d.md
+++ b/docs/prompts/i18n-session-track1-a2d.md
@@ -1,0 +1,92 @@
+---
+title: i18n Track 1 — A2-D Settings subpanels
+created_at: 2026-04-24
+parallel_track: 1 of 3
+ssot: docs/plans/i18nCompletionPlan_2026-04-24.md §"Slice A2-D"
+---
+
+# Developer Session Prompt — A2-D Settings subpanels
+
+새 Claude Code 세션에 아래 블록 전체를 붙여넣는다.
+
+```
+[작업] i18n PR A2-D — Settings subpanels 전환
+
+[SSOT]
+- docs/plans/i18nCompletionPlan_2026-04-24.md §"Slice A2-D" 먼저 읽기
+- docs/plans/i18nPlan.md (원 plan, 3계층 키 컨벤션)
+- 현재 main 이 기준. 2026-04-24 세션에서 PR #161~#169 머지 완료 상태 (A1~A3 모두 main).
+
+[브랜치]
+main 에서 feat/i18n-pr-a2d-settings 생성.
+
+[범위 — 9 파일 / ~156 Korean lines / ~120 keys 예상]
+대상:
+- src/components/tunaflow/SettingsPanel.tsx (2 lines, shell)
+- src/components/tunaflow/settings/HelpSection.tsx (28 lines)
+- src/components/tunaflow/settings/MobileSection.tsx (11 lines)
+- src/components/tunaflow/settings/IdentityAnalysisSettings.tsx (5 lines, 대부분 주석)
+- src/components/tunaflow/settings/ProfileSection.tsx (21 lines)
+- src/components/tunaflow/settings/RuntimeSection.tsx (30 lines)
+- src/components/tunaflow/settings/ConventionsSection.tsx (32 lines)
+- src/components/tunaflow/settings/PersonasSection.tsx (1 line — desc only)
+- src/components/tunaflow/settings/AgentsSection.tsx (23 lines)
+- src/components/tunaflow/settings/WorldviewSettings.tsx (3 lines — default template 상수)
+
+실측은 `grep -c "[가-힣]" <파일>` 또는 Grep 도구 활용.
+
+[Namespace] settings.* 확장 (기존 profile/worldview/identity 는 이미 존재):
+- settings.help.*
+- settings.mobile.*
+- settings.profile.* 확장 (section title, save button, saved msg, field hints)
+- settings.runtime.* (신규)
+- settings.conventions.* (신규)
+- settings.personas.* (신규)
+- settings.agents.* (신규)
+- settings.worldview.* 확장 (default_template 상수)
+- settings.identity.* (기존 유지)
+
+기존 ko/settings.json 참고 — profile/worldview/identity 섹션 구조 유지.
+
+[패턴 준수 — 기존 A2-C Sidebar PR #161 / A2-G #167 참고]
+1. `useTranslation("settings")` 훅 추가
+2. 하드코딩 한국어 → `t("<section>.<key>")` 교체
+3. interpolation: `t("...", { count, error, name })`
+4. 대형 멀티라인 template (예: WorldviewSettings 의 DEFAULT_WORLDVIEW_TEMPLATE) 은 JSON 에 `\n` 포함 단일 키로
+5. ko 가 SSOT. en 은 ko 기반 번역
+6. src/locales/index.ts / src/types/i18next.d.ts 변경 없음 — settings namespace 이미 등록됨
+
+[INV]
+- INV-1 (agent 시스템 프롬프트 영어 고정). 본 슬라이스는 UI 라벨만.
+- INV-5 (namespace.section.action 3계층 키).
+- INV-7 (다른 Track 과 파일 경로 겹침 없음 — settings/* 는 본 Track 전용).
+
+[검증]
+- npx tsc --noEmit
+- npx vitest run (기대: 322 passed 유지)
+- npx vite build (번들 성공)
+- 수동: Settings 각 탭 ko ↔ en 전환, 컬럼 폭 깨짐 없음, interpolation 정상
+
+[커밋 규약]
+- feat(i18n): 접두어
+- Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+
+[PR]
+제목: feat(i18n): PR A2-D — Settings subpanels (~120 keys)
+설명에 포함:
+- 파일별 변환 키 수 표
+- 수동 확인 checklist
+- 후속: A3-ext (lib/ + stores/ 서비스 계층)
+
+[주의 — 다른 Track 과 충돌 방지]
+- src/locales/{ko,en}/settings.json 은 본 Track 전용. 다른 Track 이 추가하지 않음
+- src/locales/{ko,en}/common.json 에 키 추가 필요하면 3계층 엄수
+- 본 Track 은 src/lib/* / src-tauri/* 건드리지 않음
+```
+
+## 참고 — 이 Track 이 아닌 것
+
+- Insight/Identity/Workflow UI (완결됨)
+- Chat/Branch/Input/Common UI (Track 3)
+- Context panel tabs (Track 2)
+- lib/stores services (A3-ext, 후속)

--- a/docs/prompts/i18n-session-track2-a2e.md
+++ b/docs/prompts/i18n-session-track2-a2e.md
@@ -1,0 +1,91 @@
+---
+title: i18n Track 2 — A2-E Context panel tabs (축소)
+created_at: 2026-04-24
+parallel_track: 2 of 3
+ssot: docs/plans/i18nCompletionPlan_2026-04-24.md §"Slice A2-E"
+---
+
+# Developer Session Prompt — A2-E Context panel tabs
+
+> **Plan 원본 대비 축소**: InsightPanel / IdentityView 는 2026-04-24 세션 PR #167 에서 이미 i18n 완결. insight namespace 도 신설 완료. 본 Track 은 **남은 7 파일** 만 처리.
+
+새 Claude Code 세션에 아래 블록 전체를 붙여넣는다.
+
+```
+[작업] i18n PR A2-E — Context panel tabs 전환 (축소)
+
+[SSOT]
+- docs/plans/i18nCompletionPlan_2026-04-24.md §"Slice A2-E"
+- 현재 main 이 기준. 2026-04-24 세션에서 insight namespace / InsightPanel / IdentityView 이미 완결 (PR #167).
+
+[브랜치]
+main 에서 feat/i18n-pr-a2e-context 생성.
+
+[범위 — 7 파일 / ~140 Korean lines / ~100 keys 예상]
+대상 (Plan 대비 InsightPanel/IdentityView 제외):
+- src/components/tunaflow/context-panel/PlansPanel.tsx (15 lines)
+- src/components/tunaflow/context-panel/TracePanel.tsx (2 lines — 거의 없음, 확인 후 포함 여부)
+- src/components/tunaflow/context-panel/QualityDashboard.tsx (17 lines)
+- src/components/tunaflow/context-panel/SkillsPanel.tsx (8 lines)
+- src/components/tunaflow/context-panel/HarnessSummary.tsx (4 lines)
+- src/components/tunaflow/context-panel/insight/insightConstants.tsx (6 lines — CATEGORY_META.label)
+- src/components/tunaflow/context-panel/PlanDocumentModal.tsx (5 lines)
+- src/components/tunaflow/context-panel/SubtaskReviewView.tsx (85 lines — 가장 큰 파일)
+
+실측 시 주석/코드 로직 구분 필수 (예: TracePanel 2 라인 = 주석만일 수 있음).
+
+[Namespace]
+기존 insight 확장 + 신규:
+- trace.* (신규)
+- quality.* (신규)
+- skills.* (신규)
+- harness.* (신규)
+- insight.category.* (기존, insightConstants.label 이관)
+- workflow.plan.* (기존, PlanDocumentModal / SubtaskReviewView / PlansPanel 일부 재사용 가능)
+
+[중요 — insightConstants.tsx CATEGORY_META 처리]
+- label 필드는 "UI 노출 label"
+- key (stability/test/...) 는 "영어 고정 identifier" — 에이전트 프롬프트 카테고리 키로 사용 (INV-1)
+- 두 축 구분: label 제거 or t() 래핑, key 는 불변
+
+2026-04-24 세션 PR #167 에서 `insight.category.{stability|test|...}` 키 이미 생성됨. insightConstants 에서는 label 필드를 제거하거나 사용처에서 `t(\`category.\${k}\`)` 로 override.
+
+[패턴 준수]
+기존 A2-E #165 / A2-G #167 참고.
+- useTranslation("<namespace>")
+- 3계층 키
+- ko SSOT, en 번역
+
+[신규 namespace 등록 필요]
+trace / quality / skills / harness 는 신규. 추가 작업:
+1. src/locales/{ko,en}/trace.json 신규
+2. src/locales/{ko,en}/quality.json 신규
+3. src/locales/{ko,en}/skills.json 신규
+4. src/locales/{ko,en}/harness.json 신규
+5. src/locales/index.ts 에 import + resources + ns 배열 등록
+6. src/types/i18next.d.ts 에 declare module 추가
+
+[INV]
+- INV-1 (agent 프롬프트 영어 고정) — 본 Track UI 만
+- INV-5 (3계층)
+- INV-7 (settings/* 는 Track 1 전용, chat/branch/common 은 Track 3 전용. 본 Track 은 context-panel/* 만)
+
+[검증]
+- npx tsc --noEmit
+- npx vitest run
+- 수동: Plans / Trace / Quality / Skills / Harness / PlanDocumentModal / SubtaskReview 각 탭 ko ↔ en
+
+[주의 — Track 충돌 방지]
+- src/locales/index.ts 편집은 Track 1/3 와 **동시 편집 시 merge conflict 가능**. 본 Track 이 가장 많은 namespace 추가하므로 Track 1/3 rebase 시 본 Track 편집분 반영.
+
+[커밋/PR]
+feat(i18n): PR A2-E — Context panel tabs (~100 keys)
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+```
+
+## 참고 — 이 Track 이 아닌 것
+
+- Settings subpanels (Track 1)
+- Chat/Branch/Input/Common UI (Track 3)
+- Plan/Workflow cards (이미 완결 — PR #165/#168)
+- InsightPanel/IdentityView (이미 완결 — PR #167)

--- a/docs/prompts/i18n-session-track3-a2g.md
+++ b/docs/prompts/i18n-session-track3-a2g.md
@@ -1,0 +1,101 @@
+---
+title: i18n Track 3 — A2-G Chat / Branch / Input / Common UI
+created_at: 2026-04-24
+parallel_track: 3 of 3
+ssot: docs/plans/i18nCompletionPlan_2026-04-24.md §"Slice A2-G"
+---
+
+# Developer Session Prompt — A2-G Chat / Branch / Input / Common
+
+> Plan 의 A2-F 는 2026-04-24 세션 PR #165/#168 에서 완결. A2-G 를 Track 3 로 앞당긴다.
+
+새 Claude Code 세션에 아래 블록 전체를 붙여넣는다.
+
+```
+[작업] i18n PR A2-G — Chat / Branch / Input / Common UI 전환
+
+[SSOT]
+- docs/plans/i18nCompletionPlan_2026-04-24.md §"Slice A2-G"
+- 현재 main 이 기준. 2026-04-24 세션에서 A2-F (Plan/Workflow cards) 이미 완결.
+
+[브랜치]
+main 에서 feat/i18n-pr-a2g-chat 생성.
+
+[범위 — ~12 파일 / ~130 Korean lines / ~130 keys 예상]
+**큰 파일 우선 (실측 많은 것):**
+- src/components/tunaflow/NewMessageInput.tsx (29 lines)
+- src/components/tunaflow/MetaAgentSelector.tsx (19 lines)
+- src/components/tunaflow/MetaFloatingChat.tsx (29 lines)
+- src/components/tunaflow/ProjectOnboardingModal.tsx (38 lines)
+- src/components/tunaflow/RuntimeStatusBar.tsx (18 lines)
+- src/components/tunaflow/ContextMenu.tsx (12 lines)
+
+**중소 파일:**
+- src/components/tunaflow/AppShell.tsx (5)
+- src/components/tunaflow/CenterPanel.tsx (6)
+- src/components/tunaflow/TerminalPanel.tsx (3)
+- src/components/tunaflow/TerminalFloatingPanel.tsx (6)
+- src/components/tunaflow/ChatPanel.tsx (5)
+- src/components/tunaflow/ErrorBoundary.tsx (4)
+- src/components/tunaflow/NotificationBell.tsx (5)
+
+**input 하위:**
+- src/components/tunaflow/input/useSendActions.ts (30 lines — INV-6 대상 있을 수 있음)
+- src/components/tunaflow/input/ContextBadges.tsx (2)
+
+**제외 (이미 거의 완료)**:
+- BranchThreadPanel.tsx (2) / CreateRoundtableDialog.tsx (2) / RoundtableView.tsx (2) / MessageItem.tsx (3) — 주석만 남음 (PR #164/#166 완결)
+- message/MessageActions.tsx (1)
+
+[Namespace]
+기존 확장:
+- chat.* (chat / message / input)
+- branch.* (이미 신설됨 — PR #166)
+- dialog.* (기존, modal / onboarding 확장)
+- common.* (AppShell / StatusBar / Terminal / ContextMenu / ErrorBoundary / NotificationBell)
+
+[신규 키 예상]
+- chat.input.* 확장 (NewMessageInput 29 라인)
+- common.app.* (AppShell)
+- common.status_bar.* (RuntimeStatusBar)
+- common.terminal.* (TerminalPanel / TerminalFloatingPanel)
+- common.context_menu.* (ContextMenu)
+- common.error_boundary.* (ErrorBoundary)
+- common.notification.* (NotificationBell)
+- dialog.onboarding.* (ProjectOnboardingModal)
+- dialog.meta_agent.* (MetaAgentSelector / MetaFloatingChat)
+
+[INV-6 주의]
+useSendActions.ts 에 sendMessage() 템플릿 있으면 locale 기반 i18n 대상 (chat 히스토리에 user msg 로 노출되면 → i18n, 순수 agent 지시 → 영어 고정).
+30 lines 중 템플릿 vs 주석 vs 토스트 분류 필수.
+
+[INV]
+- INV-1 (agent 프롬프트 영어 고정)
+- INV-5 (3계층)
+- INV-6 (useSendActions 템플릿 locale i18n)
+- INV-7 (settings/* 는 Track 1, context-panel/* 는 Track 2. 본 Track 은 그 외 주요 컴포넌트)
+
+[ErrorBoundary 특례]
+i18n 초기화 실패 시에도 렌더돼야 하므로 ErrorBoundary fallback 텍스트는 영어 hardcode 유지. `t()` 대신 literal string 사용.
+
+[검증]
+- npx tsc --noEmit
+- npx vitest run (기대: 322 pass 유지, 기존 smoke-rt-rounds/ui-regression 테스트 안 깨짐 주의)
+- 수동: Main chat 입력 / AppShell tabs / StatusBar / Terminal / ProjectOnboardingModal / RuntimeStatusBar / Notification
+
+[커밋/PR]
+feat(i18n): PR A2-G — Chat/Branch/Common (~130 keys)
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+
+[주의 — Track 1/2 와 충돌]
+- src/locales/index.ts / src/types/i18next.d.ts: Track 2 도 편집. rebase 시 Track 2 신규 namespace (trace/quality/skills/harness) 반영
+- 본 Track 은 common/chat/dialog namespace 확장 중심. settings / context-panel / lib 건드리지 않음
+```
+
+## 참고 — 이 Track 이 아닌 것
+
+- Settings subpanels (Track 1)
+- Context panel tabs (Track 2)
+- Plan/Workflow cards (이미 완결)
+- Insight/Identity (이미 완결)
+- lib/stores services (A3-ext, 후속)


### PR DESCRIPTION
## Summary

`docs/plans/i18nCompletionPlan_2026-04-24.md` 의 slice 를 2026-04-24 세션 진행 실측 기반으로 재분배 후 3 세션에 즉시 붙여넣기 가능한 prompt 3개 생성.

### Plan 대비 조정

- **A2-F 제거** — Plan/Workflow cards 는 이번 세션 PR #165 + #168 에서 완결
- **A2-E 축소** — InsightPanel / IdentityView 제외 (PR #167 완결), 나머지 7 파일만
- **Track 3 에 A2-G 앞당김** — A3-ext (lib/stores) 는 후속 세션

### Track 배분

| Track | Slice | 브랜치 | 실측 |
|---|---|---|---|
| 1 | **A2-D** Settings subpanels | `feat/i18n-pr-a2d-settings` | 9 파일 / 156 lines / ~120 keys |
| 2 | **A2-E** Context panel (축소) | `feat/i18n-pr-a2e-context` | 7 파일 / ~140 lines / ~100 keys |
| 3 | **A2-G** Chat/Branch/Input/Common | `feat/i18n-pr-a2g-chat` | 12 파일 / ~130 lines / ~130 keys |

각 prompt 에 INV-7 (파일 경로 겹침 없음) + `src/locales/index.ts` 편집 시 rebase 가이드 포함.

### 파일

- `docs/prompts/i18n-session-track1-a2d.md`
- `docs/prompts/i18n-session-track2-a2e.md`
- `docs/prompts/i18n-session-track3-a2g.md`

## Test plan

- [x] 3 파일 모두 생성 + markdown 헤더 규약 준수
- [x] 각 blob 에 브랜치명 / 범위 / namespace / INV / 검증 / PR 제목 포함
- [x] 실측 데이터 (파일별 Korean 라인 count) 기반

🤖 Generated with [Claude Code](https://claude.com/claude-code)