### PR TITLE
feat(conv): multi-Developer active plan isolation (brand-aware plan + contextpack sender)

### DIFF
--- a/docs/reference/multiDeveloperIsolationDecision_2026-04-25.md
+++ b/docs/reference/multiDeveloperIsolationDecision_2026-04-25.md
@@ -1,0 +1,94 @@
+---
+title: Multi-Developer active plan 격리 — 옵션 결정 audit
+status: decided
+priority: P1
+created_at: 2026-04-25
+canonical: true
+related:
+  - docs/plans/multiDeveloperActivePlanIsolationPlan_2026-04-25.md  # SSOT
+  - docs/plans/branchInheritsMainSessionPlan_2026-04-25.md  # brand session 재사용
+  - src-tauri/src/commands/agents_helpers/send_common/context_loading.rs
+  - src-tauri/src/commands/agents_helpers/context_pack/db_queries.rs
+---
+
+# Audit 결과 (Step 1)
+
+plan 의 옵션 A/B/C/D 를 코드베이스 현황과 대조 검증한 결과, **plan 의 권장(A+B)** 은 의도는 정확하나 옵션 A 의 정확한 의미를 정정해야 한다. 결론은 **A′ + B 조합**.
+
+## tunaFlow 데이터 모델 사실관계
+
+확인한 사실:
+
+1. `plans` 테이블의 active 상태는 `(conversation_id, status='active')` 한 자리. 같은 conv 안에서 동시 active plan 1개라는 가정이 백엔드 전체에 박혀있다 (`build_plan_section` SQL 의 `LIMIT 1`).
+2. plan 1개는 **자기 implementation brand 와 review brand 를 갖고 있다** (`plans.implementation_branch_id` / `review_branch_id`). 즉 Developer/Reviewer 는 main conv 가 아니라 **각 plan 별 shadow conv (`branch:<id>`)** 에서 일하도록 설계된 모델이다.
+3. 그러나 ContextPack 의 plan 섹션 빌드는 `resolve_plan_conversation_id(branch:* → main conv)` 로 root 로 거슬러 올라가 main conv 의 active plan 을 그대로 가져온다. 이 때문에 brand 안에서도 main conv 가 가진 1자리 active plan 이 그대로 노출되며, 다른 plan 의 brand 라 해도 같은 플랜만 보이는 게 아니라 **main 에서 마지막으로 활성화된 plan** 이 보인다.
+
+즉 사용자 보고 케이스 (Coder Claude → readme-memento, Codex → Role Adapter Phase 1) 의 원인은:
+- 두 Developer 모두 "main conv" 에서 직접 호출됐고 (brand 격리 단계 자체가 사용 안 됨), 또는
+- 두 Developer 가 각자의 brand 에 들어가도 ContextPack 이 main conv 의 active plan 1자리를 그대로 inject 해 다른 plan 으로 오염됐음.
+
+후자가 핵심이다. 이미 brand 라는 격리 단위가 존재하는데 ContextPack 빌더가 그것을 활용하지 않는다.
+
+## 옵션 재평가
+
+| 옵션 | 평가 |
+|---|---|
+| A (자동 sub-conv 격리) | UI/스토어/DB 영향 큼. 그런데 tunaFlow 는 이미 plan-당-brand 모델이 있어 신규 sub-conv 가 아니라 **기존 brand 매핑을 ContextPack 에 적용**하면 같은 격리 효과. 이게 옵션 A 의 본래 의도 (격리) 에 더 부합. → **A′** 로 변형 채택. |
+| B (ContextPack sender 명시) | 변경 표면 작음. main conv 에서 직접 일하는 Architect 사용자 시나리오 (brand 진입 X) 에서도 sender + plan title 명시로 LLM robustness 보강. → 채택. |
+| C (DB 매핑 전면 개편) | 기존 `plans.status='active'` SSOT 가 잘 자리 잡혀 있고, A′ 가 DB 변경 없이 같은 격리 효과. → **부결.** |
+| D (parser 자동 plan 전환) | parser 정확도 의존. A′+B 로 INV 커버되면 불필요. → P3 future, 본 PR 제외. |
+
+## 채택 — A′ + B
+
+### Layer A′ — brand 기반 plan filter
+
+`build_plan_section` / `load_context_data` 의 has_active_plan, plan_document 빌드 모두 **현재 conv 가 brand 면, `branches.id == implementation_branch_id || review_branch_id` 인 plan 만 surface** 한다.
+
+- **Architect (main conv 또는 일반 brand 진입, plan 매칭 X)**: 기존 동작 그대로 — main conv 의 active plan 표시
+- **Developer (impl brand 진입)**: 해당 brand_id 와 매칭되는 plan 만 노출 — 다른 plan 진행 중이라도 영향 X
+- **Reviewer (review brand 진입)**: 해당 brand_id 와 매칭되는 plan 만 노출
+
+이 변경은 데이터 모델 변경이 아닌 **lookup 정확성 향상**. brand 가 곧 plan 격리 boundary 라는 본래 설계를 ContextPack 에 일관되게 적용한다. Layer B (branchInheritsMainSession) 의 dynamic 섹션 drop 정책과도 충돌하지 않는다 (plan 섹션은 static 분류로 유지된다).
+
+### Layer B — ContextPack sender 명시
+
+active plan section 의 첫 줄에 sender 정보를 inline:
+
+```markdown
+## Active Plan (phase: implementation)
+
+> **Sender**: developer (codex / gpt-5)
+> **Plan**: Role Adapter Phase 1
+```
+
+이를 통해 같은 conv 에서 직접 (brand 진입 없이) 다른 Developer 를 호출하는 케이스 (사용자가 의도적으로 같은 conv 모드 선택 또는 brand 매핑이 아직 없는 단계) 에서도 LLM 이 "지금 메시지를 받은 Developer 와 plan 정합" 을 inline 으로 인지.
+
+sender 정보 출처:
+- **engine**: `prepare_engine_run` 의 `engine_key`
+- **persona**: `SendWithClaudeInput.persona_label`
+- **agent role**: `resolve_agent_role(conn, conversation_id)` (architect/developer/reviewer)
+
+이 셋을 한 줄로 묶어 plan section 헤더에 inject. plan 이 없는 send 에는 영향 없음 (본 줄은 plan section 안에서만 출력).
+
+## INV 만족 매핑
+
+- **INV-1** (자동 격리 OR sender 명시) — A′ + B 모두 활성. brand 진입 시 A′ 격리, plan 매칭 안 되더라도 B 가 sender 명시.
+- **INV-2** (다른 Developer plan 미주입) — A′ 가 brand 별 plan 만 노출해 직접 만족.
+- **INV-3** (override = 같은 conv 모드) — main conv 에서 직접 호출은 기존 동작이 곧 same-conv 모드. B 만 활성. 별도 toggle 불필요.
+- **INV-4** (모델별 차이 무관) — A′ 가 ContextPack 자체의 데이터를 격리하므로 Codex/Claude 의 instruction-following 차이가 영향 없음.
+
+## 회귀 0 검증 포인트
+
+1. main conv 에서 1 Developer + 1 active plan: 기존 동작 (main 의 active plan 그대로). ✅
+2. brand 매핑 없는 일반 brand 진입 (사용자가 임의로 만든 branch): main 의 active plan fallback. plan 매칭이 안 되면 main conv plan 으로. ✅
+3. `plans.implementation_branch_id` 미설정인 옛 plan (v26 이전): branch_id 매칭 자체가 0 → fallback 으로 main conv plan. ✅
+
+## Override 옵션 toggle (Settings) — 본 PR 에서 보류
+
+plan §INV-3 의 "두 Developer 같은 conv 강제" override 는 별도 UI toggle 로 명시할 수 있으나, 위 매핑처럼 main conv 에서 직접 호출 = same-conv 모드가 자연스러운 default. 현재 시점 별도 toggle 추가는 표면 확대 대비 효과 미미 → **본 PR 에서 보류**, 사용자 요청 발생 시 follow-up.
+
+## Out-of-scope (N-A 메모)
+
+- 옵션 C (DB 매핑 변경): 본 PR 비대상. 향후 multi-Developer 동시 active 가 1급 시민이 될 때 (P3 future).
+- 옵션 D (parser): 본 PR 비대상.
+- 새 sub-conv 자동 생성 + UI 라우팅: 본 PR 비대상. brand-기반 격리가 같은 효과를 더 작은 표면으로 제공.

