### PR TITLE
fix(conventions): normalize @import path to forward-slash on Windows

### DIFF
--- a/src-tauri/src/commands/conventions_sync.rs
+++ b/src-tauri/src/commands/conventions_sync.rs
@@ -342,9 +342,15 @@ pub fn sync_to_files(
         let mut s = String::from("## Project conventions (managed by tunaFlow)\n\n");
         s.push_str("> 이 영역은 tunaFlow가 자동 갱신합니다. Settings에서 편집하세요.\n\n");
         for p in &split_paths {
-            // 진입점 파일 기준 상대 경로
+            // 진입점 파일 기준 상대 경로. Claude Code 등의 `@import`는 forward-slash를 요구하므로
+            // Windows backslash 컴포넌트 구분자를 명시적으로 정규화한다.
             if let Ok(rel) = p.strip_prefix(project_root) {
-                s.push_str(&format!("@{}\n", rel.display()));
+                let rel_str = rel
+                    .components()
+                    .map(|c| c.as_os_str().to_string_lossy())
+                    .collect::<Vec<_>>()
+                    .join("/");
+                s.push_str(&format!("@{}\n", rel_str));
             }
         }
         s


### PR DESCRIPTION
## Summary

- `Path::display()` on Windows emits backslash-separated paths, breaking Claude Code's `@path` import syntax in the auto-managed section of `CLAUDE.md` / `AGENTS.md` / `GEMINI.md` when sync runs on Windows.
- Normalize via per-component forward-slash join in `conventions_sync.rs:347`. macOS/Linux output is byte-identical (already slash-based) → INV-1 (no macOS side effect) holds.
- Single hot-spot — only one occurrence of this `display()` + `@` pattern in the Rust tree.

## Plan / handoff mapping

- Handoff: `docs/prompts/windowsBetaHardeningArchitectHandoff_2026-04-29.md` — falls under hardening axis (cross-platform path normalization), discovered while running A-1 baseline.
- Plan: `docs/plans/windowsBetaHardeningPlan_2026-04-26.md` (INV-1~4 applied below).

## Invariants

- **INV-1** macOS side effect 0 — fix output byte-identical on macOS (`Path` already slash-based; per-component join collapses to same string).
- **INV-2** PR + CI watch (this PR). Will not admin-merge.
- **INV-3** No macOS-specific files touched.
- **INV-4** Single axis (path-separator normalization). Other working-tree changes (`Cargo.toml` LF/CRLF, generated schemas, `package-lock.json`) intentionally excluded from this commit.

## Verification (Windows host)

- `cargo test --lib commands::conventions_sync` → 9/9 passed (incl. previously-failing `sync_to_files_full_flow`).
- `cargo test --lib` (full) → 558 passed / 0 failed (vs. pre-fix 557 passed / 1 failed). The 1 delta vs. macOS baseline 559 is presumed `cfg(unix)`-gated; macOS CI will confirm.
- `npx tsc --noEmit` → clean.
- `npx vitest run` → 381/381 (matches FE baseline).

## Test plan

- [ ] macOS CI job passes (no regression on Rust 559 baseline).
- [ ] Windows CI job passes.
- [ ] After merge, re-run `cargo test --lib` on macOS architect host to reconfirm 559.