### PR TITLE
feat(markdown): preserve single newlines in chat (remark-breaks)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "tuna-flow",
-  "version": "0.1.0",
+  "version": "0.1.2-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tuna-flow",
-      "version": "0.1.0",
+      "version": "0.1.2-beta",
+      "license": "Apache-2.0",
       "dependencies": {
         "@radix-ui/react-context-menu": "^2.2.16",
         "@tailwindcss/vite": "^4.2.2",
@@ -37,6 +38,7 @@
         "react-qr-code": "^2.0.18",
         "react-syntax-highlighter": "^16.1.1",
         "react-virtuoso": "^4.18.3",
+        "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
@@ -5268,6 +5270,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-newline-to-break": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-newline-to-break/-/mdast-util-newline-to-break-2.0.0.tgz",
+      "integrity": "sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-find-and-replace": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-phrasing": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
@@ -6459,6 +6475,21 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/remark-breaks": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-4.0.0.tgz",
+      "integrity": "sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-newline-to-break": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark-gfm": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "react-qr-code": "^2.0.18",
     "react-syntax-highlighter": "^16.1.1",
     "react-virtuoso": "^4.18.3",
+    "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",

--- a/src/components/tunaflow/MessageItem.tsx
+++ b/src/components/tunaflow/MessageItem.tsx
@@ -1,9 +1,9 @@
 import { memo, useMemo, useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
 import { invoke } from "@tauri-apps/api/core";
 import { cn } from "@/lib/utils";
+import { REMARK_PLUGINS } from "@/lib/markdownPlugins";
 import type { Message, Branch } from "@/types";
 
 import { markdownComponents } from "./chat/MarkdownComponents";
@@ -51,9 +51,6 @@ function hasMarkdownSignal(content: string): boolean {
   if (content.length < 100) return false;
   return /^#{1,3} |```|\n- |\n\d+\. |<!-- tunaflow:|\*\*[^*]+\*\*/m.test(content);
 }
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const REMARK_PLUGINS: any[] = [[remarkGfm, { singleTilde: false }]];
 
 /**
  * Hide partially-arrived HTML comments during streaming so the raw

--- a/src/components/tunaflow/MetaFloatingChat.tsx
+++ b/src/components/tunaflow/MetaFloatingChat.tsx
@@ -9,7 +9,7 @@ import { getOrCreateMetaConversation } from "@/lib/metaConversation";
 import type { Message } from "@/types";
 import type { MetaNotification } from "@/lib/metaNotifications";
 import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
+import { REMARK_PLUGINS } from "@/lib/markdownPlugins";
 import { vizMarkersAll } from "@/lib/vizMarkers";
 
 const NOTIF_LS_KEY = "meta-notifications-v1";
@@ -689,7 +689,7 @@ function MetaMessage({ message, isStreaming }: { message: Message; isStreaming: 
             "[&_ul]:my-1 [&_li]:my-0 [&_code]:text-[11px]",
             "[&_pre]:my-2 [&_pre]:text-[11px]",
           )}>
-            <ReactMarkdown remarkPlugins={[[remarkGfm, { singleTilde: false }]]}>
+            <ReactMarkdown remarkPlugins={REMARK_PLUGINS}>
               {vizMarkersAll(message.content) || (isStreaming ? "▋" : "")}
             </ReactMarkdown>
           </div>

--- a/src/components/tunaflow/ProjectOnboardingModal.tsx
+++ b/src/components/tunaflow/ProjectOnboardingModal.tsx
@@ -3,9 +3,9 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { CheckCircle2, Circle, Loader2, AlertCircle } from "lucide-react";
 import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
+import { REMARK_PLUGINS } from "@/lib/markdownPlugins";
 import { useChatStore } from "@/stores/chatStore";
 import { MetaAgentSelector } from "./MetaAgentSelector";
 import { markdownComponents } from "./chat/MarkdownComponents";
@@ -15,9 +15,6 @@ import {
   type InitialSetupPayload,
   type InitialSetupSelection,
 } from "@/lib/initialSetupApply";
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const REMARK_PLUGINS: any[] = [[remarkGfm, { singleTilde: false }]];
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 

--- a/src/components/tunaflow/RoundtableView.tsx
+++ b/src/components/tunaflow/RoundtableView.tsx
@@ -4,13 +4,10 @@ import { Users, Loader2 } from "lucide-react";
 import { invoke } from "@tauri-apps/api/core";
 import { useState, useEffect } from "react";
 import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
 import { useChatStore } from "@/stores/chatStore";
 import type { RtParticipantStatus } from "@/stores/slices/threadSlice";
 import { markdownComponents } from "./chat/MarkdownComponents";
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const REMARK_PLUGINS: any[] = [[remarkGfm, { singleTilde: false }]];
+import { REMARK_PLUGINS } from "@/lib/markdownPlugins";
 
 /** RT topic 렌더러 — Review RT 프롬프트는 마크다운 + HTML 주석 마커를 포함하므로
  *  raw text 로 출력하면 가독성 급락. 채팅과 동일한 마크다운 파이프라인 재사용. */

--- a/src/components/tunaflow/chat/FileViewer.tsx
+++ b/src/components/tunaflow/chat/FileViewer.tsx
@@ -4,7 +4,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { X, Copy, Check, FileText } from "lucide-react";
 import { cn, errorMessage } from "@/lib/utils";
 import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
+import { REMARK_PLUGINS } from "@/lib/markdownPlugins";
 import { markdownComponents } from "./MarkdownComponents";
 
 const SyntaxHighlighter = lazy(() =>
@@ -107,7 +107,7 @@ export function FileViewer({ filePath, projectPath, lineNumber, onClose }: FileV
             file.language === "markdown" ? (
               <div className="p-5 space-y-2 text-[13px] text-foreground/90 leading-relaxed">
                 <ReactMarkdown
-                  remarkPlugins={[[remarkGfm, { singleTilde: false }]]}
+                  remarkPlugins={REMARK_PLUGINS}
                   components={markdownComponents}
                 >
                   {file.content}

--- a/src/components/tunaflow/context-panel/ArtifactsPanel.tsx
+++ b/src/components/tunaflow/context-panel/ArtifactsPanel.tsx
@@ -9,7 +9,7 @@ import {
 } from "lucide-react";
 import type { Artifact, Plan } from "@/types";
 import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
+import { REMARK_PLUGINS } from "@/lib/markdownPlugins";
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
@@ -255,7 +255,7 @@ function ArtifactDetailPanel({
       {/* Content */}
       <div className="flex-1 min-h-0 overflow-y-auto px-4 py-3">
         <div className="prose prose-sm prose-invert max-w-none text-[12px] leading-relaxed [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&>h2]:text-[14px] [&>h2]:font-semibold [&>h2]:mt-4 [&>h2]:mb-2 [&>h3]:text-[12px] [&>h3]:font-semibold [&>h3]:mt-3 [&>h3]:mb-1 [&>ul]:space-y-0.5 [&>ul>li]:text-[11px] [&>p]:text-foreground/85">
-          <ReactMarkdown remarkPlugins={[[remarkGfm, { singleTilde: false }]]}>
+          <ReactMarkdown remarkPlugins={REMARK_PLUGINS}>
             {artifact.content}
           </ReactMarkdown>
         </div>

--- a/src/components/tunaflow/context-panel/IdentityView.tsx
+++ b/src/components/tunaflow/context-panel/IdentityView.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
+import { REMARK_PLUGINS } from "@/lib/markdownPlugins";
 import { RefreshCw, Clock, AlertTriangle, Check } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useChatStore } from "@/stores/chatStore";
@@ -269,7 +269,7 @@ function Section({ title, content }: { title: string; content: string }) {
     <div>
       <h4 className="text-[11px] font-semibold text-foreground/80 mb-1">{title}</h4>
       <div className="text-[11px] leading-relaxed prose-tf prose-invert">
-        <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+        <ReactMarkdown remarkPlugins={REMARK_PLUGINS}>{content}</ReactMarkdown>
       </div>
     </div>
   );

--- a/src/components/tunaflow/context-panel/PlanDocumentModal.tsx
+++ b/src/components/tunaflow/context-panel/PlanDocumentModal.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { invoke } from "@tauri-apps/api/core";
 import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
+import { REMARK_PLUGINS } from "@/lib/markdownPlugins";
 import { X, Clock, ClipboardList, ChevronDown, ChevronRight, User, FileText } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useChatStore } from "@/stores/chatStore";
@@ -103,7 +103,7 @@ export function PlanDocumentModal({ plan, onClose }: PlanDocumentModalProps) {
               {/* Plan file content — rendered as markdown if available */}
               {planFileContent ? (
                 <div className="prose prose-invert max-w-none text-[11px] leading-relaxed [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_h1]:text-[13px] [&_h2]:text-[12px] [&_h3]:text-[11px] [&_h1]:mt-3 [&_h2]:mt-2 [&_h3]:mt-1.5 [&_p]:my-1 [&_ul]:my-1 [&_li]:my-0.5 [&_code]:text-[10px]">
-                  <ReactMarkdown remarkPlugins={[[remarkGfm, { singleTilde: false }]]} components={markdownComponents}>
+                  <ReactMarkdown remarkPlugins={REMARK_PLUGINS} components={markdownComponents}>
                     {planFileContent}
                   </ReactMarkdown>
                 </div>
@@ -179,7 +179,7 @@ export function PlanDocumentModal({ plan, onClose }: PlanDocumentModalProps) {
                               </div>
                               {taskFileContents[i + 1] ? (
                                 <div className="rounded bg-card/80 border border-border/30 px-3 py-2 prose prose-invert max-w-none text-[11px] leading-relaxed [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_h1]:text-[13px] [&_h2]:text-[12px] [&_h3]:text-[11px] [&_h1]:mt-3 [&_h2]:mt-2 [&_h3]:mt-1.5 [&_p]:my-1 [&_ul]:my-1 [&_li]:my-0.5 [&_code]:text-[10px]">
-                                  <ReactMarkdown remarkPlugins={[[remarkGfm, { singleTilde: false }]]} components={markdownComponents}>
+                                  <ReactMarkdown remarkPlugins={REMARK_PLUGINS} components={markdownComponents}>
                                     {taskFileContents[i + 1]}
                                   </ReactMarkdown>
                                 </div>

--- a/src/components/tunaflow/context-panel/ReviewPanel.tsx
+++ b/src/components/tunaflow/context-panel/ReviewPanel.tsx
@@ -4,7 +4,7 @@ import { useChatStore } from "@/stores/chatStore";
 import { FileSearch, Gavel, CheckCircle2, XCircle, X } from "lucide-react";
 import type { Artifact } from "@/types";
 import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
+import { REMARK_PLUGINS } from "@/lib/markdownPlugins";
 
 // ─── Verdict parser ──────────────────────────────────────────────────────────
 
@@ -234,7 +234,7 @@ function ReviewDetailPanel({
           </>
         ) : (
           <div className={PROSE_CLS}>
-            <ReactMarkdown remarkPlugins={[[remarkGfm, { singleTilde: false }]]}>
+            <ReactMarkdown remarkPlugins={REMARK_PLUGINS}>
               {artifact.content}
             </ReactMarkdown>
           </div>

--- a/src/components/tunaflow/context-panel/SubtaskReviewView.tsx
+++ b/src/components/tunaflow/context-panel/SubtaskReviewView.tsx
@@ -8,7 +8,7 @@ import type { Plan, PlanPhase, PlanSubtask, Branch } from "@/types";
 import * as planApi from "@/lib/api/plans";
 import { getPlanSlug, syncPlanDocument } from "@/lib/workflowOrchestration";
 import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
+import { REMARK_PLUGINS } from "@/lib/markdownPlugins";
 import { markdownComponents } from "../chat/MarkdownComponents";
 import { PlanDocumentModal } from "./PlanDocumentModal";
 import { SUBTASK_STATUS_CFG } from "./plans/constants";
@@ -599,7 +599,7 @@ function SubtaskReviewCard({
                 <span className="text-[8px] text-status-approved/50">{t("subtask_review.card.status_file_exists")}</span>
               </div>
               <div className="rounded bg-card/80 border border-border/30 px-3 py-2 prose prose-invert max-w-none text-[11px] leading-relaxed [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_h1]:text-[13px] [&_h2]:text-[12px] [&_h3]:text-[11px] [&_h1]:mt-3 [&_h2]:mt-2 [&_h3]:mt-1.5 [&_p]:my-1 [&_ul]:my-1 [&_li]:my-0.5 [&_code]:text-[10px]">
-                <ReactMarkdown remarkPlugins={[[remarkGfm, { singleTilde: false }]]} components={markdownComponents}>
+                <ReactMarkdown remarkPlugins={REMARK_PLUGINS} components={markdownComponents}>
                   {taskFileContent}
                 </ReactMarkdown>
               </div>

--- a/src/components/tunaflow/roundtable/RtMessageCard.tsx
+++ b/src/components/tunaflow/roundtable/RtMessageCard.tsx
@@ -7,7 +7,7 @@ import { RtReferenceBadge } from "./RtReferenceBadge";
 import { parsePromptSources } from "./rtUtils";
 import type { Message, RoundtableParticipant } from "@/types";
 import ReactMarkdown from "react-markdown";
-import remarkGfm from "remark-gfm";
+import { REMARK_PLUGINS } from "@/lib/markdownPlugins";
 import { Copy, Users, GitBranch, StickyNote, Forward, FileText, ShieldCheck, Trash2 } from "lucide-react";
 
 export interface RtMessageCardProps {
@@ -88,7 +88,7 @@ export function RtMessageCard({ message, isLast, onBranch, onBranchRT, onMemo, o
               <span className="typing-dot w-1 h-1 rounded-full bg-muted-foreground" />
             </div>
           ) : (
-            <ReactMarkdown remarkPlugins={[[remarkGfm, { singleTilde: false }]]} components={markdownComponents}>
+            <ReactMarkdown remarkPlugins={REMARK_PLUGINS} components={markdownComponents}>
               {content}
             </ReactMarkdown>
           )}

--- a/src/lib/markdownPlugins.ts
+++ b/src/lib/markdownPlugins.ts
@@ -1,0 +1,18 @@
+import remarkGfm from "remark-gfm";
+import remarkBreaks from "remark-breaks";
+
+/**
+ * 채팅/로그 친화 마크다운 플러그인 셋 — SSOT.
+ *
+ * - `remarkGfm`: GitHub Flavored Markdown (table / strikethrough / task list / autolink).
+ *   `singleTilde: false` 로 단일 `~` 를 strikethrough 로 해석하지 않음.
+ * - `remarkBreaks`: paragraph 안 single newline 을 `<br>` 로 변환. 채팅/로그 컨텍스트 친화.
+ *   code block / list 등 block 구조는 영향 없음 (mdast 단계 paragraph 자식만 처리).
+ *
+ * 사용처는 모두 본 SSOT 를 통해 import — `<ReactMarkdown remarkPlugins={REMARK_PLUGINS}>`.
+ * 직접 인라인 array 정의 금지 (위치별 표시 차이 방지).
+ */
+export const REMARK_PLUGINS: any[] = [
+  [remarkGfm, { singleTilde: false }],
+  remarkBreaks,
+];

--- a/src/tests/markdownPlugins.test.tsx
+++ b/src/tests/markdownPlugins.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * Regression coverage for `src/lib/markdownPlugins.ts` SSOT.
+ *
+ * Beta 사용자 보고 (2026-04-26): 채팅/로그 single newline 이 한 줄로 collapse.
+ * 해결: `remark-breaks` 플러그인 추가 → single newline → `<br>`.
+ *
+ * Invariants:
+ * - INV-1: paragraph 안 single `\n` → `<br>` 로 분리.
+ * - INV-2: 기존 `\n\n` paragraph break 보존.
+ * - INV-3: list / code block / table / strikethrough 등 GFM 동작 보존.
+ * - INV-4: code block 내부 newline 은 remark-breaks 가 건드리지 않음 (`<pre>` 보존).
+ */
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import ReactMarkdown from "react-markdown";
+import { REMARK_PLUGINS } from "@/lib/markdownPlugins";
+
+function renderMd(text: string) {
+  return render(<ReactMarkdown remarkPlugins={REMARK_PLUGINS}>{text}</ReactMarkdown>);
+}
+
+describe("markdownPlugins SSOT — REMARK_PLUGINS", () => {
+  describe("INV-1: single newline preserved as <br>", () => {
+    it("converts single newline inside a paragraph to <br>", () => {
+      const { container } = renderMd("line one\nline two\nline three");
+      const ps = container.querySelectorAll("p");
+      // 모두 같은 paragraph 안에 있어야 함 (paragraph break 가 아님)
+      expect(ps.length).toBe(1);
+      // <br> 두 개가 라인을 분리해야 함
+      const brs = container.querySelectorAll("br");
+      expect(brs.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it("renders multi-line log with brs (Beta 사용자 보고 케이스)", () => {
+      const log = [
+        "[INFO] starting service",
+        "[INFO] listening on port 8080",
+        "[ERROR] connection refused",
+      ].join("\n");
+      const { container } = renderMd(log);
+      const text = container.textContent ?? "";
+      expect(text).toContain("starting service");
+      expect(text).toContain("listening on port 8080");
+      expect(text).toContain("connection refused");
+      // single newline → 같은 paragraph + <br> 로 분리
+      expect(container.querySelectorAll("p").length).toBe(1);
+      expect(container.querySelectorAll("br").length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  describe("INV-2: paragraph break (\\n\\n) preserved", () => {
+    it("splits double-newline into separate <p> elements", () => {
+      const { container } = renderMd("first paragraph\n\nsecond paragraph");
+      const ps = container.querySelectorAll("p");
+      expect(ps.length).toBe(2);
+      expect(ps[0].textContent).toContain("first paragraph");
+      expect(ps[1].textContent).toContain("second paragraph");
+    });
+  });
+
+  describe("INV-3: GFM features preserved", () => {
+    it("renders unordered list with <ul>/<li>", () => {
+      const md = "- alpha\n- beta\n- gamma";
+      const { container } = renderMd(md);
+      const ul = container.querySelector("ul");
+      expect(ul).not.toBeNull();
+      const lis = container.querySelectorAll("li");
+      expect(lis.length).toBe(3);
+      expect(lis[0].textContent).toContain("alpha");
+    });
+
+    it("renders ordered list with <ol>/<li>", () => {
+      const md = "1. one\n2. two\n3. three";
+      const { container } = renderMd(md);
+      const ol = container.querySelector("ol");
+      expect(ol).not.toBeNull();
+      expect(container.querySelectorAll("li").length).toBe(3);
+    });
+
+    it("renders fenced code block with <pre><code> and preserves internal newlines", () => {
+      const md = "```js\nconst a = 1;\nconst b = 2;\n```";
+      const { container } = renderMd(md);
+      const pre = container.querySelector("pre");
+      const code = container.querySelector("pre code");
+      expect(pre).not.toBeNull();
+      expect(code).not.toBeNull();
+      // INV-4: code block 내부 newline 은 텍스트로 보존 (paragraph 변환 X)
+      const codeText = code?.textContent ?? "";
+      expect(codeText).toContain("const a = 1;");
+      expect(codeText).toContain("const b = 2;");
+      expect(codeText).toContain("\n");
+      // code block 안에는 <br> 가 추가되면 안 됨 (remark-breaks 가 건드리지 않음)
+      expect(pre?.querySelectorAll("br").length).toBe(0);
+    });
+
+    it("renders GFM table", () => {
+      const md = "| a | b |\n| --- | --- |\n| 1 | 2 |";
+      const { container } = renderMd(md);
+      const table = container.querySelector("table");
+      expect(table).not.toBeNull();
+      expect(container.querySelectorAll("th").length).toBe(2);
+      expect(container.querySelectorAll("td").length).toBe(2);
+    });
+
+    it("renders GFM strikethrough with double tilde", () => {
+      const { container } = renderMd("normal ~~deleted~~ text");
+      const del = container.querySelector("del");
+      expect(del).not.toBeNull();
+      expect(del?.textContent).toBe("deleted");
+    });
+
+    it("does NOT treat single tilde as strikethrough (singleTilde: false)", () => {
+      const { container } = renderMd("a ~tilde~ word");
+      const del = container.querySelector("del");
+      expect(del).toBeNull();
+      expect(container.textContent).toContain("~tilde~");
+    });
+
+    it("renders headings", () => {
+      const md = "# H1\n\n## H2\n\n### H3";
+      const { container } = renderMd(md);
+      expect(container.querySelector("h1")?.textContent).toBe("H1");
+      expect(container.querySelector("h2")?.textContent).toBe("H2");
+      expect(container.querySelector("h3")?.textContent).toBe("H3");
+    });
+
+    it("renders inline code with <code>", () => {
+      const { container } = renderMd("inline `code` here");
+      const code = container.querySelector("code");
+      expect(code?.textContent).toBe("code");
+    });
+  });
+
+  describe("INV-4: code block isolation from remark-breaks", () => {
+    it("does not insert <br> inside fenced code block lines", () => {
+      const md = "```\nfirst\nsecond\nthird\n```";
+      const { container } = renderMd(md);
+      const pre = container.querySelector("pre");
+      expect(pre).not.toBeNull();
+      // remark-breaks 는 paragraph 자식만 처리 — code block 은 영향 없어야 함
+      expect(pre?.querySelectorAll("br").length).toBe(0);
+      const codeText = pre?.querySelector("code")?.textContent ?? "";
+      expect(codeText.split("\n").filter((l) => l.length > 0).length).toBe(3);
+    });
+  });
+
+  describe("plugin set sanity", () => {
+    it("exports REMARK_PLUGINS as array with 2 entries (gfm + breaks)", () => {
+      expect(Array.isArray(REMARK_PLUGINS)).toBe(true);
+      expect(REMARK_PLUGINS.length).toBe(2);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Beta 사용자 보고 (2026-04-26): 채팅/로그 여러 줄 paste 시 single newline 이 한 줄로 collapse. CommonMark 정상 동작이지만 채팅 컨텍스트에서는 가독성 급락.
- 해결: `remark-breaks` 플러그인 도입 (single newline → `<br>`, code/list/heading 미영향)
- `src/lib/markdownPlugins.ts` SSOT 모듈 신규 — 11 위치 ReactMarkdown 사용처를 모두 통일 (위치별 표시 차이 차단)

> "입력창이 마크다운 형식으로 들어가야 뉴라인으로 인식하는건지... 로그 여러줄을 넣으면 죄다 한줄로 표현되고 있고, 뉴라인도 무시되어 한줄로 표현되는게 좀 거슬리네요." — Beta 사용자 (2026-04-26)

## SSOT 적용 위치 (11곳)

Plan 명시 4 위치:
- `src/components/tunaflow/MessageItem.tsx`
- `src/components/tunaflow/MetaFloatingChat.tsx`
- `src/components/tunaflow/ProjectOnboardingModal.tsx`
- `src/components/tunaflow/RoundtableView.tsx`

추가 grep 발견 7 위치 (동일 SSOT 적용):
- `src/components/tunaflow/chat/FileViewer.tsx`
- `src/components/tunaflow/context-panel/ReviewPanel.tsx`
- `src/components/tunaflow/context-panel/PlanDocumentModal.tsx` (2 사용처)
- `src/components/tunaflow/context-panel/ArtifactsPanel.tsx`
- `src/components/tunaflow/context-panel/IdentityView.tsx`
- `src/components/tunaflow/context-panel/SubtaskReviewView.tsx`
- `src/components/tunaflow/roundtable/RtMessageCard.tsx`

`IdentityView.tsx` 는 기존에 `[remarkGfm]` (옵션 없는 형태) 사용 중이었으나 SSOT 일관성 위해 옵션 포함 형태(`singleTilde: false`)로 통합.

## 회귀 테스트 (13 cases)

`src/tests/markdownPlugins.test.tsx` — invariants 가드:
- INV-1: paragraph 안 single `\n` → `<br>` 분리 (기본 + multi-line 로그)
- INV-2: `\n\n` paragraph break 보존
- INV-3: GFM 동작 — list / table / strikethrough / heading / code / `singleTilde: false`
- INV-4: code block 내부 newline 은 remark-breaks 가 건드리지 않음

## 검증

- [x] `npx tsc --noEmit` — pass
- [x] `npx vitest run` — 34 files / 365 tests pass (신규 13 포함)
- [x] `cd src-tauri && cargo check` — pass (기존 dead_code warning 1건, 무관)

## Test plan (수동 smoke)

- [ ] 채팅에 여러 줄 로그 paste → 줄 단위 표시 확인
- [ ] 마크다운 의도 (heading / list / code block / table / strikethrough) paste → 정상 렌더 (regression 가드)
- [ ] MetaFloatingChat 동일 확인
- [ ] ProjectOnboardingModal preview 동일 확인
- [ ] RoundtableView 메시지 표시 동일 확인

## Plan

`docs/plans/markdownSingleNewlineBreaksPlan_2026-04-26.md`

## Audit / N-A 메모

- N-A: Layer A3 (ESLint custom rule / sanity test) — grep 으로 1회 확인 충분, 향후 회귀 시 추가 검토
- N-A: Layer B2 snapshot 테스트 — DOM assertion 13건으로 충분 (snapshot 은 noise 비용 큼)

🤖 Generated with [Claude Code](https://claude.com/claude-code)