### PR TITLE
fix: result.md contamination — reviewer 입력 격리 + truncation/self-include 가드

### DIFF
--- a/src-tauri/src/commands/agents_helpers/send_common/context_loading.rs
+++ b/src-tauri/src/commands/agents_helpers/send_common/context_loading.rs
@@ -667,13 +667,7 @@ pub fn load_context_data(
                     }
                 }
 
-                // Result report (review/rework phase — Reviewer needs implementation context)
-                if phase == "review" || phase == "rework" {
-                    if let Ok(doc) = std::fs::read_to_string(plans_dir.join(format!("{}-result.md", slug))) {
-                        combined.push_str("\n\n---\n\n");
-                        combined.push_str(&doc);
-                    }
-                }
+                // 2026-04-29: result.md is auto-generated; injecting it into reviewer ContextPack created policy-violation verdict pattern. Reviewer must judge from task specs + code only.
 
                 // Latest review report (rework phase — Developer needs review feedback)
                 if phase == "rework" {

--- a/src/lib/workflow/reportSync.test.ts
+++ b/src/lib/workflow/reportSync.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { truncateSafe } from "./reportSync";
+import { truncateSafe, isResultMdEcho } from "./reportSync";
 
 describe("truncateSafe", () => {
   it("returns original string when within limit", () => {
@@ -47,5 +47,51 @@ describe("truncateSafe", () => {
     const result = truncateSafe("0123456789", 4);
     // marker 는 newline 두 개로 시작
     expect(result).toMatch(/0123\n\n\[…truncated, original 10 chars\]/);
+  });
+});
+
+describe("isResultMdEcho", () => {
+  it("returns true when both sentinel headers appear in head", () => {
+    const content = "# Implementation Result: 2026-04-29 fix\n\n> Plan Revision: r2\n\nbody...";
+    expect(isResultMdEcho(content)).toBe(true);
+  });
+
+  it("returns false when only Implementation Result header present", () => {
+    const content = "# Implementation Result: only this header\n\nsome body without revision";
+    expect(isResultMdEcho(content)).toBe(false);
+  });
+
+  it("returns false when only Plan Revision header present", () => {
+    const content = "> Plan Revision: r1\n\nstandalone revision note";
+    expect(isResultMdEcho(content)).toBe(false);
+  });
+
+  it("returns false for normal assistant message mentioning result.md plainly", () => {
+    const content = "I edited the result.md file based on your request, see diff below.";
+    expect(isResultMdEcho(content)).toBe(false);
+  });
+
+  it("returns false for code block that contains both phrases as quoted strings", () => {
+    // 정상 코드 설명에 result.md 언급 + 별개 단어로 'Plan Revision' 이 있어도
+    // 헤더 형식(`# ...:` / `> ...:`) 이 아니면 echo 아님
+    const content = "Here we describe Implementation Result: process and Plan Revision: workflow as concepts.";
+    expect(isResultMdEcho(content)).toBe(false);
+  });
+
+  it("requires headers within first 200 chars", () => {
+    const padding = "x".repeat(250);
+    const content = `${padding}\n# Implementation Result: late\n> Plan Revision: late`;
+    expect(isResultMdEcho(content)).toBe(false);
+  });
+
+  it("returns false for empty / non-string input", () => {
+    expect(isResultMdEcho("")).toBe(false);
+    // @ts-expect-error testing runtime guard
+    expect(isResultMdEcho(undefined)).toBe(false);
+  });
+
+  it("matches both headers even with extra whitespace", () => {
+    const content = "#  Implementation Result:  spaced\n>  Plan Revision:  r3";
+    expect(isResultMdEcho(content)).toBe(true);
   });
 });

--- a/src/lib/workflow/reportSync.test.ts
+++ b/src/lib/workflow/reportSync.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { truncateSafe } from "./reportSync";
+
+describe("truncateSafe", () => {
+  it("returns original string when within limit", () => {
+    expect(truncateSafe("hello", 10)).toBe("hello");
+  });
+
+  it("returns original empty string unchanged", () => {
+    expect(truncateSafe("", 10)).toBe("");
+  });
+
+  it("returns original when code-point count equals limit", () => {
+    const s = "abcde";
+    expect(truncateSafe(s, 5)).toBe(s);
+  });
+
+  it("truncates ASCII text and appends marker", () => {
+    const s = "abcdefghij"; // 10 chars
+    const result = truncateSafe(s, 5);
+    expect(result.startsWith("abcde")).toBe(true);
+    expect(result).toContain("[…truncated, original 10 chars]");
+  });
+
+  it("respects UTF-8 boundary for Korean (Hangul)", () => {
+    // 가나다라마 = 5 code points
+    const result = truncateSafe("가나다라마", 3);
+    expect(result.startsWith("가나다")).toBe(true);
+    expect(result).toContain("[…truncated, original 5 chars]");
+    // 보장: 잘려도 깨진 자모 없음
+    expect(result.includes("�")).toBe(false);
+  });
+
+  it("respects UTF-8 boundary for emoji (surrogate pair)", () => {
+    // 😀😃😄 = 3 code points, but 6 UTF-16 code units
+    const s = "😀😃😄😁😆";
+    const result = truncateSafe(s, 2);
+    expect(result.startsWith("😀😃")).toBe(true);
+    expect(result).toContain("[…truncated, original 5 chars]");
+  });
+
+  it("does not truncate when limit equals char length", () => {
+    expect(truncateSafe("가나다", 3)).toBe("가나다");
+  });
+
+  it("preserves marker format for downstream parser visibility", () => {
+    const result = truncateSafe("0123456789", 4);
+    // marker 는 newline 두 개로 시작
+    expect(result).toMatch(/0123\n\n\[…truncated, original 10 chars\]/);
+  });
+});

--- a/src/lib/workflow/reportSync.ts
+++ b/src/lib/workflow/reportSync.ts
@@ -7,6 +7,21 @@ import type { ParsedReviewVerdict } from "../planProposalParser";
 import { getProjectPath, createTestReportArtifact } from "./helpers";
 import { stripTunaflowMarkers } from "./markerScrub";
 
+/**
+ * UTF-8 boundary-safe truncation by code points.
+ * 잘렸을 때 [...truncated, original N chars] 마커를 붙여 다운스트림(reviewer 등)이
+ * 잘림 사실을 인지할 수 있게 한다. surrogate pair 안전 (Array.from 사용).
+ */
+export function truncateSafe(text: string, limit: number): string {
+  if (typeof text !== "string" || text.length === 0) return text ?? "";
+  // 빠른 경로: byte length 가 limit 보다 충분히 작으면 코드포인트 길이도 작음
+  if (text.length <= limit) return text;
+  const codePoints = Array.from(text);
+  if (codePoints.length <= limit) return text;
+  const head = codePoints.slice(0, limit).join("");
+  return `${head}\n\n[…truncated, original ${codePoints.length} chars]`;
+}
+
 /** Generate/update plan document in project directory. Fire-and-forget. */
 export async function syncPlanDocument(planId: string): Promise<void> {
   try {
@@ -61,14 +76,14 @@ export async function syncResultReport(
       : implMessages;
     const assistantMsgs = relevantMessages.filter((m) => m.role === "assistant");
     const summary = assistantMsgs.length > 0
-      ? stripTunaflowMarkers(assistantMsgs[assistantMsgs.length - 1].content.slice(0, 2000))
+      ? stripTunaflowMarkers(truncateSafe(assistantMsgs[assistantMsgs.length - 1].content, 8000))
       : "(No implementation output)";
 
     const { scanCompletedSubtasks } = await import("../planProposalParser");
     const completedNums = scanCompletedSubtasks(implMessages);
     const subtaskResults = assistantMsgs
       .slice(-10)
-      .map((m) => stripTunaflowMarkers(m.content.slice(0, 500)))
+      .map((m) => stripTunaflowMarkers(truncateSafe(m.content, 2000)))
       .filter((c) => c.trim().length > 0);
 
     const knownIssues: string[] = [];

--- a/src/lib/workflow/reportSync.ts
+++ b/src/lib/workflow/reportSync.ts
@@ -22,6 +22,20 @@ export function truncateSafe(text: string, limit: number): string {
   return `${head}\n\n[…truncated, original ${codePoints.length} chars]`;
 }
 
+/**
+ * Sentinel guard: prior result.md echo 인지 식별.
+ * `# Implementation Result:` 헤더와 `> Plan Revision:` 헤더가 본문 첫 200자 안에
+ * **둘 다** 출현하면 result.md echo 로 간주. 한쪽만 매칭하면 false positive 위험이
+ * 있어 거부. 이 함수는 syncResultReport 안에서만 사용.
+ */
+export function isResultMdEcho(content: string): boolean {
+  if (typeof content !== "string" || content.length === 0) return false;
+  const head = content.slice(0, 200);
+  const hasImplHeader = /^#\s*Implementation Result:/m.test(head);
+  const hasRevisionHeader = /^>\s*Plan Revision:/m.test(head);
+  return hasImplHeader && hasRevisionHeader;
+}
+
 /** Generate/update plan document in project directory. Fire-and-forget. */
 export async function syncPlanDocument(planId: string): Promise<void> {
   try {
@@ -74,7 +88,13 @@ export async function syncResultReport(
     const relevantMessages = lastReworkIdx >= 0
       ? implMessages.slice(lastReworkIdx + 1)
       : implMessages;
-    const assistantMsgs = relevantMessages.filter((m) => m.role === "assistant");
+    const rawAssistantMsgs = relevantMessages.filter((m) => m.role === "assistant");
+    // self-include guard: prior result.md 인용 메시지 제외 (두 헤더 동시 매칭만)
+    const assistantMsgs = rawAssistantMsgs.filter((m) => !isResultMdEcho(m.content));
+    const excludedEchoCount = rawAssistantMsgs.length - assistantMsgs.length;
+    if (excludedEchoCount > 0) {
+      console.debug(`[syncResultReport] excluded ${excludedEchoCount} echoed result.md messages`);
+    }
     const summary = assistantMsgs.length > 0
       ? stripTunaflowMarkers(truncateSafe(assistantMsgs[assistantMsgs.length - 1].content, 8000))
       : "(No implementation output)";

--- a/src/locales/en/workflow.json
+++ b/src/locales/en/workflow.json
@@ -230,7 +230,7 @@
       "prev_findings_header": "**Previous Review Findings (focus area)**:",
       "prev_findings_footer": "> Verify whether the items above were resolved.",
       "scope_note": "**Review scope**: review only Task {{ids}}. The other subtasks passed in the previous review.",
-      "body": "### 🔍 {{roundLabel}} request\n\n**Plan**: \"{{title}}\"\n\n**Verification documents**:\n- Plan: `docs/plans/{{slug}}.md`\n- Result: `docs/plans/{{slug}}-result.md`\n{{taskScope}}{{scopeNote}}{{prevFindings}}\n\nValidate the implementation against each task file's **Change description** and **Verification**.\nCode style not specified in the Plan, or existing issues in files outside scope, are not fail reasons.\n\n> Submit the review verdict when done."
+      "body": "### 🔍 {{roundLabel}} request\n\n**Plan**: \"{{title}}\"\n\n**Verification documents**:\n- Plan: `docs/plans/{{slug}}.md`\n{{taskScope}}{{scopeNote}}{{prevFindings}}\n\nValidate the implementation against each task file's **Change description** and **Verification**.\nCode style not specified in the Plan, or existing issues in files outside scope, are not fail reasons.\n\n> Submit the review verdict when done."
     },
     "sub_plan_prompt": {
       "header": "[Sub-plan request] Plan \"{{plan}}\" → Subtask {{num}} \"{{title}}\"",

--- a/src/locales/ko/workflow.json
+++ b/src/locales/ko/workflow.json
@@ -230,7 +230,7 @@
       "prev_findings_header": "**이전 Review Findings (중점 확인 대상)**:",
       "prev_findings_footer": "> 위 사항이 해결되었는지 확인하세요.",
       "scope_note": "**리뷰 범위**: Task {{ids}}번만 검토하세요. 나머지 subtask는 이전 리뷰에서 pass되었습니다.",
-      "body": "### 🔍 {{roundLabel}} 요청\n\n**Plan**: \"{{title}}\"\n\n**검증 문서**:\n- Plan: `docs/plans/{{slug}}.md`\n- 결과: `docs/plans/{{slug}}-result.md`\n{{taskScope}}{{scopeNote}}{{prevFindings}}\n\n각 task 파일의 **변경 내용**과 **검증 조건**을 기준으로 구현 결과를 검증하세요.\nPlan에 명시되지 않은 코드 스타일이나 범위 밖 파일의 기존 문제는 fail 사유가 아닙니다.\n\n> 완료 후 리뷰 verdict를 제출하세요."
+      "body": "### 🔍 {{roundLabel}} 요청\n\n**Plan**: \"{{title}}\"\n\n**검증 문서**:\n- Plan: `docs/plans/{{slug}}.md`\n{{taskScope}}{{scopeNote}}{{prevFindings}}\n\n각 task 파일의 **변경 내용**과 **검증 조건**을 기준으로 구현 결과를 검증하세요.\nPlan에 명시되지 않은 코드 스타일이나 범위 밖 파일의 기존 문제는 fail 사유가 아닙니다.\n\n> 완료 후 리뷰 verdict를 제출하세요."
     },
     "sub_plan_prompt": {
       "header": "[Sub-plan 요청] Plan \"{{plan}}\" → Subtask {{num}} \"{{title}}\"",


### PR DESCRIPTION
## Summary

리뷰어 ContextPack 에 자동 첨부되던 `*-result.md` 본문이 REVIEWER_TEMPLATE 의 "Never judge result.md" 규칙과 모순되어 정책 위반 verdict 패턴을 유발했습니다. 입력 단 차단(P0) + truncation/self-include 가드(P1) + i18n 정리(P2) 를 4 task 로 처리합니다.

Plan SSOT: `docs/plans/resultMdContaminationFixPlan_2026-04-29.md`
Handoff: `docs/prompts/resultMdContaminationFixDeveloperHandoff_2026-04-29.md`

## Tasks

| # | 파일 | 변경 | 우선 |
|---|---|---|---|
| 01 | `src-tauri/src/commands/agents_helpers/send_common/context_loading.rs` | line 670-676 result.md 첨부 블록 삭제 (주석으로 대체) | P0 |
| 02 | `src/lib/workflow/reportSync.ts` | `truncateSafe` 헬퍼 + summary 8k / subtask 2k 상한 + 잘림 마커 | P1 |
| 03 | `src/lib/workflow/reportSync.ts` | `isResultMdEcho` sentinel guard (두 헤더 동시 매칭) | P1 |
| 04 | `src/locales/ko/workflow.json` + `src/locales/en/workflow.json` | review_prompt.body 에서 result.md 라인 삭제 | P2 |

## Verification

```
$ npx tsc --noEmit                                  → PASS (exit 0)
$ npx vitest run                                    → 35 files / 381 tests PASS (baseline 365 +16 new)
$ cd src-tauri && cargo check --lib                 → PASS (warning 1: 무관한 query_expand)
$ cd src-tauri && cargo test --lib                  → 559 passed / 0 failed
```

회귀 grep:
- `phase == .review|phase == .rework` in `context_loading.rs` → 두 분기(line 659 task files, line 673 rework review report) 잔존 확인 (task 01 가드)
- `result\.md` in `src/locales/` → settings.json `artifact_hint` 두 항목만 잔존 (의도적, task 04 plan 가드)
- `syncPlanDocument` / `syncReviewReport` / `lastReworkIdx` 로직 → unchanged 확인

## e2e 수동 검증

자동화 세션 환경에서 `npm run tauri dev` GUI 실행 미수행. 대체 정적 검증:
`send_common/` 안에서 `*-result.md` 를 read 하는 코드 경로는 모두 제거되어 주석만 남음. ContextPack 빌드 시 reviewer/rework phase 어디서도 result.md 파일을 첨부하지 않음을 코드 레벨로 보장.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npx vitest run` (381 / 381)
- [x] `cd src-tauri && cargo check --lib`
- [x] `cd src-tauri && cargo test --lib` (559 / 559)
- [x] 회귀 grep — 가드 위반 없음
- [ ] 머지 후 main 에서 dummy plan e2e (sentinel false positive / reviewer verdict 품질 모니터)

🤖 Generated with [Claude Code](https://claude.com/claude-code)