### PR TITLE
feat(input): guard main chat while brand task running (PR #198 follow-up)

### DIFF
--- a/docs/plans/index.md
+++ b/docs/plans/index.md
@@ -57,6 +57,7 @@
 | [tunaflowOutboxArtifactCleanupPlan_2026-04-25](./tunaflowOutboxArtifactCleanupPlan_2026-04-25.md) | **P3 (housekeeping)** — outbox 방식 폐기 (commit 9295062) 후 4 .md 잔재 + .gitignore 누락. git rm + .gitignore 추가. Developer 핸드오프 포함 |
 | [multiDeveloperActivePlanIsolationPlan_2026-04-25](./multiDeveloperActivePlanIsolationPlan_2026-04-25.md) | **P1** — multi-Developer 동시 작업 시 active plan 1자리 충돌 (Codex 가 다른 Developer 의 plan 진행 시도). 자동 sub-conv 격리 (A) + ContextPack sender 명시 (B) 조합. Developer 핸드오프 포함 |
 | [branchCancelSemanticsPlan_2026-04-25](./branchCancelSemanticsPlan_2026-04-25.md) | **P1 (PR #198 follow-up)** — Task A same-session 모델에서 cancel 작동 안 함. stream abort token 도입 + UI cancel 의미 stream-only 로 재정의. Developer 핸드오프 포함 |
+| [mainChatBrandRunningGuardPlan_2026-04-25](./mainChatBrandRunningGuardPlan_2026-04-25.md) | **P1 (PR #198 follow-up)** — brand=main session 공유의 부작용. brand 에서 Developer 작업 중일 때 main chat 입력이 같은 process 에 끼어드는 문제. 옵션 B: main mode + brand running 시 input disable + banner + "드로어 열기". Developer 핸드오프 포함 |
 | [selfTrustCiTriggerOptimizationPlan_2026-04-25](./selfTrustCiTriggerOptimizationPlan_2026-04-25.md) | **P1 (applied)** — main 직접 push 시 CI skip. 외부 PR + release tag (build.yml) 만 검증. 인지 부담 fragmenting 해소. Revert 절차 명시 |
 | [postParityRuntimeValidationSweepPlan_2026-03-30](./postParityRuntimeValidationSweepPlan_2026-03-30.md) | P1 — parity fix 효과 재검증 |
 | [realWorkflowMemoryQualityValidationPlan_2026-03-30](./realWorkflowMemoryQualityValidationPlan_2026-03-30.md) | P1 — memory/retrieval 응답 품질 검증 |

--- a/docs/plans/mainChatBrandRunningGuardPlan_2026-04-25.md
+++ b/docs/plans/mainChatBrandRunningGuardPlan_2026-04-25.md
@@ -1,0 +1,211 @@
+---
+title: Main chat 입력 guard — brand 에서 Developer 작업 중일 때 main chat 메시지 차단 (옵션 B)
+status: ready-to-implement
+priority: P1 (사용자 보고 — brand=main session 공유의 의도외 사이드이펙트)
+created_at: 2026-04-25
+related:
+  - src/components/tunaflow/NewMessageInput.tsx        # 본 변경 위치
+  - docs/plans/branchInheritsMainSessionPlan_2026-04-25.md  # PR #198 — session 공유 결정
+  - docs/plans/multiDeveloperActivePlanIsolationPlan_2026-04-25.md  # PR #204 — ContextPack 격리만
+  - docs/reference/branchSessionPolicy.md              # session 공유 invariants
+canonical: true
+owners:
+  - architect (본 plan 작성)
+  - developer (구현)
+---
+
+# 증상 (사용자 보고, 2026-04-25)
+
+> "이거 세션을 공유하니깐 개발 소넷이 개발 중간에 본문 채팅에 던진 질문에 대답하네 ㅋㅋ"
+
+# 진단
+
+PR #198 (`branchInheritsMainSessionPlan`) 머지로 brand 와 main 이 같은 SDK WS session (process 1개) 공유. 그 부작용:
+
+- brand drawer 의 Developer subagent 가 작업 중인 동안 사용자가 *main chat* 에 메시지 입력 → 같은 process 가 수신 → Developer 가 의도외 응답
+- PR #204 (`multiDeveloperActivePlanIsolationPlan`) 가 ContextPack 차원 격리만 했고 메시지 라우팅은 단일 process 라 같은 axis
+
+**의도된 동작** = brand 작업 결과를 main 에서 자연스럽게 이어받기 (PR #198 의 정합).
+**의도외 동작** = main 입력이 *진행 중인 brand process* 에 끼어들기.
+
+# 옵션 비교
+
+| 옵션 | 설명 | Pros | Cons |
+|---|---|---|---|
+| A | send 시점에 conversation_id 분리해서 새 turn 으로 라우팅 | session 정합 유지 | SDK turn 분리 정확히 안 되면 오작동, 검증 어려움 |
+| **B (채택)** | brand 가 running 중이면 main input disable + "drawer 에서 진행 중" 안내 | 단순, 사용자 의도 가까움, race 차단 확실 | brand 작업 끝날 때까지 main 입력 못함 (수용 가능 — 어차피 같은 session) |
+| C | brand 별 process spawn (격리) | 진짜 격리 | PR #198 정합 깨짐, session 공유 이점 상실 |
+
+# 채택 — 옵션 B
+
+## 핵심 로직
+
+`NewMessageInput.tsx` 가 main mode (`threadMode === false`) 일 때:
+
+- 현재 `isCurrentThreadRunning` (line 186) 은 `effectiveThreadId` (= main 인 경우 `selectedConversationId`) 가 `runningThreadIds` 에 있는지 검사
+- **추가**: main mode 에서 *brand 도 running 중인지* 별도 체크 — `runningThreadIds` 안에 `branch:` prefix 키가 있으면 brand running
+
+```tsx
+// 새 derived state
+const brandRunning = !threadMode && runningThreadIds.some((id) => id.startsWith("branch:"));
+const inputDisabled = !selectedConversationId || isCurrentThreadRunning || brandRunning;
+```
+
+- `brandRunning` 일 때 textarea `disabled`
+- 안내 banner: "브랜치에서 작업 진행 중 — 완료 후 입력 가능"
+- Send 버튼 / 키보드 단축키 (Cmd+Enter) 도 같이 차단
+
+## 안내 UX
+
+ContextBadges 위 또는 mode bar 자리에 inline banner:
+
+```tsx
+{brandRunning && (
+  <div className="mb-1.5 flex items-center gap-2 text-[10px] rounded px-2.5 py-1 text-amber-600/70 bg-amber-500/8">
+    <Loader2 className="w-3 h-3 animate-spin" />
+    <span className="flex-1">브랜치에서 진행 중인 작업이 있어 메인 채팅 입력이 비활성화됐습니다</span>
+    <button onClick={() => useChatStore.getState().openThread(/* running brand id */)}
+      className="text-amber-600 hover:underline">드로어 열기</button>
+  </div>
+)}
+```
+
+`openThread` 클릭 시 사용자가 진행 중 brand drawer 로 이동.
+
+# Invariants
+
+- **[INV-1]** main mode + 어떤 brand 가 running (= `runningThreadIds` 에 `branch:*` 키 있음) → textarea disabled + send 차단
+- **[INV-2]** banner 표시 + "드로어 열기" 액션 — 사용자가 즉시 진행 상황 확인 가능
+- **[INV-3]** brand 작업 끝나면 (`runningThreadIds` 에서 brand 키 제거) 자동으로 input 활성화 (re-render)
+- **[INV-4]** thread mode (`threadMode === true`) 즉 brand drawer 안에서는 본 guard 무관 — drawer 내부 입력은 그대로 동작
+- **[INV-5]** main 의 다른 conversation 으로 전환했을 때도 *전역 brand running* 이면 guard 작동 (원치 않으면 후속 plan 으로 conversation_id scoping 추가)
+
+# 구현 (단일 경로)
+
+## 파일
+
+`src/components/tunaflow/NewMessageInput.tsx` 만 수정.
+
+## 변경
+
+1. **derived state 추가** (line 186 근처):
+
+```tsx
+const brandRunning = useMemo(
+  () => !threadMode && runningThreadIds.some((id) => id.startsWith("branch:")),
+  [threadMode, runningThreadIds],
+);
+const runningBrandConvId = brandRunning
+  ? runningThreadIds.find((id) => id.startsWith("branch:"))
+  : null;
+```
+
+2. **textarea disabled** (line 520) 에 추가:
+
+```tsx
+disabled={!selectedConversationId || brandRunning}
+```
+
+3. **send 버튼 disabled** (line 593) 에 추가:
+
+```tsx
+disabled={!text.trim() || !selectedConversationId || ptyRespawning || brandRunning}
+```
+
+4. **handleKeyDown** (Cmd+Enter 처리부 — 별도 함수 안에서) 에 brandRunning 체크 추가하여 send 차단
+
+5. **banner** 추가 (line 392 ContextBadges 위):
+
+```tsx
+{brandRunning && (
+  <div className="mb-1.5 flex items-center gap-2 text-[10px] rounded px-2.5 py-1 text-amber-600/70 bg-amber-500/8">
+    <Loader2 className="w-3 h-3 animate-spin" />
+    <span className="flex-1">{t("input.brand_running_guard")}</span>
+    {runningBrandConvId && (
+      <button
+        onClick={() => {
+          const branchId = runningBrandConvId.replace(/^branch:/, "");
+          useChatStore.getState().openThread(branchId);
+        }}
+        className="text-amber-600/80 hover:underline"
+      >
+        {t("input.brand_running_open_drawer")}
+      </button>
+    )}
+  </div>
+)}
+```
+
+6. **i18n key 추가** — `src/locales/ko/chat.json`, `src/locales/en/chat.json`:
+   - `input.brand_running_guard` — "브랜치에서 진행 중인 작업이 있어 메인 채팅 입력이 비활성화됐습니다" / "Branch task running — main chat input disabled"
+   - `input.brand_running_open_drawer` — "드로어 열기" / "Open drawer"
+
+# 검증
+
+## 수동 Smoke
+
+1. main 에서 conversation 선택 → message 입력 → 정상 send
+2. brand drawer 열기 → brand 에서 message send → brand 응답 streaming 중
+3. main chat 으로 이동 (drawer 그대로 둠) → textarea disabled + banner 표시 확인
+4. banner "드로어 열기" 클릭 → drawer 가 running brand 로 전환됨
+5. brand 응답 완료 후 → main 으로 이동 → textarea 활성화 (auto re-enable)
+6. thread mode (brand drawer 안) 입력은 영향 없음
+
+## 자동
+
+- `NewMessageInput.test.tsx` 추가:
+  - `runningThreadIds: ["branch:abc"]` + `threadMode: false` → input disabled + banner present
+  - `threadMode: true` → input enabled (drawer 내부 unaffected)
+
+# Developer 핸드오프 프롬프트
+
+```
+[작업] Main chat 입력 guard — brand running 중 main input disable + 안내 banner (P1, plan B)
+
+[SSOT] docs/plans/mainChatBrandRunningGuardPlan_2026-04-25.md
+
+[배경 3줄]
+- PR #198 brand=main session 공유의 부작용. brand 에서 Developer 작업 중일 때 main chat 입력이 같은 process 에 끼어들기
+- 옵션 B 채택: main mode 에서 brand running 시 input disable + "드로어 열기" 안내
+- 단일 파일 수정 (NewMessageInput.tsx) + i18n key 2개
+
+[수정 범위]
+
+1) src/components/tunaflow/NewMessageInput.tsx
+   - line 186 근처: brandRunning + runningBrandConvId derived state (useMemo)
+   - line 392 (ContextBadges 위): banner JSX (plan §구현 §5)
+   - line 520 (textarea): disabled 조건에 brandRunning 추가
+   - line 593 (send button): disabled 조건에 brandRunning 추가
+   - handleKeyDown 의 Cmd+Enter 처리부에 brandRunning 가드 추가
+
+2) src/locales/ko/chat.json + src/locales/en/chat.json
+   - input.brand_running_guard
+   - input.brand_running_open_drawer
+
+3) src/tests/components/NewMessageInput.test.tsx (또는 비슷)
+   - brandRunning 상태에서 disabled + banner 검증
+   - threadMode=true 일 땐 unaffected 검증
+
+4) docs/plans/index.md 등록
+
+[검증]
+- npx tsc --noEmit
+- npx vitest run src/tests/components/NewMessageInput.test.tsx (해당 파일)
+- 수동: plan §검증 §수동 Smoke 1~6 모두
+
+[커밋]
+- feat(input): main chat guard while brand task running (option B)
+- docs(plans): register mainChatBrandRunningGuardPlan
+- test(input): brand-running guard coverage
+
+trailer: Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+
+[PR 제목]
+feat(input): guard main chat while brand task running (PR #198 follow-up)
+```
+
+# 후속 / Sibling
+
+- `metaFloatingChatPosClampPlan_2026-04-25` — 같은 시점 보고된 별 axis (footer drift driver)
+- (후속 후보) brand running 의 *conversation scoping* — 다른 main conversation 으로 전환 시 guard 미적용 옵션. 일단 본 plan 은 전역 (모든 brand running 에 main input 차단). 사용자 사용 패턴 보고 결정.
+- (후속 후보) 옵션 A 도입 — send 시점 conversation_id 분리. 본 plan 옵션 B 가 먼저 검증되고 사용자가 진짜 분리 원하면 추가.

--- a/src/components/tunaflow/NewMessageInput.tsx
+++ b/src/components/tunaflow/NewMessageInput.tsx
@@ -186,6 +186,21 @@ export function NewMessageInput({ threadMode = false, onCreateRT }: NewMessageIn
   const isCurrentThreadRunning = !!effectiveThreadId && runningThreadIds.includes(effectiveThreadId);
   const currentQueueLength = messageQueue.filter((q) => q.threadId === selectedConversationId).length;
 
+  // [PR #198 follow-up] brand=main session 공유의 부작용 차단:
+  // brand drawer 의 Developer 가 작업 중인 동안 main chat 입력이 같은
+  // process 에 끼어들어 의도외 응답을 만드는 케이스. main mode 에서
+  // 어떤 brand 라도 running (= `runningThreadIds` 에 `branch:` prefix 키
+  // 존재) 이면 입력을 차단하고 "드로어 열기" 안내 banner 노출.
+  // 상세: `docs/plans/mainChatBrandRunningGuardPlan_2026-04-25.md`.
+  const brandRunning = useMemo(
+    () => !threadMode && runningThreadIds.some((id) => id.startsWith("branch:")),
+    [threadMode, runningThreadIds],
+  );
+  const runningBrandConvId = useMemo(
+    () => (brandRunning ? runningThreadIds.find((id) => id.startsWith("branch:")) ?? null : null),
+    [brandRunning, runningThreadIds],
+  );
+
   // 현재 엔진의 모델 목록
   const currentModels = useMemo(
     () => engineModels.filter((m) => m.engine === engine),
@@ -389,6 +404,31 @@ export function NewMessageInput({ threadMode = false, onCreateRT }: NewMessageIn
         </div>
         ); })()}
 
+      {/* Brand running guard banner — main mode 에서 brand 가 running 중일 때
+          입력 차단 안내 + "드로어 열기" 빠른 액션. PR #198 session 공유
+          부작용 차단 (`mainChatBrandRunningGuardPlan_2026-04-25.md`). */}
+      {brandRunning && (
+        <div
+          className="mb-1.5 flex items-center gap-2 text-[10px] rounded px-2.5 py-1 text-amber-600/70 bg-amber-500/8"
+          data-testid="brand-running-guard-banner"
+        >
+          <Loader2 className="w-3 h-3 animate-spin" />
+          <span className="flex-1">{t("input.brand_running_guard")}</span>
+          {runningBrandConvId && (
+            <button
+              type="button"
+              onClick={() => {
+                const branchId = runningBrandConvId.replace(/^branch:/, "");
+                useChatStore.getState().openThread(branchId);
+              }}
+              className="text-amber-600/80 hover:underline"
+            >
+              {t("input.brand_running_open_drawer")}
+            </button>
+          )}
+        </div>
+      )}
+
       {/* Context status */}
       <ContextBadges activeSkills={activeSkills} crossSessionIds={crossSessionIds} />
 
@@ -503,7 +543,18 @@ export function NewMessageInput({ threadMode = false, onCreateRT }: NewMessageIn
           ref={textareaRef}
           value={text}
           onChange={(e) => setText(e.target.value)}
-          onKeyDown={handleKeyDown}
+          onKeyDown={(e) => {
+            // brand running 가드: Enter / Cmd+Enter 모두 차단해 같은 SDK
+            // process 에 main 메시지가 끼어들지 않게 함. handleSend 자체에는
+            // 가드를 두지 않아도 disabled state 와 함께 동작하지만, IME
+            // composition 우회 등 edge case 에서 실제 send 가 진행되는
+            // 케이스를 막기 위해 keyDown 단계에서 한번 더 차단.
+            if (brandRunning) {
+              if (e.key === "Enter" && !e.shiftKey) e.preventDefault();
+              return;
+            }
+            handleKeyDown(e);
+          }}
           onPaste={handlePaste}
           onDragOver={handleDragOver}
           onDragLeave={handleDragLeave}
@@ -517,7 +568,7 @@ export function NewMessageInput({ threadMode = false, onCreateRT }: NewMessageIn
                 : t("input.placeholder_rt_empty")
               : t("input.placeholder_chat")
           }
-          disabled={!selectedConversationId}
+          disabled={!selectedConversationId || brandRunning}
           rows={1}
           className={cn(
             // `focus:outline-none` + `focus-visible:outline-none` 명시 — macOS
@@ -590,10 +641,10 @@ export function NewMessageInput({ threadMode = false, onCreateRT }: NewMessageIn
           )}
           <button
             onClick={handleSend}
-            disabled={!text.trim() || !selectedConversationId || ptyRespawning}
+            disabled={!text.trim() || !selectedConversationId || ptyRespawning || brandRunning}
             className={cn(
               "flex items-center gap-1 px-2.5 py-1 rounded text-[11px] font-medium transition-colors",
-              text.trim() && selectedConversationId && !ptyRespawning
+              text.trim() && selectedConversationId && !ptyRespawning && !brandRunning
                 ? isCurrentThreadRunning
                   ? "bg-agent-gemini/12 text-agent-gemini/80 hover:bg-agent-gemini/20"
                   : "bg-primary/90 text-primary-foreground hover:bg-primary"

--- a/src/locales/en/chat.json
+++ b/src/locales/en/chat.json
@@ -27,7 +27,9 @@
     "pty_clear_failed": "Session reset failed",
     "models_catalog_empty": "(Catalog is empty)",
     "no_previous_response": "⚠️ **No previous response to forward.**\n\nAsk the agent first, then use handoff after receiving a response.\n\nInput: `{{prompt}}` → {{engine}}",
-    "rt_config_missing": "⚠️ **Failed to load RT config.** Running with default participants.\n\nCreate a new RT or reconfigure from the sidebar [+]."
+    "rt_config_missing": "⚠️ **Failed to load RT config.** Running with default participants.\n\nCreate a new RT or reconfigure from the sidebar [+].",
+    "brand_running_guard": "Branch task running — main chat input disabled",
+    "brand_running_open_drawer": "Open drawer"
   },
   "message": {
     "role_user": "You",

--- a/src/locales/ko/chat.json
+++ b/src/locales/ko/chat.json
@@ -27,7 +27,9 @@
     "pty_clear_failed": "세션 초기화 실패",
     "models_catalog_empty": "(카탈로그가 비어 있습니다)",
     "no_previous_response": "⚠️ **넘길 이전 응답이 없습니다.**\n\n먼저 에이전트에게 질문하고, 응답을 받은 후 handoff를 사용하세요.\n\n입력: `{{prompt}}` → {{engine}}",
-    "rt_config_missing": "⚠️ **RT 설정을 불러오지 못했습니다.** 기본 참가자로 실행합니다.\n\n새 RT를 만들거나 사이드바에서 [+]로 다시 설정하세요."
+    "rt_config_missing": "⚠️ **RT 설정을 불러오지 못했습니다.** 기본 참가자로 실행합니다.\n\n새 RT를 만들거나 사이드바에서 [+]로 다시 설정하세요.",
+    "brand_running_guard": "브랜치에서 진행 중인 작업이 있어 메인 채팅 입력이 비활성화됐습니다",
+    "brand_running_open_drawer": "드로어 열기"
   },
   "message": {
     "role_user": "사용자",

--- a/src/tests/newMessageInput-brandGuard.test.tsx
+++ b/src/tests/newMessageInput-brandGuard.test.tsx
@@ -1,0 +1,207 @@
+// brand running guard 테스트 — `mainChatBrandRunningGuardPlan_2026-04-25.md` INV-1~4 검증.
+//
+// PR #198 (`branchInheritsMainSessionPlan`) 머지로 brand 와 main 이 같은 SDK
+// session (process 1개) 을 공유하게 되면서, brand 에서 Developer 가 작업 중인
+// 동안 main chat 에 입력하면 같은 process 가 메시지를 받아 의도외 응답을
+// 만드는 케이스를 확인. 본 가드는 main mode + brand running 일 때 입력을
+// 차단하고 안내 banner 를 노출.
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { NewMessageInput } from "@/components/tunaflow/NewMessageInput";
+
+// react-i18next 는 실제 i18n 인스턴스를 끌고 오면 테스트 setup 이 무거워지고,
+// 본 테스트는 banner 텍스트 자체가 아니라 동작/존재만 보면 충분하므로 식별
+// 가능한 echo mock 으로 대체.
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) =>
+      opts ? `${key}::${JSON.stringify(opts)}` : key,
+    i18n: { language: "ko", changeLanguage: () => Promise.resolve() },
+  }),
+  Trans: ({ children }: { children?: React.ReactNode }) => children,
+}));
+
+// useSendActions 는 store/zustand subscribe 에 깊게 묶여있어 테스트 단위에선
+// 외부 행동만 stub. brand-guard 자체는 input 영역에서 일어나는 일이라 send
+// 함수가 실제로 무엇을 하는지는 무관.
+vi.mock("@/components/tunaflow/input/useSendActions", () => ({
+  useSendActions: () => ({
+    handleSend: vi.fn(),
+    handleKeyDown: vi.fn(),
+    isRoundtable: false,
+    hasRtMessages: false,
+  }),
+}));
+
+// 첨부 / appStore — getSetting 호출만 막고 나머지는 사용 안 함.
+vi.mock("@/lib/appStore", () => ({
+  getSetting: vi.fn(() => Promise.resolve(false)),
+  setSetting: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  open: vi.fn(() => Promise.resolve(null)),
+}));
+
+vi.mock("@tauri-apps/plugin-fs", () => ({
+  readFile: vi.fn(() => Promise.resolve(new Uint8Array())),
+}));
+
+// usePtyStore — setup.ts mock 은 getState 만 노출. NewMessageInput 은
+// selector callable(`usePtyStore((s) => s.getSession(...))`) 로 호출하므로
+// 양쪽 모두 지원하는 hook 형태로 재정의.
+vi.mock("@/stores/ptyStore", () => {
+  const ptyState = {
+    sessions: new Map(),
+    getSession: () => null,
+    setSession: vi.fn(),
+    clearSession: vi.fn(),
+    clearAllSessions: vi.fn(),
+    isCapturing: false,
+    activeMessageId: null,
+    activeEngine: null,
+    completionSeen: false,
+    responseStarted: false,
+    startCapture: vi.fn(),
+    updateScreen: vi.fn(),
+    checkCompletion: vi.fn(() => false),
+    endCapture: vi.fn(),
+  };
+  return {
+    usePtyStore: Object.assign(
+      (selector?: (s: typeof ptyState) => unknown) =>
+        selector ? selector(ptyState) : ptyState,
+      { getState: () => ptyState },
+    ),
+    isPtyEngine: () => false,
+    PTY_ENGINES: ["claude", "codex", "gemini"],
+    getPtyBinary: () => null,
+  };
+});
+
+interface MockState {
+  selectedConversationId: string | null;
+  conversations: Array<{ id: string; mode: string }>;
+  activeBranchId: string | null;
+  closeBranchStream: () => void;
+  cancelOperation: (id?: string) => void;
+  runningThreadIds: string[];
+  messageQueue: Array<{ threadId: string }>;
+  activeSkills: string[];
+  crossSessionIds: string[];
+  engineModels: Array<{ engine: string; id: string; recommended?: boolean }>;
+  agentProfiles: Array<unknown>;
+  saveConversationEngine: () => void;
+  toggleSkill: () => void;
+  threadBranchConvId: string | null;
+  threadBranchId: string | null;
+  branches: Array<unknown>;
+  getConversationEngine: (id: string) => null;
+  selectedProjectKey: string | null;
+  ensureConversation: () => void;
+  selectConversation: () => void;
+  openThread: (id: string) => Promise<void>;
+}
+
+function makeState(overrides: Partial<MockState> = {}): MockState {
+  return {
+    selectedConversationId: "conv-main",
+    conversations: [{ id: "conv-main", mode: "chat" }],
+    activeBranchId: null,
+    closeBranchStream: vi.fn(),
+    cancelOperation: vi.fn(),
+    runningThreadIds: [],
+    messageQueue: [],
+    activeSkills: [],
+    crossSessionIds: [],
+    engineModels: [{ engine: "claude", id: "claude-sonnet-4-5", recommended: true }],
+    agentProfiles: [],
+    saveConversationEngine: vi.fn(),
+    toggleSkill: vi.fn(),
+    threadBranchConvId: null,
+    threadBranchId: null,
+    branches: [],
+    getConversationEngine: vi.fn(() => null),
+    selectedProjectKey: "test-proj",
+    ensureConversation: vi.fn(),
+    selectConversation: vi.fn(),
+    openThread: vi.fn(() => Promise.resolve()),
+    ...overrides,
+  };
+}
+
+function mockChatStore(state: MockState) {
+  vi.doMock("@/stores/chatStore", () => {
+    const setState = vi.fn();
+    return {
+      useChatStore: Object.assign(
+        // selector 호출도 직접 호출도 모두 지원.
+        (selector?: (s: MockState) => unknown) => (selector ? selector(state) : state),
+        { getState: () => state, setState },
+      ),
+    };
+  });
+}
+
+describe("NewMessageInput — brand running guard (PR #198 follow-up)", () => {
+  it("[INV-1/2] main mode + brand running → 입력 disable + banner 노출", async () => {
+    vi.resetModules();
+    mockChatStore(makeState({
+      runningThreadIds: ["branch:abc123"],
+    }));
+    const { NewMessageInput: Component } = await import("@/components/tunaflow/NewMessageInput");
+    render(<Component threadMode={false} />);
+
+    expect(screen.getByTestId("brand-running-guard-banner")).toBeInTheDocument();
+    const textareas = document.querySelectorAll("textarea");
+    expect(textareas.length).toBeGreaterThan(0);
+    expect(textareas[0]).toBeDisabled();
+  });
+
+  it("[INV-2] banner 안에 '드로어 열기' 버튼이 있고 클릭 시 openThread 호출", async () => {
+    vi.resetModules();
+    const openThread = vi.fn(() => Promise.resolve());
+    mockChatStore(makeState({
+      runningThreadIds: ["branch:abc123"],
+      openThread,
+    }));
+    const { NewMessageInput: Component } = await import("@/components/tunaflow/NewMessageInput");
+    render(<Component threadMode={false} />);
+
+    const banner = screen.getByTestId("brand-running-guard-banner");
+    const button = banner.querySelector("button");
+    expect(button).not.toBeNull();
+    button?.click();
+    expect(openThread).toHaveBeenCalledWith("abc123");
+  });
+
+  it("[INV-3] runningThreadIds 비어있으면 input 활성화 + banner 미노출", async () => {
+    vi.resetModules();
+    mockChatStore(makeState({
+      runningThreadIds: [],
+    }));
+    const { NewMessageInput: Component } = await import("@/components/tunaflow/NewMessageInput");
+    render(<Component threadMode={false} />);
+
+    expect(screen.queryByTestId("brand-running-guard-banner")).toBeNull();
+    const textareas = document.querySelectorAll("textarea");
+    expect(textareas[0]).not.toBeDisabled();
+  });
+
+  it("[INV-4] thread mode (drawer 내부) 일 땐 brand running 무관하게 input 활성화", async () => {
+    vi.resetModules();
+    mockChatStore(makeState({
+      runningThreadIds: ["branch:abc123"],
+      threadBranchConvId: "branch:abc123",
+      threadBranchId: "abc123",
+      // drawer 안에서 입력은 그대로 동작해야 하므로 selectedConversationId 가
+      // null 이어도 thread mode 의 input 은 별도 로직.
+    }));
+    const { NewMessageInput: Component } = await import("@/components/tunaflow/NewMessageInput");
+    render(<Component threadMode={true} />);
+
+    // banner 는 main mode 전용 — thread mode 에서는 노출되지 않음.
+    expect(screen.queryByTestId("brand-running-guard-banner")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- PR #198 (`branchInheritsMainSessionPlan`) 머지로 brand 와 main 이 같은 SDK WS session(process 1개)을 공유 → brand drawer 의 Developer 가 작업 중인 동안 사용자가 main chat 에 입력하면 같은 process 가 메시지를 받아 의도외 응답을 만드는 케이스 발생
- 옵션 B 채택: `NewMessageInput.tsx` 에 `brandRunning` derived state 추가 → main mode + brand running 일 때 textarea/send 차단 + 안내 banner + "드로어 열기" 빠른 액션
- i18n 키 2개 추가 (ko/en `chat.json`), brand-guard 테스트 4개 (INV-1~4) 추가

## Plan SSOT

`docs/plans/mainChatBrandRunningGuardPlan_2026-04-25.md`

## Invariants

- **INV-1** main mode + brand running (`runningThreadIds` 에 `branch:` prefix) → textarea disabled + send 차단
- **INV-2** banner 노출 + "드로어 열기" 클릭 시 `openThread(branchId)` 진입
- **INV-3** brand 종료 시 `runningThreadIds` 변경 → derived state re-render → 자동 활성화
- **INV-4** thread mode (drawer 내부) 는 본 가드 무관 — drawer 입력 unaffected
- **INV-5** 전역 brand running 시 main 의 다른 conversation 도 차단 (의도된 단순화, 후속 plan 으로 conv-scoping 검토)

## Test plan

- [x] `npx tsc --noEmit` — pass
- [x] `npx vitest run` — 33 files / 352 tests pass (신규 4 tests 포함)
- [x] `cargo check` — frontend-only 변경, warning 외 영향 없음
- [x] `cargo test --lib` — 559 tests pass
- [ ] 수동 smoke (plan §검증 §수동 1~6):
  - [ ] main 에서 정상 send → 정상 동작
  - [ ] brand 에서 send 진행 중 main 으로 이동 → input disabled + banner 노출
  - [ ] banner "드로어 열기" 클릭 → drawer 가 running brand 로 전환
  - [ ] brand 응답 완료 후 main 입력 자동 활성화
  - [ ] thread mode (drawer) 입력은 영향 없음

## Commits

1. `docs(plans): register mainChatBrandRunningGuardPlan (PR #198 follow-up)` — plan SSOT + index 등록
2. `feat(input): main chat guard while brand task running (option B)` — derived state + banner + textarea/send disable + IME-safe keyDown 가드 + i18n 키
3. `test(input): brand-running guard coverage (INV-1~4)` — 4 tests

## Files changed

- `src/components/tunaflow/NewMessageInput.tsx`
- `src/locales/ko/chat.json`
- `src/locales/en/chat.json`
- `src/tests/newMessageInput-brandGuard.test.tsx` (신규)
- `docs/plans/mainChatBrandRunningGuardPlan_2026-04-25.md` (신규)
- `docs/plans/index.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)