### PR TITLE
feat(i18n): PR A2-E — Context panel tabs (~100 keys)

### DIFF
--- a/src/components/tunaflow/context-panel/HarnessSummary.tsx
+++ b/src/components/tunaflow/context-panel/HarnessSummary.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
 import { useChatStore } from "@/stores/chatStore";
 import { ClipboardList } from "lucide-react";
@@ -54,6 +55,7 @@ interface HarnessSummaryProps {
 }
 
 export function HarnessSummary({ conversationId, activeStage, onStageClick, refreshKey }: HarnessSummaryProps) {
+  const { t } = useTranslation("harness");
   const { branches, artifacts } = useChatStore();
   const runningThreadIds = useChatStore((s) => s.runningThreadIds);
   const [allPlans, setAllPlans] = useState<Plan[]>([]);
@@ -171,7 +173,7 @@ export function HarnessSummary({ conversationId, activeStage, onStageClick, refr
         const doneCount = subtasks.filter((s) => s.status === "done").length;
         return doneCount > 0 ? (
           <p className="text-[9px] text-muted-foreground/40 px-1">
-            {activePlan.title}: {doneCount}/{subtasks.length} subtask 완료
+            {t("summary.subtask_complete", { title: activePlan.title, done: doneCount, total: subtasks.length })}
           </p>
         ) : null;
       })()}

--- a/src/components/tunaflow/context-panel/PlanDocumentModal.tsx
+++ b/src/components/tunaflow/context-panel/PlanDocumentModal.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { useTranslation } from "react-i18next";
 import { invoke } from "@tauri-apps/api/core";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -17,6 +18,7 @@ interface PlanDocumentModalProps {
 }
 
 export function PlanDocumentModal({ plan, onClose }: PlanDocumentModalProps) {
+  const { t } = useTranslation("workflow");
   const [subtasks, setSubtasks] = useState<PlanSubtask[]>([]);
   const [events, setEvents] = useState<PlanEvent[]>([]);
   const [loading, setLoading] = useState(true);
@@ -82,7 +84,7 @@ export function PlanDocumentModal({ plan, onClose }: PlanDocumentModalProps) {
             <span className="text-[9px] font-mono text-muted-foreground/50 px-1.5 rounded bg-accent/50">v{plan.versionMajor}.{plan.versionMinor}</span>
           )}
           {planFileContent && (
-            <span className="text-[8px] text-status-approved/50">파일 기반</span>
+            <span className="text-[8px] text-status-approved/50">{t("plan_document.status_file_based")}</span>
           )}
           <span className={cn("text-[9px] font-semibold px-1.5 py-0.5 rounded-full border", phaseCfg.cls)}>
             {phaseCfg.label}