--- a/src-tauri/src/commands/agents_helpers/context_pack/db_queries.rs
+++ b/src-tauri/src/commands/agents_helpers/context_pack/db_queries.rs
@@ -20,22 +20,68 @@ const RT_PARENT_RECENT: i64 = 2;
 
 // ─── Plan ────────────────────────────────────────────────────────────────────
 
+/// multiDeveloperActivePlanIsolationPlan §Layer A′: brand 진입 시 해당
+/// brand_id 와 매칭되는 plan 을 우선 lookup.
+///
+/// 본 함수는 `build_plan_section` 과 `load_context_data` 가 공유하는 단일
+/// 진입점이다. brand conv 라면:
+///   1) `branches.id` 를 추출
+///   2) `plans.implementation_branch_id` 또는 `plans.review_branch_id` 가 그
+///      brand_id 와 매칭되는 plan 을 가장 최근 갱신 순으로 1건
+/// non-brand 또는 매칭 0건이면 fallback 으로 main conv 의 active plan.
+///
+/// 같은 conv 안에서 multi-Developer 가 동시 작업할 때 한쪽 Developer 의
+/// active plan 이 다른 Developer 의 ContextPack 으로 누출되는 문제를 차단한다.
+/// 매칭이 0건이면 (옛 plan 또는 임시 brand) 기존 동작 (main 의 active) 으로
+/// graceful fallback 하므로 회귀 0.
+pub fn lookup_plan_for_conversation(
+    conn: &rusqlite::Connection,
+    conversation_id: &str,
+) -> Option<(String, String, Option<String>, String, Option<String>)> {
+    if let Some(branch_id) = conversation_id.strip_prefix("branch:") {
+        // Layer A′: brand 매핑 plan 우선
+        if let Ok(row) = conn.query_row(
+            "SELECT id, title, description, phase, slug FROM plans
+             WHERE (implementation_branch_id = ?1 OR review_branch_id = ?1)
+               AND status NOT IN ('done','abandoned')
+             ORDER BY updated_at DESC LIMIT 1",
+            [branch_id],
+            |row| Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, Option<String>>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, Option<String>>(4)?,
+            )),
+        ) {
+            return Some(row);
+        }
+    }
+
+    // Fallback: main conv 의 active plan (비-brand 또는 매칭 0건)
+    let plan_conv_id = resolve_plan_conversation_id(conn, conversation_id);
+    conn.query_row(
+        "SELECT id, title, description, phase, slug FROM plans
+         WHERE conversation_id = ?1 AND status = 'active'
+         ORDER BY updated_at DESC LIMIT 1",
+        [&plan_conv_id],
+        |row| Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, Option<String>>(2)?,
+            row.get::<_, String>(3)?,
+            row.get::<_, Option<String>>(4)?,
+        )),
+    ).ok()
+}
+
 /// Build `## Active Plan` section from DB for the given conversation.
 pub fn build_plan_section(
     conn: &rusqlite::Connection,
     conversation_id: &str,
 ) -> Option<String> {
-    let plan: (String, String, Option<String>, String, Option<String>) = conn
-        .query_row(
-            "SELECT id, title, description, phase, slug FROM plans
-             WHERE conversation_id = ?1 AND status = 'active'
-             ORDER BY updated_at DESC LIMIT 1",
-            [conversation_id],
-            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?)),
-        )
-        .ok()?;
-
-    let (plan_id, title, description, phase, slug) = plan;
+    let (plan_id, title, description, phase, slug) =
+        lookup_plan_for_conversation(conn, conversation_id)?;
 
     let mut stmt = conn
         .prepare(
@@ -349,4 +395,120 @@ pub fn build_rt_inheritance_section(
         return None;
     }
     Some(format!("## Roundtable Context\n\n{}", parts.join("\n\n")))
+}
+
+// ─── Layer A′ tests: brand-aware plan lookup ─────────────────────────────────
+
+#[cfg(test)]
+mod plan_isolation_tests {
+    use super::*;
+    use rusqlite::Connection;
+
+    fn build_db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE plans (
+                id TEXT PRIMARY KEY,
+                conversation_id TEXT NOT NULL,
+                title TEXT NOT NULL,
+                description TEXT,
+                phase TEXT NOT NULL DEFAULT 'design',
+                slug TEXT,
+                status TEXT NOT NULL DEFAULT 'active',
+                implementation_branch_id TEXT,
+                review_branch_id TEXT,
+                updated_at INTEGER NOT NULL DEFAULT 0
+             );
+             CREATE TABLE branches (
+                id TEXT PRIMARY KEY,
+                conversation_id TEXT NOT NULL
+             );",
+        )
+        .unwrap();
+        conn
+    }
+
+    fn insert_plan(
+        conn: &Connection,
+        id: &str,
+        conv: &str,
+        title: &str,
+        phase: &str,
+        slug: Option<&str>,
+        status: &str,
+        impl_branch: Option<&str>,
+        review_branch: Option<&str>,
+        ts: i64,
+    ) {
+        conn.execute(
+            "INSERT INTO plans (id, conversation_id, title, description, phase, slug, status, implementation_branch_id, review_branch_id, updated_at)
+             VALUES (?1, ?2, ?3, NULL, ?4, ?5, ?6, ?7, ?8, ?9)",
+            rusqlite::params![id, conv, title, phase, slug, status, impl_branch, review_branch, ts],
+        )
+        .unwrap();
+    }
+
+    /// Layer A′ INV-2: brand 진입 시 brand_id 매핑 plan 만 노출. main conv 의
+    /// 다른 active plan 이 누출되지 않는다.
+    #[test]
+    fn brand_lookup_isolates_developer_plan() {
+        let conn = build_db();
+        // main conv 에 두 plan 이 있고, 각각 자기 impl_branch 를 갖는다.
+        // 사용자 보고 케이스: Coder Claude → readme-memento, Codex → role-adapter.
+        // 두 plan 다 status='active' 이지만 main conv 는 plan-A (가장 최근).
+        insert_plan(&conn, "p-readme", "conv-main", "readme-memento", "implementation", Some("readme-memento"), "active", Some("br-readme"), None, 100);
+        insert_plan(&conn, "p-role",   "conv-main", "Role Adapter Phase 1", "implementation", Some("role-adapter"), "active", Some("br-role"), None, 200);
+
+        // brand 진입 시각각의 plan 만 보여야 한다.
+        let r = lookup_plan_for_conversation(&conn, "branch:br-readme").unwrap();
+        assert_eq!(r.1, "readme-memento", "Coder Claude 의 brand 는 readme-memento plan 만 본다");
+
+        let r = lookup_plan_for_conversation(&conn, "branch:br-role").unwrap();
+        assert_eq!(r.1, "Role Adapter Phase 1", "Codex 의 brand 는 role-adapter plan 만 본다");
+    }
+
+    /// Fallback: brand_id 매핑 plan 이 없으면 main conv 의 active plan 으로 graceful fallback.
+    #[test]
+    fn unmapped_brand_falls_back_to_main_active() {
+        let conn = build_db();
+        insert_plan(&conn, "p1", "conv-main", "main-plan", "design", Some("main-plan"), "active", None, None, 100);
+        // branches 테이블에 br-temp 를 main conv 로 매핑 (옛 brand 또는 임시 brand)
+        conn.execute("INSERT INTO branches (id, conversation_id) VALUES (?1, ?2)",
+                    rusqlite::params!["br-temp", "conv-main"]).unwrap();
+
+        let r = lookup_plan_for_conversation(&conn, "branch:br-temp").unwrap();
+        assert_eq!(r.1, "main-plan", "매핑 plan 없을 때 main conv 의 active plan 으로 fallback");
+    }
+
+    /// Reviewer 가 review_branch_id 매핑으로 들어가면 그 plan 만 본다.
+    #[test]
+    fn review_brand_isolates_reviewer_plan() {
+        let conn = build_db();
+        insert_plan(&conn, "p1", "conv-main", "feature-a", "review", Some("feature-a"), "active", Some("br-impl"), Some("br-rev"), 100);
+        insert_plan(&conn, "p2", "conv-main", "feature-b", "implementation", Some("feature-b"), "active", Some("br-other-impl"), None, 200);
+
+        let r = lookup_plan_for_conversation(&conn, "branch:br-rev").unwrap();
+        assert_eq!(r.1, "feature-a", "review brand 는 매핑된 plan 만 본다");
+    }
+
+    /// done/abandoned plan 은 brand 매핑 lookup 에서 제외된다 (휴면 plan 누출 방지).
+    #[test]
+    fn done_plans_excluded_from_brand_lookup() {
+        let conn = build_db();
+        insert_plan(&conn, "p1", "conv-main", "old-feature", "implementation", None, "done", Some("br-old"), None, 100);
+
+        // brand 매핑 lookup 결과 None → fallback 으로 main 도 active 없으므로 None
+        let r = lookup_plan_for_conversation(&conn, "branch:br-old");
+        assert!(r.is_none(), "done plan 은 brand 매핑 lookup 에서 제외");
+    }
+
+    /// 비-brand conv (main conv 또는 일반 chat) 는 기존 동작 — 자기 conv 의 active plan.
+    #[test]
+    fn non_brand_uses_existing_active_lookup() {
+        let conn = build_db();
+        insert_plan(&conn, "p1", "conv-main", "main-plan", "design", None, "active", None, None, 100);
+
+        let r = lookup_plan_for_conversation(&conn, "conv-main").unwrap();
+        assert_eq!(r.1, "main-plan");
+    }
 }

