### PR TITLE
fix(output): consolidate tunaflow marker scrubbing across result/insight export paths

### DIFF
--- a/src-tauri/src/commands/insight.rs
+++ b/src-tauri/src/commands/insight.rs
@@ -7,6 +7,24 @@ use std::path::Path;
 use crate::db::{migrations::now_epoch, models::{InsightSession, InsightFinding, InsightReport}, DbState};
 use crate::errors::AppError;
 
+lazy_static::lazy_static! {
+    /// tunaFlow 내부 마커를 잡는 정규식. FE 의 stripTunaflowMarkers 와 대응.
+    /// export_insight_to_files 의 2차 안전망 — DB 레거시 오염분을 런타임에 정화.
+    static ref TF_MARKER_RE: regex::Regex = regex::Regex::new(
+        r"<!--\s*(?:tunaflow:[a-z_-]+(?::\d+)?|subtask-done:\d+|impl-complete)\s*-->"
+    ).expect("TF_MARKER_RE compile");
+    /// 3개 이상 연속 개행을 2개로 정규화.
+    static ref TF_BLANKLINE_RE: regex::Regex = regex::Regex::new(r"\n{3,}").expect("blank-line RE compile");
+}
+
+/// tunaFlow 내부 마커 제거 + 연속 빈 줄 정규화 + trim.
+/// 사용자 가시 산출물 (docs/insight/*.md) 쓰기 직전 모든 텍스트 필드 통과시킬 것.
+fn strip_tf_markers(s: &str) -> String {
+    let no_markers = TF_MARKER_RE.replace_all(s, "");
+    let normalized = TF_BLANKLINE_RE.replace_all(&no_markers, "\n\n");
+    normalized.trim().to_string()
+}
+
 // ─── Input types ─────────────────────────────────────────────────────────────
 
 #[derive(Debug, Deserialize)]
@@ -447,12 +465,12 @@ pub fn export_insight_to_files(
             md.push_str(&format!("- **File**: {}{}\n", fp,
                 f.line_number.map(|n| format!(":{}", n)).unwrap_or_default()));
         }
-        md.push_str(&format!("\n## Description\n\n{}\n", f.description));
+        md.push_str(&format!("\n## Description\n\n{}\n", strip_tf_markers(&f.description)));
         if let Some(ref snippet) = f.snippet {
-            md.push_str(&format!("\n## Snippet\n\n```\n{}\n```\n", snippet));
+            md.push_str(&format!("\n## Snippet\n\n```\n{}\n```\n", strip_tf_markers(snippet)));
         }
         if let Some(ref resolution) = f.resolution {
-            md.push_str(&format!("\n## Resolution\n\n{}\n", resolution));
+            md.push_str(&format!("\n## Resolution\n\n{}\n", strip_tf_markers(resolution)));
         }
         let path = findings_dir.join(&filename);
         std::fs::write(&path, &md)
