### PR TITLE
fix(workflow): startReviewRT entry failure rollback + retry UX

### DIFF
--- a/docs/reference/reviewRTEntryFailureAudit_2026-04-25.md
+++ b/docs/reference/reviewRTEntryFailureAudit_2026-04-25.md
@@ -1,0 +1,122 @@
+---
+title: startReviewRT 진입 실패 매트릭스 — await 단계별 phase rollback 검증
+canonical: false
+status: audit-snapshot
+created_at: 2026-04-25
+related:
+  - docs/reference/asyncCancelPipelineAudit_2026-04-25.md  # 항목 2
+  - docs/plans/reviewRTEntryFailureRollbackPlan_2026-04-25.md
+  - src/lib/workflow/reviewWorkflow.ts
+---
+
+# 동기
+
+`asyncCancelPipelineAudit_2026-04-25` 의 항목 2 후속 — `startReviewRT` 가 진입 도중
+임의 단계에서 throw 했을 때 plan.phase 가 어디서 멈추는지, UI 가 사용자에게 실패를
+표면화하는지 검증. line 244 의 코멘트 "Review RT 진입 자체가 throw 되던 버그.
+s37 재현 로그로 특정" 가 시사한 동일 카테고리 잠재 버그를 모든 단계에 대해 매트릭스로
+정리한다.
+
+# 단계 식별 (현행 코드, `reviewWorkflow.ts` 기준)
+
+`startReviewRT(plan, implMessages, testOutput?, reviewers?, runManualGate?)` 의
+정상 흐름 await 단계:
+
+| # | Stage 키 | 위치 | 동작 |
+|---|---|---|---|
+| 1 | `manual_gate` | line 84-137 | ManualVerificationGate (선택) — fail 시 phase=rework + ManualVerificationFailed throw, cancel 시 phase 유지 + Error throw |
+| 2 | `update_phase_review` | line 139 | `updatePlanPhase(plan.id, "review")` — 핵심 phase 전환 |
+| 3 | `event_impl_completed` | line 140 | `createPlanEvent("impl_completed", "developer")` |
+| 4 | `sync_result_report` | line 142-143 | `syncResultReport(...)` — fire-and-forget (await 없음, 본 매트릭스 제외) |
+| 5 | `test_artifact` | line 145-147 | `createTestReportArtifact()` — testOutput 있을 때만, 동기 함수 |
+| 6 | `get_or_create_review_branch` | line 161-163 | `getOrCreateReviewBranch()` — DB write + branch 생성/재사용 |
+| 7 | `build_plan_context` | line 168 | `buildPlanContext(plan)` — context 조립 |
+| 8 | `save_rt_config` | line 245 | `invoke("save_rt_config", ...)` |
+| 9 | `save_conversation_engine` | line 254-262 | shadow conv 의 engine/model persist (try/catch 명시) |
+
+> NOTE: 실제 RT spawn (`sendThreadRoundtable`) 은 호출자 (DevProgressView) 책임.
+> 본 매트릭스는 `startReviewRT` 함수 내부에 한정.
+
+# 단계별 실패 매트릭스 (수정 전 — Layer A 적용 직전 기준)
+
+각 행 = 해당 stage 가 throw 했을 때:
+
+| Stage | phase 결과 | UI 결과 | 잠재 stuck? |
+|---|---|---|---|
+| `manual_gate` (fail) | `rework` (line 114 에서 명시 전환) | DevProgressView catch 가 phase 갱신 → rework notice | 안전 |
+| `manual_gate` (cancel) | (변동 없음) | DevProgressView catch — toast.info("수동 확인이 취소되었습니다") | 안전 |
+| `update_phase_review` | (변동 없음 — DB 업데이트 자체가 실패) | DevProgressView catch (warn) — 사용자에 표면화 약함 | **위험 1** — UI 는 review 진입 시도 흔적 없음 |
+| `event_impl_completed` | `review` | DevProgressView catch (warn) — 그러나 reviewBranch 없음 | **위험 2** — phase=review + RT 없음 stuck |
+| `test_artifact` | `review` | catch (warn) | **위험 3** — 동일 |
+| `get_or_create_review_branch` | `review` | catch (warn) — branch 미생성 | **위험 4** — phase=review + RT 없음 stuck (s37 재현 케이스 후보) |
+| `build_plan_context` | `review` | catch (warn) | **위험 5** — 동일 |
+| `save_rt_config` | `review` | catch (warn) — branch 는 있으나 RT config 없음 | **위험 6** — phase=review + branch 만 있고 RT 미시작 |
+| `save_conversation_engine` | `review` | 무시 (이미 try/catch 로 흡수됨) | 영향 미미 (engine/model 만 미저장) |
+
+## 수정 전 결론
+
+- 위험 1~6 가 invariant **[INV-1]** ("plan.phase=review ⇒ RT 존재 또는
+  review_entry_failed event") 를 깨뜨릴 수 있음.
+- DevProgressView 의 outer catch 는 단순 `console.warn("[tunaflow]", e)` 로
+  사용자에게 명시적 피드백을 주지 않음. setBusy(false) 만 하고 끝나서 사용자는
+  "버튼이 응답 없는" UX 만 경험.
+- s37 의 fix 코멘트는 stage 8 (`save_rt_config`) 의 `config` vs `configJson`
+  argument 키 오타 한 건만 다뤘음. **다른 stage 는 검증되지 않은 상태**.
+
+# 의심 시나리오 (재현 가능성 — grep + 정적 분석)
+
+| 시나리오 | 가장 영향 받는 stage | 재현 난이도 |
+|---|---|---|
+| DB write lock (busy timeout) | 2, 3, 6, 8 | 중 — 다중 panel 동시 write 부담 시 |
+| 네트워크/IPC 단절 (Tauri invoke 실패) | 2, 3, 6, 8 | 낮음 |
+| Branch 생성 중 plan FK 위반 (race) | 6 | 낮음 |
+| `buildPlanContext` 의 메모리/IO 실패 (impl_messages 매우 큰 경우) | 7 | 낮음 — 정적 함수 |
+| LLM/엔진 자체 실패 | (해당 없음 — 본 함수 내부에선 LLM 호출 없음) | — |
+
+본 함수는 LLM 직접 호출이 없으므로, "LLM/엔진 타임아웃" 시나리오는 호출자 측
+(`sendThreadRoundtable`) 의 책임. startReviewRT 단독 매트릭스는 **DB / IPC / 정적
+조립** 3 영역으로 한정.
+
+# Layer A 적용 후 매트릭스 (예측)
+
+`fix(workflow): step-wise catch + phase rollback in startReviewRT` 적용 후:
+
+| Stage | phase 결과 | UI 결과 | invariant |
+|---|---|---|---|
+| 2 (`update_phase_review`) | (변동 없음 — rollback 의미 없음, 그대로 throw) | DevProgressView 가 review_entry_failed event 감지 → 재시도 버튼 노출 | INV-1, INV-3 |
+| 3 (`event_impl_completed`) | `implementation` 으로 rollback | 재시도 버튼 | INV-1, INV-2, INV-3 |
+| 5 (`test_artifact`) | `implementation` 으로 rollback | 재시도 버튼 | INV-1, INV-2, INV-3 |
+| 6 (`get_or_create_review_branch`) | `implementation` 으로 rollback | 재시도 버튼 | INV-1, INV-2, INV-3 |
+| 7 (`build_plan_context`) | `implementation` 으로 rollback | 재시도 버튼 | INV-1, INV-2, INV-3 |
+| 8 (`save_rt_config`) | `implementation` 으로 rollback | 재시도 버튼 | INV-1, INV-2, INV-3 |
+| 9 (`save_conversation_engine`) | (변동 없음 — 기존 try/catch 유지) | 영향 미미 | — |
+
+> NOTE: rollback target 은 plan 의 직전 phase 인 `implementation` 사용.
+> Plan 본문의 "ready" 표현은 informal naming — 실제 PlanPhase enum 에는 `ready`
+> 가 없고, 사용자는 review 시작 직전 `implementation` 상태였으므로 그것이
+> 자연스러운 복귀점.
+
+# Layer B (UI) 결정 사항
+
+- **재시도 버튼 노출 조건**: 가장 최근 plan_event 가 `review_entry_failed`
+  (그 이후 `review_started` / `review_passed` / `review_failed` 등 Review 진행
+  이벤트가 추가로 없음) 이고 plan.phase 가 `implementation` 일 때.
+- **클릭 동작**: `handleStartReviewRT` (Deep RT) 또는 `handleStartReview` (Quick)
+  를 마지막 사용 트랙대로 재호출. 별도 idempotency key 는 두지 않고, startReviewRT
+  자체가 `getOrCreateReviewBranch` 의 `reused` 분기로 idempotent. 단, 사용자가
+  Quick → Deep 트랙을 변경한 후 재시도하면 새 트랙으로 진행 (의도된 동작).
+
+# Layer C (로그) 결정 사항
+
+- 각 stage 진입 직전 `console.debug("[startReviewRT.stage]", { stage })`.
+- Rust trace_log 까지는 도입하지 않음 — TS 단 함수의 단계 로깅에 무거움.
+- 디버깅 시 마지막 도달 stage 를 콘솔에서 추적 가능. plan_event 의 `review_entry_failed`
+  detail JSON 에도 `stage` 필드를 포함해 사후 분석에 사용.
+
+# 한계
+
+- 실제 재현 (DB lock 강제, 네트워크 차단) 은 본 audit 에서 수행하지 않았음.
+  Layer A 적용 후 정상 경로 unit test 만 추가하고, 실측 재현은 별도 QA 또는
+  버그 리포트 시 수행.
+- `getOrCreateReviewBranch` 내부의 race (이미 다른 panel 에서 review branch
+  생성 중) 는 본 매트릭스 범위 밖. 별 plan 후보.

--- a/src/components/tunaflow/context-panel/DevProgressView.tsx
+++ b/src/components/tunaflow/context-panel/DevProgressView.tsx
@@ -4,11 +4,11 @@ import { toast } from "sonner";
 import { invoke } from "@tauri-apps/api/core";
 import { cn } from "@/lib/utils";
 import { useChatStore } from "@/stores/chatStore";
-import { GitBranch, Check, Loader2, Clock, RotateCcw, Plus, ClipboardList, FileText } from "lucide-react";
+import { GitBranch, Check, Loader2, Clock, RotateCcw, Plus, ClipboardList, FileText, AlertTriangle } from "lucide-react";
 import type { Plan, PlanPhase, PlanSubtask } from "@/types";
 import * as planApi from "@/lib/api/plans";
 import {
-  getPlanSlug, syncResultReport, startReviewRT, ManualVerificationFailed,
+  getPlanSlug, syncResultReport, startReviewRT, ManualVerificationFailed, ReviewRTEntryFailed,
 } from "@/lib/workflowOrchestration";
 import type {
   ManualVerificationItem,
@@ -35,7 +35,7 @@ export function DevProgressView({ plan, onPlanUpdate }: DevProgressViewProps) {
   const {
     subtasks, completedNums, implComplete, loading,
     testResult, testRunning, reviewVerdict, designReviewSuggested,
-    failCount, doomLoopEscalated,
+    failCount, doomLoopEscalated, reviewEntryFailure,
   } = useSubtaskProgress(plan);
 
   const [busy, setBusy] = useState(false);
@@ -231,6 +231,13 @@ export function DevProgressView({ plan, onPlanUpdate }: DevProgressViewProps) {
         // Rework 경로로 전환됨 — startReviewRT 안에서 phase/artifact 이미 처리.
         // UI 측은 plan 상태 갱신만 하면 rework notice 섹션이 자동 노출.
         onPlanUpdate(plan.id, { phase: "rework" as PlanPhase });
+      } else if (e instanceof ReviewRTEntryFailed) {
+        // Layer A 가 phase=implementation 으로 rollback 했음. UI 동기화하고
+        // useSubtaskProgress 가 review_entry_failed event 를 polling 해서
+        // retry 영역을 자동 노출. 사용자에게는 사유를 toast 로도 알린다 (INV-3).
+        onPlanUpdate(plan.id, { phase: "implementation" as PlanPhase });
+        toast.error(t("progress.review_entry_failed.toast", { stage: e.stage }));
+        console.warn("[startReviewRT entry failure]", e.stage, e.cause);
       } else if (e instanceof Error && e.message.includes("cancelled by user")) {
         toast.info("수동 확인이 취소되었습니다");
       } else {
@@ -238,6 +245,17 @@ export function DevProgressView({ plan, onPlanUpdate }: DevProgressViewProps) {
       }
     }
     setBusy(false);
+  };
+
+  // Layer B: review_entry_failed 이후 사용자가 누르는 재시도 버튼 핸들러.
+  // 마지막 사용 트랙(Quick/Deep) 으로 다시 진입. startReviewRT 자체가
+  // getOrCreateReviewBranch 의 reused 분기로 idempotent.
+  const handleRetryReviewEntry = async () => {
+    if (reviewTrack === "deep") {
+      await handleStartReviewRT();
+    } else {
+      await handleStartReview();
+    }
   };
 
   const handleCreateSubPlan = async (subtask: PlanSubtask, index: number) => {
@@ -541,6 +559,37 @@ export function DevProgressView({ plan, onPlanUpdate }: DevProgressViewProps) {
               <pre className="text-[8px] mt-1 max-h-32 overflow-auto bg-card/50 rounded p-1.5 whitespace-pre-wrap">{testResult.output.slice(0, 2000)}</pre>
             </details>
           )}
+        </div>
+      )}
+
+      {/* Layer B (Plan reviewRTEntryFailureRollbackPlan_2026-04-25):
+         startReviewRT 진입 실패 → phase rollback 직후 retry UI. phase=implementation
+         일 때만, 그리고 가장 최근 review_entry_failed 이후 다른 review 진행 이벤트가
+         없을 때만 노출. INV-3 (사용자에 실패 표면화) 충족. */}
+      {plan.phase === "implementation" && reviewEntryFailure && (
+        <div className="rounded-md border border-status-rejected/30 bg-status-rejected/5 p-2.5 text-[10px] space-y-1.5">
+          <div className="flex items-center gap-1.5 font-medium text-status-rejected">
+            <AlertTriangle className="w-3.5 h-3.5" />
+            <span>{t("progress.review_entry_failed.title")}</span>
+          </div>
+          <p className="text-[9px] text-foreground/60">
+            {t("progress.review_entry_failed.body", {
+              stage: reviewEntryFailure.stage,
+              reason: reviewEntryFailure.reason.slice(0, 240),
+            })}
+          </p>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={handleRetryReviewEntry}
+              disabled={busy}
+              className="flex items-center gap-1 px-2.5 py-1 rounded-md text-[10px] font-medium bg-primary/10 text-primary hover:bg-primary/20 disabled:opacity-40 transition-colors"
+            >
+              <RotateCcw className="w-3 h-3" />
+              {busy
+                ? t("progress.review_entry_failed.retry_busy")
+                : t("progress.review_entry_failed.retry_button")}
+            </button>
+          </div>
         </div>
       )}
 

