### PR TITLE
security(claude): fix infinite hang on fs permission prompts (#178)

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,21 @@ Highlights:
 
 ---
 
+## Security & Permissions
+
+tunaFlow launches the Claude CLI with the `--dangerously-skip-permissions` flag. This means the CLI skips approval prompts for file access outside the project directory, system commands, and similar operations.
+
+**Your responsibilities**:
+- Choose the project directory you hand to the agent carefully — it defines the trust boundary.
+- Do not enable untrusted prompts, tools, or MCP servers.
+- Review the work the agent performed periodically; don't treat autonomous runs as unattended.
+
+Why this flag, and why no UI approval flow: the `stream-json` protocol does not emit a `permission_request` event, so there is no way for tunaFlow to intercept prompts and surface them in the UI. The CLI writes prompts directly to the terminal, and tunaFlow holds stdin for outbound messages, so prompts go unanswered — which is exactly the [#178](https://github.com/hang-in/tunaFlow/issues/178) infinite-hang path. Until Anthropic ships a first-class permission event (tracked in `postBetaBacklog` B-20), `--dangerously-skip-permissions` is the pragmatic choice.
+
+If this trade-off is unacceptable for your workflow, run Claude Code directly in a terminal instead of via tunaFlow for that task — the permission surface is identical either way, just under your direct interaction.
+
+---
+
 ## Known Constraints (Beta)
 
 ### Will be fixed (P0 / P1)

--- a/docs/plans/postBetaBacklogPlan_2026-04-24.md
+++ b/docs/plans/postBetaBacklogPlan_2026-04-24.md
@@ -182,6 +182,18 @@ MVP (`customEndpointConfigPlan_2026-04-24`, 머지: `6cc991c`) 는 Ollama / LM S
 - 피드백 반영 결과: fail 사유 입력은 **optional**, 사유 미입력 시 rework_reason 에 "manual verification failed" placeholder.
 - 요약: `impl-complete` 직후 `⚠️ Manual:` 라인 파싱 → UI dialog (pass/skip/fail + optional 사유) → fail 있으면 기존 Rework 경로, pass 면 Review 진행. Settings 에 skip 토글.
 
+### B-20. Anthropic upstream 에 stream-json permission_request 이벤트 요청 (출처: Issue #178)
+
+- 카테고리: **outreach** — upstream 기능 요청
+- 우선순위: **P2** — 단기 차단 없음 (`--dangerously-skip-permissions` 플래그로 interim fix 완료, PR #178 대응 참조)
+- 배경: Claude CLI 의 `stream-json` 프로토콜에 `permission_request` 이벤트가 부재 → tunaFlow 에서 per-tool 승인 UI 를 구현할 경로가 없음. 이슈 [#178](https://github.com/hang-in/tunaFlow/issues/178) 제보자(`batmania52`)의 기술 분석 완료.
+- 필요 요소:
+  1. Anthropic `claude-code` repo (또는 공식 채널) 에 기능 요청 이슈 제기
+  2. tunaFlow 측 대체 UI 승인 흐름 설계 (PTY 복원 또는 stdin-over-WS 채널)
+  3. 이벤트 채택 시 `--dangerously-skip-permissions` 되돌리고 per-tool 승인 UI 구현
+- 구현 부담: outreach 자체는 낮음 / 채택 후 UI 설계는 중간
+- 선결 조건: 현 hotfix (#178) 머지 ✅ / upstream 응답 대기
+
 ---
 
 ## 운영 정책

--- a/src-tauri/src/agents/claude.rs
+++ b/src-tauri/src/agents/claude.rs
@@ -159,7 +159,7 @@ where
         .arg("--output-format")
         .arg("stream-json")
         .arg("--verbose")
-        .arg("--permission-mode").arg("bypassPermissions")
+        .arg("--dangerously-skip-permissions")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .current_dir(resolve_cwd(input.project_path.as_deref()));
@@ -377,7 +377,7 @@ pub fn run(input: RunInput) -> Result<RunOutput, AppError> {
         .arg(&input.prompt)
         .arg("--output-format")
         .arg("json")
-        .arg("--permission-mode").arg("bypassPermissions")
+        .arg("--dangerously-skip-permissions")
         .current_dir(resolve_cwd(input.project_path.as_deref()));
 
     if let Some(model) = &input.model {

--- a/src-tauri/src/agents/claude_sdk_session.rs
+++ b/src-tauri/src/agents/claude_sdk_session.rs
@@ -378,7 +378,7 @@ async fn spawn_session(
         .arg("--input-format").arg("stream-json")
         .arg("--output-format").arg("stream-json")
         .arg("--replay-user-messages")
-        .arg("--permission-mode").arg("bypassPermissions")
+        .arg("--dangerously-skip-permissions")
         .env("CLAUDE_CODE_ENVIRONMENT_KIND", "bridge")
         .env("CLAUDE_CODE_SESSION_ACCESS_TOKEN", &auth_token)
         // HybridTransport: 이벤트를 HTTP POST로 전송 (Desktop 앱 동일 패턴)

--- a/src-tauri/src/agents/codex_app_server.rs
+++ b/src-tauri/src/agents/codex_app_server.rs
@@ -523,7 +523,7 @@ async fn get_or_create_thread(
     }
 
     let cwd = resolve_cwd(project_path);
-    // sandbox=danger-full-access는 claude의 --permission-mode bypassPermissions와 등가.
+    // sandbox=danger-full-access는 claude의 --dangerously-skip-permissions와 등가.
     // 이게 없으면 codex는 default sandbox(workspace-write, network 차단)에서 동작하여
     // gh/curl 등 네트워크 도구가 모두 실패한다.
     // persistExtendedHistory/experimentalRawEvents는 experimentalApi capability가 있어야


### PR DESCRIPTION
## Summary

Closes #178. Plan: `docs/plans/claudeDangerouslySkipPermissionsPlan_2026-04-24.md`.

`--permission-mode bypassPermissions` → `--dangerously-skip-permissions` 로 교체해 외부 디렉터리 접근 / OS 보안 prompt 때 발생하던 무한 hang + 10분 timeout 해결.

## 변경

| 파일 | 내용 |
|---|---|
| `src-tauri/src/agents/claude.rs:162` | `stream_run` — 플래그 교체 |
| `src-tauri/src/agents/claude.rs:380` | `run` — 플래그 교체 |
| `src-tauri/src/agents/claude_sdk_session.rs:381` | sdk-url WS session — 플래그 교체 (이슈 본문 누락분) |
| `src-tauri/src/agents/codex_app_server.rs:526` | 주석 표기 정합성 업데이트 |
| `README.md` | **Security & Permissions** 섹션 신규 — 플래그 투명 노출 + 사용자 책임 + upstream 상황 |
| `docs/plans/postBetaBacklogPlan_2026-04-24.md` | **B-20** 등재 — upstream permission_request event 요청 |

## INV 준수

- **INV-1** `rg bypassPermissions src-tauri/` → **0 건** (코드 + 주석)
- **INV-2** `rg dangerously-skip-permissions src-tauri/` → **3 건** (세 call site)
- **INV-3** README 보안 섹션에 플래그 이름 그대로 + 사용자 책임 명시

## Test plan

- [x] `cargo check --all-targets` — 기존 dead_code 경고 1건만 (무관)
- [x] 정적 grep invariant 확인
- [ ] 수동 smoke (plan §(4)):
  1. Claude 에이전트로 "프로젝트 루트에 `~/.claude/skills/test.md` 심볼릭 링크" 요청
  2. macOS 알림 없이 즉시 완료 확인
  3. 일반 in-project 작업 (`npx tsc --noEmit`) regression 없음

## 스코프 결정

- **CHANGELOG.md** — 기존 파일 없음. 단독 신설은 운영 패턴 벗어나는 결정이라 미진행 (plan 주의사항 준수).
- **커밋 구성** — plan 이 3 커밋 구조 권고했으나 결과적으로 2 커밋으로 머지 (security + README 가 한 커밋, backlog 별도). 내용 응집성 관점에서 오히려 자연스러움.

## 후속

- B-20 (upstream outreach) 로 이어감. upstream 채택 시 플래그 되돌리고 per-tool 승인 UI 설계.

🤖 Generated with [Claude Code](https://claude.com/claude-code)