--- a/src-tauri/src/commands/agents_helpers/context_pack/mod.rs
+++ b/src-tauri/src/commands/agents_helpers/context_pack/mod.rs
@@ -33,6 +33,7 @@ pub use db_queries::{
     build_lite_context_prompt,
     build_thread_inheritance_section,
     build_rt_inheritance_section,
+    lookup_plan_for_conversation,
     LITE_CONTEXT_MESSAGES_LIMIT,
 };
 

--- a/src-tauri/src/commands/agents_helpers/send_common/context_loading.rs
+++ b/src-tauri/src/commands/agents_helpers/send_common/context_loading.rs
@@ -484,6 +484,25 @@ pub struct ContextData {
     /// 각 항목: (timestamp_ms, conversation_id, content_excerpt, score, matched_keywords).
     /// `content_excerpt` 는 prompt_assembly 에서 ~200 char cap 하기 전 raw 본문.
     pub intent_lookup: Option<Vec<UserIntentMatch>>,
+
+    /// multiDeveloperActivePlanIsolationPlan §Layer B: 현재 send 의 sender
+    /// 정보를 active plan 섹션 헤더에 inline 한다. 같은 conv 에서 multi-Developer
+    /// 가 동시에 일할 때 LLM 이 "이 메시지가 어떤 Developer 한테 가는지" 와
+    /// "그 Developer 가 진행 중인 plan" 을 inline hint 로 인지 (instruction
+    /// following 약점 보강).
+    ///
+    /// 출처:
+    ///   - `sender_engine`: prepare_engine_run 의 engine_key
+    ///   - `sender_persona`: SendWithClaudeInput.persona_label
+    ///   - `sender_role`: resolve_agent_role(conn, conversation_id)
+    ///   - `sender_model`: SendWithClaudeInput.model
+    ///
+    /// load_context_data 단계에선 None — prepare_engine_run 이 채워서
+    /// assemble_prompt 가 plan section 직전에 prepend 한다.
+    pub sender_engine: Option<String>,
+    pub sender_persona: Option<String>,
+    pub sender_role: Option<String>,
+    pub sender_model: Option<String>,
 }
 
 /// userIntentSsotSurfacingPlan: 과거 사용자 메시지 매칭 결과.
