### PR TITLE
fix(onboarding): restore skip button visibility on analysis failure

### DIFF
--- a/src/components/tunaflow/ProjectOnboardingModal.tsx
+++ b/src/components/tunaflow/ProjectOnboardingModal.tsx
@@ -262,14 +262,16 @@ export function ProjectOnboardingModal() {
 
             <div className="px-6 py-4 border-t border-border flex justify-between items-center">
               {error ? (
-                // Error 상태에서 "건너뛰기" 와 "닫기" 의 사용자 의도가 동일 ("이 에러 상황 탈출")
-                // 이라 단일 "닫기" 로 통합. handleCancel 이 cancel_project_onboarding 을
-                // 호출해 rust task 까지 안전하게 정리한다.
+                // Error 상태: 사용자는 "건너뛰기" 라벨을 기대 (analysis_failed_hint 메시지가
+                // "건너뛰기를 눌러 빈 템플릿으로 시작할 수 있습니다" 라고 안내하기 때문).
+                // 2026-04-25 통합 PR(#-) 이후 라벨이 "닫기" 로 보여 회귀 (batmania52 #5 보고).
+                // 동작은 handleSkip 이 cancel_project_onboarding 을 호출해 rust task 안전 정리하므로
+                // handleCancel 과 동일 (4-25 plan §INV-1 충족) — 라벨만 hint 메시지와 일치시킨다.
                 <button
-                  onClick={handleCancel}
-                  className="ml-auto px-3 py-1.5 text-[11px] font-medium text-destructive/80 hover:text-destructive transition-colors"
+                  onClick={handleSkip}
+                  className="ml-auto px-3 py-1.5 text-[11px] font-medium text-foreground/80 hover:text-foreground transition-colors"
                 >
-                  {t("onboarding.close_button")}
+                  {t("onboarding.skip_button")}
                 </button>
               ) : (
                 <button


### PR DESCRIPTION
## Summary

batmania52 보고 #5 (2026-04-29) 회귀 수정.

- 분석 실패 모달의 hint 메시지: "**건너뛰기**를 눌러 빈 템플릿으로 시작할 수 있습니다"
- 실제 버튼 라벨: "닫기" → 사용자가 "건너뛰기" 버튼을 못 찾음
- 회귀 시점: 2026-04-25 onboardingCancelLeak 통합 PR 이후 라벨이 "닫기"로 통합되며 hint 메시지와 어긋남

라벨을 `skip_button` ("건너뛰기") 으로 복원하고, 동작은 `handleSkip` 으로 연결합니다. `handleSkip` 은 이미 `cancel_project_onboarding` 을 호출해 rust task 를 안전하게 정리하므로 4-25 plan §INV-1 (어떤 버튼을 눌러도 cancel 호출) 을 그대로 만족합니다.

## Cross-check (회귀 가드)

- `onboardingCancelLeakFixPlan_2026-04-25` cancel 흐름 보존 확인 — `handleSkip` 본체 변경 X
- `handleSkipFromSelector` 변경 X
- 정상 path (loading / preview / done) 영향 X
- `handleCancel` 도 그대로 — non-error (loading) 분기에서 계속 사용됨

## Plan SSOT

- `docs/plans/onboardingAnalysisFailureAndSkipUiPlan_2026-04-29.md` (Task 01)
- Task 02 (codex exit 1 진단) 는 분석만, 코드 변경 0 — chat 보고

## Test plan

- [x] `npx tsc --noEmit` PASS
- [x] `npx vitest run` PASS — FE 381/381 (baseline 유지, 회귀 0)
- [x] `cargo check` PASS
- [ ] manual smoke (4 state: loading / success / error / cancel) — 다른 손이 dev 빌드 켜져 있을 때 권장

🤖 Generated with [Claude Code](https://claude.com/claude-code)