--- a/src/components/tunaflow/context-panel/useSubtaskProgress.ts
+++ b/src/components/tunaflow/context-panel/useSubtaskProgress.ts
@@ -15,6 +15,39 @@ import type { ParsedReviewVerdict } from "@/lib/planProposalParser";
 // Module-level cache: prevents re-running tests on tab switch (component remount)
 const testResultCache = new Map<string, TestRunResult>();
 
+// Layer B: 가장 최근 review_entry_failed 이후 다른 review 진행 이벤트가 없으면
+// 그 entry 의 stage/reason 을 반환. 그 외엔 null. 이벤트는 createdAt asc 가정.
+function extractLatestReviewEntryFailure(
+  events: Array<{ eventType: string; detail?: string | null; createdAt: number }>,
+): { stage: string; reason: string } | null {
+  // 마지막에서 첫 review_* 또는 review_entry_failed 를 찾는다.
+  for (let i = events.length - 1; i >= 0; i--) {
+    const ev = events[i];
+    const t = ev.eventType;
+    // 정상 review 진행 이벤트가 더 최근이면 retry UI 미노출.
+    if (
+      t === "review_started" ||
+      t === "review_passed" ||
+      t === "review_failed" ||
+      t === "review_conditional"
+    ) {
+      return null;
+    }
+    if (t === "review_entry_failed") {
+      try {
+        const parsed = JSON.parse(ev.detail ?? "{}") as { stage?: string; reason?: string };
+        return {
+          stage: parsed.stage ?? "unknown",
+          reason: parsed.reason ?? "(no reason recorded)",
+        };
+      } catch {
+        return { stage: "unknown", reason: ev.detail ?? "(no reason recorded)" };
+      }
+    }
+  }
+  return null;
+}
+
 export function useSubtaskProgress(plan: Plan) {
   const [subtasks, setSubtasks] = useState<PlanSubtask[]>([]);
   const [completedNums, setCompletedNums] = useState<Set<number>>(new Set());
@@ -28,6 +61,12 @@ export function useSubtaskProgress(plan: Plan) {
   const [designReviewSuggested, setDesignReviewSuggested] = useState(false);
   const [failCount, setFailCount] = useState(0);
   const [doomLoopEscalated, setDoomLoopEscalated] = useState(false);
+  // Layer B (Plan reviewRTEntryFailureRollbackPlan_2026-04-25): 가장 최근
+  // review_entry_failed plan_event 이후 다른 review 이벤트가 없을 때만 retry UI 노출.
+  const [reviewEntryFailure, setReviewEntryFailure] = useState<{
+    stage: string;
+    reason: string;
+  } | null>(null);
 
   const scanBranchState = async (cancelled: { current: boolean }) => {
     if (!plan.implementationBranchId) return;
@@ -120,6 +159,18 @@ export function useSubtaskProgress(plan: Plan) {
         }).catch((e) => console.debug("[plan-events]", e));
       }
 
+      // Layer B: review_entry_failed 감지 — phase=implementation 일 때만 (Layer A 가
+      // rollback 한 상태). 가장 최근 review_entry_failed 이후 다른 review 진행 이벤트가
+      // 없으면 retry UI 노출.
+      if (plan.phase === "implementation") {
+        planApi.listPlanEvents(plan.id).then((events) => {
+          if (cancelled.current) return;
+          setReviewEntryFailure(extractLatestReviewEntryFailure(events));
+        }).catch((e) => console.debug("[plan-events:review_entry_failed]", e));
+      } else {
+        setReviewEntryFailure(null);
+      }
+
       setLoading(false);
     })();
 
