### PR TITLE
bug: Codex/Gemini meta-agent analysis fails (parse_output strict, prompt biased toward Claude format)

### DIFF
--- a/docs/reference/codexGeminiOnboardingResponseAudit_2026-04-25.md
+++ b/docs/reference/codexGeminiOnboardingResponseAudit_2026-04-25.md
@@ -1,0 +1,276 @@
+---
+title: Codex / Gemini 온보딩 분석 응답 형식 audit
+status: draft (코드 분석 기반 — 실측 raw 응답은 사용자/QA 환경에서 별도 수집 필요)
+created_at: 2026-04-25
+updated_at: 2026-04-25
+canonical: false  # 가설 + 코드 분석 기록. 실측 결과 수집되면 본 문서 갱신.
+related:
+  - docs/plans/codexGeminiOnboardingAnalysisFailureInvestigationPlan_2026-04-25.md
+  - https://github.com/hang-in/tunaFlow/issues/176
+  - src-tauri/src/commands/project_onboarding.rs
+---
+
+# 1. 목적
+
+Plan `codexGeminiOnboardingAnalysisFailureInvestigationPlan_2026-04-25.md` Step 1
+("Audit — raw 응답 capture") 결과 정리. **모든 CLI 엔진이 동일한 dispatcher
+(`call_cli_agent`) 를 거치지만 Codex / Gemini 만 분석 실패**하는 원인을 코드
+경로와 모델 응답 패턴으로 추적한다.
+
+> 본 문서는 실제 CLI 를 호출해 stdout 을 dump 한 결과는 아니다. CLI 환경
+> (네트워크 + 사용자 인증) 이 worktree 에서 가용하지 않기 때문이다. 대신
+> `project_onboarding.rs` 의 호출 경로를 정밀 분석하고, 각 엔진 CLI 의 일반적인
+> 출력 패턴을 기반으로 가설을 좁힌다. 후속 세션이 raw 응답을 수집하면 §6
+> "관찰 결과" 섹션을 채워 둔다.
+
+# 2. 호출 경로 사실 정리
+
+`src-tauri/src/commands/project_onboarding.rs:586-602` 의 dispatcher.
+
+```rust
+let text = match engine {
+    "claude" | "codex" | "gemini" => {
+        call_cli_agent(engine, engine, prompt, model, cancel).await?
+    }
+    "ollama"   => call_ollama(prompt, m, ep, cancel).await?,
+    "lmstudio" => call_openai_compat(prompt, m, ep, cancel).await?,
+    other      => return Err(format!("지원하지 않는 엔진: {other}")),
+};
+parse_output(&text)
+```
+
+세 CLI 엔진 모두 **동일한 prompt** 를 받고, 동일한 `parse_output` 으로 들어간다.
+즉 분기점은 **(a) `call_cli_agent` 내부 CLI argv** 와 **(b) CLI subprocess 의
+stdout 형식** 두 가지뿐이다.
+
+## 2.1 `call_cli_agent` argv 차이 (project_onboarding.rs:434-449)
+
+| 엔진 | argv | prompt 전달 방식 | output mode |
+|---|---|---|---|
+| `claude` | `claude -p <prompt> --max-turns 1 --output-format text [--model M]` | argv | `text` (JSON / stream-json 모드 아님) |
+| `gemini` | `gemini -p <prompt> [-m M]` | argv | 기본 (모드 플래그 미지정) |
+| `codex`  | `codex exec --full-auto - [--model M]` | **stdin** | 기본 (모드 플래그 미지정) |
+
+핵심 관찰:
+
+- Claude 만 `--output-format text` 가 명시. → 이게 정해진 plain-text 모드
+  (no JSON wrapping, no envelope) 를 강제하는 핵심.
+- Codex / Gemini 는 **출력 형식 플래그 없음**. 즉 각 CLI 의 default 출력으로
+  떨어진다.
+- `cmd.stderr(Stdio::null())` 라 stderr 는 버려진다. 만약 CLI 가 진단 메시지를
+  stderr 로 따로 흘려도 우리는 stdout 만 읽는다.
+
+## 2.2 `parse_output` 의 strict 가정 (project_onboarding.rs:358-381)
+
+```rust
+let claude_md = extract_between(text, "[CLAUDE_MD_START]", "[CLAUDE_MD_END]")
+    .ok_or("AI 응답에서 CLAUDE.md 섹션을 찾을 수 없습니다")?;
+let ref_index = extract_between(text, "[REF_INDEX_START]", "[REF_INDEX_END]")
+    .ok_or("AI 응답에서 Reference Index 섹션을 찾을 수 없습니다")?;
+```
+
+`extract_between` 은 단순 substring search 다 (line 383-387). 즉:
+
+- 마커 글자가 **그대로 들어간 경우만** OK.
+- `\[CLAUDE_MD_START\]` (백슬래시 escape), ` [CLAUDE_MD_START] ` (공백
+  surrounded 는 OK), `[ CLAUDE_MD_START ]` (마커 안에 공백) 등의 변형은 **모두 fail**.
+- markdown fence 안에 들어가도 substring 매칭 자체는 OK (텍스트로 그대로
+  포함되면 통과). 다만 fence 가 그 마커를 **에스케이핑** 하면 (예: 시각용으로
+  대괄호 escape) 깨진다.
+
+## 2.3 prompt 의 출력 지시 (project_onboarding.rs:266)
+
+```
+아래 두 섹션을 정확한 마커와 함께 출력하세요. 마커 외에 다른 텍스트는 추가하지 마세요.
+```
+
+지시는 한국어 1문장. "정확한 마커", "마커 외 다른 텍스트 금지" 만 명시. 다음
+요소는 명시되어 있지 않다:
+
+1. **markdown code fence 금지** (` ```markdown ... ``` ` 으로 감싸지 말 것)
+2. **introduction / preamble 금지** (`다음과 같이 정리했습니다:` 같은 prefix
+   금지)
+3. **마커 자체를 escape 하지 말 것** (e.g. `\[CLAUDE_MD_START\]` 금지)
+4. 마커는 **영어 대괄호 + ASCII** 그대로 사용 (한국어 모델이 fullwidth 괄호 등으로
+   변환하지 않도록)
+
+# 3. 가설 (실패 원인 후보)
+
+## H1 — Gemini 가 markdown 으로 응답을 감싼다 (가능성 ★★★)
+
+Gemini CLI 는 default 모드에서 응답을 **사람용 markdown 출력** 으로 렌더링하는
+경향이 있다. 또한 Gemini 모델 자체가 자주 ` ```markdown ... ``` ` 또는 다른 언어
+fence 로 응답을 감싼다.
+
+마커가 fence 안쪽에 있어도 substring 매칭은 통과하지만, 다음과 같은 변형이면
+fail:
+
+- ` ``` ` 펜스 안에 들어가서 escape 가 발생 (대괄호 escape 는 거의 없으니
+  현실적으로는 fence 자체가 문제는 아님 — 마커는 그대로 통과)
+- 그러나 prompt 끝에 "마커 외 다른 텍스트는 추가하지 마세요" 가 있어도 Gemini 가
+  "Of course! Here's the file..." 같은 introduction 을 붙이면 → 마커는 여전히
+  포함되므로 substring 은 통과. 실패 원인이 되지 않음.
+
+→ 결론: H1 단독으로는 실패를 100% 설명 못 한다. **H4** (마커 자체 변형) 가
+보조 가설로 필요하다.
+
+## H2 — Codex 가 응답을 JSON envelope 로 감싼다 (가능성 ★★)
+
+Codex CLI 의 `exec` 모드는 기본적으로 plain-text 출력이지만, `exec` mode 가
+업데이트되면서 **JSON 진행 로그 / tool use trace** 를 stdout 에 섞을 수 있다.
+정확한 동작은 codex 버전에 따라 달라진다.
+
+만약 stdout 이 다음과 같다면:
+
+```
+[2026-04-25 10:00:01Z] starting model gpt-5-codex
+[2026-04-25 10:00:05Z] thinking...
+[CLAUDE_MD_START]
+...
+```
+
+마커는 여전히 포함되므로 substring 매칭은 통과.
+
+그러나 **codex 가 응답 본체를 JSON 으로 출력** 하는 모드라면:
+
+```json
+{"role":"assistant","content":"[CLAUDE_MD_START]\n# foo\n[CLAUDE_MD_END]\n..."}
+```
+
+여기서 `\n` 이 escape 된 형태로 들어가면 `extract_between` 은 substring 으로
+열리는 마커는 찾지만, `[CLAUDE_MD_END]` 까지 사이의 본문에 escape 된 `\n` 이
+literally `\n` 두 글자로 들어와 있으면 결과가 깨진 markdown 으로 추출된다 →
+parse 단계에서는 OK 일 수 있으나 사용자 단계에서 깨진 출력.
+
+여기에 더해 codex 의 `exec` 가 응답 끝에 **반드시** progress / status footer 를
+붙이면 (`done in 5.3s`) → 마커 매칭은 여전히 통과. 실패 직접 원인은 아니다.
+
+→ 결론: H2 도 실패를 단독 설명하지 못함. **H4** 또는 **CLI 가 비정상 exit 코드
+반환** (project_onboarding.rs:411 `if !output.status.success()` 에서 fail) 가
+유력.
+
+## H3 — CLI exit code (가능성 ★★★)
+
+`await_cli_with_cancel` (project_onboarding.rs:392-419) 의:
+
+```rust
+if !output.status.success() {
+    return Err(format!("{engine} 분석 실패 (exit: {:?})", output.status.code()));
+}
+```
+
+가능성:
+
+- Codex `exec --full-auto` 가 **인증 미설정 / 모델 불일치** 시 non-zero exit
+- Gemini CLI 가 **API key 없음 / quota 초과** 시 non-zero exit (claude 는
+  보통 stdout 으로 친절한 에러 메시지를 텍스트로 뽑고 exit 0)
+- Codex 가 `--model` 인자에 잘못된 모델명을 받았을 때 non-zero exit (M2 16GB
+  사용자가 default 모델을 쓰면 plan §2.1 에 명시된 codex 의 `--model M` 미지정
+  케이스를 탄다)
+
+이 경우 `parse_output` 도달 전에 에러로 끝난다. 사용자에게는
+`project:onboarding:error` 의 `message` 가 `"codex 분석 실패 (exit: Some(1))"` 로
+보일 것이다.
+
+→ Issue #176 follow-up 의 정확한 에러 message 가 무엇이었는지 확인 필요. 만약
+"분석 실패 (exit: ...)" 류 라면 **H3 가 root cause** 이고 본 plan 의 fix 방향은
+바뀌어야 한다 (parse 가 아니라 CLI invocation 자체 문제).
+
+## H4 — 모델이 마커 자체를 변형 (가능성 ★★★)
+
+가장 흔한 모드 실패. 한국어로 prompt 를 받은 모델이:
+
+- `[CLAUDE_MD_START]` → `【CLAUDE_MD_START】` (fullwidth 괄호) 로 변환
+- `[CLAUDE_MD_START]` → `**[CLAUDE_MD_START]**` 로 markdown bold 처리
+- `[CLAUDE_MD_START]` → `[CLAUDE\_MD\_START]` 로 underscore escape (markdown
+  안전)
+- 마커를 ` ## [CLAUDE_MD_START]` 처럼 헤더로 변형
+
+substring 매칭은 모두 fail. claude 는 `[CLAUDE_MD_START]` 마커를 본 학습량이
+많아 그대로 출력할 가능성이 높지만, Gemini / Codex 는 이를 본 적 없는 임의의
+포맷 지시로 받아들이고 markdown 친화 형태로 변형할 가능성이 높다.
+
+## H5 — Gemini 가 한 번 더 codeblock 안에 마커를 넣고 끝나지 않음 (가능성 ★★)
+
+Gemini 가 응답을 다음과 같이 출력:
+
+````
+다음과 같이 정리했습니다:
+
+```markdown
+[CLAUDE_MD_START]
+# foo
+[CLAUDE_MD_END]
+
+[REF_INDEX_START]
+# bar
+[REF_INDEX_END]
+```
+
+추가로 도와드릴 점이 있으면 말씀해 주세요.
+````
+
+이 경우 **substring 매칭 자체는 통과**. claude_md = "# foo", ref_index = "# bar"
+가 정상 추출. → 실패 직접 원인이 아님.
+
+# 4. 시나리오별 fix 우선순위
+
+| 가설 | 가능성 | 영향 | fix 위치 |
+|---|---|---|---|
+| H1 markdown wrap | ★★★ | 매칭 자체에는 영향 적음 | (선택) parse 측에서 ` ``` ` strip |
+| H2 codex JSON | ★★ | 변형 형태에 따라 가변 | (선택) JSON envelope detection |
+| H3 exit code | ★★★ | 직접 fail (parse 도달 전) | **CLI argv 확정성 + 사용자에게 명확한 에러 메시지** |
+| H4 마커 변형 | ★★★ | 직접 fail | **prompt 강화 + parse 측 looser 매칭** |
+| H5 fence-in-fence | ★★ | 보통 통과 | n/a |
+
+→ **Layer A (parse looser) + Layer B (prompt 강화)** 가 H1, H4 를 동시에 흡수.
+H3 는 별도 문제 (CLI 환경) 라 본 plan 의 범위를 벗어남 (별 이슈로 뺄 것). H2 는
+실측 후 결정.
+
+# 5. fix 의 구체 형태 (본 plan Layer A/B 적용 후)
+
+## Layer A — `parse_output` 강건화
+
+substring 검색 → **regex 기반 looser matching** 으로 교체.
+
+매칭 허용 패턴:
+
+- 마커 좌우 공백 / newline 자유
+- 마커 자체가 markdown bold (`**[CLAUDE_MD_START]**`) 로 감싸진 케이스
+- 마커 앞에 fence opener (` ```markdown` 또는 ` ``` `) 가 한 줄 있는 케이스
+- 마커 뒤에 fence closer (` ``` `) 가 한 줄 있는 케이스
+- 한국어 fullwidth 괄호 `【】` 변형 흡수 (선택, low priority)
+
+마커 매칭 실패 시:
+
+- error message 에 raw 응답의 앞 200자를 포함 (디버깅용 단서)
+
+## Layer B — prompt 의 출력 지시 강화
+
+prompt 끝부분에 다음 지시 추가:
+
+```
+**중요**: 다음 규칙을 정확히 지키세요.
+1. 응답의 첫 줄은 [CLAUDE_MD_START] 로 시작.
+2. 마커는 영문 대괄호 그대로 (변형/볼드/escape 금지).
+3. 마커 외 다른 텍스트(인사, 설명, 결론) 금지.
+4. markdown code fence (```) 로 감싸지 마세요.
+5. 모든 섹션이 끝나면 [INITIAL_SETUP_END] 직후 즉시 종료.
+```
+
+# 6. 관찰 결과 (실측 후 채우기)
+
+> 후속 세션이 각 엔진별 raw stdout 을 trace_log 에 dump 한 후 본 섹션을 채운다.
+> 현재는 코드 분석에 그친다.
+
+| 엔진 | exit code | stdout 첫 100자 | 마커 형식 보존 여부 | parse 통과 |
+|---|---|---|---|---|
+| claude | TBD | TBD | TBD | TBD |
+| codex  | TBD | TBD | TBD | TBD |
+| gemini | TBD | TBD | TBD | TBD |
+
+# 7. 결론
+
+Plan 의 Layer A + Layer B 를 우선 적용 (본 PR). H3 는 실측 후 별 이슈로 분리.
+Layer C (JSON 응답 강제) 는 본 PR 범위 밖 — 변경 표면이 크고 H3 가 root cause
+이면 효과가 없다 (CLI 단계에서 fail). 따라서 본 PR 에서는 다루지 않는다.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -28,3 +28,4 @@
 - [knownIssues_2026-04-15](./knownIssues_2026-04-15.md) — 이번 세션 미해결 이슈 체크리스트 + 베타 공개 차단 여부 판단
 - [bkitReferenceReview_2026-04-24](./bkitReferenceReview_2026-04-24.md) — popup-studio-ai/bkit 계열 레퍼런스 검토, 수직 보완 관계 재프레임 + P1~P3 차용 제안
 - [asyncCancelPipelineAudit_2026-04-25](./asyncCancelPipelineAudit_2026-04-25.md) — long-running async + cancel 경로 5 영역 감사 (onboarding fix 부수 산출물). 4 영역 별 plan 후보로 등재
+- [codexGeminiOnboardingResponseAudit_2026-04-25](./codexGeminiOnboardingResponseAudit_2026-04-25.md) — Codex/Gemini 온보딩 분석 실패 (#176) 응답 형식 audit. 가설 + parse_output 강건화 / prompt 강화 fix 방향

--- a/src-tauri/src/commands/project_onboarding.rs
+++ b/src-tauri/src/commands/project_onboarding.rs
@@ -261,9 +261,16 @@ fn build_prompt(
 
 ---
 
-## 출력 형식
+## 출력 형식 (반드시 준수)
 
-아래 두 섹션을 정확한 마커와 함께 출력하세요. 마커 외에 다른 텍스트는 추가하지 마세요.
+아래 섹션들을 정확한 마커와 함께 출력하세요. 다음 규칙을 어기면 응답을 사용할 수 없습니다.
+
+**출력 규칙**:
+1. 응답의 **첫 줄은 `[CLAUDE_MD_START]`** 로 시작해야 합니다. 인사말, 머리말, "다음과 같이 정리했습니다" 등의 introduction 금지.
+2. 마커는 **영문 ASCII 대괄호** 그대로 출력하세요. `[ CLAUDE_MD_START ]` (공백), `**[CLAUDE_MD_START]**` (볼드), `[CLAUDE\_MD\_START]` (escape), `【CLAUDE_MD_START】` (전각괄호) 모두 금지.
+3. 응답을 markdown code fence (```` ``` ````) 로 감싸지 마세요. 마커 자체가 구분자입니다.
+4. 마커 사이의 본문만 작성하고, 마커 외부에는 어떤 설명/결론/맺음말도 적지 마세요.
+5. 마지막 섹션이 끝난 직후 (`[INITIAL_SETUP_END]` 또는 `[REF_INDEX_END]` 다음) **즉시 응답을 종료**하세요.
 
 [CLAUDE_MD_START]
 # {project_name} — Claude Code Handoff Document

