### PR TITLE
feat(workflow): manual verification gate between impl-complete and review (B-19 / #176)

### DIFF
--- a/docs/agents/developer.md
+++ b/docs/agents/developer.md
@@ -37,6 +37,21 @@ Verification results for Task N:
 - If a command fails for an expected reason (e.g. no server in dev), explain why
 - Do NOT claim a verification passed if you did not actually run it
 
+## Manual Verification — FLAG, DO NOT RUN
+
+Shell 로 확인 불가능한 항목 (UI 클릭, OS 다이얼로그, 외부 API 응답, 지각적 품질) 은 **직접 실행하지 말고**, 응답에 다음 형식으로 열거만 한다:
+
+```
+⚠️ Manual: Settings > Agents 에서 프로필 선택 → Engine 드롭다운 열고 "Ollama" 선택 시 Base URL 입력란이 노출되는지 확인
+⚠️ Manual: 프로젝트 리스트에서 "New Project" 버튼 클릭 → 다이얼로그가 뜨고 Cancel 시 닫히는지 확인
+```
+
+- 1 줄 1 항목. prefix `⚠️ Manual:` 은 필수 (⚠️ 는 U+26A0 U+FE0F).
+- 구체적으로 **무엇을 눌러서 / 어떤 결과가 나와야 하는지** 쓰기. "테스트해주세요" 같은 막연한 지시 금지.
+- 이 라인은 chat message 에만 쓰고 파일에는 쓰지 않는다 (기존 impl-complete 마커 규칙과 동일).
+
+tunaFlow 가 이 항목들을 모아 **사용자에게 확인 다이얼로그**로 제시한다. 사용자가 직접 pass/skip/fail 판정한다. Fail 이 하나라도 있으면 자동으로 Rework 경로로 전환되고, 실패 사유가 Developer 의 다음 rework 지시에 포함된다.
+
 ## Result Report — DO NOT WRITE
 
 tunaFlow **automatically generates** the result report (`docs/plans/{slug}-result.md`).

--- a/src/components/tunaflow/context-panel/DevProgressView.tsx
+++ b/src/components/tunaflow/context-panel/DevProgressView.tsx
@@ -1,12 +1,20 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
 import { invoke } from "@tauri-apps/api/core";
 import { cn } from "@/lib/utils";
 import { useChatStore } from "@/stores/chatStore";
 import { GitBranch, Check, Loader2, Clock, RotateCcw, Plus, ClipboardList, FileText } from "lucide-react";
 import type { Plan, PlanPhase, PlanSubtask } from "@/types";
 import * as planApi from "@/lib/api/plans";
-import { getPlanSlug, syncResultReport, startReviewRT } from "@/lib/workflowOrchestration";
+import {
+  getPlanSlug, syncResultReport, startReviewRT, ManualVerificationFailed,
+} from "@/lib/workflowOrchestration";
+import type {
+  ManualVerificationItem,
+  ManualVerificationResult,
+} from "@/lib/manualVerification";
+import { ManualVerificationGate } from "@/components/workflow/ManualVerificationGate";
 import { runProjectTests } from "@/lib/api/testRunner";
 import type { Branch, Message } from "@/types";
 import { PlanDocumentModal } from "./PlanDocumentModal";
@@ -32,6 +40,30 @@ export function DevProgressView({ plan, onPlanUpdate }: DevProgressViewProps) {
 
   const [busy, setBusy] = useState(false);
   const [showDoc, setShowDoc] = useState(false);
+
+  // Manual Verification Gate (B-19 / Issue #176) — dialog state + resolver ref.
+  // runManualGate 콜백이 items 를 state 에 세팅하고 resolver 를 ref 에 저장한 뒤
+  // Promise 를 반환. dialog 의 onComplete/onCancel 이 resolver 를 호출해 결과 전달.
+  const [manualGate, setManualGate] = useState<{ open: boolean; items: ManualVerificationItem[] }>({
+    open: false, items: [],
+  });
+  const manualGateResolverRef = useRef<((r: ManualVerificationResult[] | null) => void) | null>(null);
+  const runManualGate = (items: ManualVerificationItem[]): Promise<ManualVerificationResult[] | null> => {
+    return new Promise((resolve) => {
+      manualGateResolverRef.current = resolve;
+      setManualGate({ open: true, items });
+    });
+  };
+  const handleManualGateComplete = (results: ManualVerificationResult[]) => {
+    manualGateResolverRef.current?.(results);
+    manualGateResolverRef.current = null;
+    setManualGate({ open: false, items: [] });
+  };
+  const handleManualGateCancel = () => {
+    manualGateResolverRef.current?.(null);
+    manualGateResolverRef.current = null;
+    setManualGate({ open: false, items: [] });
+  };
   // reviewMode state 제거 (2026-04-19) — Dev 시작과 동일하게 한 번 클릭으로 즉시 실행.
   // 이전엔 "Review 시작" → select 모드 전환 → reviewer 선택 + "Review 시작" 3단계였고,
   // 이제는 implComplete 가 되면 곧바로 reviewer 선택 UI 가 노출되고 "Review 시작" 1회로 끝.
@@ -188,13 +220,23 @@ export function DevProgressView({ plan, onPlanUpdate }: DevProgressViewProps) {
       // model 이 유실 → codex_app_server fallback(gpt-5-codex) 로 귀결 → ChatGPT
       // 구독 계정에서 400 에러가 발생했음 (s37 재현).
       const reviewers = chosenProfiles.map((p) => ({ engine: p.engine, model: p.model, name: p.label }));
-      const { branch, participants, prompt, mode } = await startReviewRT(plan, msgs, testOutput, reviewers);
+      const { branch, participants, prompt, mode } = await startReviewRT(plan, msgs, testOutput, reviewers, runManualGate);
       onPlanUpdate(plan.id, { phase: "review" as PlanPhase, reviewBranchId: branch.id });
       await loadBranches(plan.conversationId);
       await openThread(branch.id);
       // Deep review = ≥2 reviewers → auto-synthesize MoA summary after the round.
       await sendThreadRoundtable(prompt, participants, mode, { autoSynthesize: true });
-    } catch (e) { console.warn("[tunaflow]", e); }
+    } catch (e) {
+      if (e instanceof ManualVerificationFailed) {
+        // Rework 경로로 전환됨 — startReviewRT 안에서 phase/artifact 이미 처리.
+        // UI 측은 plan 상태 갱신만 하면 rework notice 섹션이 자동 노출.
+        onPlanUpdate(plan.id, { phase: "rework" as PlanPhase });
+      } else if (e instanceof Error && e.message.includes("cancelled by user")) {
+        toast.info("수동 확인이 취소되었습니다");
+      } else {
+        console.warn("[tunaflow]", e);
+      }
+    }
     setBusy(false);
   };
 