@@ -109,13 +111,13 @@ export function PlanDocumentModal({ plan, onClose }: PlanDocumentModalProps) {
                 <>
                   {plan.description && (
                     <div>
-                      <h4 className="text-[10px] text-muted-foreground/60 uppercase tracking-wide mb-1">Description</h4>
+                      <h4 className="text-[10px] text-muted-foreground/60 uppercase tracking-wide mb-1">{t("plan_document.section_description")}</h4>
                       <p className="text-xs text-foreground/80 leading-relaxed whitespace-pre-wrap">{plan.description}</p>
                     </div>
                   )}
                   {plan.expectedOutcome && (
                     <div>
-                      <h4 className="text-[10px] text-muted-foreground/60 uppercase tracking-wide mb-1">Expected Outcome</h4>
+                      <h4 className="text-[10px] text-muted-foreground/60 uppercase tracking-wide mb-1">{t("plan_document.section_expected_outcome")}</h4>
                       <p className="text-xs text-foreground/80 leading-relaxed whitespace-pre-wrap">{plan.expectedOutcome}</p>
                     </div>
                   )}
@@ -125,7 +127,7 @@ export function PlanDocumentModal({ plan, onClose }: PlanDocumentModalProps) {
               {/* Subtasks — clickable to expand work instruction */}
               <div>
                 <h4 className="text-[10px] text-muted-foreground/60 uppercase tracking-wide mb-2">
-                  Subtasks ({subtasks.length})
+                  {t("plan_document.section_subtasks", { count: subtasks.length })}
                 </h4>
                 <div className="space-y-1.5">
                   {subtasks.map((st, i) => {
@@ -161,7 +163,7 @@ export function PlanDocumentModal({ plan, onClose }: PlanDocumentModalProps) {
                               <p className="text-[10px] text-muted-foreground/50 mt-0.5 line-clamp-1">{st.details}</p>
                             )}
                             {!isExpanded && !hasDetails && (
-                              <p className="text-[10px] text-amber-600/40 italic mt-0.5">상세 설계 미작성</p>
+                              <p className="text-[10px] text-amber-600/40 italic mt-0.5">{t("plan_document.empty_instructions")}</p>
                             )}
                           </div>
                         </button>
@@ -173,7 +175,7 @@ export function PlanDocumentModal({ plan, onClose }: PlanDocumentModalProps) {
                             <div className="pt-2">
                               <div className="flex items-center gap-1 mb-1">
                                 <FileText className="w-3 h-3 text-primary/50" />
-                                <span className="text-[9px] text-muted-foreground/60 uppercase tracking-wide">작업 지시서</span>
+                                <span className="text-[9px] text-muted-foreground/60 uppercase tracking-wide">{t("plan_document.section_task_instructions")}</span>
                               </div>
                               {taskFileContents[i + 1] ? (
                                 <div className="rounded bg-card/80 border border-border/30 px-3 py-2 prose prose-invert max-w-none text-[11px] leading-relaxed [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_h1]:text-[13px] [&_h2]:text-[12px] [&_h3]:text-[11px] [&_h1]:mt-3 [&_h2]:mt-2 [&_h3]:mt-1.5 [&_p]:my-1 [&_ul]:my-1 [&_li]:my-0.5 [&_code]:text-[10px]">
@@ -186,7 +188,7 @@ export function PlanDocumentModal({ plan, onClose }: PlanDocumentModalProps) {
                                   <p className="text-[11px] text-foreground/80 leading-relaxed whitespace-pre-wrap">{st.details}</p>
                                 </div>
                               ) : (
-                                <p className="text-[10px] text-amber-600/50 italic">미작성 — Subtask 검토 단계에서 Architect에게 요청하세요.</p>
+                                <p className="text-[10px] text-amber-600/50 italic">{t("plan_document.empty_task_instructions")}</p>
                               )}
                             </div>
 
@@ -198,7 +200,7 @@ export function PlanDocumentModal({ plan, onClose }: PlanDocumentModalProps) {
                                 </span>
                               )}
                               {st.lastUpdatedBy && (
-                                <span>last updated by: {st.lastUpdatedBy}</span>
+                                <span>{t("plan_document.last_updated_by", { actor: st.lastUpdatedBy })}</span>
                               )}
                             </div>
 
@@ -207,7 +209,7 @@ export function PlanDocumentModal({ plan, onClose }: PlanDocumentModalProps) {
                               <div>
                                 <div className="flex items-center gap-1 mb-1">
                                   <Clock className="w-2.5 h-2.5 text-muted-foreground/30" />
-                                  <span className="text-[8px] text-muted-foreground/40 uppercase tracking-wide">이력</span>
+                                  <span className="text-[8px] text-muted-foreground/40 uppercase tracking-wide">{t("plan_document.section_history")}</span>
                                 </div>
                                 <div className="space-y-0.5 border-l border-border/20 pl-2">
                                   {stEvents.map((ev) => {
@@ -236,7 +238,7 @@ export function PlanDocumentModal({ plan, onClose }: PlanDocumentModalProps) {
               {events.length > 0 && (
                 <div>
                   <h4 className="text-[10px] text-muted-foreground/60 uppercase tracking-wide mb-2 flex items-center gap-1">
-                    <Clock className="w-3 h-3" />Revision History
+                    <Clock className="w-3 h-3" />{t("plan_document.section_revision_history")}
                   </h4>
                   <div className="space-y-1 border-l-2 border-border/30 pl-3">
                     {events.map((ev) => {

--- a/src/components/tunaflow/context-panel/PlansPanel.tsx
+++ b/src/components/tunaflow/context-panel/PlansPanel.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
 import { invoke } from "@tauri-apps/api/core";
 import { useChatStore } from "@/stores/chatStore";
 import { ClipboardList } from "lucide-react";
@@ -13,12 +14,13 @@ import { PlanCard } from "./plans/PlanCard";
 
 /** Phase filter mapping for stage IDs.
  *  `plan-check` = drafting + subtask_review 통합 (s37) — "사용자가 plan 을
- *  검토·확정하는" 동일 맥락의 두 phase 를 하나의 stage 로. */
-const STAGE_PHASE_MAP: Record<string, { phases: PlanPhase[]; includeAbandoned?: boolean; empty: string }> = {
-  "plan-check": { phases: ["drafting", "subtask_review"],          empty: "검토 중인 Plan이 없습니다. Chat에서 Architect와 대화해 Plan을 제안받으세요." },
-  dev:          { phases: ["approval", "implementation", "rework"], empty: "구현 중인 Plan이 없습니다." },
-  review:       { phases: ["review"],                               empty: "리뷰 중인 Plan이 없습니다." },
-  done:         { phases: ["done"], includeAbandoned: true,         empty: "완료된 Plan이 없습니다." },
+ *  검토·확정하는" 동일 맥락의 두 phase 를 하나의 stage 로.
+ *  emptyKey 는 workflow.plans_panel.* 의 key suffix (t() 로 해석). */
+const STAGE_PHASE_MAP: Record<string, { phases: PlanPhase[]; includeAbandoned?: boolean; emptyKey: string }> = {
+  "plan-check": { phases: ["drafting", "subtask_review"],          emptyKey: "empty_plan_check" },
+  dev:          { phases: ["approval", "implementation", "rework"], emptyKey: "empty_dev" },
+  review:       { phases: ["review"],                               emptyKey: "empty_review" },
+  done:         { phases: ["done"], includeAbandoned: true,         emptyKey: "empty_done" },
 };
 
 interface PlansPanelProps {
@@ -33,6 +35,7 @@ interface PlansPanelProps {
 }
 
 export function PlansPanel({ activeStage, onPhaseChanged, onStatusChanged, onSwitchToChat }: PlansPanelProps) {
+  const { t } = useTranslation("workflow");
   const { selectedConversationId, activeBranchId, parentConversationId } = useChatStore();
   const [plans, setPlans] = useState<Plan[]>([]);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -140,7 +143,9 @@ export function PlansPanel({ activeStage, onPhaseChanged, onStatusChanged, onSwi
           return stageCfg.phases.includes(p.phase);
         })
       : plans.filter((p) => p.status !== "abandoned");
-  const emptyMessage = stageCfg?.empty ?? "No plans yet.";
+  const emptyMessage = stageCfg
+    ? t(`plans_panel.${stageCfg.emptyKey}` as "plans_panel.empty_plan_check")
+    : t("plans_panel.empty_default");
 
   return (
     <div ref={containerRef} className="space-y-2">
@@ -164,7 +169,7 @@ export function PlansPanel({ activeStage, onPhaseChanged, onStatusChanged, onSwi
             {draftingPlans.length > 0 && (
               <div className="space-y-2">
                 {(normalPlans.length > 0 || escalatedPlans.length > 0) && (
-                  <p className="text-[9px] font-medium text-muted-foreground/40 uppercase tracking-wider px-1">작성 중</p>
+                  <p className="text-[9px] font-medium text-muted-foreground/40 uppercase tracking-wider px-1">{t("plans_panel.section_drafting")}</p>
                 )}
                 {draftingPlans.map((plan) => (
                   <div key={plan.id} data-plan-id={plan.id} className="rounded-lg transition-all">
@@ -181,7 +186,7 @@ export function PlansPanel({ activeStage, onPhaseChanged, onStatusChanged, onSwi
             {normalPlans.length > 0 && (
               <div className={cn("space-y-2", draftingPlans.length > 0 && "mt-4")}>
                 {(draftingPlans.length > 0 || escalatedPlans.length > 0) && (
-                  <p className="text-[9px] font-medium text-muted-foreground/40 uppercase tracking-wider px-1">검토 대기</p>
+                  <p className="text-[9px] font-medium text-muted-foreground/40 uppercase tracking-wider px-1">{t("plans_panel.section_pending_review")}</p>
                 )}
                 {normalPlans.map((plan) => (
                   <div key={plan.id} data-plan-id={plan.id} className="rounded-lg transition-all">
@@ -192,7 +197,7 @@ export function PlansPanel({ activeStage, onPhaseChanged, onStatusChanged, onSwi
             )}
             {escalatedPlans.length > 0 && (
               <div className="space-y-2 mt-4">
-                <p className="text-[9px] font-medium text-amber-600/60 uppercase tracking-wider px-1">⚠️ 설계 재검토 필요</p>
+                <p className="text-[9px] font-medium text-amber-600/60 uppercase tracking-wider px-1">{t("plans_panel.section_escalated")}</p>
                 {escalatedPlans.map((plan) => (
                   <div key={plan.id} data-plan-id={plan.id} className="rounded-lg transition-all">
                     <SubtaskReviewView plan={plan} onPlanUpdate={handlePlanUpdated} onSwitchToChat={onSwitchToChat} />

--- a/src/components/tunaflow/context-panel/QualityDashboard.tsx
+++ b/src/components/tunaflow/context-panel/QualityDashboard.tsx
@@ -18,6 +18,7 @@
  *    적중률. 지금은 placeholder — 실측 값 파이프라인 후속 PR.
  */
 import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { invoke } from "@tauri-apps/api/core";
 import { useChatStore } from "@/stores/chatStore";
 import { cn } from "@/lib/utils";
@@ -125,6 +126,7 @@ function StatCard({ label, value, hint, tone }: { label: string; value: string; 
 }
 
 export function QualityDashboard() {
+  const { t } = useTranslation("quality");
   const selectedConversationId = useChatStore((s) => s.selectedConversationId);
   const selectedProjectKey = useChatStore((s) => s.selectedProjectKey);
   const [spans, setSpans] = useState<TraceSpan[]>([]);
@@ -281,8 +283,7 @@ export function QualityDashboard() {
             <div className="rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-[10px] flex items-start gap-1.5">
               <AlertTriangle className="w-3 h-3 text-destructive shrink-0 mt-0.5" />
               <span className="text-destructive/80">
-                Truncation rate 30% 초과 — ContextPack 의 budget cap 조정 또는
-                섹션별 max_chars 재조정 검토.
+                {t("warning.truncation_high")}
               </span>
             </div>
           )}

--- a/src/components/tunaflow/context-panel/SkillsPanel.tsx
+++ b/src/components/tunaflow/context-panel/SkillsPanel.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { invoke } from "@tauri-apps/api/core";
 import { cn } from "@/lib/utils";
 import { useChatStore } from "@/stores/chatStore";
@@ -42,6 +43,7 @@ interface SkillPackRec {
 }
 
 function ProjectSkillPack() {
+  const { t } = useTranslation("skills");
   const selectedProjectKey = useChatStore((s) => s.selectedProjectKey);
   const acceptRecommendedSkills = useChatStore((s) => s.acceptRecommendedSkills);
   const loadSkills = useChatStore((s) => s.loadSkills);
@@ -91,14 +93,14 @@ function ProjectSkillPack() {
     <div className="rounded-md border border-primary/25 bg-primary/5 px-2.5 py-2 space-y-1.5">
       <div className="flex items-center gap-1.5">
         <Sparkles className="w-3.5 h-3.5 text-primary/70 shrink-0" />
-        <span className="text-[10px] font-semibold text-foreground/80">프로젝트 스킬팩</span>
+        <span className="text-[10px] font-semibold text-foreground/80">{t("pack.title")}</span>
         {!pack && (
           <button
             onClick={buildPack}
             disabled={loading || !selectedProjectKey}
             className="ml-auto text-[8px] px-1.5 py-0.5 rounded bg-primary/10 text-primary hover:bg-primary/20 disabled:opacity-30 transition-colors"
           >
-            {loading ? <Loader2 className="w-3 h-3 animate-spin" /> : "분석"}
+            {loading ? <Loader2 className="w-3 h-3 animate-spin" /> : t("pack.analyze_button")}
           </button>
         )}
       </div>
@@ -106,13 +108,13 @@ function ProjectSkillPack() {
       {pack && (
         <>
           {pack.keywords.length > 0 && (
-            <p className="text-[8px] text-muted-foreground/40">감지: {pack.keywords.slice(0, 8).join(", ")}</p>
+            <p className="text-[8px] text-muted-foreground/40">{t("pack.keywords_detected", { keywords: pack.keywords.slice(0, 8).join(", ") })}</p>
           )}
 
           {/* Local skills */}
           {pack.local.length > 0 && (
             <div className="space-y-0.5">
-              <p className="text-[8px] text-muted-foreground/50 font-medium">로컬 보유</p>
+              <p className="text-[8px] text-muted-foreground/50 font-medium">{t("pack.local_header")}</p>
               <div className="flex flex-wrap gap-1">
                 {pack.local.map((name) => {
                   const label = name.indexOf("-") > 0 ? name.slice(name.indexOf("-") + 1) : name;
@@ -133,7 +135,7 @@ function ProjectSkillPack() {
           {/* Registry skills */}
           {pack.registry.length > 0 && (
             <div className="space-y-0.5">
-              <p className="text-[8px] text-muted-foreground/50 font-medium">레지스트리에서 설치 가능</p>
+              <p className="text-[8px] text-muted-foreground/50 font-medium">{t("pack.registry_header")}</p>
               <div className="flex flex-wrap gap-1">
                 {pack.registry.map((rs) => {
                   const checked = selected.has(rs.name);
@@ -156,17 +158,17 @@ function ProjectSkillPack() {
             <div className="flex items-center gap-2 pt-1">
               <button onClick={installAndApply} disabled={selected.size === 0 || !!installing}
                 className="text-[9px] font-semibold px-2 py-0.5 rounded bg-primary/20 text-primary hover:bg-primary/30 disabled:opacity-30 transition-colors">
-                {installing ? "설치 중..." : `스킬팩 적용 (${selected.size})`}
+                {installing ? t("pack.installing_status") : t("pack.apply_button", { count: selected.size })}
               </button>
               <button onClick={() => setDismissed(true)}
                 className="text-[9px] text-muted-foreground/40 hover:text-muted-foreground/60 transition-colors">
-                무시
+                {t("pack.dismiss_button")}
               </button>
             </div>
           )}
 
           {pack.local.length === 0 && pack.registry.length === 0 && (
-            <p className="text-[8px] text-muted-foreground/40">매칭되는 스킬이 없습니다.</p>
+            <p className="text-[8px] text-muted-foreground/40">{t("pack.no_match")}</p>
           )}
         </>
       )}

--- a/src/components/tunaflow/context-panel/SubtaskReviewView.tsx
+++ b/src/components/tunaflow/context-panel/SubtaskReviewView.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { useTranslation } from "react-i18next";
 import { invoke } from "@tauri-apps/api/core";
 import { cn } from "@/lib/utils";
 import { useChatStore } from "@/stores/chatStore";
@@ -25,6 +26,7 @@ interface SubtaskReviewViewProps {
 }
 
 export function SubtaskReviewView({ plan, onPlanUpdate, onSwitchToChat }: SubtaskReviewViewProps) {
+  const { t } = useTranslation("workflow");
   const { sendWithEngine, selectedConversationId, getConversationEngine,
     createBranch, openThread, sendThreadMessage, saveConversationEngine, loadBranches } = useChatStore();
   const [subtasks, setSubtasks] = useState<PlanSubtask[]>([]);
@@ -92,9 +94,9 @@ export function SubtaskReviewView({ plan, onPlanUpdate, onSwitchToChat }: Subtas
   const approveDisabledReason: string | null = busy
     ? null  // 로컬 busy 는 disable 이지만 별도 안내 불필요
     : mainConvBusy
-      ? "메인 chat 에서 Architect 가 작업 중입니다. 완료 후 활성화됩니다."
+      ? t("subtask_review.actions.approve_tooltip_busy")
       : missingDetailsCount > 0
-        ? `미완성 task 지시서 ${missingDetailsCount}건 — 전체 지시서 작성을 먼저 완료하세요.`
+        ? t("subtask_review.actions.approve_tooltip_missing", { count: missingDetailsCount })
         : null;
   const approveBlocked = busy || mainConvBusy || missingDetailsCount > 0;
   const syncBlocked = busy || mainConvBusy;
@@ -290,14 +292,14 @@ export function SubtaskReviewView({ plan, onPlanUpdate, onSwitchToChat }: Subtas
             <span className="text-[8px] font-mono text-muted-foreground/50 px-1 rounded bg-accent/50">v{plan.versionMajor}.{plan.versionMinor}</span>
           )}
           <button onClick={() => setShowDoc(true)} className="flex items-center gap-1 text-[9px] text-primary/60 hover:text-primary transition-colors">
-            <FileText className="w-3 h-3" />문서 보기
+            <FileText className="w-3 h-3" />{t("subtask_review.header.view_doc_button")}
           </button>
         </div>
         {plan.description && (
           <p className="text-[11px] text-muted-foreground leading-snug mb-1">{plan.description}</p>
         )}
         {plan.expectedOutcome && (
-          <p className="text-[10px] text-muted-foreground/60 italic">Goal: {plan.expectedOutcome}</p>
+          <p className="text-[10px] text-muted-foreground/60 italic">{t("subtask_review.header.goal_prefix", { outcome: plan.expectedOutcome })}</p>
         )}
       </div>
 
@@ -306,22 +308,22 @@ export function SubtaskReviewView({ plan, onPlanUpdate, onSwitchToChat }: Subtas
         <div className="rounded-md border border-amber-500/30 bg-amber-500/5 p-3 space-y-2">
           <p className="text-[11px] font-semibold text-amber-600">
             {reviewHistory.length === 1
-              ? `⚠️ Review 1회 실패 — 이전 싸이클 설계 재검토 이력 있음`
-              : `⚠️ Review ${reviewHistory.length}회 연속 실패로 설계 재검토 진입`}
+              ? t("subtask_review.doom_loop.title_one_fail")
+              : t("subtask_review.doom_loop.title_many_fails", { count: reviewHistory.length })}
           </p>
           <p className="text-[10px] text-foreground/60">
             {reviewHistory.length === 1
-              ? "동일 패턴 반복 시 설계 재검토가 또 필요할 수 있습니다. 아래 이력을 참고하세요."
-              : "Rework으로 해결되지 않는 반복 문제입니다. 아래 이력을 참고하여 subtask 설계를 수정하세요."}
+              ? t("subtask_review.doom_loop.body_one_fail")
+              : t("subtask_review.doom_loop.body_many_fails")}
           </p>
           <details className="text-[9px]">
             <summary className="cursor-pointer text-muted-foreground/60 hover:text-foreground">
-              실패 이력 ({reviewHistory.length}회)
+              {t("subtask_review.doom_loop.history_summary", { count: reviewHistory.length })}
             </summary>
             <div className="mt-1.5 space-y-1.5 pl-2">
               {reviewHistory.map((h) => (
                 <div key={h.round} className="border-l-2 border-amber-500/20 pl-2">
-                  <span className="font-medium text-foreground/50">{h.round}차 fail</span>
+                  <span className="font-medium text-foreground/50">{t("subtask_review.doom_loop.round_fail", { round: h.round })}</span>
                   {h.failedIds.length > 0 && (
                     <span className="text-muted-foreground/40 ml-1">
                       (Task {h.failedIds.join(", ")})
@@ -417,7 +419,7 @@ export function SubtaskReviewView({ plan, onPlanUpdate, onSwitchToChat }: Subtas
               disabled={busy}
               className="flex items-center gap-1 px-3 py-1.5 rounded-md text-xs font-medium bg-amber-500/15 text-amber-600 hover:bg-amber-500/25 disabled:opacity-50 transition-colors"
             >
-              <ArrowLeft className="w-3.5 h-3.5" />Architect에게 재설계 요청
+              <ArrowLeft className="w-3.5 h-3.5" />{t("subtask_review.actions.redesign_button")}
             </button>
           )}
           <button onClick={handleApprove} disabled={approveBlocked}
@@ -428,18 +430,18 @@ export function SubtaskReviewView({ plan, onPlanUpdate, onSwitchToChat }: Subtas
                 : "bg-status-approved/10 text-status-approved hover:bg-status-approved/20"
             )}
             title={
-              isDoomLoop ? "Architect 재설계 후 승인을 권장합니다"
+              isDoomLoop ? t("subtask_review.actions.approve_tooltip_doom")
               : approveDisabledReason ?? undefined
             }
           >
             <Check className="w-3.5 h-3.5" />
-            {isDoomLoop ? "그대로 승인 (비권장)" : "승인 → Approved"}
+            {isDoomLoop ? t("subtask_review.actions.approve_doom_loop") : t("subtask_review.actions.approve_normal")}
             {/* 상태 뱃지 — 왜 비활성인지 한 눈에 보이도록 */}
             {mainConvBusy && (
-              <span className="ml-1 text-[9px] px-1 rounded bg-amber-500/15 text-amber-600">🔒 작성 중</span>
+              <span className="ml-1 text-[9px] px-1 rounded bg-amber-500/15 text-amber-600">{t("subtask_review.actions.badge_locked")}</span>
             )}
             {!mainConvBusy && missingDetailsCount > 0 && (
-              <span className="ml-1 text-[9px] px-1 rounded bg-muted text-muted-foreground/70">⚠ 지시서 {missingDetailsCount}건 미완</span>
+              <span className="ml-1 text-[9px] px-1 rounded bg-muted text-muted-foreground/70">{t("subtask_review.actions.badge_missing_details", { count: missingDetailsCount })}</span>
             )}
           </button>
           {!isDoomLoop && (
@@ -451,10 +453,10 @@ export function SubtaskReviewView({ plan, onPlanUpdate, onSwitchToChat }: Subtas
               className="flex items-center justify-center w-8 h-8 rounded-md text-muted-foreground/40 hover:text-foreground hover:bg-accent disabled:opacity-40 transition-colors"
               title={
                 mainConvBusy
-                  ? "메인 chat 에서 Architect 가 작업 중입니다. 완료 후 사용 가능."
-                  : "Plan 문서 반영 — task 지시서(task-NN.md) 를 직접 편집한 경우 메인 plan.md 에 역반영합니다. 일반 flow 에서는 불필요."
+                  ? t("subtask_review.actions.sync_doc_tooltip_busy")
+                  : t("subtask_review.actions.sync_doc_tooltip_normal")
               }
-              aria-label="Plan 문서 반영"
+              aria-label={t("subtask_review.actions.sync_doc_aria")}
             >
               <FileText className="w-3.5 h-3.5" />
             </button>
@@ -490,9 +492,9 @@ export function SubtaskReviewView({ plan, onPlanUpdate, onSwitchToChat }: Subtas
               }}
               disabled={busy}
               className="flex items-center gap-1 px-2.5 py-1 rounded-md text-[10px] font-medium bg-muted text-muted-foreground/60 hover:text-muted-foreground border border-dashed border-border/40 disabled:opacity-40 transition-colors"
-              title="디버깅용 — 모든 subtask의 작업지시서를 일괄 요청"
+              title={t("subtask_review.actions.debug_all_tasks_tooltip")}
             >
-              <PenLine className="w-3 h-3" />전체 작업지시서 (debug)
+              <PenLine className="w-3 h-3" />{t("subtask_review.actions.debug_all_tasks_button")}
             </button>
           )}
         </div>
@@ -500,7 +502,7 @@ export function SubtaskReviewView({ plan, onPlanUpdate, onSwitchToChat }: Subtas
 
       {!isActionable && (
         <p className="text-[10px] text-muted-foreground/40 italic pt-2 border-t border-border/30">
-          읽기 전용 — 현재 phase: {plan.phase}
+          {t("subtask_review.actions.read_only_hint", { phase: plan.phase })}
         </p>
       )}
 
@@ -530,6 +532,7 @@ function SubtaskReviewCard({
   busy: boolean;
   actionable: boolean;
 }) {
+  const { t } = useTranslation("workflow");
   const [expanded, setExpanded] = useState(false);
   const [opinionMode, setOpinionMode] = useState(false);
   const [opinion, setOpinion] = useState("");
@@ -567,10 +570,10 @@ function SubtaskReviewCard({
               {statusCfg.label}
             </span>
             {!taskFileContent && !hasDetails && (
-              <span className="text-[8px] text-amber-600/50 shrink-0">파일 미생성</span>
+              <span className="text-[8px] text-amber-600/50 shrink-0">{t("subtask_review.card.status_file_missing")}</span>
             )}
             {taskFileContent && (
-              <span className="text-[8px] text-status-approved/40 shrink-0">파일</span>
+              <span className="text-[8px] text-status-approved/40 shrink-0">{t("subtask_review.card.status_file_exists")}</span>
             )}
           </div>
           {!expanded && taskFileContent && (
@@ -592,8 +595,8 @@ function SubtaskReviewCard({
             <div>
               <div className="flex items-center gap-1 mb-1">
                 <FileText className="w-3 h-3 text-primary/50" />
-                <span className="text-[9px] text-muted-foreground/60 uppercase tracking-wide">작업 지시서</span>
-                <span className="text-[8px] text-status-approved/50">파일</span>
+                <span className="text-[9px] text-muted-foreground/60 uppercase tracking-wide">{t("subtask_review.card.instructions_label")}</span>
+                <span className="text-[8px] text-status-approved/50">{t("subtask_review.card.status_file_exists")}</span>
               </div>
               <div className="rounded bg-card/80 border border-border/30 px-3 py-2 prose prose-invert max-w-none text-[11px] leading-relaxed [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_h1]:text-[13px] [&_h2]:text-[12px] [&_h3]:text-[11px] [&_h1]:mt-3 [&_h2]:mt-2 [&_h3]:mt-1.5 [&_p]:my-1 [&_ul]:my-1 [&_li]:my-0.5 [&_code]:text-[10px]">
                 <ReactMarkdown remarkPlugins={[[remarkGfm, { singleTilde: false }]]} components={markdownComponents}>
@@ -605,7 +608,7 @@ function SubtaskReviewCard({
             <div>
               <div className="flex items-center gap-1 mb-1">
                 <FileText className="w-3 h-3 text-primary/50" />
-                <span className="text-[9px] text-muted-foreground/60 uppercase tracking-wide">작업 지시서 (요약)</span>
+                <span className="text-[9px] text-muted-foreground/60 uppercase tracking-wide">{t("subtask_review.card.instructions_summary_label")}</span>
               </div>
               <div className="rounded bg-card/80 border border-border/30 px-3 py-2">
                 <p className="text-[11px] text-foreground/80 leading-relaxed whitespace-pre-wrap">{subtask.details}</p>
@@ -613,11 +616,11 @@ function SubtaskReviewCard({
             </div>
           ) : (
             <div className="rounded bg-amber-500/5 border border-amber-500/15 px-3 py-2">
-              <p className="text-[10px] text-amber-600/60 mb-1.5">작업 지시서가 아직 작성되지 않았습니다.</p>
+              <p className="text-[10px] text-amber-600/60 mb-1.5">{t("subtask_review.card.empty_instructions")}</p>
               {actionable && (
                 <button onClick={(e) => { e.stopPropagation(); onDetailRequest(); }} disabled={busy}
                   className="flex items-center gap-1 px-2 py-0.5 rounded text-[9px] font-medium bg-amber-500/10 text-amber-600 hover:bg-amber-500/20 disabled:opacity-40 transition-colors">
-                  <PenLine className="w-2.5 h-2.5" />{busy ? "요청 중..." : "작성 요청"}
+                  <PenLine className="w-2.5 h-2.5" />{busy ? t("subtask_review.card.write_busy") : t("subtask_review.card.write_button")}
                 </button>
               )}
             </div>
@@ -625,7 +628,7 @@ function SubtaskReviewCard({
 
           {/* Metadata */}
           {subtask.ownerAgent && (
-            <p className="text-[9px] text-muted-foreground/40">Owner: {subtask.ownerAgent}</p>
+            <p className="text-[9px] text-muted-foreground/40">{t("subtask_review.card.owner_label", { owner: subtask.ownerAgent })}</p>
           )}
 
           {/* Actions: discuss + revision request */}
@@ -633,12 +636,12 @@ function SubtaskReviewCard({
             <div className="flex items-center gap-2 pt-1">
               <button onClick={(e) => { e.stopPropagation(); onDiscuss(); }} disabled={busy}
                 className="flex items-center gap-0.5 text-[9px] text-primary/60 hover:text-primary disabled:opacity-40 transition-colors">
-                <ChevronRight className="w-2.5 h-2.5" />대화하기
+                <ChevronRight className="w-2.5 h-2.5" />{t("subtask_review.card.discuss_button")}
               </button>
               {hasDetails && (
                 <button onClick={(e) => { e.stopPropagation(); setOpinionMode(true); }} disabled={busy}
                   className="flex items-center gap-0.5 text-[9px] text-amber-600/60 hover:text-amber-600 disabled:opacity-40 transition-colors">
-                  <RotateCcw className="w-2.5 h-2.5" />수정 요청
+                  <RotateCcw className="w-2.5 h-2.5" />{t("subtask_review.card.revise_button")}
                 </button>
               )}
             </div>
@@ -649,7 +652,7 @@ function SubtaskReviewCard({
               <textarea
                 value={opinion}
                 onChange={(e) => setOpinion(e.target.value)}
-                placeholder="검토 의견을 작성하세요 (왜 수정이 필요한지)..."
+                placeholder={t("subtask_review.card.opinion_placeholder")}
                 rows={2}
                 className="w-full bg-input rounded-md px-2 py-1.5 text-[10px] outline-none text-foreground placeholder:text-muted-foreground border border-border focus:border-ring/50 resize-none"
                 autoFocus
@@ -658,11 +661,11 @@ function SubtaskReviewCard({
               <div className="flex gap-1.5">
                 <button onClick={(e) => { e.stopPropagation(); handleSubmitOpinion(); }} disabled={!opinion.trim() || busy}
                   className="px-2 py-0.5 rounded text-[9px] font-medium bg-amber-500/10 text-amber-600 hover:bg-amber-500/20 disabled:opacity-40 transition-colors">
-                  수정 요청 전송
+                  {t("subtask_review.card.send_revise")}
                 </button>
                 <button onClick={(e) => { e.stopPropagation(); setOpinionMode(false); setOpinion(""); }}
                   className="px-2 py-0.5 rounded text-[9px] text-muted-foreground hover:text-foreground transition-colors">
-                  취소
+                  {t("subtask_review.card.cancel_button")}
                 </button>
               </div>
             </div>

--- a/src/components/tunaflow/context-panel/insight/insightConstants.tsx
+++ b/src/components/tunaflow/context-panel/insight/insightConstants.tsx
@@ -1,13 +1,14 @@
 import { Zap, FlaskConical, Box, Gauge, Lock, Trash2, XCircle, AlertTriangle, Info } from "lucide-react";
 import type { InsightCategory, InsightFinding, InsightSeverity } from "@/types";
 
-export const CATEGORY_META: Record<InsightCategory, { label: string; icon: React.ReactNode; color: string }> = {
-  stability: { label: "안정성", icon: <Zap className="w-3 h-3" />, color: "text-yellow-500" },
-  test: { label: "테스트", icon: <FlaskConical className="w-3 h-3" />, color: "text-blue-500" },
-  architecture: { label: "아키텍처", icon: <Box className="w-3 h-3" />, color: "text-purple-500" },
-  performance: { label: "성능", icon: <Gauge className="w-3 h-3" />, color: "text-orange-500" },
-  security: { label: "보안", icon: <Lock className="w-3 h-3" />, color: "text-red-500" },
-  debt: { label: "기술 부채", icon: <Trash2 className="w-3 h-3" />, color: "text-gray-500" },
+// label 은 `insight.category.{key}` 로 이관 (PR #167). 여기선 icon/color 만.
+export const CATEGORY_META: Record<InsightCategory, { icon: React.ReactNode; color: string }> = {
+  stability: { icon: <Zap className="w-3 h-3" />, color: "text-yellow-500" },
+  test: { icon: <FlaskConical className="w-3 h-3" />, color: "text-blue-500" },
+  architecture: { icon: <Box className="w-3 h-3" />, color: "text-purple-500" },
+  performance: { icon: <Gauge className="w-3 h-3" />, color: "text-orange-500" },
+  security: { icon: <Lock className="w-3 h-3" />, color: "text-red-500" },
+  debt: { icon: <Trash2 className="w-3 h-3" />, color: "text-gray-500" },
 };
 
 export const SEVERITY_META: Record<InsightSeverity, { icon: React.ReactNode; cls: string }> = {

--- a/src/locales/en/harness.json
+++ b/src/locales/en/harness.json
@@ -1,0 +1,5 @@
+{
+  "summary": {
+    "subtask_complete": "{{title}}: {{done}}/{{total}} subtasks done"
+  }
+}

--- a/src/locales/en/quality.json
+++ b/src/locales/en/quality.json
@@ -1,0 +1,33 @@
+{
+  "header": {
+    "title": "Quality",
+    "span_count": "{{count}} spans",
+    "empty_state": "No trace data yet.",
+    "loading_state": "Loading..."
+  },
+  "stat": {
+    "truncation_label": "Truncation",
+    "truncation_hint": "{{done}} / {{total}} hit budget cap",
+    "retrieval_label": "Retrieval hit",
+    "retrieval_hint": "queries returning ≥1 chunk",
+    "context_label": "Avg ContextPack",
+    "context_hint": "chars per send",
+    "cache_label": "Cache read",
+    "cache_hint_cached": "{{count}} tokens cached",
+    "cache_hint_pending": "needs provider population"
+  },
+  "mode": {
+    "header": "ContextPack mode"
+  },
+  "section": {
+    "header": "Section avg size (per send)"
+  },
+  "warning": {
+    "truncation_high": "Truncation rate exceeds 30% — consider raising ContextPack budget cap or adjusting per-section max_chars."
+  },
+  "scope": {
+    "conversation": "Conversation",
+    "project": "Project",
+    "project_disabled": "Project scope — per-project trace aggregation lands in a follow-up"
+  }
+}

--- a/src/locales/en/skills.json
+++ b/src/locales/en/skills.json
@@ -1,0 +1,13 @@
+{
+  "pack": {
+    "title": "Project skill pack",
+    "analyze_button": "Analyze",
+    "keywords_detected": "Detected: {{keywords}}",
+    "local_header": "Already local",
+    "registry_header": "Installable from registry",
+    "installing_status": "Installing...",
+    "apply_button": "Apply skill pack ({{count}})",
+    "dismiss_button": "Dismiss",
+    "no_match": "No matching skills."
+  }
+}

--- a/src/locales/en/workflow.json
+++ b/src/locales/en/workflow.json
@@ -32,6 +32,73 @@
     "empty_details_row": "No detailed design",
     "follow_up_suffix": "\nPlease proceed with the task above."
   },
+  "plans_panel": {
+    "empty_plan_check": "No plans under review. Chat with Architect to propose a Plan.",
+    "empty_dev": "No plans currently being implemented.",
+    "empty_review": "No plans in review.",
+    "empty_done": "No completed plans.",
+    "empty_default": "No plans yet.",
+    "section_drafting": "Drafting",
+    "section_pending_review": "Pending review",
+    "section_escalated": "⚠️ Design review needed"
+  },
+  "plan_document": {
+    "status_file_based": "File-based",
+    "empty_instructions": "No detailed design",
+    "section_description": "Description",
+    "section_expected_outcome": "Expected Outcome",
+    "section_task_instructions": "Task instructions",
+    "section_history": "History",
+    "section_subtasks": "Subtasks ({{count}})",
+    "section_revision_history": "Revision History",
+    "empty_task_instructions": "Not yet written — request it from Architect during the Subtask Review step.",
+    "last_updated_by": "last updated by: {{actor}}"
+  },
+  "subtask_review": {
+    "header": {
+      "view_doc_button": "View document",
+      "goal_prefix": "Goal: {{outcome}}"
+    },
+    "doom_loop": {
+      "title_one_fail": "⚠️ Review failed once — prior cycle had design review history",
+      "title_many_fails": "⚠️ Review failed {{count}} times in a row — entering design review",
+      "body_one_fail": "If the same pattern repeats, design review may be needed again. Check the history below.",
+      "body_many_fails": "Repeating issues that Rework cannot resolve. Use the history below to revise the subtask design.",
+      "history_summary": "Failure history ({{count}} times)",
+      "round_fail": "Round {{round}} fail"
+    },
+    "actions": {
+      "redesign_button": "Request redesign from Architect",
+      "approve_doom_loop": "Approve as-is (not recommended)",
+      "approve_normal": "Approve → Approved",
+      "badge_locked": "🔒 Writing",
+      "badge_missing_details": "⚠ {{count}} instructions missing",
+      "sync_doc_tooltip_busy": "Architect is busy in the main chat. Available once complete.",
+      "sync_doc_tooltip_normal": "Reflect into Plan doc — if you edited task-NN.md files directly, back-propagate them into the main plan.md. Usually not needed in the normal flow.",
+      "sync_doc_aria": "Reflect into Plan doc",
+      "debug_all_tasks_button": "All task instructions (debug)",
+      "debug_all_tasks_tooltip": "Debug — request all subtask instructions in one batch",
+      "approve_tooltip_doom": "We recommend approving after the Architect redesign",
+      "approve_tooltip_busy": "Architect is working in the main chat. Enabled once complete.",
+      "approve_tooltip_missing": "{{count}} task instructions missing — finish all instructions first.",
+      "read_only_hint": "Read-only — current phase: {{phase}}"
+    },
+    "card": {
+      "status_file_missing": "File missing",
+      "status_file_exists": "File",
+      "instructions_label": "Task instructions",
+      "instructions_summary_label": "Task instructions (summary)",
+      "empty_instructions": "Task instructions have not been written yet.",
+      "write_button": "Request write",
+      "write_busy": "Requesting...",
+      "owner_label": "Owner: {{owner}}",
+      "discuss_button": "Discuss",
+      "revise_button": "Request revision",
+      "opinion_placeholder": "Write your review feedback (why revision is needed)...",
+      "send_revise": "Send revision request",
+      "cancel_button": "Cancel"
+    }
+  },
   "merge": {
     "busy": "Merging...",
     "button": "Merge into Plan",

--- a/src/locales/index.ts
+++ b/src/locales/index.ts
@@ -11,6 +11,9 @@ import koDialog from "./ko/dialog.json";
 import koWorkflow from "./ko/workflow.json";
 import koBranch from "./ko/branch.json";
 import koInsight from "./ko/insight.json";
+import koQuality from "./ko/quality.json";
+import koSkills from "./ko/skills.json";
+import koHarness from "./ko/harness.json";
 import enCommon from "./en/common.json";
 import enError from "./en/error.json";
 import enSettings from "./en/settings.json";
@@ -20,6 +23,9 @@ import enDialog from "./en/dialog.json";
 import enWorkflow from "./en/workflow.json";
 import enBranch from "./en/branch.json";
 import enInsight from "./en/insight.json";
+import enQuality from "./en/quality.json";
+import enSkills from "./en/skills.json";
+import enHarness from "./en/harness.json";
 
 /** Supported locales. Add 'ja', 'zh', etc. in later PRs. */
 export type SupportedLocale = "ko" | "en";
@@ -40,6 +46,9 @@ export const resources = {
     workflow: koWorkflow,
     branch: koBranch,
     insight: koInsight,
+    quality: koQuality,
+    skills: koSkills,
+    harness: koHarness,
   },
   en: {
     common: enCommon,
@@ -51,6 +60,9 @@ export const resources = {
     workflow: enWorkflow,
     branch: enBranch,
     insight: enInsight,
+    quality: enQuality,
+    skills: enSkills,
+    harness: enHarness,
   },
 } as const;
 
@@ -64,7 +76,7 @@ i18n
     // 누락 키는 빈 문자열 대신 키 그대로 표시 → 누락 즉시 인지.
     returnEmptyString: false,
     defaultNS: "common",
-    ns: ["common", "error", "settings", "sidebar", "chat", "dialog", "workflow", "branch", "insight"],
+    ns: ["common", "error", "settings", "sidebar", "chat", "dialog", "workflow", "branch", "insight", "quality", "skills", "harness"],
     detection: {
       // appStore (IndexedDB) 우선, 그 다음 localStorage/navigator.
       order: ["localStorage", "navigator"],

--- a/src/locales/ko/harness.json
+++ b/src/locales/ko/harness.json
@@ -1,0 +1,5 @@
+{
+  "summary": {
+    "subtask_complete": "{{title}}: {{done}}/{{total}} subtask 완료"
+  }
+}

--- a/src/locales/ko/quality.json
+++ b/src/locales/ko/quality.json
@@ -1,0 +1,33 @@
+{
+  "header": {
+    "title": "Quality",
+    "span_count": "{{count}} spans",
+    "empty_state": "No trace data yet.",
+    "loading_state": "Loading..."
+  },
+  "stat": {
+    "truncation_label": "Truncation",
+    "truncation_hint": "{{done}} / {{total}} hit budget cap",
+    "retrieval_label": "Retrieval hit",
+    "retrieval_hint": "queries returning ≥1 chunk",
+    "context_label": "Avg ContextPack",
+    "context_hint": "chars per send",
+    "cache_label": "Cache read",
+    "cache_hint_cached": "{{count}} tokens cached",
+    "cache_hint_pending": "needs provider population"
+  },
+  "mode": {
+    "header": "ContextPack mode"
+  },
+  "section": {
+    "header": "Section avg size (per send)"
+  },
+  "warning": {
+    "truncation_high": "Truncation rate가 30%를 초과했습니다 — ContextPack budget cap 조정 또는 섹션별 max_chars 재조정을 검토하세요."
+  },
+  "scope": {
+    "conversation": "Conversation",
+    "project": "Project",
+    "project_disabled": "Project scope — per-project trace aggregation lands in a follow-up"
+  }
+}

--- a/src/locales/ko/skills.json
+++ b/src/locales/ko/skills.json
@@ -1,0 +1,13 @@
+{
+  "pack": {
+    "title": "프로젝트 스킬팩",
+    "analyze_button": "분석",
+    "keywords_detected": "감지: {{keywords}}",
+    "local_header": "로컬 보유",
+    "registry_header": "레지스트리에서 설치 가능",
+    "installing_status": "설치 중...",
+    "apply_button": "스킬팩 적용 ({{count}})",
+    "dismiss_button": "무시",
+    "no_match": "매칭되는 스킬이 없습니다."
+  }
+}

--- a/src/locales/ko/workflow.json
+++ b/src/locales/ko/workflow.json
@@ -32,6 +32,73 @@
     "empty_details_row": "상세 설계 없음",
     "follow_up_suffix": "\n위 작업을 진행해주세요."
   },
+  "plans_panel": {
+    "empty_plan_check": "검토 중인 Plan이 없습니다. Chat에서 Architect와 대화해 Plan을 제안받으세요.",
+    "empty_dev": "구현 중인 Plan이 없습니다.",
+    "empty_review": "리뷰 중인 Plan이 없습니다.",
+    "empty_done": "완료된 Plan이 없습니다.",
+    "empty_default": "Plan이 없습니다.",
+    "section_drafting": "작성 중",
+    "section_pending_review": "검토 대기",
+    "section_escalated": "⚠️ 설계 재검토 필요"
+  },
+  "plan_document": {
+    "status_file_based": "파일 기반",
+    "empty_instructions": "상세 설계 미작성",
+    "section_description": "Description",
+    "section_expected_outcome": "Expected Outcome",
+    "section_task_instructions": "작업 지시서",
+    "section_history": "이력",
+    "section_subtasks": "Subtasks ({{count}})",
+    "section_revision_history": "Revision History",
+    "empty_task_instructions": "미작성 — Subtask 검토 단계에서 Architect에게 요청하세요.",
+    "last_updated_by": "last updated by: {{actor}}"
+  },
+  "subtask_review": {
+    "header": {
+      "view_doc_button": "문서 보기",
+      "goal_prefix": "Goal: {{outcome}}"
+    },
+    "doom_loop": {
+      "title_one_fail": "⚠️ Review 1회 실패 — 이전 싸이클 설계 재검토 이력 있음",
+      "title_many_fails": "⚠️ Review {{count}}회 연속 실패로 설계 재검토 진입",
+      "body_one_fail": "동일 패턴 반복 시 설계 재검토가 또 필요할 수 있습니다. 아래 이력을 참고하세요.",
+      "body_many_fails": "Rework으로 해결되지 않는 반복 문제입니다. 아래 이력을 참고하여 subtask 설계를 수정하세요.",
+      "history_summary": "실패 이력 ({{count}}회)",
+      "round_fail": "{{round}}차 fail"
+    },
+    "actions": {
+      "redesign_button": "Architect에게 재설계 요청",
+      "approve_doom_loop": "그대로 승인 (비권장)",
+      "approve_normal": "승인 → Approved",
+      "badge_locked": "🔒 작성 중",
+      "badge_missing_details": "⚠ 지시서 {{count}}건 미완",
+      "sync_doc_tooltip_busy": "메인 chat 에서 Architect 가 작업 중입니다. 완료 후 사용 가능.",
+      "sync_doc_tooltip_normal": "Plan 문서 반영 — task 지시서(task-NN.md) 를 직접 편집한 경우 메인 plan.md 에 역반영합니다. 일반 flow 에서는 불필요.",
+      "sync_doc_aria": "Plan 문서 반영",
+      "debug_all_tasks_button": "전체 작업지시서 (debug)",
+      "debug_all_tasks_tooltip": "디버깅용 — 모든 subtask의 작업지시서를 일괄 요청",
+      "approve_tooltip_doom": "Architect 재설계 후 승인을 권장합니다",
+      "approve_tooltip_busy": "메인 chat 에서 Architect 가 작업 중입니다. 완료 후 활성화됩니다.",
+      "approve_tooltip_missing": "미완성 task 지시서 {{count}}건 — 전체 지시서 작성을 먼저 완료하세요.",
+      "read_only_hint": "읽기 전용 — 현재 phase: {{phase}}"
+    },
+    "card": {
+      "status_file_missing": "파일 미생성",
+      "status_file_exists": "파일",
+      "instructions_label": "작업 지시서",
+      "instructions_summary_label": "작업 지시서 (요약)",
+      "empty_instructions": "작업 지시서가 아직 작성되지 않았습니다.",
+      "write_button": "작성 요청",
+      "write_busy": "요청 중...",
+      "owner_label": "Owner: {{owner}}",
+      "discuss_button": "대화하기",
+      "revise_button": "수정 요청",
+      "opinion_placeholder": "검토 의견을 작성하세요 (왜 수정이 필요한지)...",
+      "send_revise": "수정 요청 전송",
+      "cancel_button": "취소"
+    }
+  },
   "merge": {
     "busy": "병합 중...",
     "button": "Plan에 병합",

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -15,6 +15,9 @@ import type koDialog from "../locales/ko/dialog.json";
 import type koWorkflow from "../locales/ko/workflow.json";
 import type koBranch from "../locales/ko/branch.json";
 import type koInsight from "../locales/ko/insight.json";
+import type koQuality from "../locales/ko/quality.json";
+import type koSkills from "../locales/ko/skills.json";
+import type koHarness from "../locales/ko/harness.json";
 
 declare module "i18next" {
   interface CustomTypeOptions {
@@ -29,6 +32,9 @@ declare module "i18next" {
       workflow: typeof koWorkflow;
       branch: typeof koBranch;
       insight: typeof koInsight;
+      quality: typeof koQuality;
+      skills: typeof koSkills;
+      harness: typeof koHarness;
     };
   }
 }


### PR DESCRIPTION
## Summary

i18n 완결 plan (docs/plans/i18nCompletionPlan_2026-04-24.md) 의 Track 2 슬라이스. Context panel 7 파일 전환 + 신규 namespace 3 (quality/skills/harness). 2026-04-24 세션 PR #167 에서 InsightPanel/IdentityView 이미 완결됐으므로 본 Track 은 나머지 활성 파일만 처리.

### 변경 (17 파일 / +343 / -73)

| 영역 | 파일 |
|---|---|
| Context panel 컴포넌트 | `PlansPanel.tsx`, `QualityDashboard.tsx`, `SkillsPanel.tsx`, `HarnessSummary.tsx`, `PlanDocumentModal.tsx`, `SubtaskReviewView.tsx`, `insight/insightConstants.tsx` |
| 신규 namespace JSON | `locales/{ko,en}/harness.json`, `locales/{ko,en}/quality.json`, `locales/{ko,en}/skills.json` |
| 기존 namespace 확장 | `locales/{ko,en}/workflow.json` (plans_panel.* / plan_document.* / subtask_review.*) |
| 인프라 | `locales/index.ts`, `types/i18next.d.ts` (namespace 3 등록) |

### 설계 정리

- **insightConstants.CATEGORY_META.label 제거** — PR #167 에서 이미 `insight.category.*` 키로 이관 완료. 사용처 (InsightPanel / InsightFindingCards) 는 `t(\`category.\${k}\`)` 로 override 중이라 타입 에러 없음.
- **workflow namespace 확장** — PlansPanel/PlanDocumentModal/SubtaskReviewView 는 논리적으로 plan 워크플로에 속하므로 `workflow.plans_panel.*` / `workflow.plan_document.*` / `workflow.subtask_review.*` 하위에 배치.

### 제외

- **TracePanel.tsx** — 실측 결과 한국어 리터럴 없음 (주석만). 전환 불필요.
- **Agent 프롬프트 문자열** — INV-1 범위 (본 Track UI 전용). PR #168 A2-E-msg 에서 이미 처리.

## INV 준수

- **INV-1**: UI 라벨만 i18n, 에이전트 프롬프트는 영어 고정 유지.
- **INV-5**: 3계층 키 (namespace.section.key).
- **INV-7**: Track 1/3 (PR #172/#173) 와 파일 경로 겹침 **0 파일**. 공유 파일 (`locales/index.ts`, `types/i18next.d.ts`) 는 본 Track 만 편집.

## 검증

- [x] `npx tsc --noEmit` — 내 변경분 에러 0
- [x] `npx vitest run` — 322 / 322 통과
- [ ] 수동: Settings → Language ko/en 토글 후 Plans / Quality / Skills / Harness / PlanDocumentModal / SubtaskReviewView / InsightFindingCards 확인

## 병렬 세션 작업 기록

Track 1/3 와 같은 working tree 공유로 인한 파일 revert 가 몇 차례 발생. 감지 후 재적용 → 브랜치 전환 + 명시적 add + commit 순서로 격리 성공. **후속 병렬 작업은 git worktree 분리 권장**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)