@@ -135,6 +186,15 @@ export function useSubtaskProgress(plan: Plan) {
           const latest = extractLatestReviewVerdict(reviewMsgs);
           if (latest) setReviewVerdict(latest);
         }).catch((e) => console.debug("[verdict-poll]", e));
+      }
+      // Layer B: phase=implementation 인 동안 review_entry_failed 상태를 주기적으로
+      // 재확인 — 사용자가 retry 버튼을 누른 직후 버튼이 사라지도록 (성공 시 phase
+      // 가 review 로 넘어가고, 다시 실패하면 새 event 가 추가됨).
+      if (plan.phase === "implementation") {
+        planApi.listPlanEvents(plan.id).then((events) => {
+          if (cancelled.current) return;
+          setReviewEntryFailure(extractLatestReviewEntryFailure(events));
+        }).catch((e) => console.debug("[plan-events:review_entry_failed:poll]", e));
       }
     }, 5000);
 
@@ -152,5 +212,6 @@ export function useSubtaskProgress(plan: Plan) {
     designReviewSuggested,
     failCount,
     doomLoopEscalated,
+    reviewEntryFailure,
   };
 }

--- a/src/lib/workflow/reviewWorkflow.ts
+++ b/src/lib/workflow/reviewWorkflow.ts
@@ -321,6 +321,12 @@ export async function startReviewRT(
     // We intentionally do NOT create a user_message here — sendThreadRoundtable
     // persists the prompt as the user message itself, and pre-seeding it would
     // cause a duplicate prompt in the branch.
+    console.debug("[startReviewRT.stage]", {
+      stage: "complete",
+      planId: plan.id,
+      branchId: branch.id,
+      reused,
+    });
     return { branch, shadowConvId, participants, prompt, mode };
   } catch (err) {
     // Layer A: 어느 stage 에서든 throw → phase rollback + review_entry_failed 기록.

--- a/src/lib/workflow/reviewWorkflow.ts
+++ b/src/lib/workflow/reviewWorkflow.ts
@@ -51,6 +51,39 @@ export class ManualVerificationFailed extends Error {
   }
 }
 
