### PR TITLE
fix(onboarding): cancel rust task on Skip + unify error-state buttons (#189)

### DIFF
--- a/docs/plans/index.md
+++ b/docs/plans/index.md
@@ -44,6 +44,8 @@
 | [manualVerificationGatePlan_2026-04-24](./manualVerificationGatePlan_2026-04-24.md) | **P1 (ready-to-implement)** — impl-complete 와 Reviewer 사이 사용자 확인 게이트 (B-19 / Issue #176). ⚠️ Manual 파서 + dialog + Rework 경로 재사용. 피드백 반영 (fail 사유 optional 확정). Developer 핸드오프 포함 |
 | [rawqGitignoreIndexFixPlan_2026-04-24](./rawqGitignoreIndexFixPlan_2026-04-24.md) | **P0 (hotfix / Issue #180)** — rawq 가 .gitignore 무시 → target/node_modules 인덱싱 → OOM / 시스템 프리즈. ensure_index 에 빌드 산출물 14개 hardcoded exclude + rebuild UI. Developer 핸드오프 포함 |
 | [claudeDangerouslySkipPermissionsPlan_2026-04-24](./claudeDangerouslySkipPermissionsPlan_2026-04-24.md) | **P0 (hotfix / Issue #178)** — Claude headless permission 플래그 bypassPermissions → dangerously-skip-permissions. 3 call site (claude.rs L162/L380 + claude_sdk_session.rs L381). Developer 핸드오프 포함 |
+| [onboardingCancelLeakFixPlan_2026-04-25](./onboardingCancelLeakFixPlan_2026-04-25.md) | **P1 (Issue #176 follow-up)** — Codex/Gemini 메타 분석 실패 후 "건너뛰기" → 메인창 lock. handleSkip 에 cancel + error state UI 통합 + asyncCancel pipeline audit. Architect 직접 fix |
+| [toolStepsRunningStatusFinalizePlan_2026-04-25](./toolStepsRunningStatusFinalizePlan_2026-04-25.md) | **P1 (Issue #187, MERGED)** — long-doc 후 tool steps spinner 무한 회전. saveToolSteps finalize + ToolStepsView fallback 2 layer. PR #188 머지 완료 |
 | [postParityRuntimeValidationSweepPlan_2026-03-30](./postParityRuntimeValidationSweepPlan_2026-03-30.md) | P1 — parity fix 효과 재검증 |
 | [realWorkflowMemoryQualityValidationPlan_2026-03-30](./realWorkflowMemoryQualityValidationPlan_2026-03-30.md) | P1 — memory/retrieval 응답 품질 검증 |
 | [roleAssignmentCoverageUxPlan](./roleAssignmentCoverageUxPlan.md) | P2 — Settings 역할 커버리지 UX (inferred 저장 명시화 + stale ID 자동 정리 + assertRoleReady 원클릭 적용) |

--- a/docs/reference/asyncCancelPipelineAudit_2026-04-25.md
+++ b/docs/reference/asyncCancelPipelineAudit_2026-04-25.md
@@ -1,0 +1,81 @@
+---
+title: Long-running async + cancel 경로 파이프라인 감사 (5 항목)
+canonical: false
+status: audit-snapshot
+created_at: 2026-04-25
+related:
+  - docs/plans/onboardingCancelLeakFixPlan_2026-04-25.md
+---
+
+# 동기
+
+`onboardingCancelLeakFix` 의 root cause (handleSkip 이 rust task cancel 을 호출 안 해 orphaned task → UI freeze) 가 다른 long-running async 경로에서도 재발 가능한 패턴인지 확인. plan §(5) 약속 산출물.
+
+# 점검 기준 (각 항목 공통)
+
+각 long-running async 경로마다 세 질문:
+
+1. **Cancel flag/token 진입 전 셋업** — async 작업이 시작될 때 cancel 가능 여부 결정됐는가
+2. **UI dismiss → rust cancel 호출** — UI 가 모달/드로어를 닫을 때 rust task 도 취소 트리거하는가
+3. **Rust task 가 cancel 을 주기적으로 poll** — flag store(true) 만으로 즉시 응답하는가, 아니면 long await 중 무시되는가
+
+# 5 항목 결과
+
+## 1. ManualVerificationGate (B-19, 2026-04-24 머지)
+
+- **위치**: `src/components/workflow/ManualVerificationGate.tsx`, `src/lib/workflow/reviewWorkflow.ts:startReviewRT`
+- **상태**: ✅ **OK** — cancel 책임 위임 패턴
+- **근거**: ManualVerificationGate 자체엔 cancel 호출 없음. 모달 닫기는 외부에서 받은 `onCancel` callback 으로 처리. `startReviewRT` 가 dialog 결과를 await 한 뒤 `null` (cancel) → `throw new Error("Manual verification cancelled by user")` (reviewWorkflow.ts:97). 호출자 (DevProgressView) 가 catch 하면 phase 유지 + 모달 dismiss
+- **관찰**: 이 패턴은 **dialog 가 자체적으로 long-running async 를 갖지 않을 때** 유효. ManualVerificationGate 는 사용자 입력만 기다리고 백그라운드 task 가 없어 OK. onboarding 모달과 다름
+
+## 2. startReviewRT 진입 실패 시 UI 복귀
+
+- **위치**: `src/lib/workflow/reviewWorkflow.ts:244-262`
+- **상태**: ⚠️ **확인 필요 — 별 plan 후보**
+- **근거**: line 244 의 코멘트 "Review RT 진입 자체가 throw 되던 버그. s37 재현 로그로 특정" 가 과거 동일 카테고리 버그가 있었음을 시사. 현재 catch 는 `saveConversationEngine failed:` (line 262) 한 곳만 명시적. **Plan 생성/RT 브랜치 생성/persist 단계 중 실패 시 phase rollback 보장 여부 불명**
+- **후속**: 별 plan 으로 분리 — startReviewRT 의 모든 await 단계 실패 매트릭스 + UI 복귀 경로 검증
+
+## 3. Branch adopt 실패 경로
+
+- **위치**: `src/stores/slices/branchSlice.ts:124 adoptBranch`
+- **상태**: ⚠️ **확인 필요 — 별 plan 후보**
+- **근거**: adoptBranch 본문 미확인 (grep 만 수행). adopt 중 LLM 호출 / DB write / 메시지 직렬화 실패 시 부분 적용 / orphaned 상태 위험. 이전 세션 메모리 (`project_session_2026-04-12_s25.md`) 에 "adopt 중 스트리밍 메시지 소멸" 이슈가 s25 에 수정됐다고 기록 → 비슷한 잠재 위험 있음
+- **후속**: branchSlice.ts:124 본문 + branchSync.ts adopt 경로 깊은 검토. 별 plan
+
+## 4. Plan 생성 중 LLM 응답 실패 → rollback
+
+- **위치**: `src/lib/api/plans.ts:107 generatePlanDocument` (Rust 쪽으로 위임)
+- **상태**: ⚠️ **확인 필요 — 별 plan 후보**
+- **근거**: generatePlanDocument 는 Tauri command 호출이라 Rust 쪽에서 actual 실패 처리. UI 단 catch 가 phase 를 어떻게 다루는지 미확인
+- **후속**: planSlice / planApi / Rust plan generation 경로 audit. 별 plan
+
+## 5. rawq index build 중 취소
+
+- **위치**: `src-tauri/src/agents/rawq.rs ensure_index`, `start_rawq_index`
+- **상태**: ❌ **명시적 cancel 채널 부재**
+- **근거**: grep 결과 `cancel|abort` 키워드 0 건. ensure_index 는 `Command::wait_with_output` 으로 동기 대기 (`rawq.rs:348`). subprocess kill 외 cancel 경로 없음
+- **현실적 영향**: rawq index build 는 보통 수 초~분. 진행 중 사용자가 프로젝트 닫아도 background thread 가 끝까지 진행. 영향: 잠시 CPU 점유. UI freeze 까진 안 갈 가능성 (별 thread 라 main loop 안 막음). 다만 사용자 경험상 "왜 indexing 이 끊기지 않고 끝까지 가나" 의 의문 발생 가능
+- **후속**: 별 plan — rawq sidecar 에 cancel 채널 추가 (이미 daemon 모드 운영 중이라 소켓 신호 가능). 우선순위는 높지 않음
+
+# 종합
+
+| # | 영역 | 상태 | 후속 plan |
+|---|---|---|---|
+| 1 | ManualVerificationGate | ✅ OK (위임 패턴) | 없음 |
+| 2 | startReviewRT 진입 실패 | ⚠️ 추가 검토 | `reviewRTEntryFailureRollbackPlan` (가칭) |
+| 3 | Branch adopt 실패 | ⚠️ 추가 검토 | `branchAdoptRollbackPlan` (가칭) |
+| 4 | Plan 생성 실패 | ⚠️ 추가 검토 | `planGenerationRollbackPlan` (가칭) |
+| 5 | rawq index build 취소 | ❌ 부재 | `rawqIndexCancelChannelPlan` (가칭) — 우선순위 낮음 |
+
+# 일반 규칙 (제안)
+
+이번 onboarding fix 와 위 audit 에서 도출되는 invariant:
+
+- **[규칙 1]** Long-running async (LLM call, subprocess, 외부 API) 는 cancel flag 또는 token 을 받아야 한다
+- **[규칙 2]** UI 가 dismiss 되는 모든 경로에서 해당 async 의 cancel command 를 호출해야 한다 (idempotent 라면 무조건 호출 권장 — defensive)
+- **[규칙 3]** Rust 쪽 task 는 await 사이마다 cancel flag 를 poll 하거나 `tokio::select!` 로 cancel future 와 경쟁시켜야 한다
+- **[규칙 4]** Error/실패 시 UI 가 어떤 버튼을 누르든 cancel command 를 호출하는 단일 경로로 수렴해야 한다 (오늘 수정한 onboarding error state 가 이 케이스)
+
+# 본 audit 의 한계
+
+각 ⚠️ 항목은 **grep 수준 confirm** 만 수행. 코드 깊이 들어가 catch 매트릭스 / await 분기 / DB rollback 시점 검증 미수행. 별 plan 으로 승격 시 그 단계에서 깊은 audit. 본 문서는 **이 5 영역이 동일 카테고리 위험을 공유한다는 인식 + 후속 plan 후보 등재** 가 목표.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -27,3 +27,4 @@
 - [indexingPipelineBug_P0_2026-04-15](./indexingPipelineBug_P0_2026-04-15.md) — **🔴 P0** v32 후 embedding 복구 실패 3중 버그 (Vector 기능 정지, 베타 차단)
 - [knownIssues_2026-04-15](./knownIssues_2026-04-15.md) — 이번 세션 미해결 이슈 체크리스트 + 베타 공개 차단 여부 판단
 - [bkitReferenceReview_2026-04-24](./bkitReferenceReview_2026-04-24.md) — popup-studio-ai/bkit 계열 레퍼런스 검토, 수직 보완 관계 재프레임 + P1~P3 차용 제안
+- [asyncCancelPipelineAudit_2026-04-25](./asyncCancelPipelineAudit_2026-04-25.md) — long-running async + cancel 경로 5 영역 감사 (onboarding fix 부수 산출물). 4 영역 별 plan 후보로 등재

--- a/src/components/tunaflow/ProjectOnboardingModal.tsx
+++ b/src/components/tunaflow/ProjectOnboardingModal.tsx
@@ -154,6 +154,10 @@ export function ProjectOnboardingModal() {
   };
 
   const handleSkip = () => {
+    // analyze_project_for_onboarding 이 아직 진행 중이면 rust 쪽 task 도 정리한다.
+    // preview 단계에서 호출될 때는 이미 task 가 끝났으므로 idempotent 하게 무시되며,
+    // error 단계에서 호출될 때는 orphaned task → 메인창 freeze 를 막는다 (#176 follow-up).
+    invoke("cancel_project_onboarding").catch(() => {});
     cleanupRef.current.forEach((u) => u());
     setModalState("done");
     clearOnboardingProject();
@@ -261,20 +265,15 @@ export function ProjectOnboardingModal() {
 
             <div className="px-6 py-4 border-t border-border flex justify-between items-center">
               {error ? (
-                <>
-                  <button
-                    onClick={() => setModalState("skip_confirm")}
-                    className="text-[11px] text-muted-foreground hover:text-foreground transition-colors"
-                  >
-                    {t("onboarding.skip_button")}
-                  </button>
-                  <button
-                    onClick={handleCancel}
-                    className="px-3 py-1.5 text-[11px] font-medium text-destructive/80 hover:text-destructive transition-colors"
-                  >
-                    {t("onboarding.close_button")}
-                  </button>
-                </>
+                // Error 상태에서 "건너뛰기" 와 "닫기" 의 사용자 의도가 동일 ("이 에러 상황 탈출")
+                // 이라 단일 "닫기" 로 통합. handleCancel 이 cancel_project_onboarding 을
+                // 호출해 rust task 까지 안전하게 정리한다.
+                <button
+                  onClick={handleCancel}
+                  className="ml-auto px-3 py-1.5 text-[11px] font-medium text-destructive/80 hover:text-destructive transition-colors"
+                >
+                  {t("onboarding.close_button")}
+                </button>
               ) : (
                 <button
                   onClick={() => setModalState("cancel_confirm")}


### PR DESCRIPTION
## Summary

Closes #189. Community reporter on 2026-04-24 found that selecting Codex/Gemini as meta agent → analysis fails → \"Skip\" leaves main window unresponsive while \"Close\" works correctly.

Plan: \`docs/plans/onboardingCancelLeakFixPlan_2026-04-25.md\`

## Root cause

\`handleSkip\` (\`ProjectOnboardingModal.tsx:156\`) dismissed the modal without calling \`cancel_project_onboarding\`, leaving the Rust \`analyze_project_for_onboarding\` task orphaned. Compounded by an error-state UX where \"Skip\" and \"Close\" had identical user intent but different cancel behavior.

## Changes

| File | Change |
|---|---|
| \`src/components/tunaflow/ProjectOnboardingModal.tsx\` | (1) \`handleSkip\` now calls \`invoke(\"cancel_project_onboarding\")\` — idempotent on the preview-state path, primary fix on error-state path. (2) Error state \"Skip\" button removed; \"Close\" single button (\`handleCancel\` already cancels rust task). Preview-state \"Skip\" retained (different intent: discard analysis, keep empty scaffold). |
| \`docs/reference/asyncCancelPipelineAudit_2026-04-25.md\` (new) | 5-area audit of similar long-running async + cancel patterns. 4 candidates flagged for separate plans. |
| \`docs/plans/index.md\`, \`docs/reference/index.md\` | Index registration for new plan + audit + yesterday's toolSteps plan. |

## Verification

- [x] \`npx tsc --noEmit\` — 0 errors
- [ ] Manual smoke (post-merge):
  1. Codex/Gemini meta + empty project → analysis fails → \"Close\" → main window recovers ✓
  2. Preview state → \"Skip\" → empty scaffold applied (regression) ✓
  3. Claude meta + normal project → preview → apply ✓

## Out of scope

Why Codex/Gemini meta analysis fails (vs Claude succeeding) — separate PR after engine-specific prompt/parser analysis.

## Audit takeaway (separate plan candidates)

| Area | Status | Follow-up plan |
|---|---|---|
| ManualVerificationGate | ✅ OK | None |
| startReviewRT entry failure | ⚠️ Needs deeper audit | \`reviewRTEntryFailureRollbackPlan\` (TBD) |
| Branch adopt failure | ⚠️ Needs deeper audit | \`branchAdoptRollbackPlan\` (TBD) |
| Plan generation failure | ⚠️ Needs deeper audit | \`planGenerationRollbackPlan\` (TBD) |
| rawq index build cancel | ❌ No channel | \`rawqIndexCancelChannelPlan\` (low priority) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)