--- a/src-tauri/src/commands/project_onboarding.rs
+++ b/src-tauri/src/commands/project_onboarding.rs
@@ -354,17 +354,41 @@ fn build_prompt(
 }
 
 // ─── Parse output ────────────────────────────────────────────────────────────
+//
+// `parse_output` 는 Codex / Gemini / Claude 의 plain-text 응답 안에서 마커로
+// 감싼 3 섹션 (CLAUDE.md, REF_INDEX, INITIAL_SETUP) 을 추출한다. 모델별 응답
+// 형식 차이를 흡수해야 한다 — 자세한 가설은
+// docs/reference/codexGeminiOnboardingResponseAudit_2026-04-25.md 참조.
+//
+// 강건화 포인트 (Layer A):
+//
+// 1. 마커 자체가 markdown bold (`**[CLAUDE_MD_START]**`) 또는 underscore escape
+//    (`[CLAUDE\_MD\_START]`) 로 변형되어도 통과.
+// 2. 마커 앞뒤로 markdown code fence (` ```markdown ... ``` `) 가 있어도 통과.
+// 3. 마커 좌우 공백 / newline / 마크다운 헤더 prefix 자유.
+// 4. 마커 매칭 실패 시 raw 응답 앞 200자를 에러 메시지에 포함 (디버깅 단서).
+// 5. 추출된 본문에서 wrapping markdown fence 자동 strip.
 
 fn parse_output(text: &str) -> Result<(String, String, Option<serde_json::Value>), String> {
-    let claude_md = extract_between(text, "[CLAUDE_MD_START]", "[CLAUDE_MD_END]")
-        .ok_or("AI 응답에서 CLAUDE.md 섹션을 찾을 수 없습니다")?;
-    let ref_index = extract_between(text, "[REF_INDEX_START]", "[REF_INDEX_END]")
-        .ok_or("AI 응답에서 Reference Index 섹션을 찾을 수 없습니다")?;
+    let claude_md = extract_section(text, "CLAUDE_MD")
+        .ok_or_else(|| {
+            let preview = response_preview(text);
+            format!(
+                "AI 응답에서 CLAUDE.md 섹션을 찾을 수 없습니다 (응답 시작 부분: {preview})"
+            )
+        })?;
+    let ref_index = extract_section(text, "REF_INDEX")
+        .ok_or_else(|| {
+            let preview = response_preview(text);
+            format!(
+                "AI 응답에서 Reference Index 섹션을 찾을 수 없습니다 (응답 시작 부분: {preview})"
+            )
+        })?;
     // Optional — fail-soft per plan §7. Unparseable/empty JSON → None, which
     // causes the FE to skip the Initial Setup section entirely.
-    let initial_setup = extract_between(text, "[INITIAL_SETUP_START]", "[INITIAL_SETUP_END]")
+    let initial_setup = extract_section(text, "INITIAL_SETUP")
         .and_then(|raw| {
-            let trimmed = raw.trim();
+            let trimmed = strip_code_fences(raw.trim());
             if trimmed.is_empty() { return None; }
             match serde_json::from_str::<serde_json::Value>(trimmed) {
                 Ok(v) => {
@@ -377,13 +401,113 @@ fn parse_output(text: &str) -> Result<(String, String, Option<serde_json::Value>
                 }
             }
         });
-    Ok((claude_md.trim().to_string(), ref_index.trim().to_string(), initial_setup))
+    Ok((
+        clean_section(&claude_md),
+        clean_section(&ref_index),
+        initial_setup,
+    ))
 }
 
-fn extract_between<'a>(text: &'a str, start: &str, end: &str) -> Option<&'a str> {
-    let s = text.find(start)? + start.len();
-    let e = text[s..].find(end)? + s;
-    Some(&text[s..e])
+/// 강건화된 마커 추출. `name` 은 "CLAUDE_MD" 같은 베이스 이름 — 함수가 자동으로
+/// `[<name>_START]` / `[<name>_END]` 마커 변형을 매칭한다.
+///
+/// 받아들이는 변형:
+/// - `[CLAUDE_MD_START]`           — 정상
+/// - `**[CLAUDE_MD_START]**`        — markdown bold (외곽 ** 는 capture 밖)
+/// - `[CLAUDE\_MD\_START]`          — underscore escape (markdown 안전 처리)
+/// - 마커 좌우 공백 / newline 자유
+fn extract_section(text: &str, name: &str) -> Option<String> {
+    use regex::Regex;
+    // 마커 패턴 — 외곽 markdown bold (`**`) 와 underscore escape 를 허용.
+    // `name + "_START"` / `name + "_END"` 전체를 token 화 하여 마지막 underscore 도
+    // escape 허용 안에 들어오게 한다.
+    let start_token = marker_token_pattern(&format!("{name}_START"));
+    let end_token   = marker_token_pattern(&format!("{name}_END"));
+    let pattern = format!(
+        r"(?s)(?:\*\*)?\[\s*{start_token}\s*\](?:\*\*)?(.*?)(?:\*\*)?\[\s*{end_token}\s*\](?:\*\*)?",
+    );
+    let re = Regex::new(&pattern).ok()?;
+    re.captures(text)
+        .and_then(|caps| caps.get(1))
+        .map(|m| m.as_str().to_string())
+}
+
+/// 마커 이름 (`CLAUDE_MD_START` 등) 을 regex 패턴화. 언더스코어가 markdown
+/// escape (`\_`) 로 들어와도 매칭하도록 허용한다.
+fn marker_token_pattern(name: &str) -> String {
+    let mut out = String::with_capacity(name.len() * 4);
+    for ch in name.chars() {
+        if ch == '_' {
+            // 백슬래시 0개 또는 1개 + underscore. regex 입력에서 `\\?_` 는
+            // "literal backslash optional + underscore" 를 의미.
+            out.push_str(r"\\?_");
+        } else {
+            for esc_ch in regex::escape(&ch.to_string()).chars() {
+                out.push(esc_ch);
+            }
+        }
+    }
+    out
+}
+
+/// 추출된 섹션 본문 정리: trim + 양끝 markdown fence strip + 양끝 markdown
+/// emphasis (`**` / `*`) strip.
+fn clean_section(body: &str) -> String {
+    let t = body.trim();
+    let t = strip_code_fences(t);
+    let t = strip_emphasis_edges(t);
+    t.trim().to_string()
+}
+
+/// 본문 양끝에 남은 markdown emphasis 토큰을 제거. 마커가 `**[X_START]**` 식
+/// 으로 둘러싸여 있을 때 lazy regex 매칭이 capture 안에 잔재 emphasis 를 남기는
+/// 케이스를 흡수한다.
+fn strip_emphasis_edges(s: &str) -> &str {
+    let mut t = s.trim();
+    // 시작 emphasis (앞쪽)
+    while let Some(rest) = t.strip_prefix("**").or_else(|| t.strip_prefix('*')) {
+        if rest == t { break; }
+        t = rest.trim_start_matches('\n').trim_start();
+    }
+    // 끝 emphasis (뒤쪽)
+    while let Some(rest) = t.strip_suffix("**").or_else(|| t.strip_suffix('*')) {
+        if rest == t { break; }
+        t = rest.trim_end_matches('\n').trim_end();
+    }
+    t
+}
+
+/// ` ```lang\n...\n``` ` 형태의 markdown fence 가 본문 양끝을 감싸고 있으면 제거.
+/// 한 번만 strip (중첩은 다루지 않음). 닫는 ``` 가 없으면 원본 유지.
+fn strip_code_fences(s: &str) -> &str {
+    let trimmed = s.trim();
+    if !trimmed.starts_with("```") {
+        return trimmed;
+    }
+    // 첫 줄 ``` 또는 ```lang
+    let after_open = match trimmed.find('\n') {
+        Some(i) => &trimmed[i + 1..],
+        None => return trimmed,
+    };
+    // 닫는 ``` 위치
+    if let Some(close_idx) = after_open.rfind("```") {
+        let inner = &after_open[..close_idx];
+        return inner.trim_end_matches('\n');
+    }
+    trimmed
+}
+
+/// 사용자 / 로그용 응답 프리뷰 (앞 200 chars, newline → space).
+fn response_preview(text: &str) -> String {
+    let one_line: String = text.chars().map(|c| if c == '\n' { ' ' } else { c }).collect();
+    let trimmed = one_line.trim();
+    if trimmed.chars().count() > 200 {
+        let mut out: String = trimmed.chars().take(200).collect();
+        out.push_str("...");
+        out
+    } else {
+        trimmed.to_string()
+    }
 }
 
 // ─── AI call (engine-agnostic) ───────────────────────────────────────────────