+/**
+ * Review RT entry failure (Plan reviewRTEntryFailureRollbackPlan_2026-04-25).
+ *
+ * startReviewRT 의 phase 전환 이후 어느 stage 에서든 throw 되면 그 직후
+ * Layer A 가 phase 를 implementation 으로 rollback 하고 review_entry_failed
+ * plan_event 를 기록한 뒤 본 에러로 wrap 해서 다시 throw 한다.
+ *
+ * 호출자(DevProgressView)는 instanceof 로 구분해 toast 대신 재시도 UI(Layer B)를
+ * 노출. ManualVerificationFailed / cancel 경로와는 분리된다.
+ */
+export class ReviewRTEntryFailed extends Error {
+  constructor(
+    public readonly stage: string,
+    public readonly cause: unknown,
+  ) {
+    const reason = cause instanceof Error ? cause.message : String(cause);
+    super(`startReviewRT failed at stage "${stage}": ${reason}`);
+    this.name = "ReviewRTEntryFailed";
+  }
+}
+
+/**
+ * Layer A 의 stage 식별자. plan_event detail 과 console.debug 에 동일 값 사용.
+ * 매트릭스: docs/reference/reviewRTEntryFailureAudit_2026-04-25.md.
+ */
+export type StartReviewRTStage =
+  | "update_phase_review"
+  | "event_impl_completed"
+  | "test_artifact"
+  | "get_or_create_review_branch"
+  | "build_plan_context"
+  | "save_rt_config";
+
 // ─── Phase D→E: impl-complete → Start Review RT ───────────────────────────
 
 export interface StartReviewRTResult extends CreateBranchResult {
@@ -136,139 +169,182 @@ export async function startReviewRT(
     }
   }
 