@@ -598,6 +640,12 @@ export function DevProgressView({ plan, onPlanUpdate }: DevProgressViewProps) {
         )}
       </div>
       {showDoc && <PlanDocumentModal plan={plan} onClose={() => setShowDoc(false)} />}
+      <ManualVerificationGate
+        open={manualGate.open}
+        items={manualGate.items}
+        onComplete={handleManualGateComplete}
+        onCancel={handleManualGateCancel}
+      />
     </div>
   );
 }

--- a/src/components/tunaflow/settings/RuntimeSection.tsx
+++ b/src/components/tunaflow/settings/RuntimeSection.tsx
@@ -656,7 +656,49 @@ export function RuntimeSection() {
         </div>
       </div>
 
+      <ManualVerificationGateToggle />
       <AttachmentsCleanupPanel />
+    </div>
+  );
+}
+
+// ─── Manual Verification Gate Toggle (B-19 / Issue #176) ───────────────────
+
+function ManualVerificationGateToggle() {
+  const [skipGate, setSkipGate] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    let alive = true;
+    getSetting<boolean>("skipManualVerificationGate", false).then((v) => {
+      if (alive) { setSkipGate(v); setLoaded(true); }
+    });
+    return () => { alive = false; };
+  }, []);
+
+  const onToggle = async (next: boolean) => {
+    setSkipGate(next);
+    await setSetting("skipManualVerificationGate", next);
+  };
+
+  if (!loaded) return null;
+
+  return (
+    <div className="rounded-lg border border-border/30 bg-background/50 p-4 space-y-2">
+      <h3 className="text-[13px] font-medium text-foreground">Manual Verification Gate</h3>
+      <label className="flex items-center gap-2 text-[12px] text-foreground/80 cursor-pointer select-none">
+        <input
+          type="checkbox"
+          checked={skipGate}
+          onChange={(e) => onToggle(e.target.checked)}
+          className="accent-primary"
+        />
+        수동 확인 게이트 건너뛰기 (개발자 모드)
+      </label>
+      <p className="text-[11px] text-muted-foreground/60">
+        Developer 의 <code className="bg-muted/40 px-1 py-0.5 rounded">⚠️ Manual:</code> 항목을
+        다이얼로그 없이 자동으로 통과시킵니다. UI 검증을 자주 건너뛰면 회귀를 놓칠 수 있습니다.
+      </p>
     </div>
   );
 }

