### PR TITLE
feat(i18n): PR A2-D — Settings subpanels (~150 keys)

### DIFF
--- a/src/components/tunaflow/SettingsPanel.tsx
+++ b/src/components/tunaflow/SettingsPanel.tsx
@@ -83,8 +83,8 @@ export function SettingsPanel({ onClose, initialSection }: SettingsPanelProps) {
               {activeSection === "personas" && <PersonasSection />}
               {activeSection === "skills" && (
                 <div>
-                  <h2 className="text-[14px] font-[550] text-foreground mb-1">Skills</h2>
-                  <p className="text-[12px] text-muted-foreground mb-4">에이전트에게 적용할 스킬을 관리합니다.</p>
+                  <h2 className="text-[14px] font-[550] text-foreground mb-1">{t("section.skills")}</h2>
+                  <p className="text-[12px] text-muted-foreground mb-4">{t("skills_description")}</p>
                   <SkillsPanel />
                 </div>
               )}

--- a/src/components/tunaflow/settings/AgentsSection.tsx
+++ b/src/components/tunaflow/settings/AgentsSection.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
 import { Plus, Trash2, CheckCircle2, AlertCircle, AlertTriangle } from "lucide-react";
 import { useChatStore } from "@/stores/chatStore";
@@ -26,6 +27,7 @@ const ENGINE_LABELS: Record<(typeof ENGINES)[number], string> = {
 };
 
 export function AgentsSection() {
+  const { t } = useTranslation("settings");
   const profiles = useChatStore((s) => s.agentProfiles);
   const saveProfiles = useChatStore((s) => s.saveProfiles);
   const [selectedId, setSelectedId] = useState<string | null>(profiles[0]?.id ?? null);
@@ -74,8 +76,8 @@ export function AgentsSection() {
 
   return (
     <div>
-      <h2 className="text-tf-base font-[550] text-foreground mb-1">Agent Profiles</h2>
-      <p className="text-tf-caption text-muted-foreground mb-4">에이전트 프로필을 관리합니다. 각 프로필은 엔진, 모델, 기본 스킬을 하나의 실행 단위로 묶습니다.</p>
+      <h2 className="text-tf-base font-[550] text-foreground mb-1">{t("agents.heading")}</h2>
+      <p className="text-tf-caption text-muted-foreground mb-4">{t("agents.description")}</p>
 
       <RoleCoveragePanel profiles={profiles} />
       <MetaAnalysisPanel />
@@ -186,6 +188,7 @@ export function AgentsSection() {
 /** 4개 핵심 역할(Architect/Developer/Reviewers/Synthesizer) 에 대한 프로필 배정 상태.
  *  Review RT / Plan 승인 / RT 합성 직전에 이 값이 assertRoleReady() 로 검증된다. */
 function RoleCoveragePanel({ profiles }: { profiles: AgentProfile[] }) {
+  const { t } = useTranslation("settings");
   const [assignments, setAssignments] = useState<RoleAssignments>({ reviewers: [] });
   const [loaded, setLoaded] = useState(false);
 
@@ -231,14 +234,16 @@ function RoleCoveragePanel({ profiles }: { profiles: AgentProfile[] }) {
       allReady ? "border-status-approved/40 bg-status-approved/5" : "border-amber-500/40 bg-amber-500/5")}>
       <div className="flex items-center gap-2">
         {allReady ? <CheckCircle2 className="w-4 h-4 text-status-approved" /> : <AlertTriangle className="w-4 h-4 text-amber-500" />}
-        <h3 className="text-tf-sm font-medium text-foreground flex-1">역할 커버리지</h3>
+        <h3 className="text-tf-sm font-medium text-foreground flex-1">{t("agents.role_coverage.title")}</h3>
         <span className="text-tf-sm text-muted-foreground">
-          {coverage.filter((c) => c.status === "ready").length}/{coverage.length} ready
+          {t("agents.role_coverage.ready_count", {
+            ready: coverage.filter((c) => c.status === "ready").length,
+            total: coverage.length,
+          })}
         </span>
       </div>
       <p className="text-[10px] text-muted-foreground">
-        Architect(설계), Developer(구현), Reviewer(검토 ≥2), Synthesizer(RT 합성) 역할에 프로필을 배정하면
-        Review RT / Plan 승인 / RT 합성 시 설정 그대로 실행됩니다.
+        {t("agents.role_coverage.hint")}
       </p>
       <div className="space-y-1.5">
         <RoleRow label="Architect" coverage={coverage[0]!} profiles={profiles}
@@ -267,6 +272,7 @@ function RoleRow({ label, coverage, profiles, selectedId, onChange }: {
   selectedId: string;
   onChange: (v: string) => void;
 }) {
+  const { t } = useTranslation("settings");
   return (
     <div className="flex items-center gap-2">
       <div className="w-[90px] flex items-center gap-1.5 shrink-0">
@@ -275,7 +281,7 @@ function RoleRow({ label, coverage, profiles, selectedId, onChange }: {
       </div>
       <select value={selectedId} onChange={(e) => onChange(e.target.value)}
         className="flex-1 bg-background rounded px-2 py-1 text-tf-sm outline-none border border-border/30 focus:border-ring/40">
-        <option value="">— 선택 안 됨 —</option>
+        <option value="">{t("agents.role_coverage.unselected")}</option>
         {profiles.map((p) => (
           <option key={p.id} value={p.id}>{p.label} ({p.engine}{p.model ? `/${p.model}` : ""})</option>
         ))}
@@ -290,6 +296,7 @@ function ReviewersRow({ coverage, profiles, selectedIds, onToggle }: {
   selectedIds: string[];
   onToggle: (id: string) => void;
 }) {
+  const { t } = useTranslation("settings");
   return (
     <div className="flex items-start gap-2">
       <div className="w-[90px] flex items-center gap-1.5 shrink-0 pt-1">
@@ -307,7 +314,7 @@ function ReviewersRow({ coverage, profiles, selectedIds, onToggle }: {
             </button>
           );
         })}
-        {profiles.length === 0 && <span className="text-[10px] text-muted-foreground">프로필이 없습니다</span>}
+        {profiles.length === 0 && <span className="text-[10px] text-muted-foreground">{t("agents.role_coverage.no_profiles")}</span>}
       </div>
     </div>
   );
@@ -315,14 +322,14 @@ function ReviewersRow({ coverage, profiles, selectedIds, onToggle }: {
 
 // ─── Meta Analysis (Tier 2) Panel ───────────────────────────────────────────
 
-const ENGINE_OPTIONS: { value: MetaAnalysisEngine; label: string; hint: string }[] = [
-  { value: "off",           label: "끔",                  hint: "메타 자동 분석 비활성화" },
-  { value: "auto",          label: "자동",                hint: "프로젝트 스택 기반 자동 선택" },
-  { value: "claude-haiku",  label: "Claude Haiku",        hint: "JSON/한국어 요약 안정적, 저렴" },
-  { value: "gemini-flash",  label: "Gemini Flash 2.5",    hint: "대용량 input 저렴, 빠름" },
-];
-
 function MetaAnalysisPanel() {
+  const { t } = useTranslation("settings");
+  const engineOptions: { value: MetaAnalysisEngine; label: string; hint: string }[] = [
+    { value: "off",           label: t("agents.meta.engine_option.off_label"),    hint: t("agents.meta.engine_option.off_hint") },
+    { value: "auto",          label: t("agents.meta.engine_option.auto_label"),   hint: t("agents.meta.engine_option.auto_hint") },
+    { value: "claude-haiku",  label: "Claude Haiku",                                hint: t("agents.meta.engine_option.claude_haiku_hint") },
+    { value: "gemini-flash",  label: "Gemini Flash 2.5",                            hint: t("agents.meta.engine_option.gemini_flash_hint") },
+  ];
   const [cfg, setCfg] = useState<MetaAnalysisConfig>(DEFAULT_CONFIG);
   const [loaded, setLoaded] = useState(false);
 
@@ -345,21 +352,20 @@ function MetaAnalysisPanel() {
   return (
     <div className="mb-4 rounded-lg border border-border/30 bg-background/50 p-3 space-y-2.5">
       <div>
-        <h3 className="text-tf-sm font-medium text-foreground">메타 에이전트 자동 분석 (Tier 2)</h3>
+        <h3 className="text-tf-sm font-medium text-foreground">{t("agents.meta.heading")}</h3>
         <p className="text-[10px] text-muted-foreground mt-0.5">
-          주간 요약, 실패 패턴 분석, artifacts 요약 등을 저비용 엔진으로 자동 생성합니다.
-          읽기 전용 — 제안만 하며 실행은 사용자 승인 필요.
+          {t("agents.meta.description")}
         </p>
       </div>
 
       <div className="flex items-center gap-2">
-        <span className="text-[11px] text-muted-foreground w-[60px] shrink-0">엔진</span>
+        <span className="text-[11px] text-muted-foreground w-[60px] shrink-0">{t("agents.meta.engine_label")}</span>
         <select
           value={cfg.engine}
           onChange={(e) => updateAndSave({ engine: e.target.value as MetaAnalysisEngine })}
           className="flex-1 bg-background rounded px-2 py-1 text-[11px] outline-none border border-border/30 focus:border-ring/40"
         >
-          {ENGINE_OPTIONS.map((opt) => (
+          {engineOptions.map((opt) => (
             <option key={opt.value} value={opt.value}>{opt.label} — {opt.hint}</option>
           ))}
         </select>
@@ -372,14 +378,14 @@ function MetaAnalysisPanel() {
           onChange={(e) => updateAndSave({ autoTrigger: e.target.checked })}
           className="rounded border-border/40"
         />
-        <span className="text-[11px] text-foreground">자동 트리거</span>
-        <span className="text-[10px] text-muted-foreground">— 임계값 도달 시 분석 자동 실행</span>
+        <span className="text-[11px] text-foreground">{t("agents.meta.auto_trigger")}</span>
+        <span className="text-[10px] text-muted-foreground">{t("agents.meta.auto_trigger_hint")}</span>
       </label>
 
       {!disabled && cfg.autoTrigger && (
         <div className="pl-4 grid grid-cols-2 gap-x-3 gap-y-1.5 text-[10px]">
           <label className="flex items-center gap-1.5">
-            <span className="text-muted-foreground w-[90px] truncate">주간 요약 (pass 누적)</span>
+            <span className="text-muted-foreground w-[90px] truncate">{t("agents.meta.threshold.weekly_pass")}</span>
             <input
               type="number" min={1} max={100}
               value={cfg.thresholds.reviewPassedCount}
@@ -390,7 +396,7 @@ function MetaAnalysisPanel() {
             />
           </label>
           <label className="flex items-center gap-1.5">
-            <span className="text-muted-foreground w-[90px] truncate">실패 패턴 (fail 누적)</span>
+            <span className="text-muted-foreground w-[90px] truncate">{t("agents.meta.threshold.fail_pattern")}</span>
             <input
               type="number" min={1} max={50}
               value={cfg.thresholds.reviewFailedCount}
@@ -401,7 +407,7 @@ function MetaAnalysisPanel() {
             />
           </label>
           <label className="flex items-center gap-1.5">
-            <span className="text-muted-foreground w-[90px] truncate">artifact 요약 (누적)</span>
+            <span className="text-muted-foreground w-[90px] truncate">{t("agents.meta.threshold.artifact_count")}</span>
             <input
               type="number" min={1} max={100}
               value={cfg.thresholds.artifactCount}
@@ -412,7 +418,7 @@ function MetaAnalysisPanel() {
             />
           </label>
           <label className="flex items-center gap-1.5">
-            <span className="text-muted-foreground w-[90px] truncate">idle 일수</span>
+            <span className="text-muted-foreground w-[90px] truncate">{t("agents.meta.threshold.idle_days")}</span>
             <input
               type="number" min={1} max={90}
               value={cfg.thresholds.idleDays}

--- a/src/components/tunaflow/settings/ConventionsSection.tsx
+++ b/src/components/tunaflow/settings/ConventionsSection.tsx
@@ -9,6 +9,7 @@
  */
 import { useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { useTranslation } from "react-i18next";
 import { useChatStore } from "@/stores/chatStore";
 import { Loader2, RefreshCw, Trash2, Plus } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -30,17 +31,15 @@ interface SyncReport {
   truncated: string[];
 }
 
-const LAYER_OPTIONS = [
-  { id: "platform", label: "Platform / Project meta", hint: "프로젝트 path, 빌드 명령어, 언어 등" },
-  { id: "agent_role", label: "Agent role", hint: "에이전트 역할 지침 (architect/coder/reviewer 등)" },
-  { id: "persona", label: "Persona", hint: "페르소나 행동 지침" },
-  { id: "user_profile", label: "User profile", hint: "사용자 정보, 선호" },
-  { id: "plan_doc", label: "Plan document", hint: "현재 진행 중인 plan 본문 (revision 기반)" },
-  { id: "findings", label: "Findings", hint: "이전 review verdict의 findings 본문" },
-  { id: "artifact", label: "Artifact", hint: "참고 산출물 (result.md 등)" },
-];
+const LAYER_IDS = ["platform", "agent_role", "persona", "user_profile", "plan_doc", "findings", "artifact"] as const;
 
 export function ConventionsSection() {
+  const { t } = useTranslation("settings");
+  const LAYER_OPTIONS = LAYER_IDS.map((id) => ({
+    id,
+    label: t(`conventions.layer.${id}_label`),
+    hint: t(`conventions.layer.${id}_hint`),
+  }));
   const projects = useChatStore((s) => s.projects);
   const selectedProjectKey = useChatStore((s) => s.selectedProjectKey);
   const [projectKey, setProjectKey] = useState<string>(selectedProjectKey ?? "");
@@ -137,7 +136,7 @@ export function ConventionsSection() {
 
   const handleSync = async () => {
     if (!projectKey || !project?.path) {
-      setError("project 경로가 없습니다");
+      setError(t("conventions.error_no_project_path"));
       return;
     }
     setSyncing(true);
@@ -160,10 +159,9 @@ export function ConventionsSection() {
   return (
     <div className="space-y-4">
       <div>
-        <h2 className="text-[14px] font-[550] text-foreground mb-1">Conventions Context Sync</h2>
+        <h2 className="text-[14px] font-[550] text-foreground mb-1">{t("conventions.heading")}</h2>
         <p className="text-[12px] text-muted-foreground mb-2">
-          정적 ContextPack layer(platform / agent role / persona / user profile)를
-          CLAUDE.md / AGENTS.md / GEMINI.md로 sync 합니다. 편집 후 "Sync Now" 로 파일 갱신.
+          {t("conventions.description")}
         </p>
         {projectKey && (
           <label className="flex items-start gap-2 mt-2 p-2 rounded border border-border/50 bg-card/50 cursor-pointer hover:bg-card transition-colors">
@@ -176,13 +174,11 @@ export function ConventionsSection() {
             />
             <div className="flex-1">
               <div className="text-[12px] font-medium text-foreground">
-                ContextPack 에서 정적 레이어 생략
+                {t("conventions.toggle.label")}
                 {togglingSync && <Loader2 className="inline-block w-3 h-3 ml-1.5 animate-spin text-muted-foreground" />}
               </div>
               <p className="text-[10.5px] text-muted-foreground/80 mt-0.5 leading-relaxed">
-                켜면 매 turn 정적 레이어를 재송신하지 않습니다. CLI 가 CLAUDE.md/AGENTS.md 를
-                자동 prepending 하며 Anthropic API 경로에서는 prompt cache 적중으로 비용 절감.
-                먼저 아래에서 해당 프로젝트의 conventions 를 추가하고 "Sync Now" 로 파일을 만들어야 실제 효과.
+                {t("conventions.toggle.description")}
               </p>
             </div>
           </label>
@@ -196,7 +192,7 @@ export function ConventionsSection() {
           onChange={(e) => setProjectKey(e.target.value)}
           className="text-[12px] bg-input border border-border rounded px-2 py-1 outline-none"
         >
-          <option value="">— Project 선택 —</option>
+          <option value="">{t("conventions.select_project")}</option>
           {projects.map((p) => (
             <option key={p.key} value={p.key}>{p.key}</option>
           ))}
@@ -204,14 +200,14 @@ export function ConventionsSection() {
         <input
           value={personaFilter}
           onChange={(e) => setPersonaFilter(e.target.value)}
-          placeholder="Persona 필터 (비우면 공통 only)"
+          placeholder={t("conventions.persona_filter_placeholder")}
           className="flex-1 text-[12px] bg-input border border-border rounded px-2 py-1 outline-none"
         />
         <button
           onClick={reload}
           disabled={!projectKey || loading}
           className="px-2 py-1 rounded text-[11px] bg-card hover:bg-accent border border-border disabled:opacity-40"
-          title="다시 불러오기"
+          title={t("conventions.reload_title")}
         >
           {loading ? <Loader2 className="w-3 h-3 animate-spin" /> : <RefreshCw className="w-3 h-3" />}
         </button>
@@ -220,7 +216,7 @@ export function ConventionsSection() {
           disabled={!projectKey || !project?.path || syncing}
           className="px-3 py-1 rounded text-[11px] font-medium bg-primary/15 text-primary hover:bg-primary/25 disabled:opacity-40"
         >
-          {syncing ? "Syncing…" : "Sync Now"}
+          {syncing ? t("conventions.syncing") : t("conventions.sync_now")}
         </button>
       </div>
 
@@ -232,15 +228,15 @@ export function ConventionsSection() {
 
       {report && (
         <div className="text-[11px] text-status-approved bg-status-approved/8 border border-status-approved/30 rounded px-2 py-1.5">
-          ✓ Sync 완료 — entry files: {report.entryFiles}, split files: {report.splitFiles}
-          {report.truncated.length > 0 && ` (${report.truncated.length}개 truncated)`}
+          {t("conventions.sync_report", { entry: report.entryFiles, split: report.splitFiles })}
+          {report.truncated.length > 0 && t("conventions.sync_report_truncated", { count: report.truncated.length })}
         </div>
       )}
 
       {/* Rows list */}
       <div className="space-y-2">
         {rows.length === 0 && !loading && projectKey && (
-          <p className="text-[11px] text-muted-foreground/60">아직 등록된 conventions가 없습니다. 아래에서 추가하세요.</p>
+          <p className="text-[11px] text-muted-foreground/60">{t("conventions.empty_hint")}</p>
         )}
         {rows.map((row) => (
           <div key={row.id} className="rounded border border-border/40 bg-card p-2 space-y-1">
@@ -257,7 +253,7 @@ export function ConventionsSection() {
               <button
                 onClick={() => handleDelete(row)}
                 className="p-1 text-destructive/60 hover:text-destructive hover:bg-destructive/10 rounded"
-                title="삭제"
+                title={t("conventions.delete_title")}
               >
                 <Trash2 className="w-3 h-3" />
               </button>
@@ -273,7 +269,7 @@ export function ConventionsSection() {
       {/* Add new */}
       {projectKey && (
         <div className="rounded border border-primary/30 bg-primary/5 p-2 space-y-2">
-          <div className="text-[11px] font-[550] text-primary">새 convention 추가</div>
+          <div className="text-[11px] font-[550] text-primary">{t("conventions.new.heading")}</div>
           <div className="flex items-center gap-2">
             <select
               value={newLayer}
@@ -287,13 +283,13 @@ export function ConventionsSection() {
             <input
               value={newPersona}
               onChange={(e) => setNewPersona(e.target.value)}
-              placeholder="Persona (비우면 공통)"
+              placeholder={t("conventions.new.persona_placeholder")}
               className="flex-1 text-[11px] bg-input border border-border rounded px-2 py-1 outline-none"
             />
             <input
               value={newSource}
               onChange={(e) => setNewSource(e.target.value)}
-              placeholder="Source ID (선택)"
+              placeholder={t("conventions.new.source_placeholder")}
               className="flex-1 text-[11px] bg-input border border-border rounded px-2 py-1 outline-none"
             />
           </div>
@@ -301,7 +297,7 @@ export function ConventionsSection() {
           <textarea
             value={newContent}
             onChange={(e) => setNewContent(e.target.value)}
-            placeholder="Markdown 본문…"
+            placeholder={t("conventions.new.content_placeholder")}
             rows={5}
             className="w-full text-[11px] bg-input border border-border rounded px-2 py-1.5 outline-none font-mono leading-snug"
           />
@@ -311,7 +307,7 @@ export function ConventionsSection() {
               disabled={!newContent.trim()}
               className="flex items-center gap-1 px-3 py-1 rounded text-[11px] font-medium bg-status-approved/15 text-status-approved hover:bg-status-approved/25 disabled:opacity-40"
             >
-              <Plus className="w-3 h-3" />추가
+              <Plus className="w-3 h-3" />{t("conventions.new.add")}
             </button>
           </div>
         </div>

--- a/src/components/tunaflow/settings/HelpSection.tsx
+++ b/src/components/tunaflow/settings/HelpSection.tsx
@@ -1,8 +1,21 @@
 import { useEffect, useState } from "react";
+import { useTranslation, Trans } from "react-i18next";
 import { ExternalLink, Keyboard, Lightbulb, AlertTriangle, FileWarning } from "lucide-react";
 import { listRecentCrashReports, type CrashReportSummary } from "@/lib/crashReporter";
 
+const SHORTCUT_KEYS: { keys: string; descKey: string }[] = [
+  { keys: "Cmd+K", descKey: "help.shortcut_desc.cmd_k" },
+  { keys: "Cmd+Enter", descKey: "help.shortcut_desc.cmd_enter" },
+  { keys: "Shift+Enter", descKey: "help.shortcut_desc.shift_enter" },
+  { keys: "Esc", descKey: "help.shortcut_desc.esc" },
+  { keys: "Tab", descKey: "help.shortcut_desc.tab" },
+];
+
+const FEATURE_KEYS = ["pdr", "branch", "contextpack", "insight", "pty"] as const;
+const TROUBLESHOOTING_KEYS = ["no_response", "insight_reset", "cpu_high", "macos_gatekeeper"] as const;
+
 export function HelpSection() {
+  const { t } = useTranslation("settings");
   const [reports, setReports] = useState<CrashReportSummary[]>([]);
   useEffect(() => {
     listRecentCrashReports(5).then(setReports);
@@ -11,9 +24,9 @@ export function HelpSection() {
   return (
     <div className="space-y-6">
       <div>
-        <h2 className="text-[14px] font-[550] text-foreground mb-1">Help</h2>
+        <h2 className="text-[14px] font-[550] text-foreground mb-1">{t("help.heading")}</h2>
         <p className="text-[12px] text-muted-foreground">
-          tunaFlow 주요 기능, 키보드 단축키, 문제 해결 가이드.
+          {t("help.description")}
         </p>
       </div>
 
@@ -21,7 +34,7 @@ export function HelpSection() {
         <section>
           <h3 className="flex items-center gap-2 text-[13px] font-[500] text-foreground mb-2">
             <FileWarning className="w-4 h-4 text-amber-400" />
-            최근 크래시 리포트 ({reports.length})
+            {t("help.crash_reports.title", { count: reports.length })}
           </h3>
           <div className="rounded-lg border border-amber-400/20 bg-amber-400/5 p-3 space-y-1.5 text-[12px]">
             {reports.map((r) => (
@@ -35,7 +48,11 @@ export function HelpSection() {
               </div>
             ))}
             <div className="pt-2 text-muted-foreground">
-              파일 위치: <code>~/.tunaflow/crash-reports/</code> · 이슈 신고 시 첨부해주세요.
+              <Trans
+                i18nKey="help.crash_reports.location"
+                ns="settings"
+                components={{ code: <code /> }}
+              />
             </div>
           </div>
         </section>
@@ -44,15 +61,15 @@ export function HelpSection() {
       <section>
         <h3 className="flex items-center gap-2 text-[13px] font-[500] text-foreground mb-2">
           <Keyboard className="w-4 h-4 text-muted-foreground" />
-          키보드 단축키
+          {t("help.shortcuts_title")}
         </h3>
         <div className="rounded-lg border border-border/40 divide-y divide-border/40">
-          {SHORTCUTS.map(([keys, desc]) => (
+          {SHORTCUT_KEYS.map(({ keys, descKey }) => (
             <div key={keys} className="flex items-center justify-between px-3 py-2 text-[12px]">
               <kbd className="font-mono text-[11px] bg-muted/50 px-2 py-0.5 rounded border border-border/40">
                 {keys}
               </kbd>
-              <span className="text-muted-foreground">{desc}</span>
+              <span className="text-muted-foreground">{t(descKey)}</span>
             </div>
           ))}
         </div>
@@ -61,13 +78,13 @@ export function HelpSection() {
       <section>
         <h3 className="flex items-center gap-2 text-[13px] font-[500] text-foreground mb-2">
           <Lightbulb className="w-4 h-4 text-muted-foreground" />
-          주요 기능
+          {t("help.features_title")}
         </h3>
         <div className="space-y-3 text-[12px]">
-          {FEATURES.map((f) => (
-            <div key={f.title}>
-              <div className="text-foreground font-[500] mb-0.5">{f.title}</div>
-              <div className="text-muted-foreground leading-relaxed">{f.desc}</div>
+          {FEATURE_KEYS.map((key) => (
+            <div key={key}>
+              <div className="text-foreground font-[500] mb-0.5">{t(`help.features.${key}.title`)}</div>
+              <div className="text-muted-foreground leading-relaxed">{t(`help.features.${key}.desc`)}</div>
             </div>
           ))}
         </div>
@@ -76,79 +93,29 @@ export function HelpSection() {
       <section>
         <h3 className="flex items-center gap-2 text-[13px] font-[500] text-foreground mb-2">
           <AlertTriangle className="w-4 h-4 text-muted-foreground" />
-          문제 해결
+          {t("help.troubleshooting_title")}
         </h3>
         <div className="space-y-3 text-[12px]">
-          {TROUBLESHOOTING.map((t) => (
-            <div key={t.title}>
-              <div className="text-foreground font-[500] mb-0.5">{t.title}</div>
-              <div className="text-muted-foreground leading-relaxed whitespace-pre-line">{t.desc}</div>
+          {TROUBLESHOOTING_KEYS.map((key) => (
+            <div key={key}>
+              <div className="text-foreground font-[500] mb-0.5">{t(`help.troubleshooting.${key}.title`)}</div>
+              <div className="text-muted-foreground leading-relaxed whitespace-pre-line">{t(`help.troubleshooting.${key}.desc`)}</div>
             </div>
           ))}
         </div>
       </section>
 
       <section>
-        <h3 className="text-[13px] font-[500] text-foreground mb-2">외부 자료</h3>
+        <h3 className="text-[13px] font-[500] text-foreground mb-2">{t("help.external_title")}</h3>
         <div className="space-y-1.5 text-[12px]">
-          <LinkItem href="https://github.com/hang-in/tunaFlow" label="GitHub 저장소" />
-          <LinkItem href="https://github.com/hang-in/tunaFlow/issues" label="이슈 / 버그 신고" />
-          <LinkItem href="mailto:d9ng@outlook.com" label="이메일 문의: d9ng@outlook.com" />
+          <LinkItem href="https://github.com/hang-in/tunaFlow" label={t("help.external.github")} />
+          <LinkItem href="https://github.com/hang-in/tunaFlow/issues" label={t("help.external.issues")} />
+          <LinkItem href="mailto:d9ng@outlook.com" label={t("help.external.email")} />
         </div>
       </section>
     </div>
   );
 }
-
-const SHORTCUTS: [string, string][] = [
-  ["Cmd+K", "명령 팔레트 열기"],
-  ["Cmd+Enter", "현재 입력 전송"],
-  ["Shift+Enter", "입력창 줄바꿈"],
-  ["Esc", "드로어/모달 닫기"],
-  ["Tab", "포커스 순환 이동"],
-];
-
-const FEATURES: { title: string; desc: string }[] = [
-  {
-    title: "Plan → Develop → Review",
-    desc: "Architect 가 Plan 을 설계하면 Developer 가 구현하고 Reviewer 가 검증합니다. 실패하면 findings 를 기반으로 rev.N+1 Plan 을 자동 제안합니다.",
-  },
-  {
-    title: "Branch / Roundtable",
-    desc: "대화 중간에서 Branch 로 분기해 독립 실험을 하고 결과만 요약 삽입(adopt)할 수 있습니다. RT 는 여러 엔진이 순차/동시로 토론하는 Branch 확장 모드입니다.",
-  },
-  {
-    title: "ContextPack",
-    desc: "매 요청마다 프로젝트 문서, 기억, 도구 결과를 엔진 공통 포맷으로 조립합니다. Lite/Standard/Full 자동 전환으로 토큰을 절약합니다.",
-  },
-  {
-    title: "Insight",
-    desc: "안정성·테스트·아키텍처·성능·보안·기술부채 6개 카테고리로 프로젝트를 분석합니다. Quick Wins 는 에이전트가 자동 수정할 수 있습니다.",
-  },
-  {
-    title: "PTY Terminal",
-    desc: "CLI 에이전트와 `-p` 플래그 없이 인터랙티브 세션을 유지합니다. 파일 수정, 명령 실행 등 전체 도구 사용이 가능합니다.",
-  },
-];
-
-const TROUBLESHOOTING: { title: string; desc: string }[] = [
-  {
-    title: "에이전트가 응답하지 않아요",
-    desc: "Settings > Agents 에서 해당 CLI 가 감지되는지 먼저 확인하세요. Claude/Codex/Gemini 는 각자 한 번 로그인이 필요합니다. 로그인 후에도 응답이 없으면 상단 RuntimeStatusBar 를 눌러 프로세스 상태를 확인하세요.",
-  },
-  {
-    title: "Insight 분석이 시작하자마자 초기화됩니다",
-    desc: "Insight 실행 중 다른 탭으로 이동해도 상태는 Zustand 에 저장됩니다. 계속 초기화가 발생하면 Settings > Runtime 에서 rawq daemon 상태를 확인해주세요.",
-  },
-  {
-    title: "CPU 사용률이 높습니다",
-    desc: "bge-m3 임베딩 인덱싱 중일 수 있습니다. Settings > Runtime 에서 `증분 인덱싱 전용` 모드로 전환하면 대규모 재인덱싱을 피할 수 있습니다.",
-  },
-  {
-    title: "macOS 에서 앱이 열리지 않습니다",
-    desc: "ad-hoc 서명 빌드이므로 Gatekeeper 가 차단할 수 있습니다.\n터미널에서 `xattr -cr /Applications/tunaFlow.app` 실행 후 다시 열어보세요.",
-  },
-];
 
 function LinkItem({ href, label }: { href: string; label: string }) {
   return (

--- a/src/components/tunaflow/settings/HelpSection.tsx
+++ b/src/components/tunaflow/settings/HelpSection.tsx
@@ -3,13 +3,13 @@ import { useTranslation, Trans } from "react-i18next";
 import { ExternalLink, Keyboard, Lightbulb, AlertTriangle, FileWarning } from "lucide-react";
 import { listRecentCrashReports, type CrashReportSummary } from "@/lib/crashReporter";
 
-const SHORTCUT_KEYS: { keys: string; descKey: string }[] = [
+const SHORTCUT_KEYS = [
   { keys: "Cmd+K", descKey: "help.shortcut_desc.cmd_k" },
   { keys: "Cmd+Enter", descKey: "help.shortcut_desc.cmd_enter" },
   { keys: "Shift+Enter", descKey: "help.shortcut_desc.shift_enter" },
   { keys: "Esc", descKey: "help.shortcut_desc.esc" },
   { keys: "Tab", descKey: "help.shortcut_desc.tab" },
-];
+] as const;
 
 const FEATURE_KEYS = ["pdr", "branch", "contextpack", "insight", "pty"] as const;
 const TROUBLESHOOTING_KEYS = ["no_response", "insight_reset", "cpu_high", "macos_gatekeeper"] as const;

--- a/src/components/tunaflow/settings/MobileSection.tsx
+++ b/src/components/tunaflow/settings/MobileSection.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { useTranslation } from "react-i18next";
 import QRCode from "react-qr-code";
 import { Smartphone, RefreshCw, Copy, Check } from "lucide-react";
 
@@ -9,6 +10,7 @@ interface ConnectionInfo {
 }
 
 export function MobileSection() {
+  const { t } = useTranslation("settings");
   const [info, setInfo] = useState<ConnectionInfo | null>(null);
   const [loading, setLoading] = useState(false);
   const [copied, setCopied] = useState<"url" | "token" | null>(null);
@@ -37,16 +39,15 @@ export function MobileSection() {
 
   return (
     <div>
-      <h2 className="text-[14px] font-[550] text-foreground mb-1">모바일 연결</h2>
+      <h2 className="text-[14px] font-[550] text-foreground mb-1">{t("mobile.heading")}</h2>
       <p className="text-[12px] text-muted-foreground mb-5">
-        tunaFlow 모바일 앱에서 QR 코드를 스캔하면 자동으로 연결됩니다.
-        PC와 모바일이 같은 Wi-Fi 네트워크에 있어야 합니다.
+        {t("mobile.description")}
       </p>
 
       {loading && (
         <div className="flex items-center gap-2 text-[12px] text-muted-foreground">
           <RefreshCw className="w-3.5 h-3.5 animate-spin" />
-          네트워크 정보 확인 중…
+          {t("mobile.loading")}
         </div>
       )}
 
@@ -58,7 +59,7 @@ export function MobileSection() {
               <QRCode value={qrPayload} size={160} />
             </div>
             <p className="text-[11px] text-muted-foreground mt-2 text-center">
-              모바일 앱에서 스캔
+              {t("mobile.scan_hint")}
             </p>
           </div>
 
@@ -66,7 +67,7 @@ export function MobileSection() {
           <div className="flex-1 space-y-4">
             <div>
               <label className="text-[11px] font-medium text-muted-foreground uppercase tracking-wider">
-                서버 주소
+                {t("mobile.server_url")}
               </label>
               <div className="flex items-center gap-2 mt-1">
                 <code className="flex-1 text-[12px] bg-accent/50 rounded-md px-3 py-1.5 font-mono text-foreground break-all">
@@ -83,7 +84,7 @@ export function MobileSection() {
 
             <div>
               <label className="text-[11px] font-medium text-muted-foreground uppercase tracking-wider">
-                API 토큰
+                {t("mobile.api_token")}
               </label>
               <div className="flex items-center gap-2 mt-1">
                 <code className="flex-1 text-[12px] bg-accent/50 rounded-md px-3 py-1.5 font-mono text-foreground truncate">
@@ -102,9 +103,13 @@ export function MobileSection() {
               <div className="flex items-start gap-2">
                 <Smartphone className="w-4 h-4 text-muted-foreground mt-0.5 shrink-0" />
                 <div className="text-[12px] text-muted-foreground space-y-1">
-                  <p>① 모바일 브라우저에서 tunaFlow 모바일 앱을 엽니다.</p>
-                  <p>② <strong className="text-foreground">QR 코드 스캔</strong> 버튼을 눌러 위 QR 코드를 스캔하세요.</p>
-                  <p>③ 자동으로 연결됩니다. (수동 입력도 가능)</p>
+                  <p>{t("mobile.steps.step1")}</p>
+                  <p>
+                    {t("mobile.steps.step2_prefix")}
+                    <strong className="text-foreground">{t("mobile.steps.step2_strong")}</strong>
+                    {t("mobile.steps.step2_suffix")}
+                  </p>
+                  <p>{t("mobile.steps.step3")}</p>
                 </div>
               </div>
             </div>
@@ -114,7 +119,7 @@ export function MobileSection() {
               className="flex items-center gap-1.5 text-[12px] text-muted-foreground hover:text-foreground transition-colors"
             >
               <RefreshCw className="w-3 h-3" />
-              새로고침
+              {t("mobile.refresh")}
             </button>
           </div>
         </div>

--- a/src/components/tunaflow/settings/PersonasSection.tsx
+++ b/src/components/tunaflow/settings/PersonasSection.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
 import { Plus, Trash2 } from "lucide-react";
 import { getSetting, setSetting } from "@/lib/appStore";
@@ -6,6 +7,7 @@ import { DEFAULT_PERSONAS } from "@/lib/defaultPersonas";
 import type { Persona } from "@/types";
 
 export function PersonasSection() {
+  const { t } = useTranslation("settings");
   const [personas, setPersonas] = useState<Persona[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
 
@@ -47,8 +49,8 @@ export function PersonasSection() {
 
   return (
     <div>
-      <h2 className="text-[14px] font-[550] text-foreground mb-1">Personas</h2>
-      <p className="text-[12px] text-muted-foreground mb-4">에이전트의 역할과 행동 규칙을 정의합니다. Agent Profile에서 persona를 선택하여 사용합니다.</p>
+      <h2 className="text-[14px] font-[550] text-foreground mb-1">{t("personas.heading")}</h2>
+      <p className="text-[12px] text-muted-foreground mb-4">{t("personas.description")}</p>
 
       <div className="flex gap-4 min-h-[300px]">
         <div className="w-[160px] shrink-0 space-y-1">

--- a/src/components/tunaflow/settings/ProfileSection.tsx
+++ b/src/components/tunaflow/settings/ProfileSection.tsx
@@ -82,6 +82,7 @@ function SectionHeader({ icon, label }: { icon: React.ReactNode; label: string }
 }
 
 export function ProfileSection() {
+  const { t } = useTranslation("settings");
   const [profile, setProfile] = useState<UserProfile>(DEFAULT_PROFILE);
   const [saved, setSaved] = useState(false);
 
@@ -112,15 +113,15 @@ export function ProfileSection() {
   return (
     <div className="space-y-6">
       <div>
-        <h2 className="text-[14px] font-[550] text-foreground mb-1">Profile</h2>
-        <p className="text-[12px] text-muted-foreground">에이전트 컨텍스트와 개발자 정보를 설정합니다.</p>
+        <h2 className="text-[14px] font-[550] text-foreground mb-1">{t("profile.heading")}</h2>
+        <p className="text-[12px] text-muted-foreground">{t("profile.description")}</p>
       </div>
 
       <LanguageSelector />
 
       {/* ── Basic ─────────────────────────────────────────────── */}
       <div className="space-y-3">
-        <SectionHeader icon={<User className="w-3.5 h-3.5" />} label="기본 정보" />
+        <SectionHeader icon={<User className="w-3.5 h-3.5" />} label={t("profile.group.basic")} />
         <div className="flex items-start gap-4">
           {/* Avatar */}
           <div className="shrink-0">
@@ -138,13 +139,13 @@ export function ProfileSection() {
             )}
           </div>
           <div className="flex-1 grid grid-cols-2 gap-3">
-            <FieldRow label="이름">
+            <FieldRow label={t("profile.field.name")}>
               <Input value={profile.name} onChange={(v) => update({ name: v })} placeholder="Hong Gildong" />
             </FieldRow>
-            <FieldRow label="직함">
+            <FieldRow label={t("profile.field.title")}>
               <Input value={profile.title} onChange={(v) => update({ title: v })} placeholder="Software Engineer" />
             </FieldRow>
-            <FieldRow label="GitHub Username" hint="프로필 사진 자동 로드에 사용됩니다.">
+            <FieldRow label={t("profile.field.github_username")} hint={t("profile.hint.github_username")}>
               <Input value={profile.githubUsername} onChange={(v) => update({ githubUsername: v })} placeholder="octocat" />
             </FieldRow>
           </div>
@@ -153,32 +154,32 @@ export function ProfileSection() {
 
       {/* ── Agent context ──────────────────────────────────────── */}
       <div className="space-y-3">
-        <SectionHeader icon={<Code2 className="w-3.5 h-3.5" />} label="에이전트 컨텍스트" />
-        <FieldRow label="소개 메모" hint="에이전트가 사용자 배경을 이해하는 데 활용됩니다.">
+        <SectionHeader icon={<Code2 className="w-3.5 h-3.5" />} label={t("profile.group.agent_context")} />
+        <FieldRow label={t("profile.field.bio")} hint={t("profile.hint.bio")}>
           <textarea
             value={profile.bio}
             onChange={(e) => update({ bio: e.target.value })}
-            placeholder="백엔드 API 개발 주력, Rust/TypeScript 사용, 스타트업 CTO..."
+            placeholder={t("profile.placeholder.bio")}
             rows={3}
             className="w-full bg-background border border-border/40 rounded-md px-3 py-2 text-[13px] text-foreground placeholder:text-muted-foreground/30 focus:outline-none focus:border-ring/50 transition-colors resize-none"
           />
         </FieldRow>
-        <FieldRow label="선호 언어" hint="쉼표로 구분합니다.">
-          <Input value={profile.preferredLanguages} onChange={(v) => update({ preferredLanguages: v })} placeholder="TypeScript, Rust, Python" />
+        <FieldRow label={t("profile.field.preferred_languages")} hint={t("profile.hint.preferred_languages")}>
+          <Input value={profile.preferredLanguages} onChange={(v) => update({ preferredLanguages: v })} placeholder={t("profile.placeholder.preferred_languages")} />
         </FieldRow>
       </div>
 
       {/* ── Dev info ───────────────────────────────────────────── */}
       <div className="space-y-3">
-        <SectionHeader icon={<GitBranch className="w-3.5 h-3.5" />} label="개발자 정보" />
+        <SectionHeader icon={<GitBranch className="w-3.5 h-3.5" />} label={t("profile.group.dev_info")} />
         <div className="grid grid-cols-2 gap-3">
-          <FieldRow label="Git 이름">
+          <FieldRow label={t("profile.field.git_name")}>
             <Input value={profile.gitName} onChange={(v) => update({ gitName: v })} placeholder="Hong Gildong" />
           </FieldRow>
-          <FieldRow label="Git 이메일">
+          <FieldRow label={t("profile.field.git_email")}>
             <Input value={profile.gitEmail} onChange={(v) => update({ gitEmail: v })} placeholder="user@example.com" />
           </FieldRow>
-          <FieldRow label="GitHub 기본 Org">
+          <FieldRow label={t("profile.field.github_org")}>
             <Input value={profile.githubOrg} onChange={(v) => update({ githubOrg: v })} placeholder="my-org" />
           </FieldRow>
         </div>
@@ -186,17 +187,17 @@ export function ProfileSection() {
 
       {/* ── Timezone (auto) ────────────────────────────────────── */}
       <div className="space-y-3">
-        <SectionHeader icon={<Clock className="w-3.5 h-3.5" />} label="시간대" />
+        <SectionHeader icon={<Clock className="w-3.5 h-3.5" />} label={t("profile.group.timezone")} />
         <div className="flex items-center gap-2 px-3 py-2 bg-accent/20 rounded-md border border-border/20">
           <span className="text-[13px] text-foreground/60">{timezone}</span>
-          <span className="text-[11px] text-muted-foreground/40 ml-1">자동 감지</span>
+          <span className="text-[11px] text-muted-foreground/40 ml-1">{t("profile.hint.timezone_auto")}</span>
         </div>
       </div>
 
       {/* ── Advanced (GitHub Token) ────────────────────────────── */}
       <div className="space-y-3">
-        <SectionHeader icon={<KeyRound className="w-3.5 h-3.5" />} label="고급" />
-        <FieldRow label="GitHub Personal Access Token" hint="레포 클론, API 접근 시 사용됩니다. 로컬에만 저장됩니다.">
+        <SectionHeader icon={<KeyRound className="w-3.5 h-3.5" />} label={t("profile.group.advanced")} />
+        <FieldRow label={t("profile.field.github_token")} hint={t("profile.hint.github_token")}>
           <Input
             type="password"
             value={profile.githubToken}
@@ -212,10 +213,10 @@ export function ProfileSection() {
           onClick={handleSave}
           className="px-4 py-1.5 bg-primary text-primary-foreground text-[13px] font-medium rounded-md hover:bg-primary/90 transition-colors"
         >
-          저장
+          {t("profile.button.save")}
         </button>
         {saved && (
-          <span className="text-[12px] text-status-approved">저장됐습니다</span>
+          <span className="text-[12px] text-status-approved">{t("profile.saved_msg")}</span>
         )}
       </div>
     </div>

--- a/src/components/tunaflow/settings/RuntimeSection.tsx
+++ b/src/components/tunaflow/settings/RuntimeSection.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { useTranslation } from "react-i18next";
 import { copyToClipboard } from "@/lib/clipboard";
 import { invoke } from "@tauri-apps/api/core";
 import { cn, errorMessage } from "@/lib/utils";
@@ -9,13 +10,13 @@ import { SKILL_SETS, expandSkillRefs } from "@/lib/skillSets";
 
 // ─── Workflow Skills Config ──────────────────────────────────────────────────
 
-const WORKFLOW_PHASES = [
-  { key: "chat", label: "Chat / Planning", desc: "일반 대화, Architect 설계" },
-  { key: "implementation", label: "Implementation", desc: "Developer 코드 구현" },
-  { key: "review", label: "Review", desc: "Reviewer 코드 검토" },
-] as const;
-
 function WorkflowSkillsConfig() {
+  const { t } = useTranslation("settings");
+  const WORKFLOW_PHASES = [
+    { key: "chat", label: "Chat / Planning", desc: t("runtime.workflow_skills.phase.chat_desc") },
+    { key: "implementation", label: "Implementation", desc: t("runtime.workflow_skills.phase.implementation_desc") },
+    { key: "review", label: "Review", desc: t("runtime.workflow_skills.phase.review_desc") },
+  ] as const;
   const workflowSkills = useChatStore((s) => s.workflowSkills);
   const saveWorkflowSkills = useChatStore((s) => s.saveWorkflowSkills);
   const [expandedPhase, setExpandedPhase] = useState<string | null>(null);
@@ -31,8 +32,8 @@ function WorkflowSkillsConfig() {
   return (
     <div className="rounded-lg border border-border/30 bg-background/50 p-4 space-y-3">
       <div>
-        <h3 className="text-[13px] font-medium text-foreground">Workflow Skills</h3>
-        <p className="text-[11px] text-muted-foreground/60 mt-0.5">워크플로우 단계별 스킬 세트. 수동 선택과 합산됩니다.</p>
+        <h3 className="text-[13px] font-medium text-foreground">{t("runtime.workflow_skills.heading")}</h3>
+        <p className="text-[11px] text-muted-foreground/60 mt-0.5">{t("runtime.workflow_skills.description")}</p>
       </div>
       <div className="space-y-3">
         {WORKFLOW_PHASES.map(({ key, label, desc }) => {
@@ -95,13 +96,6 @@ function WorkflowSkillsConfig() {
 
 // ─── Context Budget Control ──────────────────────────────────────────────────
 
-const CONTEXT_MODES = [
-  { id: "auto", label: "Auto", desc: "대화 상태에 따라 자동 선택 (기본)" },
-  { id: "lite", label: "Lite", desc: "프로젝트 + 대화 컨텍스트만 포함" },
-  { id: "standard", label: "Standard", desc: "Lite + Plan, Findings, Artifacts" },
-  { id: "full", label: "Full", desc: "Standard + Skills, rawq, Cross-session" },
-] as const;
-
 const SECTION_POLICY: Record<string, string[]> = {
   lite: ["Project", "Context"],
   standard: ["Project", "Context", "Plan", "Findings", "Artifacts"],
@@ -124,11 +118,9 @@ interface InsightPreset {
   systemPrompt: string;
 }
 
-const INSIGHT_PRESETS: InsightPreset[] = [
+const INSIGHT_PRESETS_DATA: Omit<InsightPreset, "label" | "desc">[] = [
   {
     id: "balanced",
-    label: "Balanced (Claude)",
-    desc: "정확도와 비용의 균형. 일반적 코드 품질 분석에 적합",
     engine: "claude",
     model: "",
     systemPrompt: `You are a senior code quality analyst performing a targeted review.
@@ -147,8 +139,6 @@ const INSIGHT_PRESETS: InsightPreset[] = [
   },
   {
     id: "thorough",
-    label: "Thorough (Claude)",
-    desc: "정밀 분석. 더 많은 토큰 소비, 더 높은 정확도",
     engine: "claude",
     model: "",
     systemPrompt: `You are a principal software engineer conducting a thorough code quality audit.
@@ -175,8 +165,6 @@ Respond in Korean for descriptions, keep technical terms in English.`,
   },
   {
     id: "security",
-    label: "Security Focus (Claude)",
-    desc: "보안 취약점 중심 분석. OWASP Top 10 기반",
     engine: "claude",
     model: "",
     systemPrompt: `You are a security engineer conducting a focused vulnerability assessment.
@@ -206,8 +194,6 @@ Respond in Korean for descriptions, English for technical terms and CWE referenc
   },
   {
     id: "gemini",
-    label: "Balanced (Gemini)",
-    desc: "Gemini 엔진 사용. 다른 관점의 분석",
     engine: "gemini",
     model: "",
     systemPrompt: `You are a senior code quality analyst performing a targeted review.
@@ -225,11 +211,27 @@ Respond in Korean for descriptions, English for technical terms and CWE referenc
 const DEFAULT_INSIGHT_CONFIG = {
   engine: "claude",
   model: "",
-  systemPrompt: INSIGHT_PRESETS[0].systemPrompt,
+  systemPrompt: INSIGHT_PRESETS_DATA[0].systemPrompt,
   presetId: "balanced",
 };
 
+const INSIGHT_PRESET_I18N = {
+  balanced: { labelKey: "runtime.insight_agent.preset.balanced_claude_label", descKey: "runtime.insight_agent.preset.balanced_claude_desc" },
+  thorough: { labelKey: "runtime.insight_agent.preset.thorough_label", descKey: "runtime.insight_agent.preset.thorough_desc" },
+  security: { labelKey: "runtime.insight_agent.preset.security_label", descKey: "runtime.insight_agent.preset.security_desc" },
+  gemini: { labelKey: "runtime.insight_agent.preset.balanced_gemini_label", descKey: "runtime.insight_agent.preset.balanced_gemini_desc" },
+} as const;
+
 function InsightAgentConfig() {
+  const { t } = useTranslation("settings");
+  const INSIGHT_PRESETS: InsightPreset[] = INSIGHT_PRESETS_DATA.map((p) => {
+    const i18n = INSIGHT_PRESET_I18N[p.id as keyof typeof INSIGHT_PRESET_I18N];
+    return {
+      ...p,
+      label: i18n ? t(i18n.labelKey) : p.id,
+      desc: i18n ? t(i18n.descKey) : "",
+    };
+  });
   const [config, setConfig] = useState(DEFAULT_INSIGHT_CONFIG);
   const [expanded, setExpanded] = useState(false);
   const engineModels = useChatStore((s) => s.engineModels);
@@ -259,12 +261,12 @@ function InsightAgentConfig() {
     <div className="rounded-lg border border-border/30 bg-background/50 p-4 space-y-3">
       <div>
         <h3 className="text-[13px] font-medium text-foreground">Insight Agent</h3>
-        <p className="text-[11px] text-muted-foreground/60 mt-0.5">Insight 탭 분석에 사용할 에이전트 설정</p>
+        <p className="text-[11px] text-muted-foreground/60 mt-0.5">{t("runtime.insight_agent.description")}</p>
       </div>
 
       {/* Preset buttons */}
       <div className="space-y-1.5">
-        <span className="text-[10px] text-muted-foreground/50">프리셋</span>
+        <span className="text-[10px] text-muted-foreground/50">{t("runtime.insight_agent.preset_label")}</span>
         <div className="flex flex-wrap gap-1.5">
           {INSIGHT_PRESETS.map((p) => (
             <button
@@ -287,7 +289,7 @@ function InsightAgentConfig() {
       {/* Engine + Model */}
       <div className="flex gap-3">
         <div className="space-y-1 flex-1">
-          <span className="text-[10px] text-muted-foreground/50">엔진</span>
+          <span className="text-[10px] text-muted-foreground/50">{t("runtime.insight_agent.engine_label")}</span>
           <select
             value={config.engine}
             onChange={(e) => update({ engine: e.target.value, model: "", presetId: "custom" })}
@@ -301,7 +303,7 @@ function InsightAgentConfig() {
           </select>
         </div>
         <div className="space-y-1 flex-1">
-          <span className="text-[10px] text-muted-foreground/50">모델</span>
+          <span className="text-[10px] text-muted-foreground/50">{t("runtime.insight_agent.model_label")}</span>
           <select
             value={config.model}
             onChange={(e) => update({ model: e.target.value, presetId: "custom" })}
@@ -324,7 +326,7 @@ function InsightAgentConfig() {
           className="flex items-center gap-1 text-[10px] text-muted-foreground/50 hover:text-foreground"
         >
           {expanded ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
-          시스템 프롬프트 {config.presetId !== "custom" && `(${config.presetId})`}
+          {t("runtime.insight_agent.system_prompt")} {config.presetId !== "custom" && `(${config.presetId})`}
         </button>
         {expanded && (
           <textarea
@@ -340,6 +342,13 @@ function InsightAgentConfig() {
 }
 
 function ContextBudgetControl() {
+  const { t } = useTranslation("settings");
+  const CONTEXT_MODES = [
+    { id: "auto", label: "Auto", desc: t("runtime.context_budget.modes.auto_desc") },
+    { id: "lite", label: "Lite", desc: t("runtime.context_budget.modes.lite_desc") },
+    { id: "standard", label: "Standard", desc: t("runtime.context_budget.modes.standard_desc") },
+    { id: "full", label: "Full", desc: t("runtime.context_budget.modes.full_desc") },
+  ] as const;
   const [config, setConfig] = useState({ mode: "auto", totalCap: BUDGET_DEFAULT });
   const [loaded, setLoaded] = useState(false);
 
@@ -389,14 +398,14 @@ function ContextBudgetControl() {
         </div>
       </div>
       <div className="space-y-1.5">
-        <label className="text-[11px] text-muted-foreground">Included Sections {config.mode === "auto" ? "(Auto 모드: 최대 범위)" : ""}</label>
+        <label className="text-[11px] text-muted-foreground">{config.mode === "auto" ? t("runtime.context_budget.included_sections_auto") : t("runtime.context_budget.included_sections")}</label>
         <div className="flex flex-wrap gap-1">
           {["Project", "Context", "Persona", "Plan", "Findings", "Artifacts", "Skills", "rawq", "Cross-session", "Thread"].map((sec) => (
             <span key={sec} className={cn("px-1.5 py-0.5 rounded text-[9px] font-medium",
               sections.includes(sec) || sec === "Persona" || sec === "Thread" ? "bg-accent/60 text-foreground/60" : "bg-muted/30 text-muted-foreground/25 line-through")}>{sec}</span>
           ))}
         </div>
-        <p className="text-[9px] text-muted-foreground/30">Persona는 설정 시 항상 포함. Thread는 branch에서 자동 포함. rawq는 코드 신호 감지 시 mode 무관 포함.</p>
+        <p className="text-[9px] text-muted-foreground/30">{t("runtime.context_budget.persona_thread_note")}</p>
       </div>
     </div>
   );
@@ -523,6 +532,7 @@ function ContextHubPanel({ hubHealth }: { hubHealth: HubHealth | null }) {
 // ─── PTY Mode Toggle ────────────────────────────────────────────────────────
 
 function PtyModeToggle() {
+  const { t } = useTranslation("settings");
   const [ptyEnabled, setPtyEnabled] = useState(true);
 
   useEffect(() => {
@@ -565,7 +575,7 @@ function PtyModeToggle() {
           <span className="text-foreground/80">{ptyEnabled ? "PTY (stateful, multi-turn)" : "CLI -p (stateless, per-message)"}</span>
         </div>
         <p className="text-[11px] text-muted-foreground/50 mt-1">
-          PTY 비활성화 시 모든 메시지가 -p 모드로 전송됩니다. /clear로 세션 초기화 가능.
+          {t("runtime.pty.hint")}
         </p>
       </div>
     </div>
@@ -573,6 +583,7 @@ function PtyModeToggle() {
 }
 
 export function RuntimeSection() {
+  const { t } = useTranslation("settings");
   const rawqStatus = useChatStore((s) => s.rawqStatus);
   const engineModels = useChatStore((s) => s.engineModels);
   const loadEngineModels = useChatStore((s) => s.loadEngineModels);
@@ -588,8 +599,8 @@ export function RuntimeSection() {
   return (
     <div className="space-y-6">
       <div>
-        <h2 className="text-[14px] font-[550] text-foreground mb-1">Runtime</h2>
-        <p className="text-[12px] text-muted-foreground mb-4">런타임 환경 상태를 확인하고 관리합니다.</p>
+        <h2 className="text-[14px] font-[550] text-foreground mb-1">{t("runtime.heading")}</h2>
+        <p className="text-[12px] text-muted-foreground mb-4">{t("runtime.description")}</p>
       </div>
 
       {/* rawq */}
@@ -653,6 +664,7 @@ export function RuntimeSection() {
 // ─── Attachments Cleanup ──────────────────────────────────────────────────────
 
 function AttachmentsCleanupPanel() {
+  const { t } = useTranslation("settings");
   const selectedProjectKey = useChatStore((s) => s.selectedProjectKey);
   const [olderThanDays, setOlderThanDays] = useState(30);
   const [running, setRunning] = useState(false);
@@ -661,14 +673,14 @@ function AttachmentsCleanupPanel() {
 
   const runCleanup = async () => {
     if (!selectedProjectKey) {
-      setError("프로젝트가 선택되지 않았습니다.");
+      setError(t("runtime.attachments.error.no_project"));
       return;
     }
     setRunning(true);
     setError(null);
     try {
       const project = await invoke<{ path?: string }>("get_project", { key: selectedProjectKey });
-      if (!project.path) { setError("프로젝트 경로를 찾을 수 없습니다."); return; }
+      if (!project.path) { setError(t("runtime.attachments.error.no_path")); return; }
       const result = await invoke<{ deletedCount: number; freedBytes: number }>("cleanup_attachments", {
         projectPath: project.path,
         olderThanDays,
@@ -688,13 +700,13 @@ function AttachmentsCleanupPanel() {
   return (
     <div className="rounded-lg border border-border/30 bg-background/50 p-4 space-y-3">
       <div>
-        <h3 className="text-[13px] font-medium text-foreground">Attachments Cleanup</h3>
+        <h3 className="text-[13px] font-medium text-foreground">{t("runtime.attachments.heading")}</h3>
         <p className="text-[11px] text-muted-foreground mt-0.5">
-          `.tunaflow/attachments/` 내부의 오래된 첨부 파일을 정리합니다. (.gitignore 는 보존)
+          {t("runtime.attachments.description")}
         </p>
       </div>
       <div className="flex items-center gap-2 text-[12px]">
-        <span className="text-muted-foreground">보다 오래된 파일 삭제:</span>
+        <span className="text-muted-foreground">{t("runtime.attachments.older_than")}</span>
         <input
           type="number"
           min={0}
@@ -703,18 +715,18 @@ function AttachmentsCleanupPanel() {
           onChange={(e) => setOlderThanDays(Math.max(0, parseInt(e.target.value || "0", 10)))}
           className="w-16 px-2 py-1 rounded border border-border/40 bg-background text-foreground"
         />
-        <span className="text-muted-foreground">일 (0 = 전부)</span>
+        <span className="text-muted-foreground">{t("runtime.attachments.days_suffix")}</span>
         <button
           onClick={runCleanup}
           disabled={running || !selectedProjectKey}
           className="ml-auto px-3 py-1 rounded bg-primary text-primary-foreground text-[12px] disabled:opacity-50"
         >
-          {running ? "정리 중..." : "정리 실행"}
+          {running ? t("runtime.attachments.running") : t("runtime.attachments.run")}
         </button>
       </div>
       {lastResult && (
         <div className="text-[11px] text-muted-foreground">
-          ✅ 삭제 {lastResult.deletedCount}건 · 확보 {formatSize(lastResult.freedBytes)}
+          {t("runtime.attachments.result", { count: lastResult.deletedCount, size: formatSize(lastResult.freedBytes) })}
         </div>
       )}
       {error && (

--- a/src/components/tunaflow/settings/WorldviewSettings.tsx
+++ b/src/components/tunaflow/settings/WorldviewSettings.tsx
@@ -6,15 +6,6 @@ import { Globe, FileText } from "lucide-react";
 
 const WORLDVIEW_MAX_TOKENS = 500;
 
-const DEFAULT_WORLDVIEW_TEMPLATE = `# User Worldview
-
-## Ontology
-(기본 세계관 — 직접 작성)
-
-## Engagement preference
-(agent 와의 협업 방식 선호 — 직접 작성)
-`;
-
 // guardrail::estimate_tokens 와 동일한 휴리스틱 (ascii/4 + cjk*2/3).
 function estimateTokens(text: string): number {
   let ascii = 0;
@@ -79,7 +70,7 @@ export function WorldviewSettings() {
   };
 
   const handleLoadDefault = () => {
-    setContent(DEFAULT_WORLDVIEW_TEMPLATE);
+    setContent(t("worldview.default_template"));
     setSaved(false);
   };
 

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -12,13 +12,17 @@
     "mobile": "Mobile",
     "help": "Help"
   },
+  "skills_description": "Manage the skills applied to agents.",
   "profile": {
+    "heading": "Profile",
     "description": "Configure your agent context and developer information.",
     "group": {
       "basic": "Basic info",
       "agent_context": "Agent context",
       "dev_info": "Developer info",
-      "advanced": "Advanced"
+      "timezone": "Timezone",
+      "advanced": "Advanced",
+      "advanced_old": "Advanced"
     },
     "field": {
       "name": "Name",
@@ -28,12 +32,27 @@
       "preferred_languages": "Preferred languages",
       "git_name": "Git name",
       "git_email": "Git email",
-      "github_org": "GitHub org",
-      "github_token": "GitHub token"
+      "github_org": "GitHub default org",
+      "github_token": "GitHub Personal Access Token"
+    },
+    "hint": {
+      "github_username": "Used to auto-load your profile picture.",
+      "bio": "Helps the agent understand your background.",
+      "preferred_languages": "Comma-separated.",
+      "github_token": "Used for repo cloning and API access. Stored locally only.",
+      "timezone_auto": "Auto-detected"
+    },
+    "placeholder": {
+      "bio": "Backend API dev, Rust/TypeScript, startup CTO...",
+      "preferred_languages": "TypeScript, Rust, Python"
+    },
+    "button": {
+      "save": "Save"
     },
     "toast": {
       "saved": "Profile saved"
-    }
+    },
+    "saved_msg": "Saved"
   },
   "worldview": {
     "heading": "User Worldview",
@@ -52,7 +71,8 @@
       "toggle_on": "Worldview injection enabled",
       "toggle_off": "Worldview injection disabled"
     },
-    "placeholder": "(Empty — load default or write your own)"
+    "placeholder": "(Empty — load default or write your own)",
+    "default_template": "# User Worldview\n\n## Ontology\n(Default worldview — write your own)\n\n## Engagement preference\n(Preferred collaboration style with the agent — write your own)\n"
   },
   "identity": {
     "heading": "Identity Analysis",
@@ -81,6 +101,220 @@
       "enqueued": "Analysis job enqueued — worker will run within 30s",
       "skipped": "Skip — {{reason}}",
       "run_failed": "Run failed: {{error}}"
+    }
+  },
+  "help": {
+    "heading": "Help",
+    "description": "Overview of tunaFlow features, keyboard shortcuts, and troubleshooting.",
+    "crash_reports": {
+      "title": "Recent crash reports ({{count}})",
+      "location": "File location: <code>~/.tunaflow/crash-reports/</code> · please attach when reporting issues."
+    },
+    "shortcuts_title": "Keyboard shortcuts",
+    "features_title": "Features",
+    "troubleshooting_title": "Troubleshooting",
+    "external_title": "External resources",
+    "external": {
+      "github": "GitHub repository",
+      "issues": "Issues / bug reports",
+      "email": "Email: d9ng@outlook.com"
+    },
+    "shortcut_desc": {
+      "cmd_k": "Open command palette",
+      "cmd_enter": "Send current input",
+      "shift_enter": "Newline in input",
+      "esc": "Close drawer/modal",
+      "tab": "Cycle focus"
+    },
+    "features": {
+      "pdr": {
+        "title": "Plan → Develop → Review",
+        "desc": "The Architect designs a Plan, the Developer implements it, and the Reviewer verifies the result. On failure, a rev.N+1 Plan is proposed automatically based on findings."
+      },
+      "branch": {
+        "title": "Branch / Roundtable",
+        "desc": "Branch off from the middle of a conversation for an independent experiment and adopt only the summary back. RT is a Branch extension where multiple engines discuss sequentially or in parallel."
+      },
+      "contextpack": {
+        "title": "ContextPack",
+        "desc": "Assembles project docs, memory, and tool results into a shared format on every request. Auto-switches between Lite/Standard/Full to save tokens."
+      },
+      "insight": {
+        "title": "Insight",
+        "desc": "Analyzes the project across six categories: stability, tests, architecture, performance, security, and tech debt. Quick Wins can be auto-fixed by the agent."
+      },
+      "pty": {
+        "title": "PTY Terminal",
+        "desc": "Keeps an interactive session with CLI agents without the `-p` flag. Full tool usage including file edits and command execution is available."
+      }
+    },
+    "troubleshooting": {
+      "no_response": {
+        "title": "The agent is not responding",
+        "desc": "First check in Settings > Agents that the CLI is detected. Claude/Codex/Gemini each require a one-time login. If there is still no response after login, click the top RuntimeStatusBar to check process state."
+      },
+      "insight_reset": {
+        "title": "Insight analysis resets right after starting",
+        "desc": "State is preserved in Zustand even if you switch tabs while Insight runs. If resets continue, check the rawq daemon status in Settings > Runtime."
+      },
+      "cpu_high": {
+        "title": "CPU usage is high",
+        "desc": "The bge-m3 embedding indexer may be running. Switch to `incremental indexing only` mode in Settings > Runtime to avoid large re-indexing."
+      },
+      "macos_gatekeeper": {
+        "title": "The app won't open on macOS",
+        "desc": "This is an ad-hoc signed build, so Gatekeeper may block it.\nRun `xattr -cr /Applications/tunaFlow.app` in Terminal and try again."
+      }
+    }
+  },
+  "mobile": {
+    "heading": "Mobile connection",
+    "description": "Scan the QR code from the tunaFlow mobile app to connect automatically. PC and mobile must be on the same Wi-Fi network.",
+    "loading": "Checking network info…",
+    "scan_hint": "Scan from the mobile app",
+    "server_url": "Server URL",
+    "api_token": "API token",
+    "steps": {
+      "step1": "① Open the tunaFlow mobile app in your mobile browser.",
+      "step2_prefix": "② Tap ",
+      "step2_strong": "Scan QR",
+      "step2_suffix": " to scan the QR code above.",
+      "step3": "③ Connection is automatic. (Manual entry is also supported.)"
+    },
+    "refresh": "Refresh"
+  },
+  "personas": {
+    "heading": "Personas",
+    "description": "Define agent roles and behavior rules. Select a persona in an Agent Profile to apply it."
+  },
+  "agents": {
+    "heading": "Agent Profiles",
+    "description": "Manage agent profiles. Each profile bundles an engine, model, and default skills into a single execution unit.",
+    "role_coverage": {
+      "title": "Role coverage",
+      "ready_count": "{{ready}}/{{total}} ready",
+      "hint": "Assign profiles to the Architect (design), Developer (implement), Reviewer (≥2 reviewers), and Synthesizer (RT synthesis) roles to run Review RT / Plan approval / RT synthesis exactly as configured.",
+      "unselected": "— Not selected —",
+      "no_profiles": "No profiles available"
+    },
+    "meta": {
+      "heading": "Meta-agent auto analysis (Tier 2)",
+      "description": "Automatically generates weekly summaries, failure pattern analysis, and artifact summaries using low-cost engines. Read-only — proposes only; execution requires user approval.",
+      "engine_label": "Engine",
+      "auto_trigger": "Auto trigger",
+      "auto_trigger_hint": "— Runs analysis automatically when thresholds are reached",
+      "threshold": {
+        "weekly_pass": "Weekly summary (pass count)",
+        "fail_pattern": "Failure pattern (fail count)",
+        "artifact_count": "Artifact summary (count)",
+        "idle_days": "Idle days"
+      },
+      "engine_option": {
+        "off_label": "Off",
+        "off_hint": "Disable meta auto analysis",
+        "auto_label": "Auto",
+        "auto_hint": "Auto-select based on project stack",
+        "claude_haiku_hint": "Stable JSON/Korean summaries, inexpensive",
+        "gemini_flash_hint": "Cheap for large input, fast"
+      }
+    }
+  },
+  "runtime": {
+    "heading": "Runtime",
+    "description": "Inspect and manage the runtime environment.",
+    "workflow_skills": {
+      "heading": "Workflow Skills",
+      "description": "Skill sets per workflow phase. Combined with manual selection.",
+      "phase": {
+        "chat_desc": "General conversation, Architect design",
+        "implementation_desc": "Developer code implementation",
+        "review_desc": "Reviewer code review"
+      }
+    },
+    "context_budget": {
+      "modes": {
+        "auto_desc": "Auto-select based on conversation state (default)",
+        "lite_desc": "Project + conversation context only",
+        "standard_desc": "Lite + Plan, Findings, Artifacts",
+        "full_desc": "Standard + Skills, rawq, Cross-session"
+      },
+      "included_sections_auto": "Included Sections (Auto mode: maximum scope)",
+      "included_sections": "Included Sections",
+      "persona_thread_note": "Persona is always included when configured. Thread is automatically included for branches. rawq is included regardless of mode when code signals are detected."
+    },
+    "insight_agent": {
+      "description": "Agent configuration used by the Insight tab analysis.",
+      "preset_label": "Preset",
+      "engine_label": "Engine",
+      "model_label": "Model",
+      "system_prompt": "System prompt",
+      "preset": {
+        "balanced_claude_label": "Balanced (Claude)",
+        "balanced_claude_desc": "Balance of accuracy and cost. Suitable for general code quality analysis.",
+        "thorough_label": "Thorough (Claude)",
+        "thorough_desc": "In-depth analysis. More tokens, higher accuracy.",
+        "security_label": "Security Focus (Claude)",
+        "security_desc": "Security-focused analysis. Based on OWASP Top 10.",
+        "balanced_gemini_label": "Balanced (Gemini)",
+        "balanced_gemini_desc": "Uses the Gemini engine for a different perspective."
+      }
+    },
+    "pty": {
+      "hint": "When PTY is disabled, all messages are sent via -p mode. Session can be reset with /clear."
+    },
+    "attachments": {
+      "heading": "Attachments Cleanup",
+      "description": "Clean up old attachment files inside `.tunaflow/attachments/`. (.gitignore is preserved.)",
+      "older_than": "Delete files older than:",
+      "days_suffix": "days (0 = all)",
+      "run": "Run cleanup",
+      "running": "Cleaning...",
+      "result": "✅ Deleted {{count}} · Freed {{size}}",
+      "error": {
+        "no_project": "No project selected.",
+        "no_path": "Project path not found."
+      }
+    }
+  },
+  "conventions": {
+    "heading": "Conventions Context Sync",
+    "description": "Syncs static ContextPack layers (platform / agent role / persona / user profile) to CLAUDE.md / AGENTS.md / GEMINI.md. After editing, refresh files with \"Sync Now\".",
+    "toggle": {
+      "label": "Skip static layers in ContextPack",
+      "description": "When enabled, static layers are not resent every turn. CLI auto-prepends CLAUDE.md/AGENTS.md, and the Anthropic API path benefits from prompt cache hits for cost savings. First add conventions for the project below and build the files via \"Sync Now\" to see actual effect."
+    },
+    "select_project": "— Select project —",
+    "persona_filter_placeholder": "Persona filter (empty = common only)",
+    "reload_title": "Reload",
+    "syncing": "Syncing…",
+    "sync_now": "Sync Now",
+    "sync_report": "✓ Sync complete — entry files: {{entry}}, split files: {{split}}",
+    "sync_report_truncated": " ({{count}} truncated)",
+    "error_no_project_path": "Project path is missing",
+    "empty_hint": "No conventions registered yet. Add one below.",
+    "delete_title": "Delete",
+    "new": {
+      "heading": "Add new convention",
+      "persona_placeholder": "Persona (empty = common)",
+      "source_placeholder": "Source ID (optional)",
+      "content_placeholder": "Markdown body…",
+      "add": "Add"
+    },
+    "layer": {
+      "platform_label": "Platform / Project meta",
+      "platform_hint": "Project path, build commands, languages, etc.",
+      "agent_role_label": "Agent role",
+      "agent_role_hint": "Agent role guidance (architect/coder/reviewer, etc.)",
+      "persona_label": "Persona",
+      "persona_hint": "Persona behavior guidance",
+      "user_profile_label": "User profile",
+      "user_profile_hint": "User info and preferences",
+      "plan_doc_label": "Plan document",
+      "plan_doc_hint": "Current in-progress plan body (revision-based)",
+      "findings_label": "Findings",
+      "findings_hint": "Findings body from a previous review verdict",
+      "artifact_label": "Artifact",
+      "artifact_hint": "Reference artifact (e.g. result.md)"
     }
   }
 }

--- a/src/locales/ko/settings.json
+++ b/src/locales/ko/settings.json
@@ -12,28 +12,47 @@
     "mobile": "Mobile",
     "help": "Help"
   },
+  "skills_description": "에이전트에게 적용할 스킬을 관리합니다.",
   "profile": {
+    "heading": "Profile",
     "description": "에이전트 컨텍스트와 개발자 정보를 설정합니다.",
     "group": {
       "basic": "기본 정보",
-      "agent_context": "에이전트 맥락",
+      "agent_context": "에이전트 컨텍스트",
       "dev_info": "개발자 정보",
-      "advanced": "고급"
+      "timezone": "시간대",
+      "advanced": "고급",
+      "advanced_old": "Advanced"
     },
     "field": {
       "name": "이름",
       "title": "직함",
-      "github_username": "GitHub 사용자명",
-      "bio": "Bio",
+      "github_username": "GitHub Username",
+      "bio": "소개 메모",
       "preferred_languages": "선호 언어",
-      "git_name": "Git 사용자명",
+      "git_name": "Git 이름",
       "git_email": "Git 이메일",
-      "github_org": "GitHub 조직",
-      "github_token": "GitHub 토큰"
+      "github_org": "GitHub 기본 Org",
+      "github_token": "GitHub Personal Access Token"
+    },
+    "hint": {
+      "github_username": "프로필 사진 자동 로드에 사용됩니다.",
+      "bio": "에이전트가 사용자 배경을 이해하는 데 활용됩니다.",
+      "preferred_languages": "쉼표로 구분합니다.",
+      "github_token": "레포 클론, API 접근 시 사용됩니다. 로컬에만 저장됩니다.",
+      "timezone_auto": "자동 감지"
+    },
+    "placeholder": {
+      "bio": "백엔드 API 개발 주력, Rust/TypeScript 사용, 스타트업 CTO...",
+      "preferred_languages": "TypeScript, Rust, Python"
+    },
+    "button": {
+      "save": "저장"
     },
     "toast": {
       "saved": "프로필 저장됨"
-    }
+    },
+    "saved_msg": "저장됐습니다"
   },
   "worldview": {
     "heading": "User Worldview",
@@ -52,7 +71,8 @@
       "toggle_on": "Worldview 주입 활성화",
       "toggle_off": "Worldview 주입 비활성화"
     },
-    "placeholder": "(비어있음 — 기본 문구 로드 또는 직접 작성)"
+    "placeholder": "(비어있음 — 기본 문구 로드 또는 직접 작성)",
+    "default_template": "# User Worldview\n\n## Ontology\n(기본 세계관 — 직접 작성)\n\n## Engagement preference\n(agent 와의 협업 방식 선호 — 직접 작성)\n"
   },
   "identity": {
     "heading": "Identity Analysis",
@@ -81,6 +101,220 @@
       "enqueued": "분석 job enqueue — 30s 내 worker 가 실행",
       "skipped": "skip — {{reason}}",
       "run_failed": "실행 실패: {{error}}"
+    }
+  },
+  "help": {
+    "heading": "Help",
+    "description": "tunaFlow 주요 기능, 키보드 단축키, 문제 해결 가이드.",
+    "crash_reports": {
+      "title": "최근 크래시 리포트 ({{count}})",
+      "location": "파일 위치: <code>~/.tunaflow/crash-reports/</code> · 이슈 신고 시 첨부해주세요."
+    },
+    "shortcuts_title": "키보드 단축키",
+    "features_title": "주요 기능",
+    "troubleshooting_title": "문제 해결",
+    "external_title": "외부 자료",
+    "external": {
+      "github": "GitHub 저장소",
+      "issues": "이슈 / 버그 신고",
+      "email": "이메일 문의: d9ng@outlook.com"
+    },
+    "shortcut_desc": {
+      "cmd_k": "명령 팔레트 열기",
+      "cmd_enter": "현재 입력 전송",
+      "shift_enter": "입력창 줄바꿈",
+      "esc": "드로어/모달 닫기",
+      "tab": "포커스 순환 이동"
+    },
+    "features": {
+      "pdr": {
+        "title": "Plan → Develop → Review",
+        "desc": "Architect 가 Plan 을 설계하면 Developer 가 구현하고 Reviewer 가 검증합니다. 실패하면 findings 를 기반으로 rev.N+1 Plan 을 자동 제안합니다."
+      },
+      "branch": {
+        "title": "Branch / Roundtable",
+        "desc": "대화 중간에서 Branch 로 분기해 독립 실험을 하고 결과만 요약 삽입(adopt)할 수 있습니다. RT 는 여러 엔진이 순차/동시로 토론하는 Branch 확장 모드입니다."
+      },
+      "contextpack": {
+        "title": "ContextPack",
+        "desc": "매 요청마다 프로젝트 문서, 기억, 도구 결과를 엔진 공통 포맷으로 조립합니다. Lite/Standard/Full 자동 전환으로 토큰을 절약합니다."
+      },
+      "insight": {
+        "title": "Insight",
+        "desc": "안정성·테스트·아키텍처·성능·보안·기술부채 6개 카테고리로 프로젝트를 분석합니다. Quick Wins 는 에이전트가 자동 수정할 수 있습니다."
+      },
+      "pty": {
+        "title": "PTY Terminal",
+        "desc": "CLI 에이전트와 `-p` 플래그 없이 인터랙티브 세션을 유지합니다. 파일 수정, 명령 실행 등 전체 도구 사용이 가능합니다."
+      }
+    },
+    "troubleshooting": {
+      "no_response": {
+        "title": "에이전트가 응답하지 않아요",
+        "desc": "Settings > Agents 에서 해당 CLI 가 감지되는지 먼저 확인하세요. Claude/Codex/Gemini 는 각자 한 번 로그인이 필요합니다. 로그인 후에도 응답이 없으면 상단 RuntimeStatusBar 를 눌러 프로세스 상태를 확인하세요."
+      },
+      "insight_reset": {
+        "title": "Insight 분석이 시작하자마자 초기화됩니다",
+        "desc": "Insight 실행 중 다른 탭으로 이동해도 상태는 Zustand 에 저장됩니다. 계속 초기화가 발생하면 Settings > Runtime 에서 rawq daemon 상태를 확인해주세요."
+      },
+      "cpu_high": {
+        "title": "CPU 사용률이 높습니다",
+        "desc": "bge-m3 임베딩 인덱싱 중일 수 있습니다. Settings > Runtime 에서 `증분 인덱싱 전용` 모드로 전환하면 대규모 재인덱싱을 피할 수 있습니다."
+      },
+      "macos_gatekeeper": {
+        "title": "macOS 에서 앱이 열리지 않습니다",
+        "desc": "ad-hoc 서명 빌드이므로 Gatekeeper 가 차단할 수 있습니다.\n터미널에서 `xattr -cr /Applications/tunaFlow.app` 실행 후 다시 열어보세요."
+      }
+    }
+  },
+  "mobile": {
+    "heading": "모바일 연결",
+    "description": "tunaFlow 모바일 앱에서 QR 코드를 스캔하면 자동으로 연결됩니다. PC와 모바일이 같은 Wi-Fi 네트워크에 있어야 합니다.",
+    "loading": "네트워크 정보 확인 중…",
+    "scan_hint": "모바일 앱에서 스캔",
+    "server_url": "서버 주소",
+    "api_token": "API 토큰",
+    "steps": {
+      "step1": "① 모바일 브라우저에서 tunaFlow 모바일 앱을 엽니다.",
+      "step2_prefix": "② ",
+      "step2_strong": "QR 코드 스캔",
+      "step2_suffix": " 버튼을 눌러 위 QR 코드를 스캔하세요.",
+      "step3": "③ 자동으로 연결됩니다. (수동 입력도 가능)"
+    },
+    "refresh": "새로고침"
+  },
+  "personas": {
+    "heading": "Personas",
+    "description": "에이전트의 역할과 행동 규칙을 정의합니다. Agent Profile에서 persona를 선택하여 사용합니다."
+  },
+  "agents": {
+    "heading": "Agent Profiles",
+    "description": "에이전트 프로필을 관리합니다. 각 프로필은 엔진, 모델, 기본 스킬을 하나의 실행 단위로 묶습니다.",
+    "role_coverage": {
+      "title": "역할 커버리지",
+      "ready_count": "{{ready}}/{{total}} ready",
+      "hint": "Architect(설계), Developer(구현), Reviewer(검토 ≥2), Synthesizer(RT 합성) 역할에 프로필을 배정하면 Review RT / Plan 승인 / RT 합성 시 설정 그대로 실행됩니다.",
+      "unselected": "— 선택 안 됨 —",
+      "no_profiles": "프로필이 없습니다"
+    },
+    "meta": {
+      "heading": "메타 에이전트 자동 분석 (Tier 2)",
+      "description": "주간 요약, 실패 패턴 분석, artifacts 요약 등을 저비용 엔진으로 자동 생성합니다. 읽기 전용 — 제안만 하며 실행은 사용자 승인 필요.",
+      "engine_label": "엔진",
+      "auto_trigger": "자동 트리거",
+      "auto_trigger_hint": "— 임계값 도달 시 분석 자동 실행",
+      "threshold": {
+        "weekly_pass": "주간 요약 (pass 누적)",
+        "fail_pattern": "실패 패턴 (fail 누적)",
+        "artifact_count": "artifact 요약 (누적)",
+        "idle_days": "idle 일수"
+      },
+      "engine_option": {
+        "off_label": "끔",
+        "off_hint": "메타 자동 분석 비활성화",
+        "auto_label": "자동",
+        "auto_hint": "프로젝트 스택 기반 자동 선택",
+        "claude_haiku_hint": "JSON/한국어 요약 안정적, 저렴",
+        "gemini_flash_hint": "대용량 input 저렴, 빠름"
+      }
+    }
+  },
+  "runtime": {
+    "heading": "Runtime",
+    "description": "런타임 환경 상태를 확인하고 관리합니다.",
+    "workflow_skills": {
+      "heading": "Workflow Skills",
+      "description": "워크플로우 단계별 스킬 세트. 수동 선택과 합산됩니다.",
+      "phase": {
+        "chat_desc": "일반 대화, Architect 설계",
+        "implementation_desc": "Developer 코드 구현",
+        "review_desc": "Reviewer 코드 검토"
+      }
+    },
+    "context_budget": {
+      "modes": {
+        "auto_desc": "대화 상태에 따라 자동 선택 (기본)",
+        "lite_desc": "프로젝트 + 대화 컨텍스트만 포함",
+        "standard_desc": "Lite + Plan, Findings, Artifacts",
+        "full_desc": "Standard + Skills, rawq, Cross-session"
+      },
+      "included_sections_auto": "Included Sections (Auto 모드: 최대 범위)",
+      "included_sections": "Included Sections",
+      "persona_thread_note": "Persona는 설정 시 항상 포함. Thread는 branch에서 자동 포함. rawq는 코드 신호 감지 시 mode 무관 포함."
+    },
+    "insight_agent": {
+      "description": "Insight 탭 분석에 사용할 에이전트 설정",
+      "preset_label": "프리셋",
+      "engine_label": "엔진",
+      "model_label": "모델",
+      "system_prompt": "시스템 프롬프트",
+      "preset": {
+        "balanced_claude_label": "Balanced (Claude)",
+        "balanced_claude_desc": "정확도와 비용의 균형. 일반적 코드 품질 분석에 적합",
+        "thorough_label": "Thorough (Claude)",
+        "thorough_desc": "정밀 분석. 더 많은 토큰 소비, 더 높은 정확도",
+        "security_label": "Security Focus (Claude)",
+        "security_desc": "보안 취약점 중심 분석. OWASP Top 10 기반",
+        "balanced_gemini_label": "Balanced (Gemini)",
+        "balanced_gemini_desc": "Gemini 엔진 사용. 다른 관점의 분석"
+      }
+    },
+    "pty": {
+      "hint": "PTY 비활성화 시 모든 메시지가 -p 모드로 전송됩니다. /clear로 세션 초기화 가능."
+    },
+    "attachments": {
+      "heading": "Attachments Cleanup",
+      "description": "`.tunaflow/attachments/` 내부의 오래된 첨부 파일을 정리합니다. (.gitignore 는 보존)",
+      "older_than": "보다 오래된 파일 삭제:",
+      "days_suffix": "일 (0 = 전부)",
+      "run": "정리 실행",
+      "running": "정리 중...",
+      "result": "✅ 삭제 {{count}}건 · 확보 {{size}}",
+      "error": {
+        "no_project": "프로젝트가 선택되지 않았습니다.",
+        "no_path": "프로젝트 경로를 찾을 수 없습니다."
+      }
+    }
+  },
+  "conventions": {
+    "heading": "Conventions Context Sync",
+    "description": "정적 ContextPack layer(platform / agent role / persona / user profile)를 CLAUDE.md / AGENTS.md / GEMINI.md로 sync 합니다. 편집 후 \"Sync Now\" 로 파일 갱신.",
+    "toggle": {
+      "label": "ContextPack 에서 정적 레이어 생략",
+      "description": "켜면 매 turn 정적 레이어를 재송신하지 않습니다. CLI 가 CLAUDE.md/AGENTS.md 를 자동 prepending 하며 Anthropic API 경로에서는 prompt cache 적중으로 비용 절감. 먼저 아래에서 해당 프로젝트의 conventions 를 추가하고 \"Sync Now\" 로 파일을 만들어야 실제 효과."
+    },
+    "select_project": "— Project 선택 —",
+    "persona_filter_placeholder": "Persona 필터 (비우면 공통 only)",
+    "reload_title": "다시 불러오기",
+    "syncing": "Syncing…",
+    "sync_now": "Sync Now",
+    "sync_report": "✓ Sync 완료 — entry files: {{entry}}, split files: {{split}}",
+    "sync_report_truncated": " ({{count}}개 truncated)",
+    "error_no_project_path": "project 경로가 없습니다",
+    "empty_hint": "아직 등록된 conventions가 없습니다. 아래에서 추가하세요.",
+    "delete_title": "삭제",
+    "new": {
+      "heading": "새 convention 추가",
+      "persona_placeholder": "Persona (비우면 공통)",
+      "source_placeholder": "Source ID (선택)",
+      "content_placeholder": "Markdown 본문…",
+      "add": "추가"
+    },
+    "layer": {
+      "platform_label": "Platform / Project meta",
+      "platform_hint": "프로젝트 path, 빌드 명령어, 언어 등",
+      "agent_role_label": "Agent role",
+      "agent_role_hint": "에이전트 역할 지침 (architect/coder/reviewer 등)",
+      "persona_label": "Persona",
+      "persona_hint": "페르소나 행동 지침",
+      "user_profile_label": "User profile",
+      "user_profile_hint": "사용자 정보, 선호",
+      "plan_doc_label": "Plan document",
+      "plan_doc_hint": "현재 진행 중인 plan 본문 (revision 기반)",
+      "findings_label": "Findings",
+      "findings_hint": "이전 review verdict의 findings 본문",
+      "artifact_label": "Artifact",
+      "artifact_hint": "참고 산출물 (result.md 등)"
     }
   }
 }


### PR DESCRIPTION
## Summary

Slice **A2-D** — Settings 하위 섹션 전체를 `settings.*` namespace 로 전환.

- 대상 10 파일, 7 커밋, ~150 keys (예상 ~120 초과 — Runtime insight preset 등 확장 포함).
- INV-1 유지: Insight preset system prompt 4건은 **영어 고정**, label/desc 만 locale i18n.
- INV-5 (3계층 키) 준수, INV-7 (파일 경로 겹침 없음) 확인.

## 파일별 변환 키 수 (근사)

| 파일 | 추가 keys |
|---|---|
| SettingsPanel.tsx | 2 (skills_description + section.skills 재사용) |
| settings/HelpSection.tsx | 30 (shortcut/features/troubleshooting/external) |
| settings/MobileSection.tsx | 12 (steps × 5 + server/token/refresh 등) |
| settings/ProfileSection.tsx | 22 (group/field/hint/placeholder/button/saved_msg) |
| settings/PersonasSection.tsx | 2 |
| settings/AgentsSection.tsx | 23 (role_coverage + meta + threshold/engine_option) |
| settings/ConventionsSection.tsx | 28 (toggle/select/layer × 7 + new/sync_report) |
| settings/RuntimeSection.tsx | 30 (workflow_skills/context_budget/insight_agent/pty/attachments) |
| settings/WorldviewSettings.tsx | 1 (default_template 상수 JSON 이동) |
| settings/IdentityAnalysisSettings.tsx | 0 (기존 키만 사용) |

## 주요 리팩터

- `INSIGHT_PRESETS_DATA` 에서 label/desc 제거 → 컴포넌트 내 `t()` 주입. system prompt 는 module-level 유지 (INV-1).
- `ENGINE_OPTIONS` / `CONTEXT_MODES` / `WORKFLOW_PHASES` 를 컴포넌트 내부로 이동 (t 필요).
- `DEFAULT_WORLDVIEW_TEMPLATE` 상수 → `settings.worldview.default_template` 단일 키 (플랜의 "대형 템플릿 단일 키" 지침).
- `LAYER_OPTIONS` 는 `LAYER_IDS as const` + `t(\`conventions.layer.\${id}_label\`)` 패턴.

## 검증

- [x] \`npx tsc --noEmit\` — A2-D 대상 파일 오류 0
- [x] \`npx vitest run\` — 322 passed 유지
- [x] \`npx vite build\` — 번들 성공
- [ ] 수동: Settings 전체 탭 ko ↔ en 전환, 컬럼 폭 깨짐 없음, interpolation (count/error/reason/entry/split/size) 정상
- [ ] 수동: WorldviewSettings 기본 문구 로드 버튼으로 locale 맞춤 템플릿 삽입 확인

## 비고

- 브랜치 이름은 \`feat/i18n-pr-a2d-settings-v2\` — 기존 \`feat/i18n-pr-a2d-settings\` (머지 완료된 관련 다른 슬라이스 흔적) 과 구분.
- 병렬 세션의 동일 워킹 디렉토리 사용으로 중간 파일 revert 가 한 차례 발생해 커밋을 7개로 세분화함 (작업 안전).

## 후속

- A3-ext (lib/ + stores/ 서비스 계층) — 별도 슬라이스.

🤖 Generated with [Claude Code](https://claude.com/claude-code)