### PR TITLE
feat(session): brand inherits main CLI session — sdk-url WS key normalize + ContextPack waste fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,7 @@ cd src-tauri && cargo test --lib  # Rust unit tests (485 tests)
 | `docs/reference/sessionHistory.md` | **세션 이력 전체** — 새 세션 시작 시 또는 과거 결정 맥락 필요 시 읽기 |
 | `docs/reference/dataModelRevised.md` | 도메인 모델 SSOT |
 | `docs/reference/implementationStatus.md` | 기능별 구현 현황 + Provider 비교 테이블 |
+| `docs/reference/branchSessionPolicy.md` | **brand session = main session 공유 원칙** (interactive session backbone, INV-1~5) |
 | `docs/plans/index.md` | 40+개 plan 상태 인덱스 |
 | `docs/prompts/index.md` | 실행 프롬프트 인덱스 |
 | `docs/plans/threadModelRoundtableRedesign.md` | RT/Branch 통합 설계 |

--- a/docs/ideas/ptySessionPolicy.md
+++ b/docs/ideas/ptySessionPolicy.md
@@ -1,9 +1,19 @@
 # PTY 세션 정책 — 채팅=세션 1:1 매핑
 
-> Status: draft
+> Status: archived (superseded by `docs/reference/branchSessionPolicy.md`)
 > Created: 2026-04-11
+> Archived: 2026-04-25 (s40, sdk-url WS 전환 후 일반화)
 > Branch: `feature/pty-interactive`
 > 연관: `ptyFullIntegrationPlan.md`, `ptyInteractiveIdea.md`
+> Superseded by: `docs/reference/branchSessionPolicy.md` — PTY 의존 제거하고
+> "interactive session backbone (PTY → sdk-url WS / codex app-server)" 로
+> 일반화한 SSOT.
+
+> **본 문서의 원래 의도 (`Branch | 부모 채팅의 PTY 세션 공유`, line 164) 는
+> branchSessionPolicy.md 의 INV-1~INV-5 로 옮겨졌다.** PTY → WS 전환 후
+> 6 세션 (s36~s40) 동안 의도가 task 파이프라인으로 surface 되지 못해 코드와
+> divergence 가 발생했고, `docs/plans/branchInheritsMainSessionPlan_2026-04-25.md`
+> 가 회복 작업을 추적한다.
 
 ---
 

--- a/docs/reference/branchSessionPolicy.md
+++ b/docs/reference/branchSessionPolicy.md
@@ -1,0 +1,120 @@
+---
+title: Branch session policy — brand 는 main interactive session 을 공유한다
+status: active
+canonical: true
+priority: P1 (사용자 의도 SSOT, 토큰 낭비 방지)
+created_at: 2026-04-25
+updated_at: 2026-04-25
+supersedes:
+  - docs/ideas/ptySessionPolicy.md  # PTY 시대 정책. WS 전환 후 일반화한 본 문서가 SSOT
+related:
+  - docs/plans/branchInheritsMainSessionPlan_2026-04-25.md  # 본 정책의 코드 회복 작업
+  - docs/plans/sessionContinuityFixPlan.md
+  - docs/plans/longTermMemoryRoadmapPlan_2026-03-30.md  # SSOT-first memory 철학
+  - src-tauri/src/agents/claude_sdk_session.rs
+  - src-tauri/src/agents/codex_app_server.rs
+  - src-tauri/src/commands/agents_helpers/send_common/context_loading.rs
+---
+
+# 핵심 원칙
+
+> **branch 는 main 의 interactive session 을 그대로 이어받는다.**
+
+분기→adopt/폐기 흐름에서 brand 는 "같은 사고의 연장" 이지 "별 세션" 이 아니다.
+이 결정은 PTY 시대 (`docs/ideas/ptySessionPolicy.md:164`) 부터 사용자가 박아둔
+의도이며, sdk-url WS 모드 (s36, 2026-04-15) 와 codex app-server 모드에서도 동일
+하게 유지된다. SSOT 는 본 문서.
+
+## 사용자 직접 인용 (raw conversation log)
+
+> 브랜치는 ws모드로 입장하는데 엔진이 바뀌면 어떻게 맥락을 알려주지? 그리고
+> 가능하면 **컨텍스트팩에 모든걸 넣지말고 중요한 컨텍스트+필요시 검색할 수 있는
+> 대규모의 컨텍스트 저장소(첫대화부터 직전대화까지 모두 원본으로 저장되어있는)**
+> 가 있잖아? — 2026-04-17 (PTY → WS 전환 시기, jsonl `037bb82f`)
+
+> RT는 컨텍스트팩으로도 충분했고, **브랜치는 메인에서 바로 이어지는 건데
+> 컨텍스트팩 올리면 낭비**라고 생각했었었고 — 2026-04-25
+
+# Invariants (코드 검증 가능한 형태)
+
+- **[INV-1]** brand:* shadow conv 의 send 가 사용하는 SESSIONS / RESUME_IDS /
+  CONV_THREADS lookup 키는 **root main `conversation_id`**.
+  검증: `src-tauri/src/agents/claude_sdk_session.rs::session_key_for`,
+  `src-tauri/src/agents/codex_app_server.rs::current_thread_key/get_or_create_thread`.
+
+- **[INV-2]** brand send 시 **(same engine as root)** ContextPack 의
+  `recent_context` / `parent_messages` / `compressed_memory` /
+  `retrieval_chunks` / `cross_session_data` / `thread_inheritance` /
+  `document_chunks` 빌드 skip. 정적 레이어 (identity / persona / project /
+  agent-role) 만 포함.
+  검증: `src-tauri/src/commands/agents_helpers/send_common/context_loading.rs::apply_branch_session_inheritance`.
+
+- **[INV-3]** **engine 변경 시** (예: Claude → Codex) brand 는 별 session 으로
+  fallback. ContextPack 정상 빌드 (현재 동작 유지). brand same-engine 로직은
+  no-op.
+  검증: 위 helper 의 `is_engine_continuity` 분기.
+
+- **[INV-4]** **DB raw 메시지가 SSOT.** retrieval / compressed memory /
+  vector search 는 SSOT 위 helper layer 이며 정책 위배가 아니다. brand 가
+  필요하면 `tool-request:recent_turns:N` 마커로 명시 조회한다.
+
+- **[INV-5]** 본 정책은 brand session 통합 + ContextPack 낭비 제거 범위.
+  shadow conv DB 모델, adopt summary placeholder, branches 테이블, UI 드로어
+  등은 그대로 유지.
+
+# 데이터 모델
+
+shadow conversation 모델은 손대지 않는다 (UI 격리 + 메시지 보존). 변경 지점은
+**runtime 레지스트리 키** 와 **ContextPack 조립 로직** 두 곳뿐.
+
+| 레지스트리 | 위치 | 키 정책 |
+|---|---|---|
+| `SESSIONS` | `claude_sdk_session.rs` | brand:* → root main conv_id |
+| `RESUME_IDS` | `claude_sdk_session.rs` | brand:* → root main conv_id |
+| `CONV_THREADS` | `codex_app_server.rs` | brand:* → root main conv_id |
+| `BRANCH_ROOT_CACHE` | `claude_sdk_session.rs` | brand:* → root main conv_id (helper 1회 lookup 용) |
+| `LAST_DELIVERED_KEY` | `session_freshness.rs` | conv_id 그대로 (freshness 비교는 brand 와 main 모두 root key 의 sdk session 식별자를 보므로 동일) |
+
+# brand → main session 연결의 수명주기
+
+| 이벤트 | 동작 |
+|---|---|
+| brand 첫 send (Claude) | `cache_branch_root_from_db` 가 BRANCH_ROOT_CACHE 채움 → SESSIONS / RESUME_IDS lookup 이 root key 로 정규화 → main 의 sdk-url WS 세션 재사용 |
+| brand 첫 send (Codex) | `session_key_for` → CONV_THREADS lookup 이 root key 로 정규화 → main 의 codex thread 재사용 |
+| brand send 시 engine 동일 | ContextPack dynamic 섹션 비움 (sdk-url WS / codex thread 가 prior history 보유) |
+| brand send 시 engine 다름 | 별 session 으로 fallback. ContextPack 정상 빌드 (정적 + dynamic). main 세션은 그대로 둔다 |
+| brand adopt | shadow conv 의 메시지를 summary 로 main 에 insert. session 은 그대로 살아 있음 (다음 main send 가 같은 sdk session 재사용) |
+| brand archive/delete | 단순히 shadow conv 만 hidden. session 은 main 이 계속 사용 |
+
+# 엔진별 세션 backbone (현재)
+
+| 엔진 | Backbone | brand 공유 매커니즘 |
+|---|---|---|
+| claude (claude-code) | `claude --sdk-url` WS + HTTP POST events | SESSIONS/RESUME_IDS root key |
+| codex | `codex app-server --listen ws` (JSON-RPC 2.0) | CONV_THREADS root key |
+| gemini | one-shot CLI (현재) | brand 공유 미적용 (engine 변경 시 fallback 과 동일 경로) |
+| ollama / lmstudio | one-shot HTTP (openai-compat) | 동일 — 매 send 별 session |
+
+# 구현 가이드 — 새 backbone 추가 시
+
+새 엔진을 stateful interactive session 으로 도입할 때 본 정책을 따르려면:
+
+1. session/thread registry 의 모든 lookup 에 `claude_sdk_session::session_key_for(conv_id)` 통과
+2. ContextPack continuation 판정 (`session_freshness::current_session_key`) 에
+   해당 엔진 분기 추가 — `claude` / `codex` 와 동일한 패턴
+3. brand 첫 send 진입점에서 `cache_branch_root_from_db` 가 캐시를 채우도록 보장
+4. INV-3 (engine 변경 시 fallback) 보존 검증 — 다른 엔진의 brand 는 normalize
+   하지 않는다 (각 엔진의 session 은 분리 유지)
+
+# 사용자 의도 SSOT 보존 (메타 노트)
+
+본 정책의 invariant 들은 **사용자가 raw conversation 에 박아둔 의도** 를 코드
+가능한 형태로 옮겨 둔 것이다. s36 → s40 사이에 의도가 task 파이프라인으로
+surface 되지 못해 6 세션 간 divergence 가 누적됐고, 그 사이 (s38) 에는 반대
+방향 (brand 도 ContextPack 으로 채우는 방향) 의 변경이 들어가기까지 했다.
+
+이 클래스의 의도 누락을 막는 메타 작업은 별 plan 으로 추적된다:
+`docs/plans/userIntentSsotSurfacingPlan_2026-04-25.md`.
+
+본 문서를 옮기거나 갱신할 때는 **사용자 의도 인용** 섹션을 절대 약화시키지 말
+것 — 의도의 raw evidence 를 잃으면 같은 divergence 가 재발한다.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -5,6 +5,7 @@
 - [GLOSSARY](./GLOSSARY.md)
 - [currentStateReview](./currentStateReview.md)
 - [dataModelRevised](./dataModelRevised.md)