@@ -467,7 +485,7 @@ pub fn export_insight_to_files(
 
     let mut report = format!("# Insight Report — {}\n\n", ts);
     if let Some(ref summary) = session.summary {
-        report.push_str(&format!("{}\n\n", summary));
+        report.push_str(&format!("{}\n\n", strip_tf_markers(summary)));
     }
 
     // Group by category
@@ -498,4 +516,50 @@ pub fn export_insight_to_files(
     count += 1;
 
     Ok(count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::strip_tf_markers;
+
+    #[test]
+    fn strip_tf_markers_empty_returns_empty() {
+        assert_eq!(strip_tf_markers(""), "");
+    }
+
+    #[test]
+    fn strip_tf_markers_no_marker_leaves_text_intact() {
+        assert_eq!(strip_tf_markers("plain report body"), "plain report body");
+    }
+
+    #[test]
+    fn strip_tf_markers_removes_inline_tunaflow_marker() {
+        assert_eq!(
+            strip_tf_markers("hello <!-- tunaflow:plan-proposal --> world"),
+            "hello  world"
+        );
+    }
+
+    #[test]
+    fn strip_tf_markers_removes_subtask_done_and_normalizes_blank_lines() {
+        assert_eq!(
+            strip_tf_markers("done\n\n\n\n<!-- subtask-done:3 -->\ndone"),
+            "done\n\ndone"
+        );
+    }
+
+    #[test]
+    fn strip_tf_markers_removes_impl_complete_and_payload_markers() {
+        let input = "<!-- impl-complete -->\nresult\n<!-- tunaflow:insight-findings:12 -->";
+        assert_eq!(strip_tf_markers(input), "result");
+    }
+
+    #[test]
+    fn strip_tf_markers_preserves_non_tunaflow_html_comments() {
+        // INV-5: only tunaflow markers are matched; user-authored comments stay.
+        assert_eq!(
+            strip_tf_markers("before <!-- user comment --> after"),
+            "before <!-- user comment --> after"
+        );
+    }
 }

--- a/src/lib/insightOrchestration.ts
+++ b/src/lib/insightOrchestration.ts
@@ -25,6 +25,7 @@ import type {
 } from "./api/insight";
 import { extractInsightFindings } from "./planProposalParser";
 import type { InsightFindingItemInput } from "./schemas/insightFindings";
+import { stripTunaflowMarkers } from "./workflow/markerScrub";
 
 // ── Fix difficulty evaluation ────────────────────────────────
 
@@ -261,7 +262,7 @@ export async function runInsightAnalysis(
           session.id,
           projectKey,
           "category",
-          response.slice(0, 5000), // save first 5k chars for debugging
+          stripTunaflowMarkers(response).slice(0, 5000), // save first 5k chars for debugging
           cat,
         );
         continue;
@@ -270,7 +271,7 @@ export async function runInsightAnalysis(
       if (parsed.findings.length === 0) {
         onProgress?.(`${catLabel}: 발견 사항 없음`);
         if (parsed.summary) {
-          await insightApi.createInsightReport(session.id, projectKey, "category", parsed.summary, cat);
+          await insightApi.createInsightReport(session.id, projectKey, "category", stripTunaflowMarkers(parsed.summary), cat);
         }
         continue;
       }
@@ -282,22 +283,26 @@ export async function runInsightAnalysis(
         onProgress?.(`${catLabel}: ${filtered}개 low-confidence finding 필터링`);
       }
 
-      // Evaluate fix_difficulty and prepare for DB
-      const findingInputs = reliable.map((f) => ({
-        sessionId: session.id,
-        projectKey,
-        category: f.category || cat,
-        severity: f.severity,
-        fixDifficulty: evaluateFixDifficulty(f),
-        title: f.title,
-        description: f.evidence
-          ? `${f.description}\n\n**Evidence**: \`${f.evidence}\``
-          : f.description,
-        filePath: f.file_path,
-        lineNumber: f.line_number,
-        snippet: f.snippet,
-        estimatedFiles: f.estimated_files,
-      }));
+      // Evaluate fix_difficulty and prepare for DB.
+      // DB 쓰기 직전 마커 스크럽 — description 은 먼저 스크럽 후 evidence 병합 순서 유지.
+      const findingInputs = reliable.map((f) => {
+        const scrubbedDesc = stripTunaflowMarkers(f.description);
+        return {
+          sessionId: session.id,
+          projectKey,
+          category: f.category || cat,
+          severity: f.severity,
+          fixDifficulty: evaluateFixDifficulty(f),
+          title: f.title,
+          description: f.evidence
+            ? `${scrubbedDesc}\n\n**Evidence**: \`${f.evidence}\``
+            : scrubbedDesc,
+          filePath: f.file_path,
+          lineNumber: f.line_number,
+          snippet: f.snippet ? stripTunaflowMarkers(f.snippet) : undefined,
+          estimatedFiles: f.estimated_files,
+        };
+      });
 
       // Store findings
       const stored = await insightApi.createInsightFindingsBatch(findingInputs);
@@ -305,7 +310,7 @@ export async function runInsightAnalysis(
 
       // Store category report
       if (parsed.summary) {
-        await insightApi.createInsightReport(session.id, projectKey, "category", parsed.summary, cat);
+        await insightApi.createInsightReport(session.id, projectKey, "category", stripTunaflowMarkers(parsed.summary), cat);
       }
 
       const u = getInsightTokenUsage();

--- a/src/lib/workflow/markerScrub.test.ts
+++ b/src/lib/workflow/markerScrub.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { stripTunaflowMarkers } from "./markerScrub";
+
+describe("stripTunaflowMarkers", () => {
+  it("removes an inline tunaflow marker and leaves surrounding text", () => {
+    expect(stripTunaflowMarkers("hello <!-- tunaflow:plan-proposal --> world"))
+      .toBe("hello  world");
+  });
+
+  it("normalizes multiple blank lines around a subtask-done marker", () => {
+    expect(stripTunaflowMarkers("done\n\n\n\n<!-- subtask-done:3 -->\ndone"))
+      .toBe("done\n\ndone");
+  });
+
+  it("passes empty string through unchanged", () => {
+    expect(stripTunaflowMarkers("")).toBe("");
+  });
+
+  it("leaves marker-free text untouched (aside from trim)", () => {
+    expect(stripTunaflowMarkers("plain report body"))
+      .toBe("plain report body");
+  });
+
+  it("strips impl-complete and tunaflow payload markers together", () => {
+    const input = "<!-- impl-complete -->\nresult\n<!-- tunaflow:insight-findings:12 -->";
+    expect(stripTunaflowMarkers(input)).toBe("result");
+  });
+
+  it("preserves regular HTML comments that are not tunaflow markers", () => {
+    // INV-5: regex must only match tunaflow markers, not general HTML comments
+    expect(stripTunaflowMarkers("before <!-- user comment --> after"))
+      .toBe("before <!-- user comment --> after");
+  });
+});

--- a/src/lib/workflow/markerScrub.ts
+++ b/src/lib/workflow/markerScrub.ts
@@ -1,0 +1,28 @@
+/**
+ * tunaFlow 내부 마커 제거. 사용자 가시 산출물 (docs/plans/*.md, docs/insight/*.md)
+ * 에 새지 않아야 하는 모든 write 경로에서 이 함수를 통과시킬 것.
+ *
+ * 대상 마커:
+ *   <!-- tunaflow:TOKEN -->            (plan-proposal / insight-findings / etc.)
+ *   <!-- tunaflow:TOKEN:NUM -->        (subtask-ref 등 payload 번호가 붙는 경우)
+ *   <!-- subtask-done:N -->
+ *   <!-- impl-complete -->
+ *
+ * 추가로 연속 공백 라인(3+ \n)을 2개로 정규화하고 앞뒤 공백 trim.
+ *
+ * 이 파일은 DOM/React 의존 없음 — 워커/CLI/서비스 워커에서도 재사용 가능.
+ */
+const MARKER_PATTERNS: RegExp[] = [
+  /<!--\s*tunaflow:[a-z_-]+(?::\d+)?\s*-->/g,
+  /<!--\s*subtask-done:\d+\s*-->/g,
+  /<!--\s*impl-complete\s*-->/g,
+];
+
+export function stripTunaflowMarkers(text: string): string {
+  if (!text) return text;
+  let out = text;
+  for (const re of MARKER_PATTERNS) {
+    out = out.replace(re, "");
+  }
+  return out.replace(/\n{3,}/g, "\n\n").trim();
+}

--- a/src/lib/workflow/reportSync.ts
+++ b/src/lib/workflow/reportSync.ts
@@ -5,6 +5,7 @@ import type { Message, Plan } from "@/types";
 import * as planApi from "../api/plans";
 import type { ParsedReviewVerdict } from "../planProposalParser";
 import { getProjectPath, createTestReportArtifact } from "./helpers";
+import { stripTunaflowMarkers } from "./markerScrub";
 
 /** Generate/update plan document in project directory. Fire-and-forget. */
 export async function syncPlanDocument(planId: string): Promise<void> {
@@ -25,10 +26,14 @@ export async function syncReviewReport(
   try {
     const pp = await getProjectPath();
     if (!pp) return;
+    // testOutput 은 LLM/CI raw 문자열일 가능성이 있어 스크럽 통과.
+    // verdict.findings/recommendations 는 planProposalParser 에서 marker 제거 후
+    // payload 만 넘겨주므로 추가 처리 없음.
+    const scrubbedTestOutput = testOutput ? stripTunaflowMarkers(testOutput) : undefined;
     await planApi.generateReviewReport(
       planId, pp, verdict.verdict,
       verdict.findings, verdict.recommendations,
-      reviewerEngines, testOutput,
+      reviewerEngines, scrubbedTestOutput,
     );
   } catch (e) { console.warn("[tunaflow]", e); }
 }
@@ -44,13 +49,6 @@ export async function syncResultReport(
     const pp = await getProjectPath();
     if (!pp) return;
 
-    const stripMarkers = (text: string) =>
-      text.replace(/<!--\s*tunaflow:[a-z_-]+(?::\d+)?\s*-->/g, "")
-          .replace(/<!--\s*subtask-done:\d+\s*-->/g, "")
-          .replace(/<!--\s*impl-complete\s*-->/g, "")
-          .replace(/\n{3,}/g, "\n\n")
-          .trim();
-
     let lastReworkIdx = -1;
     for (let i = implMessages.length - 1; i >= 0; i--) {
       if (implMessages[i].role === "user" && implMessages[i].content.includes("### 🔄 Rework")) {
@@ -63,14 +61,14 @@ export async function syncResultReport(
       : implMessages;
     const assistantMsgs = relevantMessages.filter((m) => m.role === "assistant");
     const summary = assistantMsgs.length > 0
-      ? stripMarkers(assistantMsgs[assistantMsgs.length - 1].content.slice(0, 2000))
+      ? stripTunaflowMarkers(assistantMsgs[assistantMsgs.length - 1].content.slice(0, 2000))
       : "(No implementation output)";
 
     const { scanCompletedSubtasks } = await import("../planProposalParser");
     const completedNums = scanCompletedSubtasks(implMessages);
     const subtaskResults = assistantMsgs
       .slice(-10)
-      .map((m) => stripMarkers(m.content.slice(0, 500)))
+      .map((m) => stripTunaflowMarkers(m.content.slice(0, 500)))
       .filter((c) => c.trim().length > 0);
 
     const knownIssues: string[] = [];


### PR DESCRIPTION
## Summary

Plan: `docs/plans/resultReportMarkerCleanupPlan_2026-04-24.md` (C-2 / B-16).

`<!-- tunaflow:* -->`, `<!-- subtask-done:N -->`, `<!-- impl-complete -->` 내부 마커가 `docs/plans/*-result.md`, `docs/insight/findings/*.md`, `docs/insight/latest-report.md` 로 새지 않도록 **마커 스크럽 로직을 공용 유틸로 일원화 + DB 쓰기 직전 시점에 적용 + Rust export 단 2차 안전망**.

## 4 커밋 구조

| # | 커밋 | 파일 |
|---|---|---|
| 1 | `refactor(workflow): extract stripTunaflowMarkers to shared util` | `markerScrub.ts` (신규), `reportSync.ts` |
| 2 | `fix(insight): scrub tunaflow markers at DB write time` | `insightOrchestration.ts` |
| 3 | `chore(insight): Rust-side safety net for export_insight_to_files` | `src-tauri/src/commands/insight.rs` (신규 `strip_tf_markers` + 호출부 + 6 tests) |
| 4 | `test(workflow): coverage for stripTunaflowMarkers (FE)` | `markerScrub.test.ts` (신규, 6 케이스) |

## 설계 핵심

- **1 차 방어 (write 시점)**: `reportSync.syncResultReport`, `reportSync.syncReviewReport(testOutput)`, `insightOrchestration.ts` 의 4 지점 (response/summary × 2/description/snippet)
- **2 차 방어 (export 시점, Rust)**: `export_insight_to_files` 에서 `f.description / f.snippet / f.resolution / session.summary` 출력 직전 `strip_tf_markers` 통과 → DB 레거시 오염분도 런타임에 정화
- **공용 유틸 두 군데만 존재** (INV-2): FE `stripTunaflowMarkers`, Rust `strip_tf_markers`. 중복 정의 금지

## Invariants

- **INV-1** result/review/insight 산출물 어느 파일에도 마커 문자열 0 건 (rg 기반 최종 감사)
- **INV-2** 스크럽 로직은 FE + Rust 각 한 파일에만 존재 — 다른 곳 중복 정의 금지
- **INV-3** 새 사용자 가시 산출물 쓰기 경로는 반드시 이 유틸 통과 (코드 리뷰 체크리스트)
- **INV-4** DB 레거시 오염분은 Rust export 2차 안전망이 런타임 정화 → DB 마이그레이션 불요
- **INV-5** regex 는 마커만 매칭, 사용자 HTML 주석 / 일반 텍스트 보존 (Rust + FE 테스트로 증빙)

## Test plan

- [x] `npx tsc --noEmit` — 0 에러
- [x] `npx vitest run src/lib/workflow/markerScrub.test.ts` — 6 / 6 pass (FE)
- [x] `cargo test --lib` — 491 / 491 pass (기존 485 + insight 신규 6)
- [x] `cargo check --all-targets` — 기존 dead_code 1건만 (무관)
- [ ] 풀사이클 smoke (선택): 테스트 프로젝트에 plan 1회 + insight 1회 돌린 후 `rg '<!-- tunaflow:|<!-- subtask-done:|<!-- impl-complete' docs/plans/ docs/insight/` — 0 건

### Flaky test 주의

`src/tests/store-runtime.test.ts` 의 "has configs for all 4 engines" 가 전체 병렬 실행 시 timeout 간헐 발생 (단독 실행은 7/7 pass). 본 PR 변경과 무관 — `ENGINE_CONFIGS` 구조 검증 테스트로 `buildSendInput` 경로 안 거침. CI 에서 재실행 필요하면 재시도.

## 후속

- B-16 backlog 항목 **완료 처리** 표기
- 10 편 기록 업데이트 (재발 → 1원화 적용)

🤖 Generated with [Claude Code](https://claude.com/claude-code)