@@ -946,6 +965,11 @@ pub fn load_context_data(
         is_session_continuation: false, // persistence.rs 에서 필요시 true 로 override
         identity_summary_fragment,
         intent_lookup,
+        // §Layer B: persistence.rs::prepare_engine_run 에서 채워준다.
+        sender_engine: None,
+        sender_persona: None,
+        sender_role: Some(agent_role.to_string()),
+        sender_model: None,
     }
 }
 
@@ -1250,6 +1274,10 @@ mod tests {
             is_session_continuation: false,
             identity_summary_fragment: None,
             intent_lookup: None,
+            sender_engine: None,
+            sender_persona: None,
+            sender_role: None,
+            sender_model: None,
         }
     }
 

--- a/src-tauri/src/commands/agents_helpers/send_common/context_loading.rs
+++ b/src-tauri/src/commands/agents_helpers/send_common/context_loading.rs
@@ -541,10 +541,15 @@ pub fn load_context_data(
             [conversation_id], |row| row.get::<_, String>(0),
         ).ok()
     } else { None };
-    let has_active_plan: bool = conn.query_row(
-        "SELECT COUNT(*) > 0 FROM plans WHERE conversation_id = ?1 AND status = 'active'",
-        [plan_lookup_conv.as_deref().unwrap_or(conversation_id)], |row| row.get(0),
-    ).unwrap_or(false);
+
+    // multiDeveloperActivePlanIsolationPlan §Layer A′: brand 진입 시 brand_id 매핑
+    // plan 을 우선 lookup. scratchpad / main conv 는 fallback 으로 main conv active.
+    // 본 lookup 결과를 has_active_plan / plan_document / intent_lookup 가 공유해
+    // 각 단계가 어긋나지 않도록 한다.
+    let plan_lookup_target = plan_lookup_conv.as_deref().unwrap_or(conversation_id);
+    let isolated_plan: Option<(String, String, Option<String>, String, Option<String>)> =
+        super::super::context_pack::lookup_plan_for_conversation(conn, plan_lookup_target);
+    let has_active_plan: bool = isolated_plan.is_some();
 
     // Query 2: current messages — budget-based dynamic window + per-agent last-message guarantee
     let current_messages = load_recent_messages_with_author(conn, conversation_id, 20);