-  await planApi.updatePlanPhase(plan.id, "review");
-  await planApi.createPlanEvent(plan.id, "impl_completed", "developer");
+  // ─── Layer A: stage 추적 + 실패 시 phase rollback (Plan ...RollbackPlan_2026-04-25) ───
+  // 각 critical await 직전에 currentStage 를 갱신하고, 외곽 try/catch 가 실패한
+  // stage 를 잡아 phase=implementation 로 rollback + review_entry_failed plan_event 기록.
+  // INV-1/INV-2/INV-3 (audit doc 참고) 준수.
+  let currentStage: StartReviewRTStage = "update_phase_review";
+  // Layer C: 단계 식별 로그 — 디버깅 시 마지막 도달 stage 추적용.
+  console.debug("[startReviewRT.stage]", { stage: currentStage, planId: plan.id });
+  try {
+    await planApi.updatePlanPhase(plan.id, "review");
 
-  syncResultReport(plan.id, implMessages, plan.developerEngine ?? undefined,
-    plan.implementationBranchId ? `dev: ${plan.title}` : undefined);
+    currentStage = "event_impl_completed";
+    console.debug("[startReviewRT.stage]", { stage: currentStage, planId: plan.id });
+    await planApi.createPlanEvent(plan.id, "impl_completed", "developer");
 
-  if (testOutput) {
-    createTestReportArtifact(plan, testOutput);
-  }
+    syncResultReport(plan.id, implMessages, plan.developerEngine ?? undefined,
+      plan.implementationBranchId ? `dev: ${plan.title}` : undefined);
 
-  // 하위호환: string[] 로 들어오면 model 없음으로 normalize.
-  // default 는 claude/gemini — 이 둘은 무료/구독 양쪽에서 model fallback 문제가 없음.
-  const normalized: ReviewerChoice[] = (() => {
-    if (!reviewers || reviewers.length === 0) {
-      return [{ engine: "claude" }, { engine: "gemini" }];
+    if (testOutput) {
+      currentStage = "test_artifact";
+      console.debug("[startReviewRT.stage]", { stage: currentStage, planId: plan.id });
+      createTestReportArtifact(plan, testOutput);
     }
-    return (reviewers as (ReviewerChoice | string)[]).map((r) =>
-      typeof r === "string" ? { engine: r } : r,
+
+    // 하위호환: string[] 로 들어오면 model 없음으로 normalize.
+    // default 는 claude/gemini — 이 둘은 무료/구독 양쪽에서 model fallback 문제가 없음.
+    const normalized: ReviewerChoice[] = (() => {
+      if (!reviewers || reviewers.length === 0) {
+        return [{ engine: "claude" }, { engine: "gemini" }];
+      }
+      return (reviewers as (ReviewerChoice | string)[]).map((r) =>
+        typeof r === "string" ? { engine: r } : r,
+      );
+    })();
+
+    currentStage = "get_or_create_review_branch";
+    console.debug("[startReviewRT.stage]", { stage: currentStage, planId: plan.id });
+    // A안: 같은 roundtable 모드면 기존 리뷰 브랜치 재사용. 모드 달라지거나 없으면 신규.
+    const { branch, shadowConvId, reused } = await getOrCreateReviewBranch(
+      plan, `Review RT: ${plan.title}`, "roundtable",
     );
-  })();
+    if (reused) {
+      console.debug("[startReviewRT] reusing existing review branch:", branch.id);
+    }
 
-  // A안: 같은 roundtable 모드면 기존 리뷰 브랜치 재사용. 모드 달라지거나 없으면 신규.
-  const { branch, shadowConvId, reused } = await getOrCreateReviewBranch(
-    plan, `Review RT: ${plan.title}`, "roundtable",
-  );
-  if (reused) {
-    console.debug("[startReviewRT] reusing existing review branch:", branch.id);
+    currentStage = "build_plan_context";
+    console.debug("[startReviewRT.stage]", { stage: currentStage, planId: plan.id });
+    const planContext = await buildPlanContext(plan);
+    const implSummary = implMessages
+      .filter((m) => m.role === "assistant")
+      .map((m) => m.content.slice(0, 2000))
+      .join("\n---\n");
+
+    const prompt = [
+      `당신은 코드 리뷰어입니다. **코드를 읽어서** 검증하세요. 빌드/테스트 명령을 직접 실행하지 마세요.`,
+      "",
+      `## Plan (원래 요구사항)`,
+      planContext,
+      "",
+      `## Implementation (Developer 구현 결과)`,
+      implSummary.slice(0, 6000),
+      "",
+      testOutput ? `## 테스트 결과\n${testOutput.slice(0, 3000)}\n` : "",
+      `## 리뷰 절차`,
+      ``,
+      `각 subtask의 task 파일(컨텍스트에 포함됨, 또는 \`docs/plans/${getPlanSlug(plan)}-task-*.md\`에서 Read 도구로 열 수 있음)을 참고하여 아래 3가지를 확인하세요:`,
+      ``,
+      `1. **Changed files 확인**: task 파일에 명시된 파일이 실제로 수정/생성되었는가? 변경 내용이 Change description과 일치하는가?`,
+      `2. **Verification 결과 확인**: Developer가 보고한 검증 결과를 확인하세요. 모든 Verification 명령이 통과했는가?`,
+      `3. **결함 검사**: 변경된 코드에 런타임 에러, 논리 버그, 보안 취약점이 있는가? (코드를 읽어서 판단)`,
+      ``,
+      `### Pass 조건`,
+      `위 3가지가 모두 충족되면 **pass**입니다.`,
+      ``,
+      `### Fail 사유가 되지 않는 것`,
+      `- 코드 스타일/구조가 task 파일과 다르지만 결과가 올바른 경우`,
+      `- task 파일에 명시되지 않은 테스트 커버리지 부족`,
+      `- Changed files 밖 파일의 기존 품질 문제`,
+      `- "더 나은 방법이 있다"는 의견 → recommendations에 작성`,
+      ``,
+      `### 판정 형식`,
+      `- verdict: pass / fail / conditional`,
+      `- 다음 5개 차원을 각각 1~5점으로 평가하여 명시:`,
+      `  - **plan_coverage** — 모든 subtask가 task 파일 내용대로 구현되었는가`,
+      `  - **code_quality** — 런타임/논리/보안 결함 정도 (결함 없을수록 5)`,
+      `  - **test_coverage** — 테스트 결과 + Verification 통과 범위 (task 파일에 명시된 부분 기준)`,
+      `  - **doc_quality** — 주석·README·CLAUDE.md 등 문서 업데이트 적절성`,
+      `  - **convention** — 프로젝트 기존 코딩 컨벤션과의 일관성`,
+      `  점수 기준 총점: 22+ → pass / 10 미만 → fail / 그 외 → conditional (단, findings가 있으면 verdict 우선)`,
+      `- fail 시 반드시 **파일:줄번호 + 구체적 결함 설명**을 findings에 포함`,
+      `- fail 시 \`failed_subtask_ids: [N, M]\` 형식으로 해당 subtask 번호 명시`,
+      `- 개선 제안은 findings가 아닌 **recommendations**에 분리`,
+      ``,
+      `### 출력 예시`,
+      "```",
+      `<!-- tunaflow:review-verdict -->`,
+      `verdict: conditional`,
+      `plan_coverage: 4`,
+      `code_quality: 3`,
+      `test_coverage: 2`,
+      `doc_quality: 4`,
+      `convention: 5`,
+      `findings:`,
+      `- [code_quality] src/api/users.ts:42 사용자 입력을 파라미터화 없이 SQL 에 삽입`,
+      `- [test_coverage] 400/404 에러 케이스 테스트 누락`,
+      `recommendations:`,
+      `- prepared statement 사용으로 전환`,
+      `- status-code별 응답 테스트 추가`,
+      `<!-- /tunaflow:review-verdict -->`,
+      "```",
+    ].filter(Boolean).join("\n");
+
+    const participants: RoundtableParticipant[] = normalized.map((r, i) => ({
+      name: r.name ?? `Reviewer-${String.fromCharCode(65 + i)}`,
+      engine: r.engine,
+      model: r.model,
+      role: "reviewer" as const,
+    }));
+
+    const mode = "sequential" as const;
+    const rtConfig = JSON.stringify({ participants, mode });
+
+    currentStage = "save_rt_config";
+    console.debug("[startReviewRT.stage]", { stage: currentStage, planId: plan.id });
+    // Tauri camelCase: Rust 의 `config_json: String` 은 FE 에서 `configJson` 으로 호출.
+    // 이전엔 `config` 로 잘못 보내 invoke 가 실패하며 save_rt_config 가 no-op 되고
+    // Review RT 진입 자체가 throw 되던 버그. s37 재현 로그로 특정.
+    await invoke("save_rt_config", { conversationId: shadowConvId, configJson: rtConfig });
+
+    // 리뷰 브랜치 shadow conv 에도 engine/model 을 기록한다. 사용자가 RT 진행 중
+    // 리뷰 브랜치에 "직접 메시지" 를 보낼 때(handoff, follow-up 등), `resolveModel()`
+    // 이 이 엔트리를 읽어 올바른 model 을 전달할 수 있게 한다. 이전엔 RT 참여자
+    // 기반으로만 실행되고 shadow conv 엔트리가 없어서, 일반 채팅 경로로 빠질 때
+    // engine=codex/model=undefined 가 되어 app-server fallback(gpt-5 등) 이 발동하며
+    // ChatGPT 계정에서 400 에러가 나던 문제를 수정.
+    const first = participants[0];
+    if (first?.engine) {
+      try {
+        const { useChatStore } = await import("@/stores/chatStore");
+        useChatStore.getState().saveConversationEngine(shadowConvId, {
+          profileId: null,
+          engine: first.engine,
+          model: first.model,
+        });
+      } catch (e) { console.warn("[startReviewRT] saveConversationEngine failed:", e); }
+    }
+
+    // NOTE: RT execution is the caller's responsibility.
+    // After this returns, the caller should call openThread(branch.id) then
+    // sendThreadRoundtable(prompt, participants, mode) to actually run the review.
+    // We intentionally do NOT create a user_message here — sendThreadRoundtable
+    // persists the prompt as the user message itself, and pre-seeding it would
+    // cause a duplicate prompt in the branch.
+    return { branch, shadowConvId, participants, prompt, mode };
+  } catch (err) {
+    // Layer A: 어느 stage 에서든 throw → phase rollback + review_entry_failed 기록.
+    // INV-2: phase 를 implementation 으로 복귀 (PlanPhase enum 에 "ready" 가 없어
+    // review 직전 자연스러운 상태인 implementation 사용). plan 본문의 "ready"
+    // 표현은 informal naming.
+    // INV-1: review_entry_failed event 가 plan 에 남아 있어 UI 가 "phase=review 인데
+    // RT 없음" 상태와 "정상 review 진행" 을 구분 가능.
+    // INV-3: ReviewRTEntryFailed 로 wrap 해서 호출자가 instanceof 분기로 재시도 UI 노출.
+    const reason = err instanceof Error ? err.message : String(err);
+    console.warn("[startReviewRT] failed at stage", currentStage, ":", reason);
+    await planApi.updatePlanPhase(plan.id, "implementation").catch((rollbackErr) => {
+      console.warn("[startReviewRT] phase rollback failed:", rollbackErr);
+    });
+    await planApi.createPlanEvent(
+      plan.id,
+      "review_entry_failed",
+      "system",
+      JSON.stringify({ stage: currentStage, reason }),
+    ).catch((evErr) => {
+      console.warn("[startReviewRT] review_entry_failed event creation failed:", evErr);
+    });
+    throw new ReviewRTEntryFailed(currentStage, err);
   }
-
-  const planContext = await buildPlanContext(plan);
-  const implSummary = implMessages
-    .filter((m) => m.role === "assistant")
-    .map((m) => m.content.slice(0, 2000))
-    .join("\n---\n");
-
-  const prompt = [
-    `당신은 코드 리뷰어입니다. **코드를 읽어서** 검증하세요. 빌드/테스트 명령을 직접 실행하지 마세요.`,
-    "",
-    `## Plan (원래 요구사항)`,
-    planContext,
-    "",
-    `## Implementation (Developer 구현 결과)`,
-    implSummary.slice(0, 6000),
-    "",
-    testOutput ? `## 테스트 결과\n${testOutput.slice(0, 3000)}\n` : "",
-    `## 리뷰 절차`,
-    ``,
-    `각 subtask의 task 파일(컨텍스트에 포함됨, 또는 \`docs/plans/${getPlanSlug(plan)}-task-*.md\`에서 Read 도구로 열 수 있음)을 참고하여 아래 3가지를 확인하세요:`,
-    ``,
-    `1. **Changed files 확인**: task 파일에 명시된 파일이 실제로 수정/생성되었는가? 변경 내용이 Change description과 일치하는가?`,
-    `2. **Verification 결과 확인**: Developer가 보고한 검증 결과를 확인하세요. 모든 Verification 명령이 통과했는가?`,
-    `3. **결함 검사**: 변경된 코드에 런타임 에러, 논리 버그, 보안 취약점이 있는가? (코드를 읽어서 판단)`,
-    ``,
-    `### Pass 조건`,
-    `위 3가지가 모두 충족되면 **pass**입니다.`,
-    ``,
-    `### Fail 사유가 되지 않는 것`,
-    `- 코드 스타일/구조가 task 파일과 다르지만 결과가 올바른 경우`,
-    `- task 파일에 명시되지 않은 테스트 커버리지 부족`,
-    `- Changed files 밖 파일의 기존 품질 문제`,
-    `- "더 나은 방법이 있다"는 의견 → recommendations에 작성`,
-    ``,
-    `### 판정 형식`,
-    `- verdict: pass / fail / conditional`,
-    `- 다음 5개 차원을 각각 1~5점으로 평가하여 명시:`,
-    `  - **plan_coverage** — 모든 subtask가 task 파일 내용대로 구현되었는가`,
-    `  - **code_quality** — 런타임/논리/보안 결함 정도 (결함 없을수록 5)`,
-    `  - **test_coverage** — 테스트 결과 + Verification 통과 범위 (task 파일에 명시된 부분 기준)`,
-    `  - **doc_quality** — 주석·README·CLAUDE.md 등 문서 업데이트 적절성`,
-    `  - **convention** — 프로젝트 기존 코딩 컨벤션과의 일관성`,
-    `  점수 기준 총점: 22+ → pass / 10 미만 → fail / 그 외 → conditional (단, findings가 있으면 verdict 우선)`,
-    `- fail 시 반드시 **파일:줄번호 + 구체적 결함 설명**을 findings에 포함`,
-    `- fail 시 \`failed_subtask_ids: [N, M]\` 형식으로 해당 subtask 번호 명시`,
-    `- 개선 제안은 findings가 아닌 **recommendations**에 분리`,
-    ``,
-    `### 출력 예시`,
-    "```",
-    `<!-- tunaflow:review-verdict -->`,
-    `verdict: conditional`,
-    `plan_coverage: 4`,
-    `code_quality: 3`,
-    `test_coverage: 2`,
-    `doc_quality: 4`,
-    `convention: 5`,
-    `findings:`,
-    `- [code_quality] src/api/users.ts:42 사용자 입력을 파라미터화 없이 SQL 에 삽입`,
-    `- [test_coverage] 400/404 에러 케이스 테스트 누락`,
-    `recommendations:`,
-    `- prepared statement 사용으로 전환`,
-    `- status-code별 응답 테스트 추가`,
-    `<!-- /tunaflow:review-verdict -->`,
-    "```",
-  ].filter(Boolean).join("\n");
-
-  const participants: RoundtableParticipant[] = normalized.map((r, i) => ({
-    name: r.name ?? `Reviewer-${String.fromCharCode(65 + i)}`,
-    engine: r.engine,
-    model: r.model,
-    role: "reviewer" as const,
-  }));
-
-  const mode = "sequential" as const;
-  const rtConfig = JSON.stringify({ participants, mode });
-  // Tauri camelCase: Rust 의 `config_json: String` 은 FE 에서 `configJson` 으로 호출.
-  // 이전엔 `config` 로 잘못 보내 invoke 가 실패하며 save_rt_config 가 no-op 되고
-  // Review RT 진입 자체가 throw 되던 버그. s37 재현 로그로 특정.
-  await invoke("save_rt_config", { conversationId: shadowConvId, configJson: rtConfig });
-
-  // 리뷰 브랜치 shadow conv 에도 engine/model 을 기록한다. 사용자가 RT 진행 중
-  // 리뷰 브랜치에 "직접 메시지" 를 보낼 때(handoff, follow-up 등), `resolveModel()`
-  // 이 이 엔트리를 읽어 올바른 model 을 전달할 수 있게 한다. 이전엔 RT 참여자
-  // 기반으로만 실행되고 shadow conv 엔트리가 없어서, 일반 채팅 경로로 빠질 때
-  // engine=codex/model=undefined 가 되어 app-server fallback(gpt-5 등) 이 발동하며
-  // ChatGPT 계정에서 400 에러가 나던 문제를 수정.
-  const first = participants[0];
-  if (first?.engine) {
-    try {
-      const { useChatStore } = await import("@/stores/chatStore");
-      useChatStore.getState().saveConversationEngine(shadowConvId, {
-        profileId: null,
-        engine: first.engine,
-        model: first.model,
-      });
-    } catch (e) { console.warn("[startReviewRT] saveConversationEngine failed:", e); }
-  }
-
-  // NOTE: RT execution is the caller's responsibility.
-  // After this returns, the caller should call openThread(branch.id) then
-  // sendThreadRoundtable(prompt, participants, mode) to actually run the review.
-  // We intentionally do NOT create a user_message here — sendThreadRoundtable
-  // persists the prompt as the user message itself, and pre-seeding it would
-  // cause a duplicate prompt in the branch.
-  return { branch, shadowConvId, participants, prompt, mode };
 }
 
 // ─── Phase E: Process review verdict ──────────────────────────────────────

--- a/src/locales/en/workflow.json
+++ b/src/locales/en/workflow.json
@@ -197,6 +197,13 @@
       "findings_header": "Previous Review Findings (Re-review #{{round}})",
       "reverify_note": "Re-verified with focus on whether the items above were fixed."
     },
+    "review_entry_failed": {
+      "title": "Review entry failed — retry",
+      "body": "Review RT failed while entering at stage \"{{stage}}\". The plan phase has been rolled back to implementation.\n\nReason: {{reason}}",
+      "retry_button": "Retry review",
+      "retry_busy": "Retrying...",
+      "toast": "Review entry failed ({{stage}}). Plan phase rolled back to implementation."
+    },
     "summary": {
       "completed_count": "{{done}}/{{total}} done",
       "scope_label": "Review scope:",

--- a/src/locales/ko/workflow.json
+++ b/src/locales/ko/workflow.json
@@ -197,6 +197,13 @@
       "findings_header": "이전 Review Findings (Re-review #{{round}})",
       "reverify_note": "위 사항이 수정되었는지 중심으로 재검증됩니다."
     },
+    "review_entry_failed": {
+      "title": "Review 진입 실패 — 다시 시도",
+      "body": "Review RT 진입 도중 \"{{stage}}\" 단계에서 실패했습니다. plan phase 는 implementation 으로 복구되었습니다.\n\n사유: {{reason}}",
+      "retry_button": "Review 재시도",
+      "retry_busy": "재시도 중...",
+      "toast": "Review 진입 실패 ({{stage}}). plan phase 가 implementation 으로 복구되었습니다."
+    },
     "summary": {
       "completed_count": "{{done}}/{{total}} 완료",
       "scope_label": "리뷰 대상:",

--- a/src/tests/workflowOrchestration.test.ts
+++ b/src/tests/workflowOrchestration.test.ts
@@ -50,6 +50,7 @@ import {
   startReviewBranch,
   startReviewRT,
   ManualVerificationFailed,
+  ReviewRTEntryFailed,
 } from "@/lib/workflowOrchestration";
 import type { Plan, Message } from "@/types";
 
@@ -492,5 +493,62 @@ describe("startReviewRT — manual verification gate", () => {
     // phase 는 그대로 (INV-5)
     expect(planApi.updatePlanPhase).not.toHaveBeenCalledWith("p-1", "review");
     expect(planApi.updatePlanPhase).not.toHaveBeenCalledWith("p-1", "rework");
+  });
+});
+
+// ─── startReviewRT — Layer A: stage rollback (Plan reviewRTEntryFailureRollbackPlan) ───
+
+describe("startReviewRT — Layer A entry failure rollback", () => {
+  it("rollbacks phase to implementation and emits review_entry_failed when save_rt_config throws", async () => {
+    // get_or_create_review_branch 까지는 성공 → save_rt_config 단계에서 throw 시뮬레이션.
+    (invoke as any).mockImplementation((cmd: string) => {
+      if (cmd === "create_branch") return Promise.resolve({ id: "br-1", conversationId: "conv-1", label: "rev", status: "active", createdAt: 0 });
+      if (cmd === "open_branch_stream") return Promise.resolve("branch:br-1");
+      if (cmd === "save_rt_config") return Promise.reject(new Error("DB write failed"));
+      return Promise.resolve();
+    });
+
+    await expect(startReviewRT(mockPlan, [])).rejects.toBeInstanceOf(ReviewRTEntryFailed);
+    // INV-2: phase rollback to implementation
+    expect(planApi.updatePlanPhase).toHaveBeenCalledWith("p-1", "implementation");
+    // INV-1: review_entry_failed event recorded with stage info
+    expect(planApi.createPlanEvent).toHaveBeenCalledWith(
+      "p-1",
+      "review_entry_failed",
+      "system",
+      expect.stringContaining("save_rt_config"),
+    );
+  });
+
+  it("captures the stage name on the thrown ReviewRTEntryFailed", async () => {
+    (invoke as any).mockImplementation((cmd: string) => {
+      if (cmd === "create_branch") return Promise.reject(new Error("branch creation failed"));
+      return Promise.resolve();
+    });
+
+    let caught: unknown;
+    try {
+      await startReviewRT(mockPlan, []);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(ReviewRTEntryFailed);
+    expect((caught as ReviewRTEntryFailed).stage).toBe("get_or_create_review_branch");
+  });
+
+  it("does NOT rollback when ManualVerificationFailed throws (separate path)", async () => {
+    const runManualGate = vi.fn(async () => [{ status: "fail" as const, reason: "broken" }]);
+    const msgWithManual: Message[] = [{
+      id: "m1", conversationId: "c1", role: "assistant",
+      content: "implemented X\n⚠️ Manual: Click button", timestamp: 0, status: "done",
+    }];
+    await expect(startReviewRT(mockPlan, msgWithManual, undefined, undefined, runManualGate))
+      .rejects.toBeInstanceOf(ManualVerificationFailed);
+    // ManualVerificationFailed 는 phase=rework 자체 처리. Layer A 의 implementation
+    // rollback 경로로 빠지지 않아야 함 (review_entry_failed event 미발생).
+    expect(planApi.createPlanEvent).not.toHaveBeenCalledWith(
+      "p-1", "review_entry_failed", expect.anything(), expect.anything(),
+    );
+    expect(planApi.updatePlanPhase).not.toHaveBeenCalledWith("p-1", "implementation");
   });
 });


### PR DESCRIPTION
Plan: [docs/plans/reviewRTEntryFailureRollbackPlan_2026-04-25.md](docs/plans/reviewRTEntryFailureRollbackPlan_2026-04-25.md)
Audit reference: [docs/reference/reviewRTEntryFailureAudit_2026-04-25.md](docs/reference/reviewRTEntryFailureAudit_2026-04-25.md)
Sibling of #190 (asyncCancelPipelineAudit 항목 1·2 카테고리).

## Summary

`startReviewRT` 가 phase 전환 후 `getOrCreateReviewBranch` / `buildPlanContext` /
`save_rt_config` 등 임의 stage 에서 throw 되면 plan.phase 가 `review` 에 남고
RT 가 미생성된 stuck 상태가 되던 잠재 버그를 수정. s37 의 fix 가 stage 8
(`save_rt_config`) 의 인자 키 오타 한 건만 다뤄서 다른 stage 는 검증되지
않은 상태였음.

- **Step 1 — Audit**: 9 단계 await 매트릭스 + stuck 위험 분석을
  `docs/reference/reviewRTEntryFailureAudit_2026-04-25.md` 로 정리.
- **Layer A**: `reviewWorkflow.ts:startReviewRT` 의 critical await 들을 외곽
  try/catch 로 묶고, 실패 시 `phase=implementation` 로 rollback +
  `review_entry_failed` plan_event(stage/reason 포함) 기록 + 새
  `ReviewRTEntryFailed` 로 wrap throw. `ManualVerificationFailed` / cancel
  경로는 outer try 진입 전이라 영향 없음.
- **Layer B**: `useSubtaskProgress` 가 phase=implementation 동안 plan_events 를
  polling 해 가장 최근 `review_entry_failed` 이후 다른 review 진행 이벤트
  (`review_started/passed/failed/conditional`) 가 없을 때만 stage/reason 노출.
  `DevProgressView` 가 새 retry 카드 + "Review 재시도" 버튼을 그리고, 마지막
  사용 트랙(Quick/Deep) 으로 `handleStartReview*` 재호출. `ReviewRTEntryFailed`
  catch 도 추가해 toast 로 즉시 표면화 (INV-3).
- **Layer C**: 각 stage 진입 직전 `console.debug("[startReviewRT.stage]", ...)` +
  정상 종료 시 `complete` 로그.
- i18n: `ko/en` workflow.json 에 `progress.review_entry_failed` 그룹 추가.

## Invariants 준수

- **INV-1**: `phase=review ⇒ RT 또는 review_entry_failed event` — Layer A 의
  rollback 으로 `phase=review` 잔류 stuck 시나리오 제거.
- **INV-2**: `review_entry_failed` event ⇒ phase 가 `implementation` 으로 rollback
  된 상태 (Plan 본문의 "ready" 는 informal naming — 실제 PlanPhase enum 에
  `ready` 가 없어 review 직전 자연스러운 phase 인 `implementation` 사용).
- **INV-3**: 사용자에 toast + retry 카드로 즉시 표면화.

## Test plan

- [x] `npx tsc --noEmit` — 통과
- [x] `npx vitest run` — 347 / 347 passed (workflow Layer A 신규 테스트 3건 포함)
- [ ] 수동 재현: DB write 실패 / 네트워크 차단 / `save_rt_config` 강제 throw
  시나리오에서 retry 카드 노출 + 재시도 idempotent 동작 확인 (별도 QA 또는
  `getOrCreateReviewBranch` 경로 audit 시 수행)

## 관련

- 셀프 이슈 후보: "branch adopt rollback / plan generation rollback / rawq
  index cancel — asyncCancelPipelineAudit 항목 3·4·5 의 sibling plans 도 준비
  필요" (별 plan 으로 이미 등재됨, 본 PR 범위 아님)

🤖 Generated with [Claude Code](https://claude.com/claude-code)