### PR TITLE
fix(rawq): prevent OOM by excluding build artifact dirs from index (#180)

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Highlights:
 
 - **Ad-hoc Signature** — No Apple Developer ID signing in Beta. Requires Gatekeeper bypass (`xattr -cr /Applications/tunaFlow.app`).
 - **Limited mid-round RT interruption** — participant-level token streaming works in real time, but once a round is in progress, redirecting the discussion mid-round is awkward. Feedback is delivered between rounds.
-- **Initial Indexing Delay** — Large projects may take several minutes for the first run (CPU spikes mitigated via ONNX thread limits, semaphores, and incremental indexing).
+- **Initial Indexing Delay** — Large projects may take several minutes for the first run (CPU spikes mitigated via ONNX thread limits, semaphores, and incremental indexing). Build artifact directories (`target/`, `node_modules/`, `dist/`, `.venv/`, `__pycache__/` and similar) are excluded from rawq indexing to prevent OOM — full list and the `Rebuild index` button (for users upgrading from before the exclude list) are documented in [rawq-setup.md](./docs/how-to/rawq-setup.md#제외-패턴-exclude-patterns--issue-180-hotfix).
 
 Detailed list: [CLAUDE.md §5](./CLAUDE.md)
 

--- a/docs/how-to/rawq-setup.md
+++ b/docs/how-to/rawq-setup.md
@@ -99,3 +99,37 @@ src-tauri/binaries/rawq-$(rustc --print host-tuple) --version
 - rawq 실패 시 예전 최소 검색 fallback으로 조용히 내려가는 것
 
 이 둘은 운영 관점에서 원인 추적과 품질 보장을 어렵게 만든다.
+
+## 제외 패턴 (Exclude patterns) — Issue #180 hotfix
+
+rawq 의 `.gitignore` 존중이 실측상 신뢰할 수 없어 (빌드 산출물이 인덱싱되어 시스템 프리즈 유발), tunaFlow 는 `src-tauri/src/agents/rawq.rs` 의 `ensure_index` 에 **하드코딩된 `-x` 패턴**으로 방어한다.
+
+현재 제외 목록 (코드 SSOT — 변경 시 이 목록도 업데이트):
+
+| 패턴 | 대상 |
+|---|---|
+| `target/**` | Rust 빌드 출력 |
+| `node_modules/**` | Node 의존성 |
+| `dist/**` | 프런트엔드 빌드 출력 |
+| `build/**` | 일반 빌드 디렉터리 |
+| `.venv/**`, `venv/**` | Python 가상환경 |
+| `__pycache__/**` | Python 캐시 |
+| `.next/**`, `.nuxt/**` | Next.js / Nuxt 빌드 |
+| `.cache/**` | 일반 캐시 |
+| `coverage/**` | 테스트 커버리지 |
+| `*.min.js`, `*.min.css` | 미니파이 산출물 |
+| `*.lock` | lockfile |
+| `*.log` | 로그 |
+
+### 변경 정책 (INV-3)
+
+**추가만 가능, 삭제 금지.** 한 번 제외한 디렉터리를 다시 인덱싱 대상으로 바꾸면 기존 사용자의 인덱스 DB 에 대량 재인덱싱이 일시에 유발된다. 삭제가 필요하면 별도 plan 으로 분리.
+
+### 패턴 추가 요청
+
+- 새 빌드 도구 / 프레임워크 산출물이 빈번하게 인덱싱된다면 이슈 또는 PR 로 제보
+- 패턴 추가는 단일 라인 변경이라 PR 승인 빠름
+
+### 기존 사용자 — 레거시 인덱스 정리
+
+hotfix 이전에 한 번이라도 프로젝트를 열었다면 DB 에 `target/` 등이 이미 인덱싱되어 있을 수 있다. **Settings → Runtime → rawq 섹션** 의 `인덱스 재빌드` 버튼으로 기존 인덱스를 제거하고 현재 exclude 패턴으로 재빌드한다. 프로젝트 크기에 따라 수 분 소요.

--- a/src-tauri/src/agents/rawq.rs
+++ b/src-tauri/src/agents/rawq.rs
@@ -333,10 +333,28 @@ pub fn ensure_index(project_path: &str) -> Result<u64, RawqError> {
     }
 
     let bin = resolve_rawq_bin()?;
-    // Note: rawq's WalkBuilder respects .gitignore automatically.
-    // Explicit -x patterns are not needed for standard ignores.
+    // rawq WalkBuilder .gitignore 지원이 실측상 신뢰 불가 (#180). 공통 빌드
+    // 산출물은 하드코딩으로 제외해 OOM / 시스템 프리즈를 방어한다.
+    // INV-3: 패턴은 추가만 가능 — 삭제 시 기존 사용자 DB 에 대량 재인덱싱 유발.
     let child = Command::new(&bin)
-        .args(["index", "build", project_path, "--json"])
+        .args([
+            "index", "build", project_path, "--json",
+            "-x", "target/**",          // Rust
+            "-x", "node_modules/**",    // Node
+            "-x", "dist/**",            // FE build output
+            "-x", "build/**",           // general build
+            "-x", ".venv/**",           // Python
+            "-x", "venv/**",            // Python variant
+            "-x", "__pycache__/**",     // Python
+            "-x", ".next/**",           // Next.js
+            "-x", ".nuxt/**",           // Nuxt
+            "-x", ".cache/**",          // general cache
+            "-x", "coverage/**",        // test coverage
+            "-x", "*.min.js",           // minified
+            "-x", "*.min.css",
+            "-x", "*.lock",             // lockfile
+            "-x", "*.log",
+        ])
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .spawn()
@@ -366,6 +384,37 @@ pub fn ensure_index(project_path: &str) -> Result<u64, RawqError> {
     let total = parsed.get("total_files").and_then(|v| v.as_u64()).unwrap_or(0);
     eprintln!("[rawq] index built: {} files", total);
     Ok(total)
+}
+
+/// 기존 인덱스를 제거하고 재빌드. #180 hotfix 후 레거시 오염분 (target/ 등
+/// 하드코딩 exclude 이전에 인덱싱된 값) 정리용.
+///
+/// CLI: `rawq index remove <path>` → `rawq index build <path> --json -x ...`
+/// remove 실패는 무시 (인덱스 없을 수 있음). 로그만 남기고 build 로 진행.
+pub fn rebuild_index(project_path: &str) -> Result<u64, RawqError> {
+    let bin = resolve_rawq_bin()?;
+    // Step 1: 기존 인덱스 제거 시도. 실패해도 계속 진행 (처음부터 없을 수 있음).
+    match Command::new(&bin)
+        .args(["index", "remove", project_path])
+        .output()
+    {
+        Ok(out) if out.status.success() => {
+            eprintln!("[rawq] index removed for {}", project_path);
+        }
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            eprintln!(
+                "[rawq] index remove non-zero (ignored): code={} stderr={}",
+                out.status.code().unwrap_or(-1),
+                stderr.trim()
+            );
+        }
+        Err(e) => {
+            eprintln!("[rawq] index remove exec failed (ignored): {}", e);
+        }
+    }
+    // Step 2: ensure_index 재호출 (하드코딩 exclude 적용된 새 인덱스).
+    ensure_index(project_path)
 }
 
 // ─── Search ──────────────────────────────────────────────────────────────────

--- a/src-tauri/src/commands/project_tools.rs
+++ b/src-tauri/src/commands/project_tools.rs
@@ -160,6 +160,63 @@ pub fn start_rawq_index(
     Ok(())
 }
 
+/// Rebuild rawq index — drops the existing index and rebuilds with the current
+/// hardcoded exclude patterns. #180 hotfix 후 레거시 오염분 정리용.
+/// Emits the same events as start_rawq_index (rawq:indexing / rawq:indexed / rawq:error).
+#[tauri::command]
+pub fn rebuild_rawq_index(
+    project_path: String,
+    app: tauri::AppHandle,
+    indexing: State<RawqIndexing>,
+) -> Result<(), AppError> {
+    use crate::agents::rawq;
+    use tauri::Emitter;
+
+    // Duplicate guard — reuse start_rawq_index 의 set.
+    {
+        let mut set = indexing.0.lock();
+        if set.contains(&project_path) {
+            eprintln!("[rawq] already indexing {}, skipping rebuild", project_path);
+            return Ok(());
+        }
+        set.insert(project_path.clone());
+    }
+    let guard = indexing.0.clone();
+
+    let _ = app.emit("rawq:indexing", serde_json::json!({
+        "projectPath": &project_path,
+        "message": "Rebuilding code index (removing legacy data)..."
+    }));
+
+    std::thread::spawn(move || {
+        let result = match rawq::rebuild_index(&project_path) {
+            Ok(n) => RawqStatus {
+                available: true, indexed: true,
+                status: "built".into(), message: format!("rebuilt: indexed {} files", n),
+                files: Some(n), chunks: None,
+            },
+            Err(e) => {
+                eprintln!("[rebuild_rawq_index] {}", e);
+                let available = !matches!(e, rawq::RawqError::NotFound(_));
+                RawqStatus {
+                    available, indexed: false,
+                    status: if available { "error" } else { "unavailable" }.into(),
+                    message: format!("{}", e),
+                    files: None, chunks: None,
+                }
+            }
+        };
+
+        let event = if result.indexed { "rawq:indexed" } else { "rawq:error" };
+        let _ = app.emit(event, &result);
+
+        let mut set = guard.lock();
+        set.remove(&project_path);
+    });
+
+    Ok(())
+}
+
 /// Git status for a project path.
 #[derive(serde::Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -81,6 +81,7 @@ pub fn run() {
             commands::project_tools::get_project_cli_permissions,
             commands::project_tools::set_project_cli_permissions,
             commands::project_tools::start_rawq_index,
+            commands::project_tools::rebuild_rawq_index,
             commands::project_tools::get_rawq_status,
             commands::project_tools::get_git_status,
             // Conversation

--- a/src/components/tunaflow/settings/RuntimeSection.tsx
+++ b/src/components/tunaflow/settings/RuntimeSection.tsx
@@ -585,9 +585,11 @@ function PtyModeToggle() {
 export function RuntimeSection() {
   const { t } = useTranslation("settings");
   const rawqStatus = useChatStore((s) => s.rawqStatus);
+  const selectedProjectKey = useChatStore((s) => s.selectedProjectKey);
   const engineModels = useChatStore((s) => s.engineModels);
   const loadEngineModels = useChatStore((s) => s.loadEngineModels);
   const [refreshing, setRefreshing] = useState(false);
+  const [rebuilding, setRebuilding] = useState(false);
   const [hubHealth, setHubHealth] = useState<HubHealth | null>(null);
 
   useEffect(() => { invoke<HubHealth>("context_hub_health").then(setHubHealth).catch((e) => console.debug("[hub-health]", e)); }, []);
@@ -595,6 +597,27 @@ export function RuntimeSection() {
   const handleRefreshModels = async () => { setRefreshing(true); await loadEngineModels(true); setRefreshing(false); };
 
   const engineGroups = engineModels.reduce<Record<string, number>>((acc, m) => { acc[m.engine] = (acc[m.engine] ?? 0) + 1; return acc; }, {});
+
+  // Issue #180 — hardcoded exclude 적용 이전에 쌓인 target/ 등 오염 인덱스 정리용.
+  const handleRebuildIndex = async () => {
+    if (!selectedProjectKey || rebuilding) return;
+    try {
+      const project = await invoke<{ path?: string }>("get_project", { key: selectedProjectKey });
+      if (!project?.path) return;
+      const confirmed = window.confirm(
+        "기존 인덱스를 삭제하고 다시 빌드합니다. 프로젝트 크기에 따라 수 분이 걸릴 수 있습니다. 계속하시겠습니까?"
+      );
+      if (!confirmed) return;
+      setRebuilding(true);
+      // 상태는 `rawq:indexing` / `rawq:indexed` / `rawq:error` 이벤트가 store 로 반영.
+      await invoke("rebuild_rawq_index", { projectPath: project.path });
+    } catch (e) {
+      console.error("[rawq] rebuild failed:", errorMessage(e));
+    } finally {
+      // 이벤트 도착까지는 store 가 indexing 상태를 유지 — 버튼은 잠깐 deb
+      setTimeout(() => setRebuilding(false), 1500);
+    }
+  };
 
   return (
     <div className="space-y-6">
@@ -619,6 +642,21 @@ export function RuntimeSection() {
             <div className="flex items-center gap-2"><span className="text-muted-foreground w-[80px]">Available</span><span className="text-foreground/80">{rawqStatus.available ? "Yes" : "No"}</span></div>
           </div>
         ) : <p className="text-[12px] text-muted-foreground/50">No project selected</p>}
+        {/* Issue #180 — rebuild with current hardcoded exclude patterns. */}
+        {rawqStatus && rawqStatus.available && selectedProjectKey && (
+          <div className="flex items-center gap-2 pt-2">
+            <button
+              onClick={handleRebuildIndex}
+              disabled={rebuilding || rawqStatus.status === "indexing"}
+              className="text-[11px] px-2.5 py-1 rounded-md bg-primary/10 text-primary hover:bg-primary/20 transition-colors disabled:opacity-40 font-medium"
+            >
+              {rebuilding || rawqStatus.status === "indexing" ? "재빌드 중…" : "인덱스 재빌드"}
+            </button>
+            <p className="text-[10px] text-muted-foreground/60">
+              빌드 산출물 (target/, node_modules/, dist/ 등) 자동 제외. 기존 인덱스는 삭제됩니다.
+            </p>
+          </div>
+        )}
       </div>
 
       {/* Model Catalog */}


### PR DESCRIPTION
## Summary

Closes #180. Plan: `docs/plans/rawqGitignoreIndexFixPlan_2026-04-24.md`.

공개 첫날 `batmania52` 님이 제보한 시스템 프리즈 + 강제 리부트. rawq 가 `.gitignore` 를 실제로 존중하지 않아 `target/` 16GB Rust 빌드 산출물을 인덱싱 시도 → RAM 고갈 + swap 폭주. 공통 빌드 산출물 14 패턴을 `ensure_index` 에 하드코딩으로 제외 + 기존 사용자용 `인덱스 재빌드` 버튼 추가.

## 3 커밋 구조

| # | 커밋 | 변경 |
|---|---|---|
| 1 | `fix(rawq): exclude build artifact dirs from ensure_index` | `src-tauri/src/agents/rawq.rs` — 14 exclude 패턴 + `rebuild_index` 함수 |
| 2 | `feat(rawq): rebuild_index command + Settings UI button` | `project_tools.rs`, `lib.rs`, `RuntimeSection.tsx` |
| 3 | `docs(rawq): exclude pattern documentation` | `README.md`, `docs/how-to/rawq-setup.md` |

## 제외 패턴 (14)

`target/**` / `node_modules/**` / `dist/**` / `build/**` / `.venv/**` / `venv/**` / `__pycache__/**` / `.next/**` / `.nuxt/**` / `.cache/**` / `coverage/**` / `*.min.js` / `*.min.css` / `*.lock` / `*.log`

프로세스: 패턴은 **추가만 가능, 삭제 금지** (INV-3). 추가 요청은 이슈 또는 PR.

## 기존 사용자 구제

Settings → Runtime → rawq 섹션의 `인덱스 재빌드` 버튼:
1. `window.confirm` 확인 (INV-4 — 실수 클릭 방지)
2. `invoke("rebuild_rawq_index")` → rawq `index remove` 시도 → `ensure_index` (hardcoded exclude 적용)
3. 상태는 기존 `rawq:indexing` / `rawq:indexed` / `rawq:error` 이벤트로 갱신

`rawq index drop` 서브커맨드 대신 실측 존재 명령 `rawq index remove` 사용 (plan 주의 반영).

## Test plan

- [x] `cargo check --all-targets` — 기존 dead_code 경고 1건만 (무관)
- [x] `npx tsc --noEmit` — 0 에러
- [x] `npx vitest run` — 328 / 328 pass
- [ ] 수동 smoke (plan §(4)):
  1. Rust 프로젝트 (`target/` 3GB+) 열기 → Activity Monitor 로 tunaFlow 메모리 500MB 이내 확인
  2. Settings → Runtime → rawq 의 `인덱스 재빌드` 버튼 → confirm dialog → 완료
  3. `rawq search "fn main"` → `target/` 경로 결과 **0 건**

Rust 유닛 테스트는 rawq 바이너리 의존이라 CI 포함 금지 (plan 주의사항 준수).

## 관련

- Issue #178 (Claude permission flag hotfix, PR #181) 와 병행. 파일 겹침 없음.
- 후속: B-20 upstream outreach 와 같은 라인에 "rawq upstream `.gitignore` fix 후 hardcoded exclude 제거" 항목 추가 여지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)