@@ -572,11 +577,14 @@ pub fn load_context_data(
     };
 
     // Query 4-7: plan, findings, artifacts (scratchpad: use main chat's plan)
+    // multiDeveloperActivePlanIsolationPlan §Layer A′: brand 진입 시 build_plan_section
+    // 이 brand_id 매핑 plan 을 우선 lookup 하도록 conv id 를 그대로 전달. scratchpad
+    // 는 main conv 사용 (기존 동작 유지). main conv 는 자기 자신.
     let effective_conv_id = if is_scratchpad {
         plan_lookup_conv.as_deref().unwrap_or(conversation_id)
     } else { conversation_id };
     let plan_conv_id = resolve_plan_conversation_id(conn, effective_conv_id);
-    let mut plan_section = build_plan_section(conn, &plan_conv_id);
+    let mut plan_section = build_plan_section(conn, effective_conv_id);
 
     // Append completed plan titles so the agent knows what was already done
     let done_plans: Vec<String> = conn.prepare(
@@ -605,17 +613,15 @@ pub fn load_context_data(
     ).ok();
 
     // Load plan documents from filesystem (plan, result, review)
-    let plan_document: Option<String> = if has_active_plan {
+    // §Layer A′: isolated_plan 이 brand-aware 결과 — plan_id/title/desc/phase/slug.
+    // 여기서는 (title, phase, slug) 만 필요.
+    let plan_document: Option<String> = if let Some(ref plan_row_full) = isolated_plan {
         if let Some(pp) = project_path {
-            let plan_row = conn.query_row(
-                "SELECT title, phase, slug FROM plans WHERE conversation_id = ?1 AND status = 'active' LIMIT 1",
-                [plan_lookup_conv.as_deref().unwrap_or(conversation_id)],
-                |row| Ok((
-                    row.get::<_, String>(0)?,
-                    row.get::<_, String>(1)?,
-                    row.get::<_, Option<String>>(2)?,
-                )),
-            ).ok();
+            let plan_row = Some((
+                plan_row_full.1.clone(),  // title
+                plan_row_full.3.clone(),  // phase
+                plan_row_full.4.clone(),  // slug
+            ));
             plan_row.and_then(|(title, phase, slug_opt)| {
                 // Prefer the canonical slug persisted in `plans.slug` (v26). Fall
                 // back to title-based slugify only for pre-v26 rows. All writers
@@ -892,14 +898,10 @@ pub fn load_context_data(
     // prompt_assembly 에서 섹션 생략.
     let intent_lookup: Option<Vec<UserIntentMatch>> = if agent_role == "architect" {
         if let Some(pk) = project_key.as_deref() {
-            // Active plan title 을 키워드 보강에 사용
-            let active_plan_title: Option<String> = conn
-                .query_row(
-                    "SELECT title FROM plans WHERE conversation_id = ?1 AND status = 'active' LIMIT 1",
-                    [plan_lookup_conv.as_deref().unwrap_or(conversation_id)],
-                    |row| row.get(0),
-                )
-                .ok();
+            // §Layer A′: Active plan title 을 isolated_plan 결과에서 가져온다.
+            // brand-aware lookup 이므로 다른 Developer 의 plan 키워드가 섞이지 않는다.
+            let active_plan_title: Option<String> =
+                isolated_plan.as_ref().map(|(_id, title, _, _, _)| title.clone());
             let keywords = extract_intent_keywords(prompt, active_plan_title.as_deref());
             if keywords.is_empty() {
                 Some(Vec::new())

--- a/src-tauri/src/commands/agents_helpers/send_common/mod.rs
+++ b/src-tauri/src/commands/agents_helpers/send_common/mod.rs
@@ -53,6 +53,10 @@ mod tests {
             is_session_continuation: false,
             identity_summary_fragment: None,
             intent_lookup: None,
+            sender_engine: None,
+            sender_persona: None,
+            sender_role: None,
+            sender_model: None,
         }
     }
 

--- a/src-tauri/src/commands/agents_helpers/send_common/persistence.rs
+++ b/src-tauri/src/commands/agents_helpers/send_common/persistence.rs
@@ -223,6 +223,17 @@ pub fn prepare_engine_run(
             &mut ctx_data,
             engine_key,
         );
+
+        // multiDeveloperActivePlanIsolationPlan §Layer B: sender 정보 inject.
+        // load_context_data 에서 sender_role 은 이미 채웠다 (resolve_agent_role
+        // 결과). 여기서 engine / persona / model 만 추가해 active plan section
+        // 헤더에 inline 되도록 한다. 같은 conv 에서 multi-Developer 가 동시에
+        // 일할 때 LLM 이 "이 메시지 sender + 그 sender 의 plan" 을 inline 으로
+        // 인지 (instruction-following 약점 보강).
+        ctx_data.sender_engine = Some(engine_key.to_string());
+        ctx_data.sender_persona = input.persona_label.clone();
+        ctx_data.sender_model = input.model.clone();
+
         (ctx_data, pp)
     };
 

--- a/src-tauri/src/commands/agents_helpers/send_common/prompt_assembly.rs
+++ b/src-tauri/src/commands/agents_helpers/send_common/prompt_assembly.rs
@@ -52,6 +52,40 @@ pub(crate) fn build_user_intent_lookup_section(intents: &[UserIntentMatch]) -> S
     s
 }
 
+/// multiDeveloperActivePlanIsolationPlan §Layer B: 현재 send 의 sender 정보를
+/// active plan 섹션 헤더에 inline 할 한 줄을 만든다.
+///
+/// 형식 (없는 정보는 생략):
+///   `> **Sender**: developer (codex / gpt-5 · persona=Coder)`
+///
+/// 같은 conv 에서 multi-Developer 가 동시에 일할 때 LLM 이 inline 으로
+/// "이 메시지가 누구에게 가는지" 와 "그 sender 가 진행 중인 plan" 정합을
+/// 검증할 수 있도록 한다. sender_engine 이 None 이면 전체 줄 생략 (테스트
+/// fixture / load_context_data 단독 호출 케이스 대응).
+pub(crate) fn build_sender_hint_line(data: &ContextData) -> Option<String> {
+    let engine = data.sender_engine.as_deref()?;
+    let role = data.sender_role.as_deref().unwrap_or("agent");
+    let mut detail_parts: Vec<String> = Vec::new();
+    detail_parts.push(engine.to_string());
+    if let Some(model) = data.sender_model.as_deref() {
+        if !model.is_empty() {
+            detail_parts.push(model.to_string());
+        }
+    }
+    let mut tail = String::new();
+    if let Some(persona) = data.sender_persona.as_deref() {
+        if !persona.is_empty() {
+            tail.push_str(&format!(" · persona={}", persona));
+        }
+    }
+    Some(format!(
+        "> **Sender**: {} ({}){}",
+        role,
+        detail_parts.join(" / "),
+        tail,
+    ))
+}
+
 /// timestamp(ms epoch) → "YYYY-MM-DD" (UTC). chrono 추가 없이 calendar 산출.
 fn format_ymd_utc(ts_ms: i64) -> String {
     // 음수 타임스탬프는 unknown 으로 처리
@@ -414,8 +448,18 @@ pub fn assemble_prompt(
 
     // Layer 2: Structured task memory — highest priority after context window
     if ctx_mode >= ContextMode::Standard {
+        // multiDeveloperActivePlanIsolationPlan §Layer B: plan section 직전에
+        // 한 줄 sender hint 를 inline. 같은 conv 에서 다른 Developer 의 plan 이
+        // 누출돼도 LLM 이 inline 으로 정합 검증할 수 있도록 한다 (instruction
+        // following 약점 보강 — Codex 류).
+        let plan_section_with_sender = data.plan_section.as_ref().map(|s| {
+            let sender_line = build_sender_hint_line(data);
+            if let Some(line) = sender_line {
+                format!("{}\n{}", line, s)
+            } else { s.clone() }
+        });
         if let Some(s) = guardrail::truncate_section(
-            data.plan_section.clone(),
+            plan_section_with_sender,
             dyn_cap("plan"),
         ) {
             sections.push(s);
@@ -800,6 +844,10 @@ mod tests {
             is_session_continuation: false,
             identity_summary_fragment: None,
             intent_lookup: None,
+            sender_engine: None,
+            sender_persona: None,
+            sender_role: None,
+            sender_model: None,
         }
     }
 
@@ -1010,5 +1058,78 @@ mod tests {
     fn format_ymd_handles_negative_or_zero() {
         assert_eq!(format_ymd_utc(0), "unknown");
         assert_eq!(format_ymd_utc(-1), "unknown");
+    }
+
+    // ─── multiDeveloperActivePlanIsolationPlan §Layer B: sender hint ────────
+
+    /// sender_engine 이 채워진 상태에서 plan section 이 있으면 sender 한 줄이
+    /// plan section 헤더 앞에 inline 된다.
+    #[test]
+    fn sender_hint_prepended_to_plan_section() {
+        let tmp = TempDir::new().unwrap();
+        let mut data = empty_context_data(Some(tmp.path().to_string_lossy().to_string()));
+        data.plan_section = Some("## Active Plan (phase: implementation)\n\n### Role Adapter".into());
+        data.context_mode_override = Some("standard".into());
+        data.sender_engine = Some("codex".into());
+        data.sender_role = Some("developer".into());
+        data.sender_model = Some("gpt-5".into());
+        data.sender_persona = Some("Coder".into());
+
+        let (assembled, _, meta) = assemble_prompt(&data, None);
+        assert!(meta.sections.contains(&"plan".to_string()));
+        assert!(
+            assembled.contains("**Sender**: developer (codex / gpt-5) · persona=Coder"),
+            "Layer B sender 줄이 plan section 헤더에 포함되어야: {}", assembled
+        );
+    }
+
+    /// sender_engine 이 None 이면 sender 줄을 출력하지 않는다 (테스트 fixture
+    /// 또는 load_context_data 단독 호출 케이스 회귀 0).
+    #[test]
+    fn sender_hint_absent_when_engine_none() {
+        let tmp = TempDir::new().unwrap();
+        let mut data = empty_context_data(Some(tmp.path().to_string_lossy().to_string()));
+        data.plan_section = Some("## Active Plan\n\n### Some plan".into());
+        data.context_mode_override = Some("standard".into());
+        // sender_engine 명시적으로 None
+        data.sender_engine = None;
+
+        let (assembled, _, _) = assemble_prompt(&data, None);
+        assert!(!assembled.contains("**Sender**"));
+    }
+
+    /// plan section 이 없으면 sender 줄도 미출력 (sender hint 는 plan section
+    /// 안에서만 의미가 있음).
+    #[test]
+    fn sender_hint_absent_without_plan_section() {
+        let tmp = TempDir::new().unwrap();
+        let mut data = empty_context_data(Some(tmp.path().to_string_lossy().to_string()));
+        data.plan_section = None;
+        data.sender_engine = Some("codex".into());
+        data.sender_role = Some("developer".into());
+
+        let (assembled, _, meta) = assemble_prompt(&data, None);
+        assert!(!meta.sections.contains(&"plan".to_string()));
+        assert!(!assembled.contains("**Sender**"));
+    }
+
+    /// model 이 비어 있어도 engine + role 만으로 sender 줄을 만든다.
+    #[test]
+    fn sender_hint_omits_blank_model_and_persona() {
+        let tmp = TempDir::new().unwrap();
+        let mut data = empty_context_data(Some(tmp.path().to_string_lossy().to_string()));
+        data.plan_section = Some("## Active Plan\n\n### Plan".into());
+        data.context_mode_override = Some("standard".into());
+        data.sender_engine = Some("claude".into());
+        data.sender_role = Some("architect".into());
+        data.sender_model = Some("".into());
+        data.sender_persona = None;
+
+        let (assembled, _, _) = assemble_prompt(&data, None);
+        assert!(
+            assembled.contains("**Sender**: architect (claude)"),
+            "engine 만 있는 케이스에도 sender 줄 출력: {}", assembled
+        );
+        assert!(!assembled.contains("persona="));
     }
 }


### PR DESCRIPTION
## Summary

Multi-Developer 동시 작업 시 같은 conv 의 active plan 1자리가 충돌하던
문제 (사용자 보고 2026-04-25: Coder Claude 가 readme-memento 시작한
conv 에서 Codex 에 Role Adapter Phase 1 명령 → Codex 가 readme-memento
진행 시도) 의 root cause 차단.

SSOT: \`docs/plans/multiDeveloperActivePlanIsolationPlan_2026-04-25.md\`

## Audit (Step 1)

\`docs/reference/multiDeveloperIsolationDecision_2026-04-25.md\` 참조.

plan 의 권장 A+B 를 코드 현황과 대조한 결과:

- 옵션 A 의 \"신규 sub-conv 자동 생성\" 은 UI/스토어 영향이 큰데, tunaFlow
  는 이미 plan 별 implementation/review brand 매핑 (\`plans.implementation_branch_id\`
  / \`review_branch_id\`) 이 존재한다. 그런데 ContextPack 빌더가 brand
  진입 시에도 \`resolve_plan_conversation_id(branch:* → main)\` 으로 root
  의 active plan 1자리를 그대로 가져와 다른 plan 으로 오염되는 게 root cause.
- → **A′** 변형 (기존 brand 매핑을 ContextPack 에 적용) + **B** (sender
  명시) 채택. 옵션 C (DB 매핑) / D (parser) 는 부결, 옵션 D 는 P3 future.

## Changes

### Layer A′ — brand 기반 plan filter (1 commit)

- \`lookup_plan_for_conversation\`: brand 진입 시 brand_id 매핑 plan 우선,
  매칭 0건이면 main conv active 로 fallback (회귀 0)
- \`build_plan_section\` / \`load_context_data\` 의 has_active_plan / plan_document
  / intent_lookup active_plan_title 모두 같은 lookup 사용 (단일 SSOT)
- 단위테스트 5건 — brand 격리 / fallback / Reviewer / done 제외 / 비-brand

### Layer B — ContextPack sender hint inline (1 commit)

- ContextData 에 sender_engine/persona/role/model 추가
- prepare_engine_run 이 engine_key + persona_label + model 채움
- load_context_data 가 sender_role 미리 설정 (resolve_agent_role 재사용)
- plan section 헤더 직전에 한 줄 sender hint prepend:
  \`> **Sender**: developer (codex / gpt-5 · persona=Coder)\`
- sender_engine None 또는 plan_section None 일 때 미출력 (회귀 0)
- 단위테스트 4건

### Decision audit doc (1 commit)

- \`docs/reference/multiDeveloperIsolationDecision_2026-04-25.md\`

## Invariants 만족

- **INV-1** (자동 격리 OR sender 명시) — A′ + B 모두 활성
- **INV-2** (다른 Developer plan 미주입) — A′ 가 brand 별 plan 만 노출 → 직접 만족
- **INV-3** (override = 같은 conv 모드) — main conv 직접 호출이 자연스러운 default. 별도 toggle 본 PR 보류
- **INV-4** (모델별 차이 무관) — A′ 가 ContextPack 데이터 자체를 격리 → Codex/Claude 차이 무관

## 검증

- \`cargo check --lib\`: ✅
- \`cargo test --lib\`: 556 passed (기존 547 + 신규 9)
- \`npx tsc --noEmit\`: ✅
- \`npx vitest run\`: 347 passed

## Test plan (수동 smoke)

- [ ] **재현 시나리오**: 같은 conv 에서 Coder Claude 가 plan-A 의 impl brand 진입,
      Codex 가 plan-B 의 impl brand 진입 → 각자 자기 plan 만 ContextPack 에 surface
- [ ] **Override**: main conv 에서 직접 두 Developer 호출 → 같은 active plan
      이지만 sender hint 줄이 plan section 헤더에 inline (LLM robustness)
- [ ] **회귀**: 단일 Developer + 단일 plan 시나리오에서 기존 동작 그대로

## N-A (out-of-scope)

- 옵션 C (DB 매핑 전면 개편) — 미래 multi-Developer 가 1급 시민이 될 때
- 옵션 D (parser 자동 plan 전환) — P3 future
- 신규 sub-conv 자동 생성 + UI 라우팅 — A′ 가 같은 격리 효과를 더 작은 표면으로 제공
- Settings same-conv override toggle — main conv 직접 호출이 자연스러운 default

## Sibling

- \`docs/plans/branchCancelSemanticsPlan_2026-04-25\` (사용자가 같이 보고한 brand cancel 이슈, 별 axis)

🤖 Generated with [Claude Code](https://claude.com/claude-code)