### PR TITLE
feat(openai-compat): UI override for Ollama / LM Studio base URL (#175)

### DIFF
--- a/src-tauri/src/commands/agents.rs
+++ b/src-tauri/src/commands/agents.rs
@@ -53,6 +53,12 @@ pub struct SendWithClaudeInput {
     /// read the image via `Read` tool from the prompt path section.
     #[serde(default)]
     pub image_paths: Vec<String>,
+    /// Base URL override for OpenAI-compatible engines (ollama / lmstudio).
+    /// Empty string and None both mean "fallback to env / hardcoded default".
+    /// Issue #175: lets users point at remote Ollama (Tailscale / NAS) or an
+    /// alternate LM Studio port without relying on env vars.
+    #[serde(default)]
+    pub custom_base_url: Option<String>,
 }
 
 /// Wrap persona_fragment with identity framing block for a given engine.
@@ -462,6 +468,8 @@ pub async fn start_openai_compat_stream(
     let write_arc = db_write_arc(&state);
     let cid = input.conversation_id.clone();
     let mo = input.model.clone();
+    // Preserve custom base URL override before `input` is moved into spawn_blocking.
+    let custom_base_url_override = input.custom_base_url.clone();
 
     let prep = tokio::task::spawn_blocking(move || {
         // Local models have limited context — cap budget to avoid exceeding model limits.
@@ -476,7 +484,20 @@ pub async fn start_openai_compat_stream(
     let ret = prep.msg_id.clone();
     let system_prompt = prep.system_context.clone();
     let PreparedRun { msg_id, job_id, enriched_prompt, project_path, ctx_meta, audit_session_id, .. } = prep;
-    let base_url = if is_lmstudio { openai_compat::lmstudio_base_url() } else { std::env::var("OLLAMA_HOST").unwrap_or_else(|_| "http://localhost:11434".into()) };
+    // Priority: UI override (non-empty) → env var → hardcoded default.
+    // INV-1: env-var users keep working when UI override is empty.
+    let base_url = custom_base_url_override
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_owned)
+        .unwrap_or_else(|| {
+            if is_lmstudio {
+                openai_compat::lmstudio_base_url()
+            } else {
+                std::env::var("OLLAMA_HOST").unwrap_or_else(|_| "http://localhost:11434".into())
+            }
+        });
 
     let cid2 = cid.clone();
     let el = engine_label.to_string();

--- a/src/components/tunaflow/settings/AgentsSection.tsx
+++ b/src/components/tunaflow/settings/AgentsSection.tsx
@@ -4,6 +4,7 @@ import { cn } from "@/lib/utils";
 import { Plus, Trash2, CheckCircle2, AlertCircle, AlertTriangle } from "lucide-react";
 import { useChatStore } from "@/stores/chatStore";
 import { DEFAULT_PERSONAS } from "@/lib/defaultPersonas";
+import { getSetting, setSetting } from "@/lib/appStore";
 import { AgentAvatar } from "../AgentAvatar";
 import type { AgentProfile } from "@/types";
 import {
@@ -68,6 +69,28 @@ export function AgentsSection() {
     updateField("defaultSkills", has
       ? selected.defaultSkills.filter((sk: string) => sk !== skillName)
       : [...selected.defaultSkills, skillName]);
+  };
+
+  // Issue #175 MVP — Ollama / LM Studio base URL override.
+  // Keyed by engine; appStore key pattern `engineEndpoint:{engine}` mirrors
+  // existing conventions (activeSkills:{pk}, skillDetectionDismissed:{pk}).
+  const [endpointOverride, setEndpointOverride] = useState<Record<"ollama" | "lmstudio", string>>({
+    ollama: "",
+    lmstudio: "",
+  });
+  useEffect(() => {
+    (async () => {
+      const [ol, ls] = await Promise.all([
+        getSetting<string>("engineEndpoint:ollama", ""),
+        getSetting<string>("engineEndpoint:lmstudio", ""),
+      ]);
+      setEndpointOverride({ ollama: ol, lmstudio: ls });
+    })();
+  }, []);
+  const handleEndpointChange = async (engine: "ollama" | "lmstudio", value: string) => {
+    const trimmed = value.trim();
+    setEndpointOverride((prev) => ({ ...prev, [engine]: trimmed }));
+    await setSetting(`engineEndpoint:${engine}`, trimmed);
   };
 
   if (profiles.length === 0) return null;
@@ -135,6 +158,29 @@ export function AgentsSection() {
                 </select>
               </div>
             </div>
+
+            {/* Issue #175 MVP — Ollama / LM Studio base URL override */}
+            {(selected.engine === "ollama" || selected.engine === "lmstudio") && (
+              <div>
+                <label className="text-tf-sm text-muted-foreground mb-1 block">
+                  {t("agents.endpoint.label")}
+                </label>
+                <input
+                  type="text"
+                  value={endpointOverride[selected.engine]}
+                  onChange={(e) => handleEndpointChange(selected.engine as "ollama" | "lmstudio", e.target.value)}
+                  placeholder={
+                    selected.engine === "ollama"
+                      ? t("agents.endpoint.placeholder_ollama")
+                      : t("agents.endpoint.placeholder_lmstudio")
+                  }
+                  className="w-full bg-background rounded-lg px-3 py-2 text-tf-caption font-mono outline-none border border-border/30 focus:border-ring/40"
+                />
+                <p className="text-tf-caption text-muted-foreground mt-1">
+                  {t("agents.endpoint.hint")}
+                </p>
+              </div>
+            )}
 
             <div>
               <label className="text-tf-sm text-muted-foreground mb-1 block">Model</label>

--- a/src/lib/sendPipeline/buildSendInput.ts
+++ b/src/lib/sendPipeline/buildSendInput.ts
@@ -45,6 +45,16 @@ export async function buildSendInput(p: BuildSendInputParams): Promise<SendWithC
   }).catch(() => null);
   const activeSkills = p.getEffectiveSkills(planPhase, p.prompt);
 
+  // Issue #175 — forward UI base URL override for openai-compat engines.
+  // Empty string is equivalent to "no override" so the backend falls back to
+  // env var / hardcoded default; only non-empty trimmed value is forwarded.
+  let customBaseUrl: string | undefined;
+  if (p.engine === "ollama" || p.engine === "lmstudio") {
+    const raw = await getSetting<string>(`engineEndpoint:${p.engine}`, "");
+    const trimmed = raw.trim();
+    if (trimmed) customBaseUrl = trimmed;
+  }
+
   return {
     projectKey: p.projectKey,
     conversationId: p.conversationId,
@@ -63,5 +73,6 @@ export async function buildSendInput(p: BuildSendInputParams): Promise<SendWithC
     ...(p.opts?.imagePaths && p.opts.imagePaths.length > 0
       ? { imagePaths: p.opts.imagePaths }
       : {}),
+    ...(customBaseUrl ? { customBaseUrl } : {}),
   };
 }

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -190,6 +190,12 @@
   "agents": {
     "heading": "Agent Profiles",
     "description": "Manage agent profiles. Each profile bundles an engine, model, and default skills into a single execution unit.",
+    "endpoint": {
+      "label": "Base URL (leave empty to use the default)",
+      "hint": "For remote Ollama (Tailscale / NAS) or an alternate LM Studio port. Empty value falls back to OLLAMA_HOST / LMSTUDIO_ENDPOINT env var, then the hardcoded default.",
+      "placeholder_ollama": "http://localhost:11434",
+      "placeholder_lmstudio": "http://localhost:1234"
+    },
     "role_coverage": {
       "title": "Role coverage",
       "ready_count": "{{ready}}/{{total}} ready",

--- a/src/locales/ko/settings.json
+++ b/src/locales/ko/settings.json
@@ -190,6 +190,12 @@
   "agents": {
     "heading": "Agent Profiles",
     "description": "에이전트 프로필을 관리합니다. 각 프로필은 엔진, 모델, 기본 스킬을 하나의 실행 단위로 묶습니다.",
+    "endpoint": {
+      "label": "Base URL (비우면 기본값 사용)",
+      "hint": "원격 Ollama (Tailscale / NAS) 또는 LM Studio 대체 포트용. 빈 값이면 OLLAMA_HOST / LMSTUDIO_ENDPOINT 환경변수 → 기본값 순으로 사용합니다.",
+      "placeholder_ollama": "http://localhost:11434",
+      "placeholder_lmstudio": "http://localhost:1234"
+    },
     "role_coverage": {
       "title": "역할 커버리지",
       "ready_count": "{{ready}}/{{total}} ready",

--- a/src/tests/streaming-flow.test.ts
+++ b/src/tests/streaming-flow.test.ts
@@ -17,7 +17,13 @@ import { listen } from "@tauri-apps/api/event";
 // ─── Mock dependencies ─────────────────────────────────────────────────────
 
 vi.mock("@/lib/appStore", () => ({
-  getSetting: vi.fn(() => Promise.resolve({ mode: "auto", totalCap: 60000 })),
+  getSetting: vi.fn((key: string, fallback: unknown) => {
+    // Issue #175 — engineEndpoint:* is read by buildSendInput for openai-compat
+    // engines. Tests don't exercise the override path, so return the fallback
+    // (empty string) instead of the legacy contextBudgetConfig shape.
+    if (key.startsWith("engineEndpoint:")) return Promise.resolve(fallback);
+    return Promise.resolve({ mode: "auto", totalCap: 60000 });
+  }),
   setSetting: vi.fn(() => Promise.resolve()),
 }));
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -196,6 +196,10 @@ export interface SendWithClaudeInput {
   /** Absolute paths of image attachments — used by Codex CLI (`-i <path>`).
    *  Other engines read the image via `Read` tool from the prompt path section. */
   imagePaths?: string[];
+  /** Base URL override for OpenAI-compatible engines (ollama / lmstudio).
+   *  Empty/undefined falls back to env var (OLLAMA_HOST / LMSTUDIO_ENDPOINT)
+   *  then the hardcoded default. Issue #175 MVP. */
+  customBaseUrl?: string;
 }
 
 export interface RoundtableParticipant {


### PR DESCRIPTION
## Summary

Closes #175 MVP. 백엔드 `stream_run_with_base` 는 이미 임의 URL 수용 — UI/settings gap 만 있던 것을 Settings → Agents 의 base URL override 입력으로 연결.

Plan: `docs/plans/customEndpointConfigPlan_2026-04-24.md`

### 우선순위

**UI 설정값 (non-empty trimmed) → env var (`OLLAMA_HOST` / `LMSTUDIO_ENDPOINT`) → hardcoded default**

env var 사용자는 UI 를 비워두면 그대로 동작 (INV-1).

### 변경 (3 커밋)

| # | 커밋 | 파일 |
|---|---|---|
| 1 | `feat(openai-compat): accept customBaseUrl in SendWithClaudeInput` | `src-tauri/src/commands/agents.rs` |
| 2 | `feat(settings): add Ollama/LM Studio base URL override UI` | `AgentsSection.tsx`, `locales/{ko,en}/settings.json` |
| 3 | `feat(runtime): inject customBaseUrl into sendWithEngine invoke args` | `types/index.ts`, `buildSendInput.ts`, `streaming-flow.test.ts` |

### 설계 요약

1. **Backend** — `SendWithClaudeInput` 에 `#[serde(default)] custom_base_url: Option<String>` 필드 추가. `start_openai_compat_stream` 에서 `input.custom_base_url` 을 spawn_blocking 전에 clone 후 우선순위 분기에 적용.
2. **UI** — Settings → Agents 의 Engine select 아래 조건부 렌더 (engine === ollama | lmstudio). appStore key `engineEndpoint:{engine}` 으로 저장 (`activeSkills:{pk}` 등 기존 네이밍 컨벤션 준수).
3. **Runtime injection** — `buildSendInput` 에서 engine 분기 후 getSetting 으로 값 읽어 `customBaseUrl` 로 합성. 빈 값은 field 자체 생략 (Rust 측 `Option::None` → env/default fallback).

### Test mock 업데이트

`streaming-flow.test.ts` 의 `getSetting` mock 이 flat 으로 `{ mode, totalCap }` 반환하던 것을 key 분기로 변경. `engineEndpoint:*` 키는 fallback (빈 문자열) 반환 → `.trim()` TypeError 방지.

## INV 준수

- **INV-1** env-var users unaffected when UI override empty — buildSendInput 이 빈 값을 spread 하지 않으므로 백엔드가 None 수신 → env → default 순
- **INV-2** 빈 문자열 = override 미적용 — trim + backend `filter(|s| !s.trim().is_empty())` 이중 보장
- **INV-3** `stream_run_with_base` 시그니처 불변
- **INV-4** Setting 키 `engineEndpoint:ollama` / `engineEndpoint:lmstudio` 고정 (Extended 확장 시 `engineEndpoint:custom:{label}` 자연 확장)
- **INV-5** i18n 키 ko/en 동시 추가

## Test plan

- [x] `npx tsc --noEmit` 통과
- [x] `npx vitest run` — 322 / 322 통과
- [x] `cargo check --all-targets` — 기존 dead_code 경고 1건 외 깨끗
- [ ] 수동 smoke (plan §(7) 참고):
  1. Settings → Agents → Ollama 선택 → `http://remote-nas:11434` 입력 → appStore 저장 확인
  2. 메시지 전송 → reqwest 로그로 실제 요청 경로 확인 (`[openai-compat] engine=...` eprintln 후속)
  3. UI 값 빈 리셋 → 로컬 기본값 (`localhost:11434`) 으로 폴백
  4. `OLLAMA_HOST=http://x.y:11434 npm run tauri dev` → UI 빈 상태 → env 값 그대로 사용
  5. LM Studio 동일 3 단계

## Extended (범위 외, 별도 이슈)

- 임의 label 의 커스텀 OpenAI-compat 엔드포인트 등록 (vLLM / Groq / Together AI / OpenRouter)
- API key per-endpoint
- `GET {base}/v1/models` HTTP discovery (원격 서버 모델 자동 감지)
- `ENGINE_CONFIGS` 동적화
→ `docs/plans/postBetaBacklogPlan_2026-04-24.md` B-18 등재

## 주의

- Issue #175 보고자 (batmania52) — PR 머지 후 이슈 댓글로 MVP 완료 안내 필요. Extended 는 별도 이슈로 유도.

🤖 Generated with [Claude Code](https://claude.com/claude-code)