### PR TITLE
fix(cancel): stream abort semantics for same-session brand cancel (Task A follow-up)

### DIFF
--- a/docs/reference/branchCancelAudit_2026-04-25.md
+++ b/docs/reference/branchCancelAudit_2026-04-25.md
@@ -1,0 +1,163 @@
+---
+title: Branch cancel semantics — audit (Task A same-session model 후속)
+status: completed
+created_at: 2026-04-25
+updated_at: 2026-04-25
+canonical: true
+related:
+  - docs/plans/branchCancelSemanticsPlan_2026-04-25.md
+  - docs/plans/branchInheritsMainSessionPlan_2026-04-25.md  # PR #198 머지 완료
+  - src-tauri/src/agents/claude_sdk_session.rs
+  - src-tauri/src/commands/agents.rs
+  - src-tauri/src/commands/roundtable.rs
+  - src/stores/slices/runtimeSlice.ts
+  - src/components/tunaflow/NewMessageInput.tsx
+---
+
+# 배경
+
+PR #198 (`branchInheritsMainSession`) 머지 후 brand 에서 cancel 버튼이 작동하지 않는 사용자 보고 (2026-04-25).
+PR #198 은 SESSIONS / RESUME_IDS 키를 main root 로 normalize 했지만, cancel 경로는 동일 normalize 가 안 됐다.
+
+# 현재 cancel 경로 (BE)
+
+## CancelRegistry (`src-tauri/src/lib.rs:13`)
+
+```rust
+pub struct CancelRegistry(pub Arc<parking_lot::Mutex<HashSet<String>>>);
+```
+
+- `cancel(conv_id)` → set 에 conv_id insert
+- `check_and_consume(conv_id)` → set 에 있으면 remove 후 true
+- `clear(conv_id)` → 정상 완료 시 호출 (실제로는 미사용)
+
+키 = conversation_id. brand 는 `branch:<branch_id>` 그대로 사용 — normalize 없음.
+
+## cancel_running tauri command (`src-tauri/src/commands/roundtable.rs:385`)
+
+```rust
+pub fn cancel_running(conversation_id: String, cancel: State<CancelRegistry>) -> Result<(), AppError> {
+    cancel.cancel(&conversation_id);
+    Ok(())
+}
+```
+
+전달된 conv_id 그대로 set 에 넣음. normalize 안 함.
+
+## is_cancelled callback in stream_run_sdk (`src-tauri/src/agents/claude_sdk_session.rs:708,749`)
+
+```rust
+// agents.rs:239
+{ let c = cid2.clone(); let r = cancel_arc; move || { r.lock().remove(&c) } }
+```
+
+- closure 가 `cid2` (start_claude_stream 으로 들어온 conv_id, brand 면 `branch:b20`) 캡처
+- `set.remove(&cid2)` — set 에 자기 conv_id 가 있으면 true 반환 (consume)
+
+cancel branch (claude_sdk_session.rs:752):
+```rust
+let interrupt = serde_json::json!({ "type": "control_request", "request": { "subtype": "interrupt" }}).to_string();
+let _ = session.to_claude_tx.send(interrupt);
+return Err(AppError::Agent("cancelled by user".into()));
+```
+
+→ 진행 중 stream interrupt + 함수 Err return. `finalize_engine_run` 이 그 Err 을 받아 message status 갱신.
+→ session (process / SESSIONS / RESUME_IDS) 은 그대로 살아있음. **이미 옵션 X (stream abort only) 에 가까운 동작.**
+
+# 현재 cancel 경로 (FE)
+
+## runtimeSlice.cancelOperation (`src/stores/slices/runtimeSlice.ts:321`)
+
+```ts
+cancelOperation: async (threadId?: string) => {
+    const target = threadId ?? get().selectedConversationId;
+    if (target) {
+        try { await invoke("cancel_running", { conversationId: target }); } catch ...
+    }
+    ...
+}
+```
+
+caller 가 threadId 안 넘기면 selectedConversationId fallback. brand 는 caller 가 brand 의 shadow conv_id 를 명시적으로 넘겨야 함.
+
+## NewMessageInput cancel 버튼 (`src/components/tunaflow/NewMessageInput.tsx:579-586`)
+
+```tsx
+{isCurrentThreadRunning && (
+    <button onClick={() => cancelOperation(selectedConversationId ?? undefined)} ... >
+        Cancel
+    </button>
+)}
+```
+
+- `isCurrentThreadRunning = !!effectiveThreadId && runningThreadIds.includes(effectiveThreadId)` (line 186)
+- `effectiveThreadId = threadMode ? threadBranchConvId : selectedConversationId` (line 185)
+
+→ 버튼 visibility 는 `effectiveThreadId` (brand 면 `branch:b20`) 기준이지만, **클릭 핸들러는 `selectedConversationId` (main conv id) 를 cancel 에 넘김**. 불일치.
+
+# 진단 — 왜 brand cancel 이 작동 안 하나 (옵션 A 추정)
+
+PR #198 의 normalize 는 SESSIONS / RESUME_IDS 만 root main 으로 정규화. cancel registry 는 conv_id 단위 그대로:
+
+1. brand 송신 → `start_claude_stream(input.conversation_id="branch:b20")` → `cid2 = "branch:b20"` 캡처
+2. brand 의 `is_cancelled` callback 은 `set.remove("branch:b20")` 호출
+3. 사용자가 cancel 클릭 → FE 가 `cancel_running(selectedConversationId="conv-abc")` 호출
+4. registry: `set.insert("conv-abc")` — brand:b20 이 아닌 main conv id 추가
+5. brand 의 `is_cancelled` callback → `set.remove("branch:b20")` → 없음 → false → cancel 무시
+
+→ **No-op (사용자 보고와 일치).**
+
+만약 FE 가 brand 모드에서 brand:* 를 cancel 에 정확히 넘기더라도:
+- `set.insert("branch:b20")` → brand 의 callback 이 `set.remove("branch:b20")` 으로 정상 cancel
+- 그러나 main 동일 송신 후 cancel 도 같은 brand session 의 stream 임 (PR #198 same-session) → main 송신 → main `is_cancelled` callback 은 `set.remove("conv-abc")` 보는데, brand 가 아닌 main 의 cancel 은 그 키로 들어가야 cancel 됨
+- 즉 brand send / main send 별로 cancel 키 분리되면 same-session 이라도 stream 식별이 명확
+
+# 결론 — 두 곳 fix 필요 (옵션 X)
+
+## (1) FE — Cancel 버튼이 effectiveThreadId 를 정확히 넘김
+
+`NewMessageInput.tsx:581` 변경:
+```tsx
+onClick={() => cancelOperation(effectiveThreadId ?? undefined)}
+```
+
+## (2) BE — cancel registry 키 그대로 유지 (normalize 안 함)
+
+PR #198 의 SESSIONS / RESUME_IDS 와 달리, **cancel 은 conv_id 단위로 분리** 가 의도에 맞음:
+- 같은 main session (brand=main 공유) 에서도 brand 의 stream 만 abort 하고 싶으면 conv_id 단위 식별이 필요
+- brand 에서 cancel 클릭 → brand 의 is_cancelled callback 만 발동 → brand 의 stream 만 interrupt → main 영향 없음
+
+cancel registry 의 conv_id 키는 그대로 두고 (normalize 안 함), 단 FE 가 정확한 conv_id (brand 면 brand:*, main 면 main) 를 전달해야 함.
+
+## (3) Cancel 의미 stream abort only 재확인
+
+기존 코드 `claude_sdk_session.rs:749-757` 가 이미:
+- control_request "interrupt" 보내고
+- Err("cancelled by user") return
+- session / SESSIONS / RESUME_IDS / process 모두 유지
+
+→ **이미 옵션 X 에 가까운 구현**. 추가 stream abort token 도입 불필요. 단지 normalize 분리 정책 + FE 호출자 fix.
+
+# Invariants 만족 여부
+
+| INV | 현재 상태 | fix 후 |
+|---|---|---|
+| INV-1: stream abort only, session 유지 | claude_sdk_session.rs 이미 그렇게 구현 | OK |
+| INV-2: brand cancel 이 main 영향 없음 | brand cancel 자체가 동작 안 함 | OK (FE 가 brand:* 를 정확히 전달) |
+| INV-3: main cancel 도 stream abort | main 은 동작 (selectedConversationId 일치) | OK |
+| INV-4: session kill 은 별도 명시적 command | restart_sdk_session 그대로 유지 | OK |
+
+# 비고 — codex_app_server / claude CLI / gemini
+
+각 엔진의 `is_cancelled` callback 도 `cancel_arc.lock().remove(&conv_id)` 패턴으로 동일 — start_claude_stream / start_gemini_stream / start_codex_run 의 cid 캡처 유지하면 PR #198 normalize 와 무관하게 conv_id 단위로 동작. 추가 변경 불필요.
+
+# 변경 범위 (작은)
+
+- FE: `src/components/tunaflow/NewMessageInput.tsx:581` 한 줄
+- BE: 변경 없음 (이미 옵션 X 의미 충족)
+- 테스트: cancel 계약 단위 테스트 보강 (brand cancel main 미영향 등)
+
+# 후속 (선택)
+
+- 옵션 Z (per-sender 격리, 동일 conv 내 메시지별 식별) 은 future plan. 현재는 conv 단위 격리만으로 사용자 의도 충족.
+- session kill scenario (engine 변경 등) 는 `restart_sdk_session` 명시 호출 — UI cancel 버튼과는 별 경로 유지 확인.

--- a/src-tauri/src/agents/claude_sdk_session.rs
+++ b/src-tauri/src/agents/claude_sdk_session.rs
@@ -700,6 +700,19 @@ async fn events_handler(
 /// claude `--sdk-url` 세션을 통해 메시지를 전송하고 스트리밍 응답을 수집한다.
 ///
 /// 기존 `claude::stream_run` 과 동일한 인터페이스.
+///
+/// `is_cancelled` 는 **stream abort token** 이다 (옵션 X, plan
+/// `branchCancelSemanticsPlan_2026-04-25.md`):
+///
+/// - true 반환 시 → 진행 중 stream 만 abort (control_request "interrupt"
+///   전송 후 `Err("cancelled by user")` return)
+/// - **session / SESSIONS / RESUME_IDS / process 는 모두 유지** — 다음
+///   send 가 자연 이어진다 (history 보존)
+/// - session 자체를 죽이려면 별도 `kill_session_clear_resume` 또는
+///   `restart_sdk_session` 명시 호출 (engine/model 변경 시)
+///
+/// brand 와 main 의 cancel 식별: 호출자가 conv_id 단위로 토큰을 분리해
+/// 캡처해야 한다 (PR #198 의 SESSIONS/RESUME_IDS normalize 와 의도가 다름).
 pub async fn stream_run_sdk<F, G, C>(
     conv_id: &str,
     input: RunInput,
@@ -749,6 +762,9 @@ where
                         if is_cancelled() { break; }
                     }
                 } => {
+                    // Stream abort only (옵션 X). control_request "interrupt"
+                    // 로 진행 중 응답만 끊고, session/SESSIONS/RESUME_IDS/process
+                    // 는 모두 보존 — 다음 send 가 history 그대로 이어진다.
                     let interrupt = serde_json::json!({
                         "type": "control_request",
                         "request": { "subtype": "interrupt" }

--- a/src-tauri/src/commands/agents.rs
+++ b/src-tauri/src/commands/agents.rs
@@ -95,6 +95,12 @@ pub fn get_claude_mode(conversation_id: String) -> String {
     resolve_claude_mode(&conversation_id).to_string()
 }
 
+/// Hard-restart the SDK session — process kill + RESUME_IDS clear.
+///
+/// 이 명령은 **session kill** 의미다. UI cancel 버튼과는 분리된 경로이며,
+/// 명시적 시나리오 (engine/model 변경, 외부 process 망실 복구 등) 에서만
+/// 호출해야 한다. 일반 cancel 은 `cancel_running` (stream abort only) 사용
+/// — `docs/plans/branchCancelSemanticsPlan_2026-04-25.md` 참조.
 #[tauri::command]
 pub fn restart_sdk_session(conversation_id: String) {
     if resolve_claude_mode(&conversation_id) == "sdk-url" {

--- a/src-tauri/src/commands/roundtable.rs
+++ b/src-tauri/src/commands/roundtable.rs
@@ -380,14 +380,25 @@ pub async fn roundtable_followup(
     Ok(all_messages)
 }
 
-/// Cancel a specific thread/conversation by its id.
+/// Stream-abort the in-flight run for a specific conversation/thread.
+///
+/// 의미 (옵션 X, `branchCancelSemanticsPlan_2026-04-25.md`):
+/// - 진행 중 stream 만 abort. session / SESSIONS / RESUME_IDS / process 보존.
+/// - 다음 send 는 동일 session 위에서 history 보존하며 이어진다.
+/// - session kill 이 필요하면 별도 `restart_sdk_session` 호출 (engine/model
+///   변경 등 명시적 시나리오).
+///
+/// brand/main 식별: 호출자가 정확한 conv_id 를 넘겨야 한다 — brand 모드면
+/// `branch:<branch_id>` shadow conv_id, main 모드면 main conv_id. 두 키는
+/// CancelRegistry 안에서 분리 관리된다 (PR #198 의 SESSIONS/RESUME_IDS
+/// normalize 와 다른 정책).
 #[tauri::command]
 pub fn cancel_running(
     conversation_id: String,
     cancel: State<CancelRegistry>,
 ) -> Result<(), AppError> {
     cancel.cancel(&conversation_id);
-    eprintln!("[cancel] registered for {}", conversation_id);
+    eprintln!("[cancel] stream abort registered for {}", conversation_id);
     Ok(())
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,26 +7,40 @@ mod errors;
 mod guardrail;
 mod http_api;
 
-/// Thread-aware cooperative cancellation registry.
-/// Keys are conversation IDs (including branch shadow IDs like "branch:xxx").
-/// A thread checks its own conversation_id; only sees its own cancel flag.
+/// Thread-aware cooperative **stream abort** registry.
+///
+/// 의미 (옵션 X, `docs/plans/branchCancelSemanticsPlan_2026-04-25.md`):
+/// 이 registry 의 flag 는 **진행 중 stream 만 abort** 하는 신호다 — session
+/// kill 이 아니다. agent stream loop 이 자기 conv_id 의 flag 를 체크해서
+/// `Err("cancelled by user")` 로 빠져나오고, session / SESSIONS / RESUME_IDS
+/// / process 는 그대로 살아있어 다음 send 가 history 그대로 이어진다.
+///
+/// 키 = conversation_id (brand 는 `branch:<branch_id>` shadow conv_id).
+/// **PR #198 의 SESSIONS/RESUME_IDS normalize 와 의도가 다름** — 이 registry
+/// 는 brand 와 main 의 cancel 을 의도적으로 분리해 격리한다 (brand 에서
+/// cancel 해도 main 의 다음 send 가 영향 없도록).
+///
+/// session 자체를 죽이는 건 별도 명시적 command
+/// (`restart_sdk_session`, `kill_session_clear_resume`) — UI cancel
+/// 버튼은 이 registry 만 건드린다.
 pub struct CancelRegistry(pub std::sync::Arc<parking_lot::Mutex<std::collections::HashSet<String>>>);
 
 impl CancelRegistry {
-    /// Mark a conversation/thread as cancelled.
+    /// Request stream abort for a conversation/thread.
+    /// 진행 중 stream 만 끊는다 — session 은 유지.
     pub fn cancel(&self, conversation_id: &str) {
         let mut set = self.0.lock();
         set.insert(conversation_id.to_string());
     }
 
-    /// Check and consume the cancel flag for a conversation/thread.
-    /// Returns true if cancelled (and clears the flag).
+    /// Check and consume the stream-abort flag for a conversation/thread.
+    /// Returns true if abort requested (and clears the flag).
     pub fn check_and_consume(&self, conversation_id: &str) -> bool {
         let mut set = self.0.lock();
         set.remove(conversation_id)
     }
 
-    /// Clear cancel flag for a conversation (e.g., on normal completion).
+    /// Clear stream-abort flag for a conversation (e.g., on normal completion).
     pub fn clear(&self, conversation_id: &str) {
         let mut set = self.0.lock();
         set.remove(conversation_id);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -47,6 +47,59 @@ impl CancelRegistry {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_registry() -> CancelRegistry {
+        CancelRegistry(std::sync::Arc::new(parking_lot::Mutex::new(
+            std::collections::HashSet::new(),
+        )))
+    }
+
+    #[test]
+    fn cancel_inserts_flag_and_check_and_consume_removes_it() {
+        let r = make_registry();
+        r.cancel("conv-1");
+        assert!(r.check_and_consume("conv-1"), "first check returns true");
+        assert!(
+            !r.check_and_consume("conv-1"),
+            "second check returns false (consumed)"
+        );
+    }
+
+    #[test]
+    fn brand_and_main_keys_are_isolated() {
+        // INV-2: brand cancel 이 main 의 stream abort 를 trigger 하면 안 됨.
+        // CancelRegistry 는 PR #198 의 SESSIONS/RESUME_IDS normalize 와 의도가
+        // 다르다 — brand/main 키가 별로 들어가야 하고, brand cancel 이 main
+        // 의 flag 에 영향을 주면 안 된다.
+        let r = make_registry();
+        r.cancel("branch:b20");
+        assert!(
+            !r.check_and_consume("conv-main"),
+            "brand cancel must not bleed into main"
+        );
+        assert!(
+            r.check_and_consume("branch:b20"),
+            "brand cancel must be visible on its own key"
+        );
+    }
+
+    #[test]
+    fn clear_is_idempotent_and_independent() {
+        let r = make_registry();
+        r.cancel("conv-1");
+        r.clear("conv-1");
+        assert!(
+            !r.check_and_consume("conv-1"),
+            "clear removes the flag without consuming"
+        );
+        // clear 가 등록 안 된 키에 호출돼도 panic 안 남
+        r.clear("never-set");
+    }
+}
+
 pub fn run() {
     bootstrap::env::inherit_shell_path();
     bootstrap::crash::install_panic_hook();

--- a/src/components/tunaflow/NewMessageInput.tsx
+++ b/src/components/tunaflow/NewMessageInput.tsx
@@ -578,7 +578,11 @@ export function NewMessageInput({ threadMode = false, onCreateRT }: NewMessageIn
           <span className="flex-1" />
           {isCurrentThreadRunning && (
             <button
-              onClick={() => cancelOperation(selectedConversationId ?? undefined)}
+              // brand 모드면 effectiveThreadId = threadBranchConvId (branch:<id>),
+              // main 모드면 selectedConversationId. CancelRegistry 는 conv_id
+              // 단위로 brand/main 을 분리 격리하므로 정확한 conv_id 를 넘겨야
+              // brand cancel 이 동작 (`branchCancelSemanticsPlan_2026-04-25.md`).
+              onClick={() => cancelOperation(effectiveThreadId ?? undefined)}
               className="px-2 py-1 rounded text-[11px] font-medium text-destructive/60 hover:text-destructive hover:bg-destructive/8 transition-colors"
             >
               Cancel

--- a/src/stores/slices/runtimeSlice.ts
+++ b/src/stores/slices/runtimeSlice.ts
@@ -319,6 +319,10 @@ export const createRuntimeSlice = (set: SetState, get: GetState): RuntimeSlice =
   },
 
   cancelOperation: async (threadId?: string) => {
+    // Stream abort only (옵션 X, branchCancelSemanticsPlan_2026-04-25):
+    // 진행 중 stream 만 끊고 session/SESSIONS/RESUME_IDS/process 는 유지.
+    // brand 모드에선 caller 가 brand:<id> shadow conv_id 를 명시적으로
+    // 넘겨야 한다 (CancelRegistry 는 conv_id 단위로 brand/main 격리).
     const target = threadId ?? get().selectedConversationId;
 
     if (target) {

--- a/src/tests/streaming-flow.test.ts
+++ b/src/tests/streaming-flow.test.ts
@@ -582,6 +582,28 @@ describe("Streaming flow — cancelOperation", () => {
     expect(get().runningThreadIds).not.toContain("conv-1");
     expect(get().messageQueue.filter((q) => q.threadId === "conv-1").length).toBe(0);
   });
+
+  it("forwards explicit threadId to cancel_running (brand:<id> isolation)", async () => {
+    const { get } = createMockStore();
+    get()._startRun("branch:b20");
+    get()._startRun("conv-1");
+
+    vi.mocked(invoke).mockResolvedValue([]);
+    await get().cancelOperation("branch:b20");
+    await vi.advanceTimersByTimeAsync(100);
+
+    // brand cancel must use branch:<id>, not the parent conv_id.
+    // INV-2: brand cancel 이 main session 에 영향 없도록 격리.
+    const calls = vi.mocked(invoke).mock.calls.filter(
+      ([cmd]) => cmd === "cancel_running",
+    );
+    expect(calls.length).toBeGreaterThan(0);
+    expect(calls[0]?.[1]).toMatchObject({ conversationId: "branch:b20" });
+
+    expect(get().runningThreadIds).not.toContain("branch:b20");
+    // main thread (conv-1) 는 그대로 살아있어야 함 — INV-2.
+    expect(get().runningThreadIds).toContain("conv-1");
+  });
 });
 
 // ─── _startRun / _endRun ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

PR #198 (`branchInheritsMainSession`) 머지 후 brand drawer 에서 cancel 버튼이 작동 안 하는 사용자 보고에 대한 후속 fix. Plan: `docs/plans/branchCancelSemanticsPlan_2026-04-25.md`.

옵션 X (stream abort only) 채택 — UI cancel 의 의미를 진행 중 stream abort 로 통일하고 session kill 과 분리.

## Audit 결론 (자세히는 docs/reference/branchCancelAudit_2026-04-25.md)

- BE 의 `cancel_running` / `is_cancelled` callback / `stream_run_sdk` 는 **이미 옵션 X 에 가까운 동작** — control_request "interrupt" 전송 후 `Err("cancelled by user")` return, session/SESSIONS/RESUME_IDS/process 모두 보존
- 실제 버그는 FE — `NewMessageInput.tsx:581` 의 cancel 버튼이 `selectedConversationId` (main conv id) 를 cancel 에 넘김. brand 모드에선 `effectiveThreadId` (`branch:<id>` shadow conv_id) 가 들어가야 함
- BE callback (`cid2` 캡처) 이 `branch:<id>` 를 보고 있으므로, FE 가 main conv id 를 set 에 넣으면 no-op (사용자 보고와 일치)

## Fix

- **FE** (`src/components/tunaflow/NewMessageInput.tsx`): cancel 버튼이 `effectiveThreadId` 전달 (brand 면 `branch:<id>`, main 이면 main conv)
- **FE** (`src/stores/slices/runtimeSlice.ts`): `cancelOperation` 주석에 caller 컨벤션 명시
- **BE** (`src-tauri/src/lib.rs`, `src-tauri/src/agents/claude_sdk_session.rs`, `src-tauri/src/commands/roundtable.rs`, `src-tauri/src/commands/agents.rs`): CancelRegistry 와 cancel_running 의 의미를 stream abort token 으로 명시. session kill 은 `restart_sdk_session` 명시 분리 — 코드 동작 변경 없음, 의미만 못박음
- **테스트**: 
  - FE `streaming-flow.test.ts` — brand cancel 이 main 미영향 보장 (INV-2)
  - BE `lib.rs` unit test — CancelRegistry 의 brand/main key 격리 검증

## Layer 별 커밋

1. `docs(ref): branch cancel semantics audit` — 진단 기록
2. `refactor(session): clarify stream abort token semantics` — BE 의미 명시 (no behavior change)
3. `fix(cancel): UI cancel button uses effective thread id (brand 격리)` — 실제 fix + 테스트
4. `chore(session): note that session kill stays on restart_sdk_session` — kill 경로 분리 명시

## Invariants

- INV-1: stream abort only, session 유지 — BE 이미 해당
- INV-2: brand cancel 이 main 영향 없음 — FE fix + 자동 테스트로 보장
- INV-3: main cancel 도 stream abort 의미
- INV-4: session kill 은 별도 `restart_sdk_session` 명시 호출

## Test plan

- [x] `npx tsc --noEmit` — pass
- [x] `npx vitest run` — 32 files / 348 tests pass
- [x] `cd src-tauri && cargo check` — pass (warning 1, dead code 무관)
- [x] `cd src-tauri && cargo test --lib` — 550 pass (CancelRegistry 새 unit test 포함)
- [ ] Manual smoke (사용자 검증):
  1. brand 진입 → 송신 → 응답 진행 중 cancel 클릭 → stream stop, brand 살아있고 history 보존, 다음 send 정상 이어짐
  2. main 송신 후 cancel → 동일 동작
  3. engine 변경 시 명시적 `restart_sdk_session` 호출만 session kill

## Related

- Plan: `docs/plans/branchCancelSemanticsPlan_2026-04-25.md`
- PR #198: brand=main session 공유 (이미 머지)
- Audit: `docs/reference/branchCancelAudit_2026-04-25.md`