@@ -710,7 +834,7 @@ pub fn apply_project_onboarding(
 
 #[cfg(test)]
 mod tests {
-    use super::parse_output;
+    use super::{parse_output, strip_code_fences};
 
     #[test]
     fn parse_output_legacy_without_initial_setup() {
@@ -795,5 +919,98 @@ b
     fn parse_output_missing_claude_md_errors() {
         let text = "[REF_INDEX_START]\nx\n[REF_INDEX_END]\n";
         assert!(parse_output(text).is_err());
+    }
+
+    // ─── Layer A 강건화 fixture (codexGeminiOnboardingResponseAudit_2026-04-25) ──
+
+    /// Gemini-style: 마커 앞에 introduction + 응답 전체를 markdown fence 로
+    /// 감싸기. 본문 안에 마커가 그대로 남아 있으면 통과해야 한다.
+    #[test]
+    fn parse_output_gemini_markdown_fence_with_intro() {
+        let text = "다음과 같이 정리했습니다:\n\n```markdown\n[CLAUDE_MD_START]\n# foo\n[CLAUDE_MD_END]\n\n[REF_INDEX_START]\n# bar\n[REF_INDEX_END]\n```\n\n추가 도움이 필요하면 말씀해 주세요.";
+        let (md, idx, init) = parse_output(text).expect("should parse with intro + fence");
+        assert_eq!(md, "# foo");
+        assert_eq!(idx, "# bar");
+        assert!(init.is_none());
+    }
+
+    /// Codex / Claude 가 마커 자체를 markdown bold 로 처리한 케이스.
+    #[test]
+    fn parse_output_marker_with_bold_emphasis() {
+        let text = "**[CLAUDE_MD_START]**\n# foo\n**[CLAUDE_MD_END]**\n\n**[REF_INDEX_START]**\n# bar\n**[REF_INDEX_END]**";
+        let (md, idx, _init) = parse_output(text).expect("bold marker should parse");
+        assert_eq!(md, "# foo");
+        assert_eq!(idx, "# bar");
+    }
+
+    /// 한국어 모델이 underscore 를 markdown escape (`\_`) 로 변환한 케이스.
+    #[test]
+    fn parse_output_marker_with_underscore_escape() {
+        let text = r#"[CLAUDE\_MD\_START]
+# foo
+[CLAUDE\_MD\_END]
+[REF\_INDEX\_START]
+# bar
+[REF\_INDEX\_END]
+"#;
+        let (md, idx, _init) = parse_output(text).expect("escaped underscore should parse");
+        assert_eq!(md, "# foo");
+        assert_eq!(idx, "# bar");
+    }
+
+    /// 마커 양옆에 공백 포함 (`[ CLAUDE_MD_START ]`).
+    #[test]
+    fn parse_output_marker_with_inner_whitespace() {
+        let text = "[ CLAUDE_MD_START ]\n# foo\n[ CLAUDE_MD_END ]\n[ REF_INDEX_START ]\n# bar\n[ REF_INDEX_END ]";
+        let (md, idx, _init) = parse_output(text).expect("padded marker should parse");
+        assert_eq!(md, "# foo");
+        assert_eq!(idx, "# bar");
+    }
+
+    /// 마커 매칭 실패 시 raw 응답의 앞 200자가 에러 메시지에 포함되어야 한다.
+    #[test]
+    fn parse_output_failure_includes_response_preview() {
+        let text = "Sure! Here is the answer to your question:\n\nThe project looks like a Rust app...";
+        let err = parse_output(text).expect_err("should fail without markers");
+        assert!(
+            err.contains("Sure! Here is the answer"),
+            "preview missing in error: {err}"
+        );
+    }
+
+    /// 추출된 INITIAL_SETUP JSON 본문이 ```json fence 안에 들어 있어도 통과해야 한다.
+    #[test]
+    fn parse_output_initial_setup_inside_fence() {
+        let text = r#"[CLAUDE_MD_START]
+a
+[CLAUDE_MD_END]
+[REF_INDEX_START]
+b
+[REF_INDEX_END]
+[INITIAL_SETUP_START]
+```json
+{
+  "agent_profiles": [],
+  "skills": ["rust-review"],
+  "workflow": { "review_track": "deep", "context_mode": "auto", "rt_participants": [] },
+  "rationale": "fence 안에 든 JSON"
+}
+```
+[INITIAL_SETUP_END]
+"#;
+        let (_md, _idx, init) = parse_output(text).expect("fenced JSON should parse");
+        let v = init.expect("initial_setup present");
+        assert_eq!(v["skills"][0], "rust-review");
+        assert_eq!(v["workflow"]["review_track"], "deep");
+    }
+
+    /// `strip_code_fences` 단위 동작.
+    #[test]
+    fn strip_code_fences_basic() {
+        assert_eq!(strip_code_fences("plain"), "plain");
+        assert_eq!(strip_code_fences("```\nhello\n```"), "hello");
+        assert_eq!(strip_code_fences("```json\n{\"a\":1}\n```"), "{\"a\":1}");
+        // 닫는 ``` 가 없으면 원본 유지
+        assert_eq!(strip_code_fences("```\nhello"), "```\nhello");
     }
 }


### PR DESCRIPTION
## Summary

Plan: [`docs/plans/codexGeminiOnboardingAnalysisFailureInvestigationPlan_2026-04-25.md`](../blob/main/docs/plans/codexGeminiOnboardingAnalysisFailureInvestigationPlan_2026-04-25.md)
Sibling issues: #176 (community report, follow-up confirms engine-dependency) / #189 + PR #190 (cancel leak fix)

`call_cli_agent` 가 세 엔진 (claude/codex/gemini) 공통 dispatcher 라 분기점은 **(a) CLI argv** 와 **(b) 모델 응답 형식** 두 가지뿐. Claude 는 `--output-format text` 명시 + 마커를 본 학습 노출이 많아 그대로 출력. Codex/Gemini 는 마커를 임의 포맷 지시로 받아들이고 markdown 친화 형태로 변형 → 기존 strict substring 매칭이 fail.

본 PR 은 Layer A (parse 강건화) + Layer B (prompt 강화) 를 적용. Layer C (JSON 응답 강제) 는 변경 표면이 크고 Issue #176 의 root cause 가 H3 (CLI exit code) 일 가능성도 있어 본 PR 범위 밖으로 분리.

## 변경 요약

- **`docs/reference/codexGeminiOnboardingResponseAudit_2026-04-25.md`** — 코드 경로 분석 + 5개 가설 (H1~H5) + fix 우선순위 정리
- **Layer A: `parse_output` 강건화** — substring `extract_between` 을 regex 기반 `extract_section` 으로 교체. 다음 변형을 흡수:
  - markdown bold (`**[CLAUDE_MD_START]**`)
  - underscore escape (`[CLAUDE\_MD\_START]`)
  - 마커 좌우 공백 / heading prefix
  - 응답 전체를 ` ```markdown ... ``` ` 로 감싸기
  - INITIAL_SETUP JSON 본문이 ` ```json ... ``` ` 안에 들어 있는 케이스
  - 마커 매칭 실패 시 raw 응답 앞 200자를 에러 메시지에 포함 (디버깅 단서)
- **Layer B: `build_prompt` 강화** — 출력 규칙 5건 명시 (intro 금지 / ASCII 대괄호만 / fence 금지 / 외부 텍스트 금지 / `[_END]` 즉시 종료)
- **신규 fixture 7건** (기존 5 → 12). Gemini intro+fence, bold marker, underscore escape, padded marker, failure preview, fenced INITIAL_SETUP, `strip_code_fences` 단위.

## Test plan

- [x] `cargo check --lib` OK (warning 1건은 기존 dead code)
- [x] `cargo test --lib commands::project_onboarding` — 12 passed
- [x] `cargo test --lib` 전체 — 503 passed
- [ ] (수동, 후속) 빈 프로젝트 + Codex / Gemini 메타 분석 실제 실행 → `[CLAUDE_MD_START]...` 추출 성공. raw stdout 은 audit 문서 §6 에 추가
- [ ] (수동, 후속) Issue #176 follow-up 의 정확한 에러 message 가 "분석 실패 (exit: ...)" 류 였는지 확인 → H3 (CLI exit code) 별 이슈 분리 여부 결정

## 후속

- **H3 (CLI exit code)** — Codex `--full-auto` 인증 미설정 / 모델 불일치 시 non-zero exit 가능성. 별 이슈로 분리 예정.
- **Layer C (JSON 응답 강제)** — H1~H5 가 Layer A/B 로 흡수되지 않으면 Issue 재오픈 후 도입.

🤖 Generated with [Claude Code](https://claude.com/claude-code)