### PR TITLE
docs(plan): Windows dependency bootstrap — chub + code-review-graph

### DIFF
--- a/docs/plans/windowsDependencyBootstrapPlan_2026-04-29.md
+++ b/docs/plans/windowsDependencyBootstrapPlan_2026-04-29.md
@@ -1,0 +1,218 @@
+---
+title: Windows 의존성 부트스트랩 플랜 — context-hub / code-review-graph 인식 + 배포 패키지 포함
+created_at: 2026-04-29
+calling_role: architect (Windows 머신)
+target_role: developer → reviewer (Codex, optional)
+related_plans:
+  - docs/plans/windowsBetaHardeningPlan_2026-04-26.md
+  - docs/plans/windowsBuildPlan_2026-04-24.md
+  - docs/plans/cicdReleasePlan.md
+status: draft
+---
+
+# Windows 의존성 부트스트랩 플랜
+
+## 0. 요약 (1 단락)
+
+`context-hub` (`@aisuite/chub` npm) 와 `code-review-graph` (pip) 두 사이드카가
+mac 환경에는 미리 설치돼 있어 Settings → Runtime 에 `ready` 로 표기되지만,
+Windows 환경(이 머신 포함)에는 미설치 상태라 두 항목 모두 `unavailable` 로 보인다.
+README 의 *"Auto-installed on first run"* 표기와 달리 backend 코드에는 자동 설치 로직이
+**전혀 없다** (`auto_install`/`install_if_missing`/`npm install -g`/`pip install` grep 0건).
+즉 mac 측 정상 동작은 *사용자 / architect 가 수동 설치한 결과* 이며 Windows 측에서는
+그 manual setup 이 누락된 채 silent unavailable 로 빠진다. 이 플랜은
+(1) 두 의존성을 Windows 측에서도 정상 인식되게 하고,
+(2) 배포 패키지(NSIS installer) 첫 실행 단계에서 *user consent 후* 설치를 시도하며,
+(3) 호환성 문제 시 안내 → 재시도 가능한 회복 경로를 제공한다.
+
+## 1. Invariants
+
+| ID | 내용 |
+|---|---|
+| **INV-1** 🔴 | **macOS tunaFlow 에 사이드 이펙트 0**. Windows 측 변경은 `#[cfg(target_os = "windows")]` 격리, macOS 무관 새 파일 추가, 또는 macOS CI 빌드 통과 검증 후에만. |
+| **INV-2** | **PR + CI watch 필수**. macOS + Windows 양쪽 CI ✓ 후 머지. `gh pr merge --admin` 금지. |
+| **INV-3** | macOS-specific 경로/스크립트(`bootstrap/env.rs` macOS PATH 보강, `scripts/build-rawq.sh` 등) 변경 X. |
+| **INV-4** | **단일 axis per commit**. T1~T7 각 task 마다 별 commit + 별 PR. |
+| **INV-DEP-A** (신규) | **자동 설치는 user consent 후에만**. silent global install 금지. 첫 실행 시 다이얼로그 → 사용자가 "설치" 선택 시에만 진행. |
+| **INV-DEP-B** (신규) | **설치 실패 시 graceful degradation**. 의존성 미설치는 unavailable 상태로 두고 앱 진입 차단 금지. context-hub 미설치 = 검색 비활성, code-review-graph 미설치 = CRG 섹션 skip. 다른 기능 정상 동작. |
+| **INV-DEP-C** (신규) | **README 표기와 실제 동작 일치**. "Auto-installed on first run" 이 silent install 을 의미하지 않음을 명확히 (consent UX 포함하도록 README 수정 또는 실제 silent 자동 설치 + opt-out 토글). 둘 중 한 쪽으로 통일. |
+
+## 2. 현황 매트릭스
+
+### 2.1 의존성 인벤토리 (Windows 머신, 2026-04-29 기준)
+
+| 의존성 | 설치 위치 (mac/win) | 자동? | UI 영향 | Status |
+|---|---|---|---|---|
+| Node.js + npm | (toolchain) | 사용자 사전 | base | ✅ 설치됨 |
+| Python 3 + pip | (toolchain) | 사용자 사전 | base | ✅ 설치됨 |
+| claude CLI | `~/.local/bin/claude.exe` | 사용자 수동 | engine 미인식 | ✅ 설치됨 |
+| codex CLI | `%APPDATA%\npm\codex.cmd` | 사용자 수동 | engine 미인식 | ✅ 설치됨 |
+| gemini CLI | `%APPDATA%\npm\gemini.cmd` | 사용자 수동 | engine 미인식 | ✅ 설치됨 |
+| **rawq sidecar** | `src-tauri/binaries/rawq-*.exe` | 빌드 시 (`scripts/build-rawq.{sh,ps1}`) | rawq footer | ✅ 빌드 (PR 후 NSIS 번들) |
+| rawq daemon spawn | `bootstrap/services.rs` | 자동 (앱 시작 시) | — | ✅ 자동 |
+| rawq snowflake 임베딩 | `%LOCALAPPDATA%\rawq\models\` | 자동 (rawq daemon 다운로드) | — | ✅ 자동 |
+| **bge-m3 ONNX 모델** | `init_global_embedder_async` | 자동 (huggingface 다운로드) | secall RAG | ⚠ 첫 실행 시 ~2GB |
+| **vendor skills** | `~/.tunaflow/skills/` | `scripts/publish-skills.sh` 수동 | Settings → Skills | ⚠ 수동 publish 필요 |
+| **chub** (`@aisuite/chub`) | `%APPDATA%\npm\chub.cmd` | **없음** (코드 grep 0건) | context-hub 카드 | 🟢 본 PR 로 설치 + 부트스트랩 |
+| **code-review-graph** | `<python>/Scripts/code-review-graph.exe` | **없음** | ContextPack CRG 섹션 | 🟢 본 PR 로 설치 + 부트스트랩 |
+| ollama / lmstudio | (옵션, 사용자 사전) | — | 옵션 엔진 | (본 PR 범위 외) |
+
+### 2.2 백엔드 detection 코드 검토
+
+- **`src-tauri/src/agents/context_hub.rs:resolve_bin()`** — `HOME` env var 기반 후보 + `/usr/local/bin` 등 unix 절대 경로 + 마지막 PATH fallback (`Command::new("chub").arg("--help")`).
+  - Windows native process 는 `HOME` 이 보통 미설정 (대신 `USERPROFILE`). 첫 1단계 candidate Vec 이 통째로 skip.
+  - PATH fallback 은 정상 동작 — Windows 에서 `Command::new("chub")` 가 `chub.cmd` shim 을 발견. 그러나 Rust 1.77+ 의 `BatBadBat` (CVE-2024-24576) 보안 패치 이후 인자 sanitization 이 추가됨 — `--help` 정도의 단순 호출은 무관, 그러나 `chub search "query with spaces"` 같은 실 호출에서 escape 회귀 위험 있음. 별도 회귀 점검 필요.
+- **`src-tauri/src/agents/crg.rs:resolve_bin()`** — `HOME/.local/bin/code-review-graph`, `/opt/homebrew/...` 등 unix 경로만. Windows PATH fallback 유무 미확인 (T2 에서 점검).
+
+### 2.3 README 와 실제 동작 불일치
+
+- README.{md,ko.md} : *"context-hub …  Auto-installed on first run"*
+- 실제 코드 : detect → silent unavailable. 사용자 안내 없음.
+- INSTALL.md §128 표 : "앱 내 안내 표시" — 안내 UI 도 미구현.
+- 결론: 표기·문서·코드 셋 다 정합성 깨짐. **INV-DEP-C** 로 통일 방향 결정 필요.
+
+## 3. 설계 선택 — bundle vs first-run vs 안내만
+
+각 의존성을 다음 중 하나로 분류:
+
+| 모드 | 의미 | 적합 의존성 |
+|---|---|---|
+| **A. bundle** | NSIS installer 자체에 포함, 별도 설치 불필요 | rawq sidecar (이미 적용), vendor skills (작음), 향후 chub binary 형태 가능 시 |
+| **B. first-run with consent** | 앱 첫 실행 시 다이얼로그 → 사용자 동의 후 백그라운드 install | **chub** (npm i -g), **code-review-graph** (pip install) |
+| **C. 안내만** | 미설치 감지 → UI 안내 + 사용자 가이드 링크. 자동 설치 없음 | claude/codex/gemini/ollama 같은 *사용자 정체성에 묶이는* CLI |
+| **D. 자동 다운로드** | 앱이 직접 fetch (코드 내장) | bge-m3 모델 (이미 적용) |
+
+**권장 분류**:
+
+| 의존성 | 권장 모드 | 이유 |
+|---|---|---|
+| chub | **B** (first-run consent) | npm 글로벌 — Node 환경 의존, 글로벌 install 은 사용자 환경에 영향이라 silent 금지 |
+| code-review-graph | **B** (first-run consent) | pip 글로벌 — 큰 의존성 트리 (tree-sitter 등), Python venv 우선 권유 안내 포함 |
+| vendor skills | **A** (bundle) | 작음, 정적, idempotent. NSIS 설치 시 `%USERPROFILE%\.tunaflow\skills\` 에 풀어두면 됨 |
+| bge-m3 | **D** (현행 유지) | 2GB → bundle 비현실. 첫 indexing/search 시 progress UI |
+
+## 4. Phase 분해 (P0 → P3)
+
+### Phase 1 — Backend 인식 정상화 (P0, 본 PR 의 즉시 차단 사유 해소)
+
+#### T1 — `context_hub::resolve_bin()` Windows 호환 검증 + 보강
+- **파일**: `src-tauri/src/agents/context_hub.rs`
+- **현황**: PATH fallback 으로 chub.cmd 인식 가능 *should be*. dev 빌드에서 실제 동작 확인.
+- **변경**:
+  - `Windows` cfg 분기 추가: `USERPROFILE\\AppData\\Roaming\\npm\\chub.cmd` 후보를 candidates 에 push (PATH fallback 보다 명시적이라 빠름 + 안정).
+  - `HOME` 분기는 그대로 유지 (Linux/macOS 호환).
+- **테스트**: 단위 테스트 — Windows env 모의(`std::env::set_var("USERPROFILE", ...)` + temp dir) 에서 candidate path 가 결과에 포함되는지.
+- **INV**: cfg 격리, macOS 영향 0.
+
+#### T2 — `crg::resolve_bin()` Windows 호환 추가
+- **파일**: `src-tauri/src/agents/crg.rs`
+- **현황**: unix 경로 candidate + which 호출. Windows PATH fallback 부재 가능성.
+- **변경**:
+  - cfg(windows) 분기: `<python>/Scripts/code-review-graph.exe` 후보 (USERPROFILE 또는 sys.executable 추론). 또는 PATH fallback 으로 `Command::new("code-review-graph").arg("--version")` 추가.
+  - 가장 단순한 안: PATH fallback (`Command::new("code-review-graph")`). cfg 분기 없이 cross-platform.
+- **테스트**: T1 과 동일 패턴.
+- **INV**: PATH fallback 이면 macOS 도 동일 코드 실행 — but 이미 unix candidate 가 먼저 hit 하므로 동작 변경 없음.
+
+#### T3 — README/INSTALL.md 의 자동 설치 문구 정정
+- **파일**: `README.md`, `README.ko.md`, `INSTALL.md`
+- **변경**: *"Auto-installed on first run"* → *"prompted to install on first run"* (consent UX 명시) 또는 silent install 을 채택할 경우 그대로 유지하고 코드를 맞추는 방향. INV-DEP-C 결정 후 한 쪽.
+- **INV**: docs only, 코드 회귀 0.
+
+### Phase 2 — First-run consent UI + auto-install (P1)
+
+#### T4 — installer 후보 detection + dialog
+- **파일**: `src-tauri/src/commands/dependency_install.rs` (신규), `src/components/tunaflow/FirstRunDependencyDialog.tsx` (신규)
+- **로직**:
+  1. 앱 시작 시 `setting("first_run_dependency_check_done")` 플래그 검사. 미수행이면 다이얼로그 표시.
+  2. 검사 항목: chub, code-review-graph. 각각 `available: bool, installer_command: String, requires: String` 반환.
+  3. 다이얼로그: 항목별 체크박스 (기본 ON) + "건너뛰기" / "설치". 선택 시 `install_dependency(name)` invoke.
+  4. install 명령:
+     - chub: `npm install -g @aisuite/chub` (`Command::new("npm")`)
+     - code-review-graph: `pip install code-review-graph` (`Command::new("pip")`)
+  5. 결과 status 이벤트 `dependency:install_result` emit. 실패 시 안내 + 수동 설치 명령 표시.
+- **INV-DEP-A** 충족: user consent 후에만 실행.
+- **INV-DEP-B** 충족: 다이얼로그 닫아도 앱 진행 가능.
+
+#### T5 — Settings → Runtime 에 *수동 설치 트리거* 버튼 추가
+- **파일**: `src/components/tunaflow/settings/RuntimeSection.tsx` 의 `ContextHubPanel`, 그리고 CRG 섹션이 있다면 그곳에 동일 버튼.
+- **변경**: `unavailable` 상태일 때 "Install via npm/pip" 버튼 표시 → T4 의 `install_dependency` invoke. 이미 설치된 사용자에겐 안 보임.
+- **INV**: macOS UI 도 동일하게 보이지만 macOS 에선 이미 설치된 경우가 보통이라 버튼 자체가 숨겨짐 → 영향 0.
+
+### Phase 3 — Bundled assets (P2)
+
+#### T6 — vendor skills 를 NSIS installer 에 번들
+- **파일**: `src-tauri/tauri.conf.json` (resources 항목), `src-tauri/src/bootstrap/services.rs` (first-run 시 unpack)
+- **변경**:
+  - build 시 `_research/_skills` 또는 `agents/_skills` 의 sn snapshot 을 installer resources 에 포함.
+  - 첫 실행 시 `~/.tunaflow/skills/` 가 비어 있으면 번들된 snapshot 을 unpack. 이후 사용자가 publish-skills 로 갱신 가능.
+- **INV**: macOS 빌드도 같은 resources 항목 사용 가능 (cross-platform). 다만 macOS 측 publish-skills.sh 는 그대로 유지 — 두 경로 공존.
+- **사이즈 영향**: 238 skills × 평균 SKILL.md ~5~50KB = 약 5~15MB. 허용 가능.
+
+#### T7 — Windows installer 후 reboot/relaunch 가이드
+- **파일**: NSIS .nsi (또는 `tauri.conf.json` bundle 설정)
+- **변경**: post-install 단계에서 PATH 갱신 안내 (npm/pip 으로 새로 설치된 binary 가 같은 세션에서 인식 안 될 수 있어 dev 모드 재시작 필요). 다이얼로그 또는 README 보강.
+
+### Phase 4 — 추후 개선 (P3, 본 plan 외 axis)
+
+- chub 정적 binary 번들 (npm 의존 제거) — chub 가 단일 binary release 를 제공하면 mode A 로 격상 가능. 현재 npm-only 라 Phase 2 의 mode B 유지.
+- code-review-graph 의 PyInstaller 단일 실행 파일 번들 — Python 의존 제거 가능. 단 사이즈 크고 Python ABI 호환성 위험. 본 plan 범위 외.
+
+## 5. 작업 분해 — developer 인계용
+
+| Task | 파일 | 검증 명령 | 예상 LOC |
+|---|---|---|---|
+| **T1** | `src-tauri/src/agents/context_hub.rs` (+test) | `cargo test --lib agents::context_hub` | +30 / -0 |
+| **T2** | `src-tauri/src/agents/crg.rs` (+test) | `cargo test --lib agents::crg` | +20 / -0 |
+| **T3** | `README.md`, `README.ko.md`, `INSTALL.md` | docs only | +5 / -3 |
+| **T4** | `src-tauri/src/commands/dependency_install.rs` (신규), `src/components/.../FirstRunDependencyDialog.tsx` (신규) | `cargo test`, `vitest run` | +150 / -0 |
+| **T5** | `src/components/tunaflow/settings/RuntimeSection.tsx` | `vitest run` | +40 / -0 |
+| **T6** | `src-tauri/tauri.conf.json`, `src-tauri/src/bootstrap/services.rs` | install + first run | +30 / -0 |
+| **T7** | NSIS .nsi or tauri bundle config | install smoke | +10 / -0 |
+
+각 Task → **별 commit + 별 PR + macOS+Windows CI ✓ 후 머지** (INV-2/4).
+
+## 6. 회귀 가드 / 검증 시나리오
+
+### 6.1 macOS 회귀 가드 (INV-1)
+- T1/T2: macOS 환경에서 `cargo test --lib agents::{context_hub,crg}` baseline 카운트 동일.
+- T3: docs only, code 무관.
+- T4/T5: macOS 에서도 dialog/button 코드 컴파일/렌더 OK. 단 macOS 사용자에겐 *이미 설치돼 있음* 으로 invisible (UX 영향 0).
+- T6: macOS 빌드 시 resources 포함 여부는 conf 설정에 따름. macOS 측 publish-skills.sh 동작 동일.
+
+### 6.2 Windows 검증 (T1~T7 누적 후)
+| ID | 시나리오 | 기대 결과 |
+|---|---|---|
+| W-1 | clean Windows VM 에 chub/crg 미설치 상태로 NSIS installer 설치 | 첫 실행 시 dialog → "설치" 선택 → chub + crg 글로벌 설치 → ready |
+| W-2 | 같은 VM 에 chub 만 미리 설치된 상태로 dialog | crg 만 표시 (chub 항목 자동 hide) |
+| W-3 | dialog "건너뛰기" → 앱 정상 진입, Settings → Runtime 의 두 카드 unavailable, 수동 설치 버튼 노출 |
+| W-4 | npm install -g 권한 부족 (Roaming 쓰기 거부) → 실패 메시지 + 수동 명령 표시 |
+| W-5 | 인터넷 차단 → npm/pip timeout 후 graceful 실패 메시지 |
+| W-6 | 두 의존성 설치 후 dev 모드 재시작 → backend resolve_bin 즉시 인식, status `ready` |
+
+### 6.3 회귀 카운트 baseline
+- 본 plan 시작 시점: FE 381 / Rust 558 (Windows). FE/Rust 양쪽 +N (테스트 추가) 만 허용, 감소 금지.
+
+## 7. 리뷰어(Codex) review 포인트
+
+- **R-1** chub.cmd 인자 escape 회귀 (Rust 1.77+ CVE-2024-24576 영향) — `chub search "복합 query"` 같은 실 호출이 Windows 에서 정상 작동하는지.
+- **R-2** Python 환경 가정 — 사용자가 `python3` 가 아닌 `python` 으로만 PATH 에 있을 때 `pip install` 호출 분기.
+- **R-3** consent dialog 의 i18n — ko/en 양쪽 문구.
+- **R-4** Settings install 버튼이 macOS 에서도 *동일 코드*로 렌더되지만 detection 결과 `available:true` 라 hidden 인지 (INV-1 안전성).
+- **R-5** `dependency:install_result` 이벤트가 background 작업이라 hang 가능성 — timeout (예: npm 60s, pip 120s) 적용 여부.
+- **R-6** README 표기 변경 (T3) 이 ko/en 양쪽 동일 의미 유지.
+
+## 8. 오픈 질문 (architect → 사용자 / mac architect)
+
+| Q | 결정 필요한 사항 |
+|---|---|
+| Q-1 | INV-DEP-C 통일 방향 — 문구를 *consent UX* 로 정정할지, 또는 silent install + opt-out 토글로 README 와 일치시킬지. |
+| Q-2 | T6 (skills bundle) 우선순위 — 현재 publish-skills.sh 수동 publish 로도 동작하므로 P3 로 미룰 수 있음. NSIS 사이즈 영향 vs 사용자 편의 trade. |
+| Q-3 | code-review-graph 가 Python 패키지라 venv 사용 여부 권장 — global pip install 이 사용자 환경에 영향이라 OS-wide 사이드이펙트. dialog 에 *"venv 사용 권장"* 안내 포함 여부. |
+| Q-4 | T4 의 dialog 가 핸드오프 §B (startup race) 진단을 방해하지 않는지 — 첫 실행 시 dialog 표시가 "엔진/모델 감지" 단계 hang 과 별 axis 임을 명시. |
+
+## 9. 진행 메모 (architect → developer)
+
+- 본 plan 작성 직전, Windows architect 가 **수동으로** `npm install -g @aisuite/chub` (chub 0.1.4) 와 `pip install code-review-graph` (crg 2.3.2) 를 설치 완료. 따라서 T1/T2 검증은 이 머신에서 **즉시** 가능.
+- T1~T2 만 머지해도 본 머신의 unavailable 표시는 ready 로 변경됨 (재시작 후). T4~T5 는 다른 Windows 사용자를 위한 일반 사용자 가치.
+- 핸드오프 `windowsBetaHardeningArchitectHandoff_2026-04-29.md` 의 트랙 §B (startup race) / §C (DB path stale) / §D (watchdog compat) 와 axis 분리 — 본 plan 의 PR 은 별도로 머지.
+- 머지 순서 권장: **T1 → T2 → T3 → T4 → T5 → (T6 → T7)**. 각 PR 사이 baseline 회귀 카운트 확인.

--- a/docs/plans/windowsDependencyBootstrapPlan_2026-04-29.md
+++ b/docs/plans/windowsDependencyBootstrapPlan_2026-04-29.md
@@ -7,7 +7,7 @@ related_plans:
   - docs/plans/windowsBetaHardeningPlan_2026-04-26.md
   - docs/plans/windowsBuildPlan_2026-04-24.md
   - docs/plans/cicdReleasePlan.md
-status: draft
+status: ready (mac architect review APPROVE 2026-04-29)
 ---
 
 # Windows 의존성 부트스트랩 플랜
@@ -114,8 +114,8 @@ README 의 *"Auto-installed on first run"* 표기와 달리 backend 코드에는
 - **INV**: PATH fallback 이면 macOS 도 동일 코드 실행 — but 이미 unix candidate 가 먼저 hit 하므로 동작 변경 없음.
 
 #### T3 — README/INSTALL.md 의 자동 설치 문구 정정
-- **파일**: `README.md`, `README.ko.md`, `INSTALL.md`
-- **변경**: *"Auto-installed on first run"* → *"prompted to install on first run"* (consent UX 명시) 또는 silent install 을 채택할 경우 그대로 유지하고 코드를 맞추는 방향. INV-DEP-C 결정 후 한 쪽.
+- **파일**: `README.md`, `README.ko.md`, `INSTALL.md` (특히 §128 "Lite 트랙 — 추가 기능 자동 설치" 표 — "앱 내 안내 표시" 도 미구현이므로 동일 정정 대상)
+- **변경**: *"Auto-installed on first run"* → *"prompted to install on first run"* (consent UX 명시). [Q-1 결정: consent UX 채택]
 - **INV**: docs only, 코드 회귀 0.
 
 ### Phase 2 — First-run consent UI + auto-install (P1)
@@ -124,36 +124,37 @@ README 의 *"Auto-installed on first run"* 표기와 달리 backend 코드에는
 - **파일**: `src-tauri/src/commands/dependency_install.rs` (신규), `src/components/tunaflow/FirstRunDependencyDialog.tsx` (신규)
 - **로직**:
   1. 앱 시작 시 `setting("first_run_dependency_check_done")` 플래그 검사. 미수행이면 다이얼로그 표시.
+     - **모달 직렬 보장 [Q-4]**: dependency dialog → onboarding 분석 모달 순서. dependency dialog dismiss 후에만 onboarding 모달이 뜨도록 store 의 모달 큐에 우선순위 명시.
+     - **디버그 토글**: `first_run_dependency_check_done=true` 를 미리 set 하면 dialog 무시 — startup race (§B) 진단 시 사용.
   2. 검사 항목: chub, code-review-graph. 각각 `available: bool, installer_command: String, requires: String` 반환.
   3. 다이얼로그: 항목별 체크박스 (기본 ON) + "건너뛰기" / "설치". 선택 시 `install_dependency(name)` invoke.
-  4. install 명령:
-     - chub: `npm install -g @aisuite/chub` (`Command::new("npm")`)
-     - code-review-graph: `pip install code-review-graph` (`Command::new("pip")`)
-  5. 결과 status 이벤트 `dependency:install_result` emit. 실패 시 안내 + 수동 설치 명령 표시.
-- **INV-DEP-A** 충족: user consent 후에만 실행.
-- **INV-DEP-B** 충족: 다이얼로그 닫아도 앱 진행 가능.
+     - **venv 안내 [Q-3]**: 다이얼로그에 1줄 — *"venv 가 활성화되어 있으면 그 안에 설치합니다. 시스템 전역 설치를 피하려면 venv 활성 후 진행하세요"*. silent venv 생성 금지.
+  4. install 명령 (timeout 명시 [R-5]):
+     - chub: `npm install -g @aisuite/chub` (`Command::new("npm")`) — **timeout 60s**
+     - code-review-graph: pip 호출 [Q-3 — venv 자동 활용]
+       - `VIRTUAL_ENV` env var 가 set 되어 있으면 그 안의 `<venv>/Scripts/pip.exe` (Windows) 또는 `<venv>/bin/pip` (Unix) 사용 → venv 안에 설치
+       - 미설정이면 system `pip install code-review-graph` (global) — **timeout 120s**
+  5. 결과 status 이벤트 `dependency:install_result` emit. 실패/timeout 시 안내 + 수동 설치 명령 표시 (graceful degradation).
+- **INV-DEP-A** 충족: user consent 후에만 실행. silent venv 생성도 금지.
+- **INV-DEP-B** 충족: 다이얼로그 닫아도 앱 진행 가능. timeout/실패 시 dialog 안 hang.
 
 #### T5 — Settings → Runtime 에 *수동 설치 트리거* 버튼 추가
 - **파일**: `src/components/tunaflow/settings/RuntimeSection.tsx` 의 `ContextHubPanel`, 그리고 CRG 섹션이 있다면 그곳에 동일 버튼.
 - **변경**: `unavailable` 상태일 때 "Install via npm/pip" 버튼 표시 → T4 의 `install_dependency` invoke. 이미 설치된 사용자에겐 안 보임.
 - **INV**: macOS UI 도 동일하게 보이지만 macOS 에선 이미 설치된 경우가 보통이라 버튼 자체가 숨겨짐 → 영향 0.
 
-### Phase 3 — Bundled assets (P2)
+### Phase 3 — Bundled assets (본 plan 외 axis로 격하 [Q-2])
 
-#### T6 — vendor skills 를 NSIS installer 에 번들
-- **파일**: `src-tauri/tauri.conf.json` (resources 항목), `src-tauri/src/bootstrap/services.rs` (first-run 시 unpack)
-- **변경**:
-  - build 시 `_research/_skills` 또는 `agents/_skills` 의 sn snapshot 을 installer resources 에 포함.
-  - 첫 실행 시 `~/.tunaflow/skills/` 가 비어 있으면 번들된 snapshot 을 unpack. 이후 사용자가 publish-skills 로 갱신 가능.
-- **INV**: macOS 빌드도 같은 resources 항목 사용 가능 (cross-platform). 다만 macOS 측 publish-skills.sh 는 그대로 유지 — 두 경로 공존.
-- **사이즈 영향**: 238 skills × 평균 SKILL.md ~5~50KB = 약 5~15MB. 허용 가능.
+#### T6 — vendor skills 를 NSIS installer 에 번들 *(P3, 별 plan 후속)*
+- **격하 사유 [Q-2]**: 현재 mac 측 `publish-skills.sh` 수동 publish 가 정상 동작 중이고 사용자 보고 0건. T1~T5 의 즉시 가치(chub/crg unavailable 해소)가 우선. macOS 의 publish-skills.sh 와 first-run unpack 사이의 race 위험 회피.
+- **본 plan 범위 외**. Windows 첫 install 시 skills 가 비어있으면 first-run dialog 또는 README 안내(T3)로 사용자에게 `publish-skills.sh` 또는 동등 절차 안내. 자동 unpack 은 별 plan 으로 이관.
 
-#### T7 — Windows installer 후 reboot/relaunch 가이드
-- **파일**: NSIS .nsi (또는 `tauri.conf.json` bundle 설정)
-- **변경**: post-install 단계에서 PATH 갱신 안내 (npm/pip 으로 새로 설치된 binary 가 같은 세션에서 인식 안 될 수 있어 dev 모드 재시작 필요). 다이얼로그 또는 README 보강.
+#### T7 — Windows installer 후 reboot/relaunch 가이드 *(P3, 별 plan 후속)*
+- T6 와 같은 axis(installer 정비)라 함께 후속 plan 으로 이관.
 
 ### Phase 4 — 추후 개선 (P3, 본 plan 외 axis)
 
+- T6/T7 (위 격하)
 - chub 정적 binary 번들 (npm 의존 제거) — chub 가 단일 binary release 를 제공하면 mode A 로 격상 가능. 현재 npm-only 라 Phase 2 의 mode B 유지.
 - code-review-graph 의 PyInstaller 단일 실행 파일 번들 — Python 의존 제거 가능. 단 사이즈 크고 Python ABI 호환성 위험. 본 plan 범위 외.
 
@@ -161,13 +162,17 @@ README 의 *"Auto-installed on first run"* 표기와 달리 backend 코드에는
 
 | Task | 파일 | 검증 명령 | 예상 LOC |
 |---|---|---|---|
-| **T1** | `src-tauri/src/agents/context_hub.rs` (+test) | `cargo test --lib agents::context_hub` | +30 / -0 |
-| **T2** | `src-tauri/src/agents/crg.rs` (+test) | `cargo test --lib agents::crg` | +20 / -0 |
-| **T3** | `README.md`, `README.ko.md`, `INSTALL.md` | docs only | +5 / -3 |
-| **T4** | `src-tauri/src/commands/dependency_install.rs` (신규), `src/components/.../FirstRunDependencyDialog.tsx` (신규) | `cargo test`, `vitest run` | +150 / -0 |
-| **T5** | `src/components/tunaflow/settings/RuntimeSection.tsx` | `vitest run` | +40 / -0 |
-| **T6** | `src-tauri/tauri.conf.json`, `src-tauri/src/bootstrap/services.rs` | install + first run | +30 / -0 |
-| **T7** | NSIS .nsi or tauri bundle config | install smoke | +10 / -0 |
+| Task | 파일 | 검증 명령 | 예상 LOC | 우선순위 |
+|---|---|---|---|---|
+| **T1** | `src-tauri/src/agents/context_hub.rs` (+test) | `cargo test --lib agents::context_hub` + 수동 `chub search "복합 query"` 회귀 [R-1] | +30 / -0 | P0 |
+| **T2** | `src-tauri/src/agents/crg.rs` (+test) | `cargo test --lib agents::crg` | +20 / -0 | P0 |
+| **T3** | `README.md`, `README.ko.md`, `INSTALL.md` (§128 표 포함) | docs only | +5 / -3 | P0 |
+| **T4** | `src-tauri/src/commands/dependency_install.rs` (신규), `src/components/.../FirstRunDependencyDialog.tsx` (신규) | `cargo test`, `vitest run` | +180 / -0 | P1 |
+| **T5** | `src/components/tunaflow/settings/RuntimeSection.tsx` | `vitest run` | +40 / -0 | P1 |
+| ~~T6~~ | ~~vendor skills bundle~~ | ~~install + first run~~ | — | **P3 (별 plan 후속)** |
+| ~~T7~~ | ~~installer post 가이드~~ | ~~install smoke~~ | — | **P3 (별 plan 후속)** |
+
+본 plan 범위 = **T1~T5**. T6/T7 은 [Q-2] 결정으로 제외.
 
 각 Task → **별 commit + 별 PR + macOS+Windows CI ✓ 후 머지** (INV-2/4).
 
@@ -179,18 +184,24 @@ README 의 *"Auto-installed on first run"* 표기와 달리 backend 코드에는
 - T4/T5: macOS 에서도 dialog/button 코드 컴파일/렌더 OK. 단 macOS 사용자에겐 *이미 설치돼 있음* 으로 invisible (UX 영향 0).
 - T6: macOS 빌드 시 resources 포함 여부는 conf 설정에 따름. macOS 측 publish-skills.sh 동작 동일.
 
-### 6.2 Windows 검증 (T1~T7 누적 후)
+### 6.2 Windows 검증 (T1~T5 누적 후)
 | ID | 시나리오 | 기대 결과 |
 |---|---|---|
-| W-1 | clean Windows VM 에 chub/crg 미설치 상태로 NSIS installer 설치 | 첫 실행 시 dialog → "설치" 선택 → chub + crg 글로벌 설치 → ready |
+| W-1 | clean Windows VM 에 chub/crg 미설치 상태로 NSIS installer 설치 | 첫 실행 시 dialog → "설치" 선택 → chub + crg 설치 → ready |
 | W-2 | 같은 VM 에 chub 만 미리 설치된 상태로 dialog | crg 만 표시 (chub 항목 자동 hide) |
 | W-3 | dialog "건너뛰기" → 앱 정상 진입, Settings → Runtime 의 두 카드 unavailable, 수동 설치 버튼 노출 |
 | W-4 | npm install -g 권한 부족 (Roaming 쓰기 거부) → 실패 메시지 + 수동 명령 표시 |
-| W-5 | 인터넷 차단 → npm/pip timeout 후 graceful 실패 메시지 |
+| W-5 | 인터넷 차단 → npm/pip timeout (60s/120s) 후 graceful 실패 메시지 |
 | W-6 | 두 의존성 설치 후 dev 모드 재시작 → backend resolve_bin 즉시 인식, status `ready` |
+| W-7 | venv 활성 상태(`VIRTUAL_ENV` set)로 dialog → crg 가 venv 안에 설치, system pip 미사용 [Q-3] |
+| W-8 | dependency dialog dismiss 후 onboarding 분석 모달이 그제서야 표시 [Q-4 직렬 보장] |
+| W-9 | 디버그 토글: `first_run_dependency_check_done=true` 미리 set → dialog 스킵 (startup race §B 진단용) |
 
 ### 6.3 회귀 카운트 baseline
-- 본 plan 시작 시점: FE 381 / Rust 558 (Windows). FE/Rust 양쪽 +N (테스트 추가) 만 허용, 감소 금지.
+- **Windows baseline (PR #213 머지 직전)**: FE 381 / Rust 557 passed + 1 failed (= 558 실행, conventions_sync path-sep 회귀). PR #213 머지 후 558 passed / 0 failed.
+- **macOS baseline (PR #211/#212/cc3e14e 머지 직후)**: Rust 559 passed. 1 의 차이는 `cfg(unix)`-gated 테스트로 추정 — 본 plan T1~T5 작업 후에도 두 환경의 차이는 동일하게 유지되어야 함. *macOS 559 / Windows 558* 을 같은 baseline 으로 본다.
+- T1~T5 머지 후 양 환경 모두 +N (테스트 추가) 만 허용, 감소 금지.
+- **측정 시점 명시 [mac architect 보강]**: PR #213 머지 후 첫 측정값 기준. 디벨로퍼는 본 plan 작업 시작 직전 `cargo test --lib` / `vitest run` 을 한 번 더 돌려 환경별 정확한 baseline 을 PR description 에 기록한 후 비교.
 
 ## 7. 리뷰어(Codex) review 포인트
 
@@ -201,18 +212,29 @@ README 의 *"Auto-installed on first run"* 표기와 달리 backend 코드에는
 - **R-5** `dependency:install_result` 이벤트가 background 작업이라 hang 가능성 — timeout (예: npm 60s, pip 120s) 적용 여부.
 - **R-6** README 표기 변경 (T3) 이 ko/en 양쪽 동일 의미 유지.
 
-## 8. 오픈 질문 (architect → 사용자 / mac architect)
+## 8. 결정 사항 (mac architect review 후 확정, 2026-04-29)
 
-| Q | 결정 필요한 사항 |
+| Q | 결정 |
 |---|---|
-| Q-1 | INV-DEP-C 통일 방향 — 문구를 *consent UX* 로 정정할지, 또는 silent install + opt-out 토글로 README 와 일치시킬지. |
-| Q-2 | T6 (skills bundle) 우선순위 — 현재 publish-skills.sh 수동 publish 로도 동작하므로 P3 로 미룰 수 있음. NSIS 사이즈 영향 vs 사용자 편의 trade. |
-| Q-3 | code-review-graph 가 Python 패키지라 venv 사용 여부 권장 — global pip install 이 사용자 환경에 영향이라 OS-wide 사이드이펙트. dialog 에 *"venv 사용 권장"* 안내 포함 여부. |
-| Q-4 | T4 의 dialog 가 핸드오프 §B (startup race) 진단을 방해하지 않는지 — 첫 실행 시 dialog 표시가 "엔진/모델 감지" 단계 hang 과 별 axis 임을 명시. |
+| **Q-1** | **consent UX 정정**. global npm/pip 은 OS-wide 부작용이라 silent 금지. README 문구를 *"prompted to install on first run"* 으로 정정 + INV-DEP-A 와 일치. (T3 반영) |
+| **Q-2** | **T6 P3 격하**. 현재 mac 측 `publish-skills.sh` 정상 동작, 사용자 보고 0건. T1~T5 의 즉시 가치 우선. publish-skills 와 first-run unpack 사이 race 위험 회피. (§4 Phase 3 / §5 표 반영) |
+| **Q-3** | **활성 venv 자동 활용 + global pip fallback + 1줄 안내**. `VIRTUAL_ENV` env 검사로 venv 우선, 없으면 global. silent venv 생성 금지. dialog 안내 1줄 추가. (T4 반영) |
+| **Q-4** | **axis 다름 + 직렬 보장 필요**. dependency dialog 와 startup race 는 다른 axis. 다만 *모달 직렬 보장*: dependency dialog → onboarding 모달 순서. 디버그 토글(`first_run_dependency_check_done` 미리 set)로 dialog 스킵 가능 — startup race 진단 시 사용. (T4 + W-8/W-9 반영) |
+
+### 8.1 mac architect 추가 보강 (반영 완료)
+
+| ID | 보강 | 반영 위치 |
+|---|---|---|
+| B-1 | T1 verification 에 `chub search "복합 query"` 실 호출 회귀 점검 명시 (CVE-2024-24576) | §5 표 T1 검증 명령 |
+| B-2 | T4 install 명령에 timeout (npm 60s / pip 120s) spec 명시 | §4 T4 본문 |
+| B-3 | T3 정정 대상에 INSTALL.md §128 "앱 내 안내 표시" 표기 포함 | §4 T3 본문 |
+| B-4 | baseline 카운트의 측정 시점 (PR #213 머지 후) + macOS 559 / Windows 558 차이가 `cfg(unix)`-gated 임을 명시 | §6.3 |
+| B-5 | T6 P3 격하 후 §4 Phase 3 / §5 표 갱신 | 완료 |
 
 ## 9. 진행 메모 (architect → developer)
 
 - 본 plan 작성 직전, Windows architect 가 **수동으로** `npm install -g @aisuite/chub` (chub 0.1.4) 와 `pip install code-review-graph` (crg 2.3.2) 를 설치 완료. 따라서 T1/T2 검증은 이 머신에서 **즉시** 가능.
 - T1~T2 만 머지해도 본 머신의 unavailable 표시는 ready 로 변경됨 (재시작 후). T4~T5 는 다른 Windows 사용자를 위한 일반 사용자 가치.
 - 핸드오프 `windowsBetaHardeningArchitectHandoff_2026-04-29.md` 의 트랙 §B (startup race) / §C (DB path stale) / §D (watchdog compat) 와 axis 분리 — 본 plan 의 PR 은 별도로 머지.
-- 머지 순서 권장: **T1 → T2 → T3 → T4 → T5 → (T6 → T7)**. 각 PR 사이 baseline 회귀 카운트 확인.
+- 머지 순서 권장: **T1 → T2 → T3 → T4 → T5**. T6/T7 은 본 plan 외 별 plan 후속 (Q-2). 각 PR 사이 baseline 회귀 카운트 확인.
+- mac architect review (2026-04-29) APPROVE 완료, Q-1~4 결정 + B-1~5 보강 모두 본 plan 반영. 디벨로퍼 세션은 본 갱신본 기준으로 진행.

--- a/docs/prompts/windowsDependencyBootstrapDeveloperHandoff_2026-04-29.md
+++ b/docs/prompts/windowsDependencyBootstrapDeveloperHandoff_2026-04-29.md
@@ -1,0 +1,324 @@
+---
+title: Windows 의존성 부트스트랩 — Developer 세션 핸드오프
+plan: docs/plans/windowsDependencyBootstrapPlan_2026-04-29.md
+created_at: 2026-04-29
+calling_role: architect (Windows 머신)
+target_role: developer (신규 세션, 프로젝트 디렉토리 cwd)
+session_branch_strategy: task 단위 별 브랜치 + PR + CI watch (INV-2)
+---
+
+# Windows 의존성 부트스트랩 Developer 핸드오프
+
+당신은 사용자의 **Windows 머신** 에서 새 세션으로 진입한 **developer** 입니다.
+본 세션 이전 컨텍스트가 전혀 없으므로 §0 read-first 를 *반드시 그 순서대로* 읽고 시작합니다.
+코드를 손대기 전에 §1 invariants 와 §2 환경 점검을 마쳐야 합니다.
+
+이 세션의 목표: **Plan `windowsDependencyBootstrapPlan_2026-04-29.md` §5 의 T1~T7
+을 한 task 씩 별 commit + 별 PR 로 구현**. macOS 사이드이펙트 0 을 최우선
+으로 한다.
+
+---
+
+## 0. 작업 시작 전 — 반드시 read-first
+
+다음을 **순서대로** 읽고 시작합니다. 각 문서의 의도/제약을 이해하지 않은 상태로
+코드를 손대지 마세요.
+
+1. **`CLAUDE.md`** (프로젝트 루트) — tunaFlow 프로젝트 전체 핸드오프. §1~§5 (개요/스택/아키텍처/현재 상태) + §15 작업 안전 규칙 + §16 코딩 컨벤션 + §17 개발 도구 활용.
+2. **`docs/reference/dataModelRevised.md`** — 도메인 모델 SSOT. 본 task 는 새 entity 추가 없으므로 빠르게 훑기.
+3. **`docs/reference/coding-convention.md`** — 코딩 컨벤션. 한국어 응답 / Zustand selector / 5-engine parity / cfg 분기 패턴.
+4. **`docs/reference/work-safety.md`** — 작업 안전 규칙. UI 진입점 변경 전 대체 경로 작동 확인 / 한 번에 한 경로만 수정.
+5. **`docs/reference/tool-usage.md`** — 개발 도구 활용. `find → fd` / `grep → rg` / `sed → sd` / 멀티 파일 치환은 `fd ... | xargs sd ...`.
+6. **본 plan**: `docs/plans/windowsDependencyBootstrapPlan_2026-04-29.md` — invariants + 의존성 매트릭스 + Phase + T1~T7 작업 분해 + 회귀 가드. **이 문서가 SSOT**.
+7. **관련 핸드오프** (architect 가 이미 처리한 axis 와 axis 분리 위해 컨텍스트 확보):
+   - `docs/prompts/windowsBetaHardeningArchitectHandoff_2026-04-29.md` — 별 axis (startup race / DB path / watchdog compat).
+   - 직전 머지된 fix: `fix(conventions): normalize @import path to forward-slash on Windows` (PR #213, conventions_sync.rs path separator). 본 task 와 무관하나 같은 Windows hardening 흐름.
+
+---
+
+## 1. Invariants — 절대 깨지 마세요
+
+본 plan §1 그대로 적용. 요약:
+
+- **[INV-1] 🔴 macOS tunaFlow 에 사이드 이펙트 0**. Windows 변경은:
+  1. `#[cfg(target_os = "windows")]` / `#[cfg(windows)]` 안에 격리, 또는
+  2. macOS 무관 새 파일 추가 (e.g. `dependency_install.rs`), 또는
+  3. cross-platform 변경 시 *macOS CI 빌드 통과 확인* 후에만 머지.
+- **[INV-2]** PR + CI watch 필수. macOS + Windows CI 양쪽 ✓ 후 머지. `gh pr merge --admin` 금지.
+- **[INV-3]** macOS-specific 코드 (`bootstrap/env.rs` macOS PATH 보강 등) 변경 X.
+- **[INV-4]** 단일 axis per commit. T1 과 T2 같은 PR 에 묶지 말 것 — 회귀 시 이등분 가능해야 함.
+- **[INV-DEP-A]** 자동 설치는 user consent 후에만. silent global install 금지.
+- **[INV-DEP-B]** 설치 실패 시 graceful degradation. 앱 진입 차단 금지.
+- **[INV-DEP-C]** README 표기와 실제 동작 일치.
+
+---
+
+## 2. 환경 점검 (작업 시작 직후)
+
+```powershell
+# 위치 확인
+cd D:\privateProject\tunaFlow
+git status                       # working tree clean 이어야 함
+git fetch origin
+git pull origin main             # 최신 main 동기화
+git log --oneline -10            # PR #213 머지 commit + cc3e14e 이후 head 확인
+
+# Toolchain
+rustc --version                  # stable
+node --version
+npm --version
+where chub                       # %APPDATA%\npm\chub.cmd 가 떠야 함 (architect 가 수동 설치 완료)
+where code-review-graph          # <python>\Scripts\code-review-graph.exe
+where claude                     # claude CLI
+```
+
+### Baseline (회귀 비교 기준)
+
+작업 시작 전 baseline 카운트를 *반드시 기록*. 이후 매 PR 마다 비교.
+
+```powershell
+npm install --no-audit --no-fund   # 보통 변동 없음
+cd src-tauri ; cargo check ; cd ..
+npx tsc --noEmit                   # 통과해야 함
+npx vitest run                     # 기록: FE __ tests
+cd src-tauri ; cargo test --lib ; cd ..   # 기록: Rust __ passed
+```
+
+기준치 (PR #213 머지 직후): **FE 381 / Rust 558 (Windows). macOS 측 559**.
+같거나 +N 만 허용. 감소 시 회귀.
+
+---
+
+## 3. 작업 순서 — T1 → T2 → T3 → T4 → T5 → (T6 → T7)
+
+각 task 는 **별 commit + 별 PR + CI watch + 머지** 한 사이클.
+이전 task 의 PR 이 머지되어야 다음 시작.
+
+### T1 — `context_hub::resolve_bin()` Windows 호환 보강 [P0]
+
+- **파일**: `src-tauri/src/agents/context_hub.rs`
+- **현황**: PATH fallback 으로 chub.cmd 인식 가능 *should be*. 현재 candidates Vec 은 unix HOME 기반 + `/usr/local/bin/...` 등 unix 절대 경로뿐. Windows native process 에서 `HOME` 미설정.
+- **변경 핵심**:
+  ```rust
+  #[cfg(target_os = "windows")]
+  {
+      if let Ok(appdata) = std::env::var("APPDATA") {
+          c.push(PathBuf::from(&appdata).join("npm").join("chub.cmd"));
+      }
+      if let Ok(userprofile) = std::env::var("USERPROFILE") {
+          c.push(PathBuf::from(&userprofile).join("AppData").join("Roaming").join("npm").join("chub.cmd"));
+      }
+  }
+  ```
+  (HOME 분기 그대로 유지 — Linux/macOS 호환.)
+- **테스트**:
+  - 단위: temp dir + `set_var("APPDATA", ...)` 모의로 candidate 가 결과에 포함되는지 (`#[cfg(windows)]` 게이트).
+  - 통합 (수동): dev 모드 재시작 → Settings → Runtime → context-hub 카드 `ready`.
+- **회귀 가드**: macOS path (`/usr/local/bin/chub`) 검사 여전히 동작.
+- **PR title**: `fix(context-hub): Windows resolve_bin candidate paths (npm global)`
+- **branch**: `fix/win-context-hub-resolve`
+
+### T2 — `crg::resolve_bin()` Windows 호환 추가 [P0]
+
+- **파일**: `src-tauri/src/agents/crg.rs`
+- **현황**: candidate 가 `~/.local/bin/code-review-graph`, `/opt/homebrew/...`, `/usr/local/bin/...` (unix 위주). PATH fallback 유무 코드 확인 후 결정.
+- **변경 (가장 단순한 안)**:
+  ```rust
+  // After existing unix candidates:
+  for name in ["code-review-graph"] {
+      if Command::new(name).no_console().arg("--version")
+          .stdout(Stdio::null()).stderr(Stdio::null())
+          .output().map(|o| o.status.success()).unwrap_or(false)
+      {
+          return Ok(PathBuf::from(name));
+      }
+  }
+  ```
+  PATH fallback 이라 macOS/Linux 도 동일 코드 — but 이미 unix candidate 가 먼저 hit 하므로 동작 변경 없음 (INV-1 안전).
+- **테스트**: T1 패턴.
+- **PR title**: `fix(crg): Windows PATH fallback for code-review-graph binary`
+- **branch**: `fix/win-crg-resolve`
+
+### T3 — README/INSTALL.md 자동 설치 문구 정정 [P0, docs-only]
+
+- **파일**: `README.md`, `README.ko.md`, `INSTALL.md`
+- **변경**: *"Auto-installed on first run"* → 사용자가 결정한 방향 (consent UX 로 가는 것이 권장. plan §1 INV-DEP-C 참조).
+- **PR title**: `docs: align context-hub install wording with actual UX (consent-first)`
+- **branch**: `docs/install-wording`
+- **검증**: docs only — `npm run` 변동 없음. CI lint 만.
+
+### T4 — First-run consent dialog + auto-install [P1]
+
+- **신규 파일**:
+  - `src-tauri/src/commands/dependency_install.rs` (Tauri command + install runner)
+  - `src/components/tunaflow/FirstRunDependencyDialog.tsx`
+- **로직** (plan §4 Phase 2 T4):
+  1. 앱 시작 시 `setting("first_run_dependency_check_done")` 검사. 미수행이면 dialog 표시.
+  2. detect: chub, code-review-graph 별 `available: bool, command: String, requires: String`.
+  3. dialog: 항목별 체크박스 + "건너뛰기" / "설치".
+  4. invoke `install_dependency(name)`:
+     - chub: `Command::new("npm").args(["install", "-g", "@aisuite/chub"])`
+     - crg: `Command::new("pip").args(["install", "code-review-graph"])`
+  5. timeout (npm 60s / pip 120s) — INV-DEP-B graceful failure.
+  6. 결과 이벤트 `dependency:install_result` emit.
+- **i18n**: `src/locales/{ko,en}/dialog.json` 신규 키.
+- **테스트**:
+  - vitest: dialog snapshot + "건너뛰기" 시 setting 갱신.
+  - cargo: install_dependency 의 명령 escape 회귀 (R-1).
+- **INV-DEP-A** 충족: consent 후에만 실행.
+- **PR title**: `feat(installer): first-run dependency consent dialog + auto-install`
+- **branch**: `feat/first-run-dependency-dialog`
+
+### T5 — Settings → Runtime 수동 설치 트리거 [P1]
+
+- **파일**: `src/components/tunaflow/settings/RuntimeSection.tsx` (`ContextHubPanel`, CRG 섹션이 있다면 동등 위치).
+- **변경**: 카드의 `unavailable` 상태일 때 "Install via npm/pip" 버튼 노출. 클릭 시 T4 의 `install_dependency` invoke.
+- **macOS 영향**: 이미 설치된 사용자에게는 `available:true` 라 버튼 hidden — 영향 0 (INV-1).
+- **PR title**: `feat(runtime-settings): manual install trigger for context-hub & crg`
+- **branch**: `feat/runtime-manual-install`
+
+### T6 — vendor skills 를 NSIS installer 에 번들 [P2]
+
+- **파일**: `src-tauri/tauri.conf.json` (resources), `src-tauri/src/bootstrap/services.rs` (first-run unpack).
+- 사용자 결정 Q-2 에 따라 *P3 로 미룰 수 있음*. P2 채택 시:
+  - build 시 `_research/_skills` snapshot 을 `resources` 에 포함 (~5~15MB).
+  - 첫 실행 시 `~/.tunaflow/skills/` 비어있으면 unpack.
+- **branch**: `feat/skills-bundle`
+
+### T7 — installer post 단계 PATH 갱신 안내 [P2]
+
+- **파일**: NSIS .nsi 또는 `tauri.conf.json` bundle 설정.
+- **branch**: `chore/installer-path-notice`
+
+---
+
+## 4. 회귀 가드 — 매 PR 마다 확인
+
+```powershell
+# 1. 코드 회귀
+cd src-tauri ; cargo check ; cargo test --lib ; cd ..
+npx tsc --noEmit
+npx vitest run
+
+# 2. baseline 비교 — FE/Rust 카운트 동일 또는 +N
+# 3. macOS-specific 파일 미변경 grep
+git diff main..HEAD -- src-tauri/src/bootstrap/env.rs scripts/build-rawq.sh   # 비어야 함
+
+# 4. PR description 에 다음 명시:
+#    - read-first list (§0 어디까지 읽었는지)
+#    - 변경 axis 1개임 (INV-4)
+#    - macOS 영향성 평가
+#    - 회귀 카운트 비교
+```
+
+---
+
+## 5. PR 생성 / CI watch 정책
+
+```powershell
+git checkout -b <branch>
+git add <changed-files>             # axis 외 파일 add 금지
+git commit -m "<message>"
+git push -u origin <branch>
+gh pr create --base main --head <branch> --title "<title>" --body "<body>"
+gh pr checks <pr-number> --watch    # macOS + Windows 양쪽 ✓ 까지 대기 (INV-2)
+gh pr merge <pr-number> --merge     # admin 금지 (INV-2)
+```
+
+PR body 템플릿:
+
+```markdown
+## Summary
+- (1~3 bullet)
+
+## Plan / handoff mapping
+- Plan: `docs/plans/windowsDependencyBootstrapPlan_2026-04-29.md`
+- Handoff: `docs/prompts/windowsDependencyBootstrapDeveloperHandoff_2026-04-29.md`
+- Task: T_
+
+## Invariants
+- INV-1: (macOS 영향 평가)
+- INV-4: 단일 axis (axis 외 변경 없음)
+
+## Verification (Windows host)
+- cargo test --lib: __ passed
+- vitest run: __ passed
+- tsc --noEmit: clean
+- (수동 smoke: ...)
+
+## Test plan
+- [ ] macOS CI ✓
+- [ ] Windows CI ✓
+```
+
+---
+
+## 6. 보고 포맷 (각 task 완료 시 chat)
+
+- **Task ID** + 변경 라인 수 + 핵심 파일
+- **검증 결과**: cargo test, vitest, tsc PASS/FAIL + 핵심 출력 1~2 줄
+- **baseline 카운트**: FE/Rust 비교 (감소 시 즉시 보고)
+- **PR URL** + CI 양쪽 ✓ 확인 + 머지 commit hash
+- **INV 위반 없음 확인**: macOS-specific 파일 미변경 git diff 결과
+- **다음 task 진행 여부** 또는 escalate 사유
+
+---
+
+## 7. 막히면 — escalate (chat 보고 + 사용자 판단 대기)
+
+다음 상황에서는 **임의 fix 금지**. chat 으로 사용자에게 보고:
+
+- macOS CI 회귀 (어떤 task 라도 macOS job 실패) → 즉시 PR 닫고 회귀만 좁혀 별 PR.
+- chub.cmd 가 PATH 에 있는데도 backend 가 인식 못 함 → R-1 (Rust escape 회귀) 가설 진단 후 보고.
+- pip install 시 권한/네트워크 에러 → 사용자에게 venv 사용 여부 확인 (Q-3 미해결이면).
+- consent dialog UX 가 §B startup race 진단을 방해할 가능성 (Q-4) → 사용자 판단.
+- Plan §8 의 **오픈 질문 Q-1~4** 가 답 없는 채로 task 가 막힐 때 — 본 plan 세션은 architect 가 작성했으므로 Q 답을 받기 전에 그 task 보류.
+
+---
+
+## 8. 도구 활용 / 안전 규칙 요약 (CLAUDE.md §15-§17 발췌)
+
+- **검색**: `fd`, `rg`, `rawq search` (시맨틱). `grep` 대신 `rg`. 멀티 파일 치환 `fd ... | xargs sd ...` — Read+Edit 루프 금지.
+- **그래프 영향 분석**: `code-review-graph detect-changes` — 본 task 후 dependency 가 정상 인식되면 사용 가능.
+- **UI 진입점 변경 전**: 대체 경로 작동 확인 (2026-03-29 RT 사고 회피).
+- **5-engine parity**: 모든 UI-연결 엔진(claude/codex/gemini/ollama/lmstudio)이 `build_normalized_prompt_with_budget()` 단일 경로. 본 task 는 그 hot-path 미터치.
+- **finalize_engine_run**: mutex re-entrant 위험 자리. 본 task 와 무관.
+
+---
+
+## 9. 오늘 작업 종료 시 정리 (architect → developer 인계 후 세션 끝낼 때)
+
+- 머지된 PR 목록 + 머지 commit hash
+- 남은 task (T_ 까지 완료, T_+1 부터 미수행) — 다음 세션의 entry point 명시
+- baseline 카운트 비교 (시작 vs 종료, 회귀 0 확인)
+- `windowsDependencyBootstrapPlan_2026-04-29.md` §4 Phase status 갱신 (P0 완료 / P1 진행 중 등)
+- chat 으로 architect (사용자) 에게 day-end 보고:
+  - PR ___ ~ ___ 머지 완료
+  - 검증 통과 / 회귀 0
+  - 잔여 task 와 권장 다음 세션 entry
+
+---
+
+## 10. 빠른 명령 모음 (cheat sheet)
+
+```powershell
+# Status / sync
+git status; git fetch origin; git pull origin main
+
+# Build / test
+cd src-tauri; cargo check; cargo test --lib; cd ..
+npx tsc --noEmit
+npx vitest run
+
+# Dev mode
+npm run tauri dev
+
+# Release smoke (T1~T2 머지 후)
+npm run tauri build
+
+# 의존성 재확인
+where chub
+where code-review-graph
+chub --cli-version
+code-review-graph --version
+```


### PR DESCRIPTION
## Summary

- New plan + developer handoff for Windows-side dependency bootstrap.
- Two sidecars (`chub` from `@aisuite/chub`, `code-review-graph` from pip) currently surface as `unavailable` on Windows because the README's *"Auto-installed on first run"* wording is not backed by code (`auto_install`/`install_if_missing`/`npm install -g`/`pip install` grep = 0 hits).
- Plan defines INV-DEP-A/B/C (consent-first install, graceful degradation, doc/code parity) and decomposes work into T1~T7 axes for the developer session.

## Files

- `docs/plans/windowsDependencyBootstrapPlan_2026-04-29.md` — SSOT for the architect-level design (invariants, phases, regression guards, open questions Q-1~4).
- `docs/prompts/windowsDependencyBootstrapDeveloperHandoff_2026-04-29.md` — entry prompt for the developer session (read-first list, env check, per-task implementation hints, PR template, escalation rules).

## Plan / handoff mapping

- Architect handoff that originated this work: `docs/prompts/windowsBetaHardeningArchitectHandoff_2026-04-29.md` — separate axis (startup race / DB path / watchdog compat). This plan is its sibling axis.
- Related plan: `docs/plans/windowsBetaHardeningPlan_2026-04-26.md`, `docs/plans/windowsBuildPlan_2026-04-24.md`.

## Invariants

- **INV-1**: docs-only PR — no source code changed, no macOS side effect possible.
- **INV-4**: single axis (docs only). No code, schema, or config changes piggyback on this PR.
- Open questions Q-1~4 in the plan §8 are intentionally left for the user/mac architect to decide before T1 lands.

## Verification

- docs-only — no `cargo`/`vitest`/`tsc` baseline change expected.
- Plan + handoff cross-reference each other and reference existing SSOT docs (CLAUDE.md, plans, references).

## Test plan

- [ ] CI lint passes (docs-only)
- [ ] Reviewer (mac architect) reviews invariants INV-DEP-A/B/C
- [ ] User decides Q-1~4 (consent UX wording, skills bundle priority, venv vs global pip, dialog vs startup race ordering)
- [ ] Developer session can read both files from disk (no missing references)