+- [branchSessionPolicy](./branchSessionPolicy.md) — brand 가 main interactive session 을 공유한다는 SSOT (INV-1~5). Layer A/B/C 코드 회복은 `docs/plans/branchInheritsMainSessionPlan_2026-04-25.md`
 - [frontendArchitecture](./frontendArchitecture.md)
 - [implementationStatus](./implementationStatus.md)
 - [modelDiscoveryNotes](./modelDiscoveryNotes.md)

--- a/src-tauri/src/agents/claude_sdk_session.rs
+++ b/src-tauri/src/agents/claude_sdk_session.rs
@@ -153,7 +153,9 @@ lazy_static::lazy_static! {
 /// 을 잡는 부담을 피하기 위함.
 ///
 /// non-branch conv_id 는 그대로 반환.
-fn session_key_for(conv_id: &str) -> String {
+///
+/// pub: session_freshness 모듈 (LAST_DELIVERED 키 normalize) 에서도 사용.
+pub fn session_key_for(conv_id: &str) -> String {
     if conv_id.starts_with("branch:") {
         if let Some(root) = BRANCH_ROOT_CACHE.lock().get(conv_id).cloned() {
             return root;

--- a/src-tauri/src/agents/claude_sdk_session.rs
+++ b/src-tauri/src/agents/claude_sdk_session.rs
@@ -127,10 +127,88 @@ impl Drop for SdkSession {
 type SessionRegistry = Arc<PlMutex<HashMap<String, Arc<SdkSession>>>>;
 /// conversation_id → 마지막 result session_id (세션 종료 후에도 --resume용으로 보존)
 type ResumeRegistry = Arc<PlMutex<HashMap<String, String>>>;
+/// `branch:<branch_id>` shadow conv → root main conversation_id 캐시.
+///
+/// **의도** (`docs/plans/branchInheritsMainSessionPlan_2026-04-25.md`):
+/// brand 는 main session 을 공유해야 한다 (사용자 원래 의도, raw log
+/// `037bb82f` 2026-04-17). SESSIONS / RESUME_IDS 는 root main conv_id 로
+/// keying 하여 brand send 가 main 의 claude `--sdk-url` 세션을 그대로
+/// 이어받는다.
+///
+/// 캐시 채우는 시점: `bootstrap_resume_id_from_db` 등 DbState 가 있는 진입점.
+/// cache miss 시엔 fallback 으로 conv_id 자체 사용 (backward-compatible).
+type BranchRootCache = Arc<PlMutex<HashMap<String, String>>>;
 
 lazy_static::lazy_static! {
     static ref SESSIONS: SessionRegistry = Arc::new(PlMutex::new(HashMap::new()));
     static ref RESUME_IDS: ResumeRegistry = Arc::new(PlMutex::new(HashMap::new()));
+    static ref BRANCH_ROOT_CACHE: BranchRootCache = Arc::new(PlMutex::new(HashMap::new()));
+}
+
+/// brand:* conv_id 를 root main conversation_id 로 normalize.
+///
+/// 메모리 캐시 (`BRANCH_ROOT_CACHE`) 만 본다. 캐시가 비어 있으면 conv_id 자체를
+/// 반환 — 호출자는 사전에 `cache_branch_root_from_db` 로 채워두어야 한다.
+/// 이렇게 분리한 이유: 여러 hot path (SESSIONS lookup 등) 에서 매번 DB read lock
+/// 을 잡는 부담을 피하기 위함.
+///
+/// non-branch conv_id 는 그대로 반환.
+fn session_key_for(conv_id: &str) -> String {
+    if conv_id.starts_with("branch:") {
+        if let Some(root) = BRANCH_ROOT_CACHE.lock().get(conv_id).cloned() {
+            return root;
+        }
+    }
+    conv_id.to_string()
+}
+
+/// brand:* conv_id 의 root main conv_id 를 DB 에서 조회해 캐시에 저장.
+///
+/// `branches.conversation_id` 컬럼은 이미 root main conv_id 를 보유한다
+/// (`commands/branches.rs:120-141` 의 `root_conv_id` resolution).
+///
+/// `parent_branch_id` 체인은 nested branch (b1.1, b1.1.1 등) 의 경우에도
+/// 같은 row 의 `conversation_id` 가 root 를 가리키므로 1회 lookup 으로 충분.
+///
+/// 호출 지점: `bootstrap_resume_id_from_db`. non-branch conv 또는 이미
+/// 캐시된 경우 no-op.
+pub fn cache_branch_root_from_db(conv_id: &str, db: &crate::db::DbState) {
+    let Some(branch_id) = conv_id.strip_prefix("branch:") else {
+        return;
+    };
+    if BRANCH_ROOT_CACHE.lock().contains_key(conv_id) {
+        return;
+    }
+    let Ok(conn) = db.read.lock() else { return };
+    let root: Option<String> = conn
+        .query_row(
+            "SELECT conversation_id FROM branches WHERE id = ?1",
+            [branch_id],
+            |row| row.get::<_, String>(0),
+        )
+        .ok();
+    if let Some(root_id) = root {
+        // branches.conversation_id 가 root 가 아닌 경우는 거의 없지만
+        // (create_branch 가 root 로 정규화함) 방어적으로 다시 strip 한다.
+        let normalized = if let Some(inner) = root_id.strip_prefix("branch:") {
+            // 이론상 도달하지 않는 경로 — fallback 으로 한 단계 더.
+            conn.query_row(
+                "SELECT conversation_id FROM branches WHERE id = ?1",
+                [inner],
+                |row| row.get::<_, String>(0),
+            )
+            .unwrap_or(root_id.clone())
+        } else {
+            root_id
+        };
+        BRANCH_ROOT_CACHE
+            .lock()
+            .insert(conv_id.to_string(), normalized.clone());
+        eprintln!(
+            "[sdk-session] branch root cached: {} → {}",
+            conv_id, normalized
+        );
+    }
 }
 
 /// DB 의 `conversations.resume_token` 을 `RESUME_IDS` 메모리 레지스트리로 로드한다.
@@ -148,8 +226,13 @@ lazy_static::lazy_static! {
 ///
 /// sessionContinuityFixPlan.md task-02 (INV-4).
 pub fn bootstrap_resume_id_from_db(conv_id: &str, db: &crate::db::DbState) -> Option<String> {
+    // brand:* 진입점 — root conv 로 normalize 하기 위해 캐시 채움.
+    // (claude session 통합: brand 는 main 의 sdk-url WS 세션을 공유한다.)
+    cache_branch_root_from_db(conv_id, db);
+    let key = session_key_for(conv_id);
+
     // 이미 메모리에 있으면 skip (DB 보다 메모리 값이 최신일 수 있음)
-    if let Some(existing) = RESUME_IDS.lock().get(conv_id).cloned() {
+    if let Some(existing) = RESUME_IDS.lock().get(&key).cloned() {
         return Some(existing);
     }
     let conn = db.read.lock().ok()?;
@@ -159,15 +242,15 @@ pub fn bootstrap_resume_id_from_db(conv_id: &str, db: &crate::db::DbState) -> Op
              WHERE id = ?1 \
                AND resume_token IS NOT NULL \
                AND resume_token_engine IN ('claude','claude-code')",
-            [conv_id],
+            [&key],
             |row| row.get(0),
         )
         .ok();
     if let Some(ref t) = token {
-        RESUME_IDS.lock().insert(conv_id.to_string(), t.clone());
+        RESUME_IDS.lock().insert(key.clone(), t.clone());
         eprintln!(
-            "[sdk-session] bootstrapped RESUME_IDS conv={} from DB resume_token",
-            conv_id
+            "[sdk-session] bootstrapped RESUME_IDS conv={} (key={}) from DB resume_token",
+            conv_id, key
         );
     }
     token
@@ -187,10 +270,13 @@ pub async fn get_or_create_session(
         _ => "claude-sonnet-4-6",
     };
 
+    // brand 가 main 세션을 공유하도록 키 normalize (Layer A).
+    let key = session_key_for(conv_id);
+
     // 기존 세션 확인 (sync lock, await 없음)
     let existing = {
         let sessions = SESSIONS.lock();
-        sessions.get(conv_id).map(|s| Arc::clone(s))
+        sessions.get(&key).map(|s| Arc::clone(s))
     };
 
     if let Some(session) = existing {
@@ -204,15 +290,17 @@ pub async fn get_or_create_session(
         // UI는 무한 streaming 대신 명확한 에러를 받게 된다.
         send_set_model(&session, effective_model)?;
         *session.model.lock() = effective_model.to_string();
-        eprintln!("[sdk-session] model changed via control_request: {} → {} for conv: {}",
-            current_model, effective_model, conv_id);
+        eprintln!("[sdk-session] model changed via control_request: {} → {} for conv: {} (key={})",
+            current_model, effective_model, conv_id, key);
         return Ok(session);
     }
 
     // 기존 세션 없음 — 새로 스폰. RESUME_IDS의 prior session_id로 --resume 가능.
-    let resume_id = RESUME_IDS.lock().get(conv_id).cloned();
-    let session = spawn_session(conv_id, project_path, effective_model, resume_id.as_deref()).await?;
-    SESSIONS.lock().insert(conv_id.to_string(), Arc::clone(&session));
+    let resume_id = RESUME_IDS.lock().get(&key).cloned();
+    // spawn_session 내부의 monitor task 가 SESSIONS 에서 entry 를 제거할 때 같은 key 를
+    // 써야 하므로 key (root main conv) 를 전달.
+    let session = spawn_session(&key, project_path, effective_model, resume_id.as_deref()).await?;
+    SESSIONS.lock().insert(key, Arc::clone(&session));
     Ok(session)
 }
 
@@ -250,19 +338,27 @@ pub fn kill_session_clear_resume(conv_id: &str) {
 }
 
 fn kill_session_with_resume(conv_id: &str, keep_resume: bool) {
-    SESSIONS.lock().remove(conv_id);
+    let key = session_key_for(conv_id);
+    SESSIONS.lock().remove(&key);
     if !keep_resume {
-        RESUME_IDS.lock().remove(conv_id);
+        RESUME_IDS.lock().remove(&key);
     }
-    // ContextPack freshness: 세션이 죽으면 LAST_DELIVERED도 무효화 — 다음 send는 full로 강제
+    // ContextPack freshness: 세션이 죽으면 LAST_DELIVERED도 무효화 — 다음 send는 full로 강제.
+    // brand 와 main 모두 무효화해야 일관성 유지.
     crate::commands::agents_helpers::send_common::session_freshness::clear_delivered_key(conv_id);
+    if key != conv_id {
+        crate::commands::agents_helpers::send_common::session_freshness::clear_delivered_key(&key);
+    }
     // SdkSession Drop → _shutdown_tx 전송 → axum 서버 종료 → _monitor_abort 취소
 }
 
 /// 해당 conversation에 활성 SDK 세션이 있는지 확인한다.
 /// UI send-guard용 (WS 연결 전 send 시도 차단).
+///
+/// brand:* conv 는 main session 을 공유하므로 main 의 활성 여부를 본다 (Layer A).
 pub fn has_active_session(conv_id: &str) -> bool {
-    SESSIONS.lock().contains_key(conv_id)
+    let key = session_key_for(conv_id);
+    SESSIONS.lock().contains_key(&key)
 }
 
 /// ContextPack freshness 판정용 — 현재 활성 세션의 식별 키.
@@ -277,15 +373,18 @@ pub fn has_active_session(conv_id: &str) -> bool {
 /// router UUID 로 떨어지되, 키 prefix 를 `claude-ws:router:` 로 분리해 누수 시
 /// 쉽게 식별. process_alive=false 이면 None — is_session_continuation=false 강제.
 pub fn current_session_key(conv_id: &str) -> Option<String> {
+    // brand:* 는 main session 공유 (Layer A).
+    let key = session_key_for(conv_id);
+
     // (a) Claude 자체 session identity 우선. WS respawn 후에도 유지.
-    if let Some(sid) = RESUME_IDS.lock().get(conv_id).cloned() {
+    if let Some(sid) = RESUME_IDS.lock().get(&key).cloned() {
         return Some(format!("claude-ws:{}", sid));
     }
     // (b) Fallback — 첫 send, RESUME_IDS 미채워짐. router UUID 를 prefix 로 분리.
     //     첫 send 는 어차피 LAST_DELIVERED 가 비어 있어 is_session_continuation=false
     //     로 자연스럽게 흐르므로 이 fallback 이 계속 쓰이는 일은 없다.
     let sessions = SESSIONS.lock();
-    let s = sessions.get(conv_id)?;
+    let s = sessions.get(&key)?;
     if !s.process_alive.load(std::sync::atomic::Ordering::Relaxed) {
         return None;
     }
@@ -302,12 +401,13 @@ pub async fn prewarm_session(
     project_path: Option<&str>,
     model: Option<&str>,
 ) {
-    // 이미 세션이 있으면 스킵
-    let exists = SESSIONS.lock().contains_key(conv_id);
+    // brand:* 는 main session 공유 — main 의 세션이 있으면 prewarm 스킵 (Layer A).
+    let key = session_key_for(conv_id);
+    let exists = SESSIONS.lock().contains_key(&key);
     if exists { return; }
 
     match get_or_create_session(conv_id, project_path, model).await {
-        Ok(_) => eprintln!("[sdk-session] prewarmed conv={}", conv_id),
+        Ok(_) => eprintln!("[sdk-session] prewarmed conv={} (key={})", conv_id, key),
         Err(e) => eprintln!("[sdk-session] prewarm failed conv={}: {}", conv_id, e),
     }
 }
@@ -630,6 +730,8 @@ where
     on_progress("Agent initializing...".into());
 
     let conv_id_owned = conv_id.to_string();
+    // brand:* conv 는 main 의 root key 로 RESUME_IDS / freshness 를 관리한다 (Layer A).
+    let session_key_owned = session_key_for(conv_id);
     let mut accumulated_input_tokens: i64 = 0;
     let mut accumulated_output_tokens: i64 = 0;
 
@@ -785,17 +887,24 @@ where
                 // 않으면 "claude 는 기억 없는데 tunaFlow 는 있다고 착각" 하는 다른
                 // 경로의 맥락 유실이 발생한다.
                 if let Some(sid) = &parsed.session_id {
-                    let prior = RESUME_IDS.lock().insert(conv_id_owned.clone(), sid.clone());
+                    // brand 와 main 은 같은 root key 로 RESUME_IDS 공유 (Layer A).
+                    let prior = RESUME_IDS.lock().insert(session_key_owned.clone(), sid.clone());
                     if let Some(p) = prior {
                         if p != *sid {
                             eprintln!(
                                 "[sdk-session] claude returned new session_id (prior={} new={}) — \
-                                 --resume likely rejected; invalidating LAST_DELIVERED for conv={}",
-                                p, sid, conv_id_owned
+                                 --resume likely rejected; invalidating LAST_DELIVERED for conv={} (key={})",
+                                p, sid, conv_id_owned, session_key_owned
                             );
                             crate::commands::agents_helpers::send_common::session_freshness::clear_delivered_key(
                                 &conv_id_owned,
                             );
+                            // root key 도 invalidate — main 에서 진행 중인 trace 가 있을 수 있음.
+                            if session_key_owned != conv_id_owned {
+                                crate::commands::agents_helpers::send_common::session_freshness::clear_delivered_key(
+                                    &session_key_owned,
+                                );
+                            }
                         }
                     }
                 }
@@ -1177,5 +1286,184 @@ mod tests {
         assert!(last_delivered_key(&conv).is_some());
 
         RESUME_IDS.lock().remove(&conv);
+    }
+
+    // ─── Layer A: brand session inheritance (branchInheritsMainSessionPlan) ─────
+
+    /// `conversations` + `branches` 테이블을 갖춘 in-memory DbState.
+    /// brand:* shadow 와 root main conv 양쪽 row 를 모두 채워준다.
+    fn build_test_db_with_branch(
+        root_conv_id: &str,
+        branch_id: &str,
+        resume_token: Option<&str>,
+        engine: Option<&str>,
+    ) -> crate::db::DbState {
+        use std::sync::{Arc, Mutex};
+        let read = rusqlite::Connection::open_in_memory().unwrap();
+        read.execute_batch(
+            "CREATE TABLE conversations (
+                id TEXT PRIMARY KEY,
+                resume_token TEXT,
+                resume_token_engine TEXT
+             );
+             CREATE TABLE branches (
+                id TEXT PRIMARY KEY,
+                conversation_id TEXT NOT NULL
+             );",
+        )
+        .unwrap();
+        // root main conv (resume_token 부모)
+        if let Some(tok) = resume_token {
+            read.execute(
+                "INSERT INTO conversations (id, resume_token, resume_token_engine) VALUES (?1, ?2, ?3)",
+                rusqlite::params![root_conv_id, tok, engine.unwrap_or("claude")],
+            )
+            .unwrap();
+        } else {
+            read.execute(
+                "INSERT INTO conversations (id, resume_token, resume_token_engine) VALUES (?1, NULL, NULL)",
+                rusqlite::params![root_conv_id],
+            )
+            .unwrap();
+        }
+        // branches row — root_conv_id 가 branches.conversation_id 에 들어 있어야
+        // session_key_for(brand:*) 가 root 로 정규화된다.
+        read.execute(
+            "INSERT INTO branches (id, conversation_id) VALUES (?1, ?2)",
+            rusqlite::params![branch_id, root_conv_id],
+        )
+        .unwrap();
+        let write = rusqlite::Connection::open_in_memory().unwrap();
+        crate::db::DbState {
+            read: Arc::new(Mutex::new(read)),
+            write: Arc::new(Mutex::new(write)),
+        }
+    }
+
+    fn clear_branch_cache(brand_conv: &str) {
+        BRANCH_ROOT_CACHE.lock().remove(brand_conv);
+    }
+
+    #[test]
+    fn session_key_for_returns_conv_id_unchanged_for_non_branch() {
+        let conv = unique_conv("non-branch");
+        assert_eq!(session_key_for(&conv), conv);
+    }
+
+    #[test]
+    fn session_key_for_returns_root_when_branch_root_cached() {
+        let root = unique_conv("root-A");
+        let branch_id = format!("b-{}", uuid::Uuid::new_v4());
+        let brand_conv = format!("branch:{}", branch_id);
+
+        // 캐시 직접 주입 (DB 없이 helper 단독 검증)
+        BRANCH_ROOT_CACHE.lock().insert(brand_conv.clone(), root.clone());
+
+        assert_eq!(session_key_for(&brand_conv), root);
+
+        clear_branch_cache(&brand_conv);
+    }
+
+    #[test]
+    fn session_key_for_falls_back_to_conv_id_when_cache_miss() {
+        // 잘못된 prefix / DB 미조회 상태 — fallback 으로 conv_id 그대로 반환
+        let brand_conv = format!("branch:{}", uuid::Uuid::new_v4());
+        clear_branch_cache(&brand_conv);
+        assert_eq!(session_key_for(&brand_conv), brand_conv);
+    }
+
+    #[test]
+    fn cache_branch_root_from_db_populates_cache_for_branch() {
+        let root = unique_conv("layerA-root");
+        let branch_id = format!("b-{}", uuid::Uuid::new_v4());
+        let brand_conv = format!("branch:{}", branch_id);
+        clear_branch_cache(&brand_conv);
+
+        let db = build_test_db_with_branch(&root, &branch_id, Some("tok"), Some("claude"));
+        cache_branch_root_from_db(&brand_conv, &db);
+
+        assert_eq!(
+            BRANCH_ROOT_CACHE.lock().get(&brand_conv).cloned(),
+            Some(root.clone())
+        );
+        assert_eq!(session_key_for(&brand_conv), root);
+
+        clear_branch_cache(&brand_conv);
+    }
+
+    #[test]
+    fn cache_branch_root_from_db_is_noop_for_non_branch_conv_id() {
+        // non-branch conv_id 는 캐시에 들어가지 않아야 함 (불필요한 항목 방지).
+        let conv = unique_conv("plain-conv");
+        let db = build_test_db_with_branch(
+            &conv,
+            "some-branch",
+            None,
+            None,
+        );
+        cache_branch_root_from_db(&conv, &db);
+        assert!(BRANCH_ROOT_CACHE.lock().get(&conv).is_none());
+    }
+
+    #[test]
+    fn cache_branch_root_from_db_is_noop_when_already_cached() {
+        let root = unique_conv("already-cached-root");
+        let branch_id = format!("b-{}", uuid::Uuid::new_v4());
+        let brand_conv = format!("branch:{}", branch_id);
+
+        // 캐시 선점
+        BRANCH_ROOT_CACHE
+            .lock()
+            .insert(brand_conv.clone(), "PRE-EXISTING".into());
+
+        // DB 에는 다른 root 가 있어도 캐시는 변하지 않아야 함
+        let db = build_test_db_with_branch(&root, &branch_id, None, None);
+        cache_branch_root_from_db(&brand_conv, &db);
+
+        assert_eq!(
+            BRANCH_ROOT_CACHE.lock().get(&brand_conv).cloned().as_deref(),
+            Some("PRE-EXISTING"),
+            "이미 캐시된 값은 덮어쓰지 않아야 함"
+        );
+
+        clear_branch_cache(&brand_conv);
+    }
+
+    #[test]
+    fn bootstrap_resume_id_for_branch_keys_root_conv() {
+        // INV-1: brand:* 진입 시 RESUME_IDS 는 root key 로 들어가야 한다.
+        let root = unique_conv("inv1-root");
+        let branch_id = format!("b-{}", uuid::Uuid::new_v4());
+        let brand_conv = format!("branch:{}", branch_id);
+
+        RESUME_IDS.lock().remove(&root);
+        RESUME_IDS.lock().remove(&brand_conv);
+        clear_branch_cache(&brand_conv);
+
+        let db = build_test_db_with_branch(&root, &branch_id, Some("ROOT-TOK"), Some("claude"));
+        // brand:* conv 로 진입했지만 DB 에는 root 의 resume_token 만 있다.
+        let got = bootstrap_resume_id_from_db(&brand_conv, &db);
+        assert_eq!(got.as_deref(), Some("ROOT-TOK"));
+
+        // RESUME_IDS 에는 root key 로 저장되어야 함 (brand 키 아님)
+        assert_eq!(
+            RESUME_IDS.lock().get(&root).cloned().as_deref(),
+            Some("ROOT-TOK"),
+            "RESUME_IDS 는 root main conv 키로 저장되어야 함"
+        );
+        assert!(
+            RESUME_IDS.lock().get(&brand_conv).is_none(),
+            "brand:* 키로는 RESUME_IDS 에 entry 가 들어가면 안 됨"
+        );
+
+        // current_session_key 도 brand → root 로 normalize 되어 같은 값 반환
+        let key_from_brand = current_session_key(&brand_conv);
+        let key_from_root = current_session_key(&root);
+        assert_eq!(key_from_brand, key_from_root);
+        assert_eq!(key_from_brand.as_deref(), Some("claude-ws:ROOT-TOK"));
+
+        // cleanup
+        RESUME_IDS.lock().remove(&root);
+        clear_branch_cache(&brand_conv);
     }
 }

--- a/src-tauri/src/agents/codex_app_server.rs
+++ b/src-tauri/src/agents/codex_app_server.rs
@@ -105,15 +105,22 @@ pub fn is_available() -> bool {
 
 /// ContextPack freshness 판정용 — 현재 활성 thread의 식별 키.
 /// 같은 키 = 같은 codex thread (replay 히스토리 보유). 없으면 None (=> full ContextPack 필요).
+///
+/// brand:* shadow conv 는 root main conv 와 같은 thread 를 공유하도록 키 normalize
+/// (Layer C, branchInheritsMainSessionPlan). main 의 BRANCH_ROOT_CACHE 는
+/// `claude_sdk_session::cache_branch_root_from_db` 가 채우지만 codex 진입 시점에는
+/// 비어 있을 수 있어 cache miss 시 conv_id 그대로 fallback 한다.
 pub fn current_thread_key(conv_id: &str) -> Option<String> {
-    CONV_THREADS.lock().get(conv_id).map(|t| format!("codex-app:{}", t.thread_id))
+    let key = crate::agents::claude_sdk_session::session_key_for(conv_id);
+    CONV_THREADS.lock().get(&key).map(|t| format!("codex-app:{}", t.thread_id))
 }
 
 /// conversation이 제거될 때 해당 thread를 레지스트리에서 제거한다.
 /// 서버 자체는 계속 실행된다.
 #[allow(dead_code)]
 pub fn kill_thread(conv_id: &str) {
-    CONV_THREADS.lock().remove(conv_id);
+    let key = crate::agents::claude_sdk_session::session_key_for(conv_id);
+    CONV_THREADS.lock().remove(&key);
 }
 
 /// app-server 세션을 통해 메시지를 전송하고 스트리밍 응답을 수집한다.
@@ -504,10 +511,13 @@ async fn get_or_create_thread(
     model: &str,
     project_path: Option<&str>,
 ) -> Result<String, AppError> {
+    // brand:* 는 main 의 codex thread 를 공유 (Layer C, branchInheritsMainSessionPlan).
+    let key = crate::agents::claude_sdk_session::session_key_for(conv_id);
+
     // 기존 스레드 확인
     let existing = CONV_THREADS
         .lock()
-        .get(conv_id)
+        .get(&key)
         .map(|t| (t.thread_id.clone(), t.model.clone()));
 
     if let Some((thread_id, current_model)) = existing {
@@ -516,10 +526,10 @@ async fn get_or_create_thread(
         }
         // 모델 변경 — 기존 스레드 폐기, 새 스레드 시작
         eprintln!(
-            "[codex-app-server] model changed ({} → {}), starting new thread for conv={}",
-            current_model, model, conv_id
+            "[codex-app-server] model changed ({} → {}), starting new thread for conv={} (key={})",
+            current_model, model, conv_id, key
         );
-        CONV_THREADS.lock().remove(conv_id);
+        CONV_THREADS.lock().remove(&key);
     }
 
     let cwd = resolve_cwd(project_path);
@@ -550,7 +560,7 @@ async fn get_or_create_thread(
         .to_string();
 
     CONV_THREADS.lock().insert(
-        conv_id.to_string(),
+        key.clone(),
         ConvThread {
             thread_id: thread_id.clone(),
             model: model.to_string(),
@@ -558,8 +568,8 @@ async fn get_or_create_thread(
     );
 
     eprintln!(
-        "[codex-app-server] created thread {} for conv={}",
-        thread_id, conv_id
+        "[codex-app-server] created thread {} for conv={} (key={})",
+        thread_id, conv_id, key
     );
     Ok(thread_id)
 }

--- a/src-tauri/src/commands/agents_helpers/send_common/context_loading.rs
+++ b/src-tauri/src/commands/agents_helpers/send_common/context_loading.rs
@@ -13,6 +13,119 @@ pub fn load_project_path(conn: &Connection, project_key: &str) -> Option<String>
     .flatten()
 }
 
+/// brand:* shadow conv 의 root main conversation_id 를 `branches` 테이블에서 조회.
+///
+/// `branches.conversation_id` 컬럼에는 이미 root 가 저장되어 있다
+/// (`commands/branches.rs::create_branch` 의 `root_conv_id` 정규화).
+/// non-branch conv_id 또는 lookup 실패 시 None.
+pub fn lookup_branch_root_conv_id(conn: &Connection, conv_id: &str) -> Option<String> {
+    let branch_id = conv_id.strip_prefix("branch:")?;
+    conn.query_row(
+        "SELECT conversation_id FROM branches WHERE id = ?1",
+        [branch_id],
+        |row| row.get::<_, String>(0),
+    )
+    .ok()
+}
+
+/// brand 가 main 과 같은 엔진을 사용하는지 검사.
+///
+/// 같은 엔진이면 brand send 가 main 의 sdk-url WS 세션을 그대로 이어받아
+/// prior history 가 자동 포함된다 → ContextPack dynamic 섹션 (recent / parent /
+/// compressed / retrieval) 재주입은 토큰 낭비 + 오염원.
+///
+/// 다른 엔진 (예: Claude → Codex) 이면 새 session 이라 ContextPack 정상 빌드 필요.
+///
+/// engine name normalization:
+/// - `claude` / `claude-code` 는 같은 엔진으로 간주 (resume_token_engine 표기 차이)
+/// - 그 외는 문자열 일치
+///
+/// 검사 기준: root main conv 의 가장 최근 assistant 메시지의 `engine` 컬럼.
+/// root 에 메시지가 없으면 (= 처음 brand 진입) `true` 로 본다 — 어차피 첫 send
+/// 라 LAST_DELIVERED 도 비어 있어 ContextPack full 경로가 자연스럽게 동작.
+fn is_engine_continuity(conn: &Connection, root_conv_id: &str, current_engine: &str) -> bool {
+    let last_engine: Option<String> = conn
+        .query_row(
+            "SELECT engine FROM messages
+             WHERE conversation_id = ?1 AND role = 'assistant' AND status = 'done'
+             ORDER BY timestamp DESC LIMIT 1",
+            [root_conv_id],
+            |row| row.get(0),
+        )
+        .ok()
+        .flatten();
+    let Some(last) = last_engine else { return true };
+    normalize_engine(&last) == normalize_engine(current_engine)
+}
+
+fn normalize_engine(engine: &str) -> &str {
+    match engine {
+        "claude-code" => "claude",
+        e => e,
+    }
+}
+
+/// Layer B (branchInheritsMainSessionPlan): brand send 가 main 의 sdk-url WS 세션
+/// 을 그대로 이어받을 수 있을 때 ContextPack 의 dynamic 섹션을 비운다.
+///
+/// 조건:
+/// - `data.is_branch == true` (brand:* shadow conv 진입)
+/// - root main 의 마지막 assistant 메시지 engine 이 현재 send 의 engine 과 같다
+///   (= claude_sdk_session 의 SESSIONS / RESUME_IDS 가 root key 로 통합되어 있어
+///    같은 SdkSession 을 재사용)
+///
+/// 효과:
+/// - `is_session_continuation = true` 강제 (assemble_prompt 가 recent_context /
+///   compressed_memory / cross-session 을 skip)
+/// - `parent_messages` / `retrieval_chunks` / `document_chunks` 비움 (brand 만의
+///   "main 으로부터 분기" 이라는 사실은 이미 claude session history 에 들어 있음)
+///
+/// 정적 레이어 (identity / persona / project / agent-role 등) 는 유지 — engine
+/// 이 매 send 마다 system_prompt 를 새로 받으므로 retain.
+///
+/// engine 이 달라지면 (Claude → Codex) 별 session 으로 분리되므로 본 helper 는
+/// no-op (= 정상 ContextPack 빌드, INV-3).
+pub fn apply_branch_session_inheritance(
+    conn: &Connection,
+    data: &mut ContextData,
+    engine: &str,
+) -> bool {
+    if !data.is_branch {
+        return false;
+    }
+    let Some(root_conv) = lookup_branch_root_conv_id(conn, &data.conversation_id) else {
+        return false;
+    };
+    if !is_engine_continuity(conn, &root_conv, engine) {
+        eprintln!(
+            "[branch-session] engine differs (root last engine ≠ {}) for conv={} — keep ContextPack full",
+            engine,
+            &data.conversation_id[..data.conversation_id.len().min(20)]
+        );
+        return false;
+    }
+
+    eprintln!(
+        "[branch-session] brand same-engine continuation conv={} engine={} → \
+         drop dynamic ContextPack sections (rely on main's sdk-url session)",
+        &data.conversation_id[..data.conversation_id.len().min(20)],
+        engine
+    );
+
+    data.is_session_continuation = true;
+    data.parent_messages.clear();
+    data.current_messages.clear();
+    data.retrieval_chunks.clear();
+    data.document_chunks.clear();
+    data.cross_session_data.clear();
+    data.compressed_memory = None;
+    data.compressed_memory_source = None;
+    // thread_inheritance 도 brand 전용 prepend 인데, claude session 이 자체 history
+    // 를 갖고 있으므로 중복. 제거.
+    data.thread_inheritance = None;
+    true
+}
+
 /// Build an enriched prompt with lite context prefix for non-Claude engines.
 /// Retained for roundtable participant paths that don't carry full SendWithClaudeInput.
 #[allow(dead_code)]
@@ -767,4 +880,173 @@ fn search_failure_lessons_for_rework(
         .take(5)
         .map(|(_, l)| l)
         .collect()
+}
+
+// ─── Layer B: branch session inheritance tests ────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+
+    fn build_db_with_branch(root_conv_id: &str, branch_id: &str) -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE branches (
+                id TEXT PRIMARY KEY,
+                conversation_id TEXT NOT NULL
+             );
+             CREATE TABLE messages (
+                id TEXT PRIMARY KEY,
+                conversation_id TEXT NOT NULL,
+                role TEXT NOT NULL,
+                content TEXT NOT NULL,
+                timestamp INTEGER NOT NULL,
+                status TEXT NOT NULL DEFAULT 'done',
+                engine TEXT
+             );",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO branches (id, conversation_id) VALUES (?1, ?2)",
+            rusqlite::params![branch_id, root_conv_id],
+        )
+        .unwrap();
+        conn
+    }
+
+    fn insert_assistant_message(conn: &Connection, conv: &str, engine: &str, ts: i64) {
+        conn.execute(
+            "INSERT INTO messages (id, conversation_id, role, content, timestamp, status, engine)
+             VALUES (?1, ?2, 'assistant', 'reply', ?3, 'done', ?4)",
+            rusqlite::params![format!("m-{}-{}", conv, ts), conv, ts, engine],
+        )
+        .unwrap();
+    }
+
+    fn empty_data(conv_id: &str, is_branch: bool) -> ContextData {
+        ContextData {
+            conversation_id: conv_id.into(),
+            project_path: None,
+            prompt: "hi".into(),
+            is_branch,
+            has_active_plan: false,
+            current_messages: vec![],
+            parent_messages: vec![],
+            plan_section: None,
+            plan_document: None,
+            findings_section: None,
+            artifacts_section: None,
+            retrieval_chunks: vec![],
+            document_chunks: vec![],
+            compressed_memory: None,
+            compressed_memory_source: None,
+            cross_session_data: vec![],
+            thread_inheritance: None,
+            agent_role_doc: None,
+            previous_impl_status: None,
+            active_skills: vec![],
+            cross_session_ids: vec![],
+            persona_fragment: None,
+            context_mode_override: None,
+            context_budget_cap: None,
+            user_profile: None,
+            conventions_synced: false,
+            is_session_continuation: false,
+            identity_summary_fragment: None,
+        }
+    }
+
+    #[test]
+    fn lookup_branch_root_returns_main_conv_id() {
+        let conn = build_db_with_branch("conv-main", "b1");
+        let got = lookup_branch_root_conv_id(&conn, "branch:b1");
+        assert_eq!(got.as_deref(), Some("conv-main"));
+    }
+
+    #[test]
+    fn lookup_branch_root_returns_none_for_non_branch_conv() {
+        let conn = build_db_with_branch("conv-main", "b1");
+        assert!(lookup_branch_root_conv_id(&conn, "conv-main").is_none());
+        assert!(lookup_branch_root_conv_id(&conn, "branch:unknown").is_none());
+    }
+
+    #[test]
+    fn engine_continuity_treats_claude_and_claude_code_as_same() {
+        let conn = build_db_with_branch("conv-main", "b1");
+        insert_assistant_message(&conn, "conv-main", "claude-code", 1000);
+        assert!(is_engine_continuity(&conn, "conv-main", "claude"));
+        assert!(is_engine_continuity(&conn, "conv-main", "claude-code"));
+    }
+
+    #[test]
+    fn engine_continuity_returns_false_for_different_engine() {
+        let conn = build_db_with_branch("conv-main", "b1");
+        insert_assistant_message(&conn, "conv-main", "claude-code", 1000);
+        assert!(!is_engine_continuity(&conn, "conv-main", "codex"));
+        assert!(!is_engine_continuity(&conn, "conv-main", "gemini"));
+    }
+
+    #[test]
+    fn engine_continuity_returns_true_when_no_prior_messages() {
+        // root 에 메시지가 없으면 첫 send 라 continuation 로 본다 (LAST_DELIVERED 가
+        // 비어 있어 어차피 full ContextPack 으로 흐르지만, dynamic 섹션은 비울 수 있음)
+        let conn = build_db_with_branch("conv-main", "b1");
+        assert!(is_engine_continuity(&conn, "conv-main", "claude"));
+    }
+
+    #[test]
+    fn apply_branch_session_inheritance_same_engine_clears_dynamic_sections() {
+        // INV-2: brand:* same engine 진입 시 dynamic 섹션이 비워지고
+        //        is_session_continuation=true 가 셋팅된다.
+        let conn = build_db_with_branch("conv-main", "b1");
+        insert_assistant_message(&conn, "conv-main", "claude-code", 1000);
+
+        let mut data = empty_data("branch:b1", true);
+        data.parent_messages = vec![("user".into(), "hi".into(), None, None)];
+        data.current_messages = vec![("assistant".into(), "ok".into(), Some("claude".into()), None)];
+        data.compressed_memory = Some("memo".into());
+        data.thread_inheritance = Some("inherit".into());
+
+        let applied = apply_branch_session_inheritance(&conn, &mut data, "claude");
+        assert!(applied, "same-engine brand 면 inheritance 가 적용되어야 함");
+        assert!(data.is_session_continuation);
+        assert!(data.parent_messages.is_empty());
+        assert!(data.current_messages.is_empty());
+        assert!(data.compressed_memory.is_none());
+        assert!(data.thread_inheritance.is_none());
+        assert!(data.retrieval_chunks.is_empty());
+    }
+
+    #[test]
+    fn apply_branch_session_inheritance_different_engine_keeps_full_pack() {
+        // INV-3: engine 변경 시는 별 session 이라 ContextPack 정상 빌드 유지.
+        let conn = build_db_with_branch("conv-main", "b1");
+        insert_assistant_message(&conn, "conv-main", "claude-code", 1000);
+
+        let mut data = empty_data("branch:b1", true);
+        data.parent_messages = vec![("user".into(), "hi".into(), None, None)];
+        data.compressed_memory = Some("memo".into());
+
+        let applied = apply_branch_session_inheritance(&conn, &mut data, "codex");
+        assert!(!applied, "다른 engine 으로 brand 진입 시 inheritance 미적용");
+        assert!(!data.is_session_continuation);
+        assert_eq!(data.parent_messages.len(), 1, "parent 메시지가 보존되어야");
+        assert_eq!(data.compressed_memory.as_deref(), Some("memo"));
+    }
+
+    #[test]
+    fn apply_branch_session_inheritance_skips_non_branch_conv() {
+        // brand 가 아니면 무조건 false (정상 ContextPack).
+        let conn = build_db_with_branch("conv-main", "b1");
+        insert_assistant_message(&conn, "conv-main", "claude-code", 1000);
+
+        let mut data = empty_data("conv-main", false);
+        data.parent_messages = vec![("user".into(), "hi".into(), None, None)];
+
+        let applied = apply_branch_session_inheritance(&conn, &mut data, "claude");
+        assert!(!applied, "non-branch conv 는 inheritance 미적용");
+        assert!(!data.is_session_continuation);
+        assert_eq!(data.parent_messages.len(), 1);
+    }
 }

--- a/src-tauri/src/commands/agents_helpers/send_common/persistence.rs
+++ b/src-tauri/src/commands/agents_helpers/send_common/persistence.rs
@@ -208,11 +208,20 @@ pub fn prepare_engine_run(
     let (mut data, project_path) = {
         let conn = state.read.lock().map_err(|_| crate::errors::AppError::Lock)?;
         let pp = load_project_path(&conn, &input.project_key);
-        let ctx_data = load_context_data(
+        let mut ctx_data = load_context_data(
             &conn, &input.conversation_id, &input.prompt, pp.as_deref(),
             &input.active_skills, &input.cross_session_ids, identity_frag,
             input.context_mode_override.as_deref(), input.context_budget_cap,
             input.user_profile_json.as_deref(),
+        );
+        // Layer B (branchInheritsMainSessionPlan): brand 가 main 의 sdk-url WS
+        // 세션을 그대로 이어받을 수 있는 조건 (same engine) 이면 dynamic
+        // ContextPack 섹션을 비운다. 정적 레이어 (identity/persona/project) 는
+        // 매 send 마다 system_prompt 로 다시 들어가야 하므로 유지.
+        super::context_loading::apply_branch_session_inheritance(
+            &conn,
+            &mut ctx_data,
+            engine_key,
         );
         (ctx_data, pp)
     };

--- a/src-tauri/src/commands/agents_helpers/send_common/prompt_assembly.rs
+++ b/src-tauri/src/commands/agents_helpers/send_common/prompt_assembly.rs
@@ -367,8 +367,13 @@ pub fn assemble_prompt(
         }
     }
 
-    // Layer 3: Retrieval memory — past conversation chunks, ranked and deduped
-    if ctx_mode >= ContextMode::Standard {
+    // Layer 3: Retrieval memory — past conversation chunks, ranked and deduped.
+    // Session continuation 에서는 drop (Claude/Codex 자체 세션이 prior context 갖고 있음).
+    // brand same-session 진입 시 main 의 retrieval 까지 brand 에 prepend 하면 토큰 낭비
+    // + 모델이 "tunaFlow 가 권위 있는 latest" 로 오인 (Layer B, branchInheritsMainSessionPlan).
+    if data.is_session_continuation {
+        included_sections.push("retrieval:skipped(session-continuation)".into());
+    } else if ctx_mode >= ContextMode::Standard {
         let current_size: usize = sections.iter().map(|s| s.len()).sum();
         let remaining = total_budget.saturating_sub(current_size);
         if remaining > profile.retrieval_min_remaining {


### PR DESCRIPTION
## Summary

User intent (oldest 2026-04-17, jsonl `037bb82f`): brand should inherit main CLI session in sdk-url WS mode. ContextPack re-injection on brand send is a token waste because Claude session already holds the prior history.

s36 (2026-04-15, PTY → WS transition) 시 brand-session 통합이 별 task 로 띄워지지 않아 6 세션 (s36~s40) 동안 코드와 사용자 의도 사이 divergence 가 누적되었다. s38 은 반대 방향 (brand 도 ContextPack 으로 채우는 방향) 으로 작업했다. 본 PR 은 코드를 의도에 맞춤 + 토큰 낭비 제거.

Plan: `docs/plans/branchInheritsMainSessionPlan_2026-04-25.md`

## Changes

- **Layer A** — `claude_sdk_session.rs` SESSIONS / RESUME_IDS key normalize (`branch:*` → root main `conversation_id`). `BRANCH_ROOT_CACHE` + `session_key_for` + `cache_branch_root_from_db` 도입. (commit `4d17054`)
- **Layer B** — `context_loading::apply_branch_session_inheritance` 헬퍼. brand+same-engine 시 `is_session_continuation=true` + parent/recent/retrieval/cross/document/thread_inheritance/compressed_memory 비움. `prompt_assembly` 의 retrieval 도 명시적 skip. (commit `c5f868c`)
- **Layer C** — Codex app-server `CONV_THREADS` 도 동일 key normalize. (commit `4e053b9`)
- **Layer D** — `docs/reference/branchSessionPolicy.md` 승격 (`canonical: true`). `docs/ideas/ptySessionPolicy.md` archive. CLAUDE.md §13 reference. (commit `aceb4d0`)

## Invariants 충족

- **INV-1** brand:* send 시 SESSIONS / RESUME_IDS / CONV_THREADS lookup 키 = root main conv_id. (코드 + unit test `bootstrap_resume_id_for_branch_keys_root_conv`)
- **INV-2** brand send 시 (same engine) ContextPack dynamic 섹션 skip. (코드 + unit test `apply_branch_session_inheritance_same_engine_clears_dynamic_sections`)
- **INV-3** engine 변경 시 fallback. (코드 + unit test `apply_branch_session_inheritance_different_engine_keeps_full_pack`)
- **INV-4** DB raw 메시지 = SSOT (retrieval / compressed memory 는 helper layer)
- **INV-5** shadow conv DB 모델 / branches 테이블 / UI 드로어 손 안 댐

## 검증

- `npx tsc --noEmit` — pass
- `npx vitest run` — 347/347 pass (32 files)
- `cargo check --lib` — pass (warning 1: 무관, query_expand `InvokeClaude` dead code)
- `cargo test --lib` — 528/528 pass (Layer A 7 + Layer B 8 신규 포함)

## 관련 이슈

본 PR 은 **plan-only audit-fix self-issue** 형태. 별도 GitHub Issue 미생성 — plan 문서 자체가 SSOT.

## Sibling

`docs/plans/userIntentSsotSurfacingPlan_2026-04-25.md` — 메타 level. tunaFlow conversation DB 를 architect 진입 시 자동 surface. 본 PR 머지 후 진행.

## Test plan

- [x] Layer A: SESSIONS/RESUME_IDS root key 정규화 unit test (7 cases)
- [x] Layer B: apply_branch_session_inheritance unit test (8 cases, INV-2/INV-3 직접 검증)
- [x] Layer C: Codex app-server CONV_THREADS root key (compile-time 보장; unit test 는 server lifecycle 의존성으로 생략 — claude session_key_for 재사용 path)
- [x] Layer D: docs canonical 표기 + index 등록
- [ ] **Manual smoke (PR 머지 전 권장)**:
  1. Same engine continuation: 메인 (Claude) 5턴 → 브랜치 (Claude) 3턴 → adopt → 메인에서 다음 메시지. architect 가 brand 본문 자연 access 확인
  2. Engine 변경 fallback: 메인 (Claude) → 브랜치 (Codex) → ContextPack 정상 빌드 확인
  3. Token 측정: brand send prompt token 이 fix 전 대비 감소

🤖 Generated with [Claude Code](https://claude.com/claude-code)