### PR TITLE
fix(layout): add min-h-0 to main flex parent so long drawer content can't stretch viewport (#191)

### DIFF
--- a/src/components/tunaflow/AppShell.tsx
+++ b/src/components/tunaflow/AppShell.tsx
@@ -183,14 +183,19 @@ export function AppShell() {
         )}
 
         {/* Main area */}
-        <div className="flex-1 min-w-0 h-full relative flex">
+        {/* `min-h-0` 필수 — 누락 시 자식 (BranchThreadPanel 안의 NewMessageInput 등)
+             이 길어지면 flex parent 가 viewport 밖으로 stretch 되어 메인 UI 전체가
+             밀려 올라가는 현상 발생 (#191). */}
+        <div className="flex-1 min-w-0 min-h-0 h-full relative flex">
           {/* Meta floating chat — anchored to top-left of main area */}
           {selectedProjectKey && (
             <MetaFloatingChat projectKey={selectedProjectKey} />
           )}
 
-          {/* CenterPanel — full width when no drawer, or flex-1 when pinned */}
-          <div className={drawerOpen && drawerPinned ? "flex-1 min-w-0 h-full" : "flex-1 min-w-0 h-full"}>
+          {/* CenterPanel — full width when no drawer, or flex-1 when pinned.
+               양쪽 className 이 동일해 삼항 의미 없음 — 단일 string 으로 정리하면서
+               `min-h-0` 추가 (메인 area 와 동일 이유). */}
+          <div className="flex-1 min-w-0 min-h-0 h-full">
             <CenterPanel />
           </div>
 

--- a/src/components/tunaflow/BranchThreadPanel.tsx
+++ b/src/components/tunaflow/BranchThreadPanel.tsx
@@ -290,7 +290,8 @@ export function BranchThreadPanel() {
       )}
 
       {/* Thread messages */}
-      <div className="flex-1 overflow-y-auto">
+      {/* `min-h-0` defensive — flex 자식 grow 가 부모 panel 을 stretch 시키지 않도록. AppShell main flex 와 짝. */}
+      <div className="flex-1 min-h-0 overflow-y-auto">
         {threadMessages.length === 0 ? (
           <div className="flex flex-col items-center justify-center h-32 text-muted-foreground/40 text-[12px] gap-1.5">
             {isRT ? <Users className="w-4 h-4" /> : <GitBranch className="w-4 h-4" />}


### PR DESCRIPTION
## Summary

Closes #191. Long content in the branch drawer (paste / long response) was stretching the main flex container past the viewport — main area shifted upward, footer appeared taller, status bar pushed off-screen.

Root cause: standard Tailwind/flexbox gotcha — \`min-w-0\` was set but \`min-h-0\` was missing on the main area flex parent (\`AppShell.tsx:186\`). Children default to \`min-height: auto\` (content size), so any growth in the drawer (NewMessageInput growth, mode bar wrap, long message list) propagated up instead of being absorbed by internal scroll containers.

## Changes

| File | Change |
|---|---|
| \`AppShell.tsx:186\` | \`min-h-0\` added to main flex container |
| \`AppShell.tsx:193\` | \`min-h-0\` added to CenterPanel wrapper + redundant ternary (identical className on both branches) flattened to single string |
| \`BranchThreadPanel.tsx:293\` | \`min-h-0\` added to message list (defensive, pairs with main fix) |

Tailwind class additions only, no logic change.

## Verification

- [x] \`npx tsc --noEmit\` — 0 errors
- [ ] Manual smoke (post-merge):
  1. Branch drawer Pinned mode → paste a long block → main area stays put ✓
  2. Long agent response → status bar stays in place ✓
  3. Drawer Overlay mode → no regression ✓
  4. Drawer closed → no regression (main area sized correctly) ✓

## Why this is safe

\`min-h-0\` constrains overflow propagation upward — it doesn't change the layout's allocated height, only allows the parent to refuse stretching beyond it. Internal \`overflow-y-auto\` containers (message list, etc.) take effect properly once the parent is constrained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)