--- a/src/components/workflow/ManualVerificationGate.test.tsx
+++ b/src/components/workflow/ManualVerificationGate.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ManualVerificationGate } from "./ManualVerificationGate";
+import type { ManualVerificationItem } from "@/lib/manualVerification";
+
+const items: ManualVerificationItem[] = [
+  { label: "Open Settings and verify toggle", source: "developer" },
+  { label: "Click New Project button", source: "developer" },
+];
+
+describe("ManualVerificationGate", () => {
+  it("renders each item label", () => {
+    render(
+      <ManualVerificationGate
+        open
+        items={items}
+        onComplete={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+    expect(screen.getByText(items[0].label)).toBeInTheDocument();
+    expect(screen.getByText(items[1].label)).toBeInTheDocument();
+  });
+
+  it("disables the 진행 button until every item has a status selected", () => {
+    render(
+      <ManualVerificationGate
+        open
+        items={items}
+        onComplete={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+    const submit = screen.getByRole("button", { name: /진행/ });
+    expect(submit).toBeDisabled();
+    // pick status for both items
+    const passButtons = screen.getAllByRole("button", { name: "Pass" });
+    fireEvent.click(passButtons[0]);
+    fireEvent.click(passButtons[1]);
+    expect(submit).not.toBeDisabled();
+  });
+
+  it("shows a reason textarea only when Fail is selected", () => {
+    render(
+      <ManualVerificationGate
+        open
+        items={items}
+        onComplete={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+    expect(screen.queryByPlaceholderText(/실패 사유/)).not.toBeInTheDocument();
+    const failButtons = screen.getAllByRole("button", { name: "Fail" });
+    fireEvent.click(failButtons[0]);
+    expect(screen.getByPlaceholderText(/실패 사유/)).toBeInTheDocument();
+  });
+
+  it("모두 Pass button marks every item as pass and enables submit", () => {
+    render(
+      <ManualVerificationGate
+        open
+        items={items}
+        onComplete={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: "모두 Pass" }));
+    expect(screen.getByRole("button", { name: /진행/ })).not.toBeDisabled();
+  });
+
+  it("submits results in items order with optional fail reasons", () => {
+    const onComplete = vi.fn();
+    render(
+      <ManualVerificationGate
+        open
+        items={items}
+        onComplete={onComplete}
+        onCancel={vi.fn()}
+      />
+    );
+    const passButtons = screen.getAllByRole("button", { name: "Pass" });
+    const failButtons = screen.getAllByRole("button", { name: "Fail" });
+    fireEvent.click(passButtons[0]);
+    fireEvent.click(failButtons[1]);
+    const textarea = screen.getByPlaceholderText(/실패 사유/);
+    fireEvent.change(textarea, { target: { value: "button did not respond" } });
+    fireEvent.click(screen.getByRole("button", { name: /진행/ }));
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onComplete.mock.calls[0][0]).toEqual([
+      { status: "pass", reason: undefined },
+      { status: "fail", reason: "button did not respond" },
+    ]);
+  });
+});

--- a/src/components/workflow/ManualVerificationGate.tsx
+++ b/src/components/workflow/ManualVerificationGate.tsx
@@ -1,0 +1,182 @@
+/**
+ * Manual verification gate dialog (B-19 / Issue #176).
+ *
+ * Developer 가 `⚠️ Manual:` 로 열거한 항목들을 사용자에게 보여주고
+ * pass/skip/fail 판정 + 선택적 fail 사유를 수집한다. 결과는 onComplete 로
+ * items 와 동일 순서/길이 배열로 돌아간다.
+ *
+ * 상위 (예: DevProgressView impl-complete 핸들러) 가 이 dialog 를 띄워 결과를
+ * startReviewRT 의 runManualGate 콜백에 넘긴다.
+ */
+import { useState, useMemo } from "react";
+import { X, Check } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type {
+  ManualVerificationItem,
+  ManualVerificationResult,
+} from "@/lib/manualVerification";
+
+type Status = "pass" | "skip" | "fail" | null;
+
+interface ManualVerificationGateProps {
+  open: boolean;
+  items: ManualVerificationItem[];
+  onComplete: (results: ManualVerificationResult[]) => void;
+  onCancel: () => void;
+}
+
+const STATUS_LABEL: Record<Exclude<Status, null>, string> = {
+  pass: "Pass",
+  skip: "Skip",
+  fail: "Fail",
+};
+
+const STATUS_CLS: Record<Exclude<Status, null>, string> = {
+  pass: "bg-status-approved/20 text-status-approved border-status-approved/40",
+  skip: "bg-muted/30 text-muted-foreground border-border/40",
+  fail: "bg-destructive/20 text-destructive border-destructive/40",
+};
+
+export function ManualVerificationGate({
+  open,
+  items,
+  onComplete,
+  onCancel,
+}: ManualVerificationGateProps) {
+  const [statuses, setStatuses] = useState<Status[]>(() => items.map(() => null));
+  const [reasons, setReasons] = useState<Record<number, string>>({});
+
+  // items 가 바뀌면 상태 초기화 (다른 게이트 호출이 같은 dialog 인스턴스를 재사용할 때).
+  useMemo(() => {
+    setStatuses(items.map(() => null));
+    setReasons({});
+  }, [items]);
+
+  if (!open) return null;
+
+  const allSelected = statuses.every((s) => s !== null);
+
+  const setAll = (status: "pass") => {
+    setStatuses(items.map(() => status));
+  };
+
+  const setStatusAt = (idx: number, status: Exclude<Status, null>) => {
+    setStatuses((prev) => prev.map((s, i) => (i === idx ? status : s)));
+    if (status !== "fail") {
+      setReasons((prev) => {
+        const next = { ...prev };
+        delete next[idx];
+        return next;
+      });
+    }
+  };
+
+  const handleSubmit = () => {
+    if (!allSelected) return;
+    const results: ManualVerificationResult[] = statuses.map((s, i) => {
+      const status = s as Exclude<Status, null>;
+      const reason = status === "fail" ? reasons[i]?.trim() || undefined : undefined;
+      return { status, reason };
+    });
+    onComplete(results);
+  };
+
+  return (
+    <div className="fixed inset-0 z-[60] flex items-center justify-center">
+      <div className="absolute inset-0 bg-black/30 backdrop-blur-[1px]" onClick={onCancel} />
+
+      <div className="relative bg-card border border-border/40 rounded-lg shadow-2xl w-[540px] max-h-[85vh] overflow-y-auto">
+        {/* Header */}
+        <div className="flex items-center gap-2 px-4 h-11 border-b border-border/30">
+          <span className="text-[13px] font-medium text-foreground flex-1">
+            수동 확인이 필요한 항목
+          </span>
+          <button
+            onClick={onCancel}
+            className="p-1 rounded hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"
+            title="취소"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        <div className="p-4 space-y-4">
+          <p className="text-[11px] text-muted-foreground/70">
+            Developer 가 직접 확인할 수 없어 사용자 확인을 요청했습니다. 각 항목을
+            실제로 돌려보고 결과를 선택해 주세요. fail 시 실패 사유는 선택입니다.
+          </p>
+
+          <div className="space-y-3">
+            {items.map((item, idx) => {
+              const current = statuses[idx];
+              return (
+                <div
+                  key={idx}
+                  className="rounded-md border border-border/30 bg-background/50 p-3 space-y-2"
+                >
+                  <p className="text-[12px] text-foreground/90 leading-snug">{item.label}</p>
+                  <div className="flex items-center gap-1.5">
+                    {(["pass", "skip", "fail"] as const).map((s) => (
+                      <button
+                        key={s}
+                        onClick={() => setStatusAt(idx, s)}
+                        className={cn(
+                          "px-2.5 py-1 rounded-md text-[11px] font-medium border transition-colors",
+                          current === s
+                            ? STATUS_CLS[s]
+                            : "bg-accent/20 text-muted-foreground border-transparent hover:text-foreground/80"
+                        )}
+                      >
+                        {STATUS_LABEL[s]}
+                      </button>
+                    ))}
+                  </div>
+                  {current === "fail" && (
+                    <textarea
+                      value={reasons[idx] ?? ""}
+                      onChange={(e) =>
+                        setReasons((prev) => ({ ...prev, [idx]: e.target.value }))
+                      }
+                      placeholder="실패 사유 (선택) — Developer rework 지시에 포함됩니다"
+                      rows={2}
+                      className="w-full bg-input rounded-md px-2.5 py-1.5 text-[11px] outline-none text-foreground placeholder:text-muted-foreground/40 border border-border/30 focus:border-ring/40 resize-none"
+                    />
+                  )}
+                </div>
+              );
+            })}
+          </div>
+
+          <div className="flex items-center gap-2 pt-2 border-t border-border/20">
+            <button
+              onClick={() => setAll("pass")}
+              className="px-2.5 py-1 rounded-md text-[11px] text-muted-foreground hover:text-foreground hover:bg-accent/40 transition-colors"
+            >
+              모두 Pass
+            </button>
+            <span className="flex-1" />
+            <button
+              onClick={onCancel}
+              className="px-3 py-1.5 rounded-md text-[11px] text-muted-foreground hover:bg-accent transition-colors"
+            >
+              취소
+            </button>
+            <button
+              onClick={handleSubmit}
+              disabled={!allSelected}
+              className={cn(
+                "flex items-center gap-1.5 px-4 py-1.5 rounded-md text-[11px] font-medium transition-colors",
+                allSelected
+                  ? "bg-primary/15 text-primary hover:bg-primary/25"
+                  : "bg-muted/30 text-muted-foreground/40 cursor-not-allowed"
+              )}
+            >
+              <Check className="w-3 h-3" />
+              진행
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/manualVerification.test.ts
+++ b/src/lib/manualVerification.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { extractManualItems } from "./manualVerification";
+import type { Message } from "@/types";
+
+function msg(role: "user" | "assistant", content: string): Message {
+  return {
+    id: `test-${Math.random()}`,
+    conversationId: "test",
+    role,
+    content,
+    timestamp: Date.now(),
+    status: "done",
+  } as Message;
+}
+
+describe("extractManualItems", () => {
+  it("returns empty array when no manual lines present", () => {
+    const messages = [msg("assistant", "Regular response without manual flags.")];
+    expect(extractManualItems(messages)).toEqual([]);
+  });
+
+  it("extracts a single manual item", () => {
+    const messages = [msg("assistant", "Done.\n⚠️ Manual: Click the dropdown to verify it opens")];
+    const items = extractManualItems(messages);
+    expect(items).toHaveLength(1);
+    expect(items[0].label).toBe("Click the dropdown to verify it opens");
+    expect(items[0].source).toBe("developer");
+  });
+
+  it("extracts multiple manual items across lines", () => {
+    const content = [
+      "Implementation complete.",
+      "⚠️ Manual: Open Settings and toggle Skip gate",
+      "⚠️ Manual: Click File > New Project",
+      "⚠️ Manual: Verify the toast disappears after 3 seconds",
+    ].join("\n");
+    const items = extractManualItems([msg("assistant", content)]);
+    expect(items).toHaveLength(3);
+    expect(items.map((i) => i.label)).toEqual([
+      "Open Settings and toggle Skip gate",
+      "Click File > New Project",
+      "Verify the toast disappears after 3 seconds",
+    ]);
+  });
+
+  it("scopes extraction to messages after the last Rework marker", () => {
+    const messages = [
+      msg("assistant", "⚠️ Manual: Old item from previous cycle"),
+      msg("user", "### 🔄 Rework\n수정 필요"),
+      msg("assistant", "Fixed.\n⚠️ Manual: New item only"),
+    ];
+    const items = extractManualItems(messages);
+    expect(items).toHaveLength(1);
+    expect(items[0].label).toBe("New item only");
+  });
+
+  it("preserves non-ASCII Unicode labels intact", () => {
+    const content = "⚠️ Manual: 한글로 된 확인 항목 — 이모지 ✅ 와 기호 포함";
+    const items = extractManualItems([msg("assistant", content)]);
+    expect(items).toHaveLength(1);
+    expect(items[0].label).toBe("한글로 된 확인 항목 — 이모지 ✅ 와 기호 포함");
+  });
+
+  it("ignores blank labels after prefix (e.g. `⚠️ Manual:   `)", () => {
+    const content = "⚠️ Manual:    \n⚠️ Manual: valid item";
+    const items = extractManualItems([msg("assistant", content)]);
+    // Blank-label line doesn't match the `.+` quantifier so only the valid item survives.
+    expect(items).toHaveLength(1);
+    expect(items[0].label).toBe("valid item");
+  });
+});

--- a/src/lib/manualVerification.ts
+++ b/src/lib/manualVerification.ts
@@ -1,0 +1,62 @@
+/**
+ * Manual verification gate (B-19 / Issue #176).
+ *
+ * Developer 가 `⚠️ Manual:` prefix 로 자기 응답에 열거한 "shell 로 확인 불가한
+ * 항목" 을 파싱해 UI 다이얼로그 입력으로 넘긴다. pass/skip/fail 판정은
+ * `ManualVerificationResult` 로 돌아와 reviewWorkflow 가 review/rework 분기.
+ *
+ * 이 파일은 DOM/React 의존 없음 — 순수 TS 유틸. 테스트 mock 쉬움.
+ */
+import type { Message } from "@/types";
+
+export interface ManualVerificationItem {
+  /** "⚠️ Manual:" prefix 제거 후 본문. 사용자에게 그대로 표시된다. */
+  label: string;
+  /** 항목의 출처. 향후 확장 (plan 선언 manual 등) 을 위한 discriminator. */
+  source: "developer";
+}
+
+export interface ManualVerificationResult {
+  status: "pass" | "skip" | "fail";
+  /** fail 일 때 사용자가 선택적으로 입력한 실패 사유. 없으면 undefined. */
+  reason?: string;
+}
+
+export interface ManualVerificationReport {
+  items: ManualVerificationItem[];
+  /** `items` 와 동일 길이 · 순서. i18next 무관 — UI 가 결과 수집 후 전달. */
+  results: ManualVerificationResult[];
+}
+
+/**
+ * Developer 의 마지막 assistant 메시지에서 `⚠️ Manual: ...` 라인을 추출.
+ *
+ * Rework 가 있었으면 마지막 Rework 이후 범위만 본다 (syncResultReport 와 동일
+ * 필터링 — 이전 싸이클 항목이 다시 튀어나오지 않도록).
+ *
+ * ⚠️ 는 U+26A0 U+FE0F (variation selector 포함). 정규식에 UTF-8 리터럴로 그대로.
+ */
+export function extractManualItems(implMessages: Message[]): ManualVerificationItem[] {
+  let lastReworkIdx = -1;
+  for (let i = implMessages.length - 1; i >= 0; i--) {
+    if (implMessages[i].role === "user" && implMessages[i].content.includes("### 🔄 Rework")) {
+      lastReworkIdx = i;
+      break;
+    }
+  }
+  const relevant = lastReworkIdx >= 0 ? implMessages.slice(lastReworkIdx + 1) : implMessages;
+  const lastAssistant = [...relevant].reverse().find((m) => m.role === "assistant");
+  if (!lastAssistant) return [];
+
+  const items: ManualVerificationItem[] = [];
+  // `\s` 는 newline 을 포함하므로 `\s*` 가 multi-line 을 가로질러 인접 항목까지
+  // 한 매치에 삼킬 수 있다. 수평 공백만 허용하는 `[ \t]*` 로 좁혀 라인 단위
+  // 매칭을 보장 (⚠️ 는 U+26A0 U+FE0F 그대로 유지).
+  const re = /^[ \t]*⚠️[ \t]*Manual:[ \t]*(.+)$/gm;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(lastAssistant.content)) !== null) {
+    const label = match[1].trim();
+    if (label.length > 0) items.push({ label, source: "developer" });
+  }
+  return items;
+}

--- a/src/lib/workflow/reviewWorkflow.ts
+++ b/src/lib/workflow/reviewWorkflow.ts
@@ -5,6 +5,12 @@
 import { invoke } from "@tauri-apps/api/core";
 import type { Message, Plan, RoundtableParticipant } from "@/types";
 import * as planApi from "../api/plans";
+import { getSetting } from "../appStore";
+import {
+  extractManualItems,
+  type ManualVerificationItem,
+  type ManualVerificationResult,
+} from "../manualVerification";
 import * as failureLessonsApi from "../api/failureLessons";
 import * as insightApi from "../api/insight";
 import { dispatchMetaNotification } from "../metaNotifications";
@@ -31,6 +37,20 @@ import type { ParsedImplPlan, ParsedReviewVerdict } from "../planProposalParser"
 
 export type { CreateBranchResult };
 
+/**
+ * Manual verification gate error (B-19 / Issue #176).
+ *
+ * Gate 결과에 fail 이 있을 때 startReviewRT 가 던진다. 호출부는 instanceof 로
+ * 구분해 DevProgressView 의 기존 rework 상태 전환 UI 를 트리거하고 toast 는
+ * 띄우지 않는다 (normal "review failed" 경로와 UX 맞춤).
+ */
+export class ManualVerificationFailed extends Error {
+  constructor(public readonly failedItems: Array<{ label: string; reason?: string }>) {
+    super(`Manual verification failed: ${failedItems.length} item(s)`);
+    this.name = "ManualVerificationFailed";
+  }
+}
+
 // ─── Phase D→E: impl-complete → Start Review RT ───────────────────────────
 
 export interface StartReviewRTResult extends CreateBranchResult {
@@ -54,7 +74,68 @@ export async function startReviewRT(
   implMessages: Message[],
   testOutput?: string,
   reviewers?: ReviewerChoice[] | string[],
+  /**
+   * Manual verification gate callback (B-19). 호출부가 UI dialog 를 띄우고
+   * results (items 와 동일 순서/길이) 를 resolve, 사용자 취소 시 null 을 resolve.
+   * 제공 안 하면 게이트 skip (기존 플로우 유지 — 테스트/CLI 호환).
+   */
+  runManualGate?: (items: ManualVerificationItem[]) => Promise<ManualVerificationResult[] | null>,
 ): Promise<StartReviewRTResult> {
+  // ─── Manual Verification Gate (B-19) ───
+  // Phase 전환 전에 수행 — fail 시 review phase 로 잘못 진입 방지 (INV-1).
+  const skipGate = await getSetting<boolean>("skipManualVerificationGate", false).catch(() => false);
+  if (!skipGate && runManualGate) {
+    const manualItems = extractManualItems(implMessages);
+    if (manualItems.length === 0) {
+      // INV-3: 0 items 면 다이얼로그 안 띄움. 이 경우에만 skipped 기록 (plan 주의).
+      await planApi.createPlanEvent(plan.id, "manual_verification_skipped", "system",
+        JSON.stringify({ reason: "no manual items found in impl response" })).catch(() => {});
+    } else {
+      const results = await runManualGate(manualItems);
+      if (results === null) {
+        // 사용자가 dialog 취소 → phase 유지. INV-5.
+        throw new Error("Manual verification cancelled by user");
+      }
+      const hasFail = results.some((r) => r.status === "fail");
+      const eventType = hasFail ? "manual_verification_failed" : "manual_verification_passed";
+      await planApi.createPlanEvent(plan.id, eventType, "user", JSON.stringify({
+        items: manualItems.map((it, i) => ({
+          label: it.label,
+          status: results[i].status,
+          reason: results[i].reason,
+        })),
+      })).catch((e) => console.warn("[manual-gate] plan_event failed:", e));
+
+      if (hasFail) {
+        // Rework 경로 진입. INV-1: phase 를 review 로 넘기지 않는다.
+        const failItems = manualItems
+          .map((it, i) => ({ label: it.label, reason: results[i].reason }))
+          .filter((_, i) => results[i].status === "fail");
+        await planApi.updatePlanPhase(plan.id, "rework");
+        // INV-6: rework_reason identity-input artifact 에 manual 실패 항목 포함.
+        // 기존 createReworkReasonArtifact 는 ParsedReviewVerdict 시그니처라 inline
+        // invoke 로 manual 전용 artifact 작성.
+        invoke("create_identity_artifact", {
+          input: {
+            kind: "rework_reason",
+            conversationId: plan.conversationId,
+            planId: plan.id,
+            subtaskId: null,
+            title: `Manual verification failed: ${plan.title}`,
+            content: {
+              source: "manual_verification",
+              failedItems: failItems.map((f) => ({
+                label: f.label,
+                reason: f.reason || "manual verification failed",
+              })),
+            },
+          },
+        }).catch((e) => console.warn("[manual-gate] artifact failed:", e));
+        throw new ManualVerificationFailed(failItems);
+      }
+    }
+  }
+
   await planApi.updatePlanPhase(plan.id, "review");
   await planApi.createPlanEvent(plan.id, "impl_completed", "developer");
 

--- a/src/tests/workflowOrchestration.test.ts
+++ b/src/tests/workflowOrchestration.test.ts
@@ -31,8 +31,15 @@ vi.mock("@/lib/api/plans", () => ({
   listPlanEvents: vi.fn(() => Promise.resolve([])),
 }));
 
+// Mock appStore — skipManualVerificationGate default false; individual tests override.
+vi.mock("@/lib/appStore", () => ({
+  getSetting: vi.fn((_key: string, fallback: unknown) => Promise.resolve(fallback)),
+  setSetting: vi.fn(() => Promise.resolve()),
+}));
+
 import { invoke } from "@tauri-apps/api/core";
 import * as planApi from "@/lib/api/plans";
+import * as appStore from "@/lib/appStore";
 import {
   approveAndStartImplementation,
   approveImplPlan,
@@ -42,6 +49,7 @@ import {
   slugifyPlanTitle,
   startReviewBranch,
   startReviewRT,
+  ManualVerificationFailed,
 } from "@/lib/workflowOrchestration";
 import type { Plan, Message } from "@/types";
 
@@ -417,5 +425,72 @@ describe("startReviewRT", () => {
     expect(config.participants[0]).toMatchObject({ engine: "codex", model: "gpt-5", name: "Reviewer-Codex" });
     expect(config.participants[1]).toMatchObject({ engine: "gemini", model: "gemini-2.5-pro" });
     expect(result.participants[0].model).toBe("gpt-5");
+  });
+});
+
+// ─── startReviewRT — Manual Verification Gate (B-19) ───────────────────────
+
+describe("startReviewRT — manual verification gate", () => {
+  const msgWithManual: Message[] = [
+    {
+      id: "m1", conversationId: "c1", role: "assistant",
+      content: "implemented X\n⚠️ Manual: Click button to verify",
+      timestamp: 0, status: "done",
+    },
+  ];
+
+  it("bypasses the gate when skipManualVerificationGate=true", async () => {
+    (appStore.getSetting as any).mockImplementationOnce(() => Promise.resolve(true));
+    const runManualGate = vi.fn();
+    const result = await startReviewRT(mockPlan, msgWithManual, undefined, undefined, runManualGate);
+    expect(runManualGate).not.toHaveBeenCalled();
+    expect(result.branch.id).toBe("br-1");
+    expect(planApi.updatePlanPhase).toHaveBeenCalledWith("p-1", "review");
+  });
+
+  it("skips gate when there are no manual items", async () => {
+    const msgsNoManual: Message[] = [{
+      id: "m1", conversationId: "c1", role: "assistant",
+      content: "implemented X", timestamp: 0, status: "done",
+    }];
+    const runManualGate = vi.fn();
+    await startReviewRT(mockPlan, msgsNoManual, undefined, undefined, runManualGate);
+    expect(runManualGate).not.toHaveBeenCalled();
+    // plan 주의사항: 0-items 케이스만 manual_verification_skipped 기록
+    expect(planApi.createPlanEvent).toHaveBeenCalledWith(
+      "p-1", "manual_verification_skipped", "system", expect.any(String),
+    );
+  });
+
+  it("records manual_verification_passed and proceeds to review on all-pass", async () => {
+    const runManualGate = vi.fn(async () => [{ status: "pass" as const }]);
+    const result = await startReviewRT(mockPlan, msgWithManual, undefined, undefined, runManualGate);
+    expect(runManualGate).toHaveBeenCalledTimes(1);
+    expect(planApi.createPlanEvent).toHaveBeenCalledWith(
+      "p-1", "manual_verification_passed", "user", expect.any(String),
+    );
+    expect(planApi.updatePlanPhase).toHaveBeenCalledWith("p-1", "review");
+    expect(result.branch.id).toBe("br-1");
+  });
+
+  it("throws ManualVerificationFailed and enters rework on any fail", async () => {
+    const runManualGate = vi.fn(async () => [{ status: "fail" as const, reason: "button broken" }]);
+    await expect(startReviewRT(mockPlan, msgWithManual, undefined, undefined, runManualGate))
+      .rejects.toBeInstanceOf(ManualVerificationFailed);
+    expect(planApi.createPlanEvent).toHaveBeenCalledWith(
+      "p-1", "manual_verification_failed", "user", expect.any(String),
+    );
+    expect(planApi.updatePlanPhase).toHaveBeenCalledWith("p-1", "rework");
+    // INV-1: review phase 로 진입하지 않는다.
+    expect(planApi.updatePlanPhase).not.toHaveBeenCalledWith("p-1", "review");
+  });
+
+  it("throws a generic Error when the user cancels the dialog", async () => {
+    const runManualGate = vi.fn(async () => null);
+    await expect(startReviewRT(mockPlan, msgWithManual, undefined, undefined, runManualGate))
+      .rejects.toThrow(/cancelled by user/);
+    // phase 는 그대로 (INV-5)
+    expect(planApi.updatePlanPhase).not.toHaveBeenCalledWith("p-1", "review");
+    expect(planApi.updatePlanPhase).not.toHaveBeenCalledWith("p-1", "rework");
   });
 });


### PR DESCRIPTION
## Summary

Closes #176. Plan: `docs/plans/manualVerificationGatePlan_2026-04-24.md`.

Reviewer persona 는 shell 실행 불가라 UI 클릭 · OS 다이얼로그 · 외부 API · 지각적 품질 검증의 **owner 가 없다**. Developer 가 `⚠️ Manual:` 라인으로 이런 항목을 열거하면 tunaFlow 가 사용자에게 확인 다이얼로그를 띄워 pass/skip/fail 을 수집한다. Fail 이 있으면 기존 Rework 경로 재사용, pass 면 Review 진행.

## 5 커밋 구조

| # | 커밋 | 변경 |
|---|---|---|
| 1 | `feat(workflow): extract ⚠️ Manual items parser + types` | `manualVerification.ts` + 6 tests |
| 2 | `feat(ui): ManualVerificationGate dialog` | `components/workflow/ManualVerificationGate.tsx` + 5 tests |
| 3 | `feat(workflow): wire manual gate into startReviewRT (pass/fail/skip/cancel)` | `reviewWorkflow.ts` (+ `ManualVerificationFailed` export) + 5 integration tests |
| 4 | `feat(ui+settings): wire ManualVerificationGate into DevProgressView + skip toggle` | `DevProgressView.tsx`, `RuntimeSection.tsx` |
| 5 | `docs(persona): developer ⚠️ Manual verification guidance` | `docs/agents/developer.md` |

## 흐름 요약

1. **Developer** 가 impl 응답에 `⚠️ Manual: ...` 라인을 써서 shell 로 못 잡는 항목 열거 (persona 문서에 명시)
2. **DevProgressView** 가 Review RT 시작 시 `runManualGate` 콜백 주입
3. **startReviewRT** 가 phase 전환 전에:
   - `skipManualVerificationGate` 토글 ON → 우회
   - `extractManualItems` = 0 → `manual_verification_skipped` 기록 후 우회
   - 0 초과 → dialog 호출 → 결과 분기
4. **all pass** → `manual_verification_passed` 이벤트 + Review 진행
5. **any fail** → `manual_verification_failed` 이벤트 + phase=`rework` + `rework_reason` artifact + `throw ManualVerificationFailed`
6. **cancel** → phase 유지 + `throw Error("cancelled by user")`

DevProgressView 는 `instanceof ManualVerificationFailed` 로 구분해 rework UI 전환, cancel 에는 toast 만.

## Invariants

- **INV-1** fail 시 phase 는 절대 `review` 로 들어가지 않음 (integration test 보증)
- **INV-2** `skipGate=true` 면 `extractManualItems` 도 호출 안 함 — getSetting 1회만
- **INV-3** items=0 시 다이얼로그 안 띄움 (첫 사용 UX 보호)
- **INV-4** 결과는 `plan_events` 에 JSON detail 로 기록 (Insight 분석 연계 가능)
- **INV-5** cancel 시 phase 유지 — impl-complete 다시 눌러 재진입 가능
- **INV-6** rework_reason artifact 에 실패 항목 + 사용자 사유 포함 (사유 없으면 `manual verification failed` placeholder)

## Test plan

- [x] `npx tsc --noEmit` — 0 에러
- [x] `npx vitest run` — 344 / 344 (기존 328 + 신규 parser 6 · gate 5 · integration 5 = 16)
- [ ] 수동 풀사이클 smoke (plan §(7)):
  1. impl 응답에 `⚠️ Manual` 2줄 포함 → dialog 등장
  2. 모두 Pass → Review RT 자동 시작
  3. 1 Fail + 사유 → Rework 상태 + artifact 에 사유 포함
  4. Settings → RuntimeSection → 토글 ON → 다이얼로그 스킵

## Scope 명시

- **Deep RT 경로 (DevProgressView.handleStartReviewRT) 만** 게이트 적용. Quick review (PlanCard) 는 별도 PR 로 분리.
- Extended (자동 스크린샷 / QA agent 기반 자동 확인 / item DAG / Insight 연계) 는 plan Extended 섹션에 기록.

🤖 Generated with [Claude Code](https://claude.com/claude-code)