### PR TITLE
feat(settings): global Cmd+, shortcut + macOS menu (Plan C Task 01)

### DIFF
--- a/src-tauri/src/bootstrap/menu.rs
+++ b/src-tauri/src/bootstrap/menu.rs
@@ -1,0 +1,81 @@
+//! Application menu — minimal native menu so Settings is accessible from the
+//! macOS menu bar (Cmd+,) and Windows/Linux menu before any project is
+//! selected.
+//!
+//! Scope (`docs/plans/globalSettingsAndRecentProjectsPlan_2026-04-29.md`,
+//! Task 01):
+//! - Add a single "Settings..." item under the app submenu (macOS — first
+//!   submenu) and under a top-level `tunaFlow` submenu on Win/Linux.
+//! - Wire its activation to a frontend event (`tunaflow:open-settings`) so
+//!   the menu and the global keyboard listener share the same code path.
+//! - Frontend already listens to `tunaflow:open-settings` at AppShell root.
+//!
+//! We deliberately keep the menu small: full edit/window menus add UX noise
+//! on Windows/Linux where they are not standard. macOS gets the standard
+//! app submenu (About, Hide, Quit) via `PredefinedMenuItem` so the system
+//! menu bar isn't empty.
+//!
+//! ### Cmd+, accelerator
+//!
+//! macOS shows the accelerator hint on the menu item (assigned via the
+//! second arg of `MenuItemBuilder::accelerator`). The actual key handling
+//! is done in the frontend (`AppShell.tsx` keydown listener) so that
+//! ProjectStartup screen (where no menu may yet be visible) also responds
+//! to the shortcut. Both paths emit the same `tunaflow:open-settings`
+//! event and converge at the AppShell-level mount.
+
+use tauri::menu::{
+    AboutMetadata, MenuBuilder, MenuItemBuilder, PredefinedMenuItem, SubmenuBuilder,
+};
+use tauri::{App, AppHandle, Emitter};
+
+const SETTINGS_MENU_ID: &str = "tf_settings_open";
+
+/// Build and attach the app-level menu, and register the menu-event handler.
+///
+/// Called from `lib.rs` `.setup(...)`. Errors are propagated as
+/// `Box<dyn Error>` consistent with other bootstrap functions.
+pub fn install(app: &App) -> Result<(), Box<dyn std::error::Error>> {
+    let handle = app.handle();
+
+    // Settings... item — Cmd+, on macOS, Ctrl+, elsewhere.
+    let settings_item = MenuItemBuilder::with_id(SETTINGS_MENU_ID, "Settings...")
+        .accelerator("CmdOrCtrl+,")
+        .build(handle)?;
+
+    // App submenu (first submenu — becomes the macOS app menu when packaged
+    // under the app bundle name; on Win/Linux it shows as a top-level
+    // "tunaFlow" menu).
+    let app_submenu = SubmenuBuilder::new(handle, "tunaFlow")
+        .item(&PredefinedMenuItem::about(
+            handle,
+            Some("About tunaFlow"),
+            Some(AboutMetadata::default()),
+        )?)
+        .separator()
+        .item(&settings_item)
+        .separator()
+        .item(&PredefinedMenuItem::hide(handle, None)?)
+        .item(&PredefinedMenuItem::hide_others(handle, None)?)
+        .item(&PredefinedMenuItem::show_all(handle, None)?)
+        .separator()
+        .item(&PredefinedMenuItem::quit(handle, None)?)
+        .build()?;
+
+    let menu = MenuBuilder::new(handle).item(&app_submenu).build()?;
+
+    // Tauri 2.x: app-level set_menu so it applies to all windows + macOS bar.
+    app.set_menu(menu)?;
+
+    // Wire menu events — only one item at the moment, but match on id so
+    // adding more items later is mechanical.
+    app.on_menu_event(move |app_handle: &AppHandle, event| {
+        if event.id() == SETTINGS_MENU_ID {
+            if let Err(e) = app_handle.emit("tunaflow:menu-open-settings", ()) {
+                eprintln!("[menu] emit open-settings failed: {e}");
+            }
+        }
+    });
+
+    Ok(())
+}

--- a/src-tauri/src/bootstrap/mod.rs
+++ b/src-tauri/src/bootstrap/mod.rs
@@ -5,5 +5,6 @@
 pub mod crash;
 pub mod db;
 pub mod env;
+pub mod menu;
 pub mod services;
 pub mod window;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -130,6 +130,13 @@ pub fn run() {
 
             bootstrap::window::restore_window_state(app)?;
 
+            // Native menu — ensures Settings is reachable from the macOS
+            // menu bar (Cmd+,) and Windows/Linux menu before any project is
+            // selected. Failure is logged but non-fatal: app keeps booting.
+            if let Err(e) = bootstrap::menu::install(app) {
+                eprintln!("[bootstrap] install menu failed: {e}");
+            }
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![

--- a/src/components/tunaflow/AppShell.tsx
+++ b/src/components/tunaflow/AppShell.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useCallback, useMemo } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
 import { useChatStore } from "@/stores/chatStore";
 import { getSetting, setSetting } from "@/lib/appStore";
 import { Sidebar } from "./Sidebar";
@@ -15,6 +16,7 @@ import { CommandPalette } from "./CommandPalette";
 import { TitleBar } from "./TitleBar";
 import { MetaFloatingChat } from "./MetaFloatingChat";
 import { ProjectOnboardingModal } from "./ProjectOnboardingModal";
+import { SettingsPanel } from "./SettingsPanel";
 
 // ─── Panel width constraints ─────────────────────────────────────────────────
 const SIDEBAR_MIN = 220;
@@ -35,6 +37,15 @@ export function AppShell() {
   const [drawerW, setDrawerW] = useState(DRAWER_DEFAULT);
   const [loaded, setLoaded] = useState(false);
   const [themeMode, setThemeMode] = useState<"dark" | "light">("dark");
+
+  // Settings 진입점은 RuntimeStatusBar 내부 state 였으나 (s40 기준), Cmd+, /
+  // macOS 메뉴 / Command Palette 등 어디서든 — 프로젝트 선택 전 ProjectStartup
+  // 화면에서도 — 열려야 하므로 AppShell 루트로 끌어올렸다. RuntimeStatusBar
+  // 의 SettingsPanel mount + 'tunaflow:open-settings' listener 는 제거되고,
+  // 기존의 이벤트 디스패치 경로 (CommandPalette / roleAssignments) 는 그대로
+  // 본 컴포넌트가 받는다 — 즉 진입점만 추가, 기존 경로 영향 0.
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [settingsInitialSection, setSettingsInitialSection] = useState<string | undefined>(undefined);
   // Auto-hide sidebar when window is too narrow (< sidebar + min chat width)
   const SIDEBAR_HIDE_THRESHOLD = SIDEBAR_MIN + 680; // ~900px
   const [sidebarAutoHidden, setSidebarAutoHidden] = useState(() => window.innerWidth < SIDEBAR_MIN + 680);
@@ -103,6 +114,50 @@ export function AppShell() {
     return () => window.removeEventListener("resize", onResize);
   }, [SIDEBAR_HIDE_THRESHOLD]);
 
+  // 'tunaflow:open-settings' 이벤트 listener — 기존에 RuntimeStatusBar 안에
+  // 있던 코드를 root level 로 끌어올림. ProjectStartup 화면에서도 동작해야 하기
+  // 때문. (CommandPalette / roleAssignments / 본 컴포넌트의 Cmd+, 핸들러가
+  // 디스패처 측.)
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent<{ section?: string }>).detail;
+      setSettingsInitialSection(detail?.section);
+      setSettingsOpen(true);
+    };
+    window.addEventListener("tunaflow:open-settings", handler);
+    return () => window.removeEventListener("tunaflow:open-settings", handler);
+  }, []);
+
+  // Cmd+, (macOS) / Ctrl+, (Win/Linux) — 어디서든 Settings 열림.
+  // - IME 충돌 방지: composing 중인 IME 입력은 무시 (Korean/Japanese 등).
+  // - 일반 텍스트 입력 (textarea/input) focus 와 무관 — 사용자가 명시적으로
+  //   "," 키와 modifier 를 함께 누른 경우에만 trigger 되므로 textarea 안에서
+  //   ',' 를 그냥 입력하는 흐름과 충돌하지 않는다.
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "," && !e.altKey && !e.shiftKey) {
+        // IME 조합 중인 키는 브라우저가 isComposing=true 로 표시.
+        if ((e as any).isComposing) return;
+        e.preventDefault();
+        e.stopPropagation();
+        window.dispatchEvent(new CustomEvent("tunaflow:open-settings"));
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
+
+  // macOS 메뉴 → Settings... 클릭 시 Rust 가 'tunaflow:menu-open-settings'
+  // 이벤트를 emit. 같은 internal `tunaflow:open-settings` window event 로
+  // 합류시켜 단일 처리 경로를 유지한다 (macOS 메뉴 / Cmd+, / Command Palette
+  // / 톱니 버튼 모두 동일).
+  useEffect(() => {
+    const unlistenPromise = listen("tunaflow:menu-open-settings", () => {
+      window.dispatchEvent(new CustomEvent("tunaflow:open-settings"));
+    });
+    return () => { unlistenPromise.then((u) => u()).catch(() => {}); };
+  }, []);
+
   // Persist on resize end
   const persistSidebar = useCallback(() => { setSetting("sidebarWidth", sidebarW); }, [sidebarW]);
   const persistDrawer = useCallback(() => { setSetting("drawerWidth", drawerW); }, [drawerW]);
@@ -147,9 +202,22 @@ export function AppShell() {
     </div>
   );
 
-  // Project-first startup: show selector if no project is selected
+  // Project-first startup: show selector if no project is selected.
+  // SettingsPanel 은 ProjectStartup 화면에서도 Cmd+, / 메뉴로 열 수 있어야
+  // 하므로 함께 mount. (RuntimeStatusBar 가 미렌더링 상태이기 때문)
   if (!selectedProjectKey) {
-    return <ProjectStartup />;
+    return (
+      <>
+        <ProjectStartup />
+        <Toaster position="bottom-right" theme={themeMode} richColors closeButton />
+        {settingsOpen && (
+          <SettingsPanel
+            onClose={() => { setSettingsOpen(false); setSettingsInitialSection(undefined); }}
+            initialSection={settingsInitialSection}
+          />
+        )}
+      </>
+    );
   }
 
   return (
@@ -315,6 +383,12 @@ export function AppShell() {
           projectPath={projectPath}
           lineNumber={viewerFile.line}
           onClose={() => setViewerFile(null)}
+        />
+      )}
+      {settingsOpen && (
+        <SettingsPanel
+          onClose={() => { setSettingsOpen(false); setSettingsInitialSection(undefined); }}
+          initialSection={settingsInitialSection}
         />
       )}
     </div>

--- a/src/components/tunaflow/RuntimeStatusBar.tsx
+++ b/src/components/tunaflow/RuntimeStatusBar.tsx
@@ -5,7 +5,6 @@ import { cn } from "@/lib/utils";
 import { useChatStore } from "@/stores/chatStore";
 import { usePtyStore } from "@/stores/ptyStore";
 import { Activity, Loader2, Zap, Terminal, Settings, Moon, Sun, Brain } from "lucide-react";
-import { SettingsPanel } from "./SettingsPanel";
 import { TraceModal } from "./TraceModal";
 import { getSetting, setSetting } from "@/lib/appStore";
 import { countBackgroundJobs, type BackgroundJobCounts } from "@/lib/api/identityAnalysis";
@@ -93,21 +92,13 @@ export function RuntimeStatusBar() {
   const [traceOpen, setTraceOpen] = useState(false);
   const terminalOpen = usePtyStore((s) => s.terminalOpen);
   const toggleTerminal = usePtyStore((s) => s.toggleTerminal);
-  const [settingsOpen, setSettingsOpen] = useState(false);
-  const [settingsInitialSection, setSettingsInitialSection] = useState<string | undefined>(undefined);
   const hasPtySession = usePtyStore((s) => s.sessions.size > 0);
   const [bgJobs, setBgJobs] = useState<BackgroundJobCounts>({ pending: 0, running: 0 });
 
-  // 외부 컴포넌트(역할 게이트, CommandPalette)가 Settings 를 여는 단일 이벤트.
-  useEffect(() => {
-    const handler = (e: Event) => {
-      const detail = (e as CustomEvent<{ section?: string }>).detail;
-      setSettingsInitialSection(detail?.section);
-      setSettingsOpen(true);
-    };
-    window.addEventListener("tunaflow:open-settings", handler);
-    return () => window.removeEventListener("tunaflow:open-settings", handler);
-  }, []);
+  // SettingsPanel mount + 'tunaflow:open-settings' listener 는 AppShell 로
+  // 끌어올렸다 — 프로젝트 미선택(ProjectStartup) 화면에서도 Cmd+, /
+  // 메뉴로 Settings 를 열 수 있어야 하기 때문. 본 컴포넌트는 footer 의 톱니
+  // 버튼이 동일 이벤트를 디스패치하기만 하면 된다.
 
   const isRunning = runningThreadIds.length > 0;
   const runningEngines = [...new Set(jobs.filter((j) => j.status === "running").map((j) => j.engine))];
@@ -290,9 +281,9 @@ export function RuntimeStatusBar() {
       <div className="flex items-center h-7 shrink-0 text-tf-xs text-prose-muted select-none">
         {/* Settings + theme toggle — far left of footer */}
         <button
-          onClick={() => setSettingsOpen(true)}
+          onClick={() => window.dispatchEvent(new CustomEvent("tunaflow:open-settings"))}
           className="flex items-center px-2.5 h-full text-muted-foreground/50 hover:text-muted-foreground transition-colors"
-          title="Settings"
+          title="Settings (Cmd+,)"
         >
           <Settings className="w-3.5 h-3.5" />
         </button>
@@ -447,7 +438,6 @@ export function RuntimeStatusBar() {
       </div>
 
       {traceOpen && <TraceModal onClose={() => setTraceOpen(false)} />}
-      {settingsOpen && <SettingsPanel onClose={() => setSettingsOpen(false)} initialSection={settingsInitialSection} />}
     </>
   );
 }


### PR DESCRIPTION
## Summary

batmania52 보고 처리 — 프로젝트 선택 전 화면(ProjectStartup)에서도 설정 진입이 가능해진다.

- AppShell 루트로 SettingsPanel mount + 'tunaflow:open-settings' 리스너 이전 (기존 RuntimeStatusBar 내부 state 정리)
- 전역 Cmd+, / Ctrl+, 단축키 (IME composing 중에는 무시)
- Tauri 2 native menu — \"Settings...\" 항목 + Cmd+, accelerator. macOS 표준 항목(About/Hide/Quit) 함께 등록

진입 경로 4종(macOS 메뉴 / Cmd+, / Command Palette / 톱니 버튼)이 모두 같은 `tunaflow:open-settings` window event 로 합류 — 단일 처리 경로 유지.

Plan: `docs/plans/globalSettingsAndRecentProjectsPlan_2026-04-29.md` (Task 01)

## Verification

- [x] \`npx tsc --noEmit\` — PASS
- [x] \`npx vitest run\` — 381 passed (baseline 381)
- [x] \`cargo check\` — PASS
- [x] \`cargo test --lib\` — 559 passed (baseline 559)

## Test plan

- [ ] macOS dev 실행: 프로젝트 미선택(ProjectStartup) 화면에서 Cmd+, → Settings 열림
- [ ] 메뉴 바 \"tunaFlow\" → \"Settings...\" 클릭 → 동일 동작
- [ ] 프로젝트 선택 후에도 Cmd+, / 톱니 버튼 / Command Palette 모두 동작
- [ ] 한글 IME 입력 중 Cmd+, 트리거 안 됨 확인

## 회귀 가드 (확인됨)

- 기존 진입점 (CommandPalette / roleAssignments) `dispatchEvent` 호출 변경 0
- `initialSection` prop 전달 보존 (역할 게이트가 'agents' 섹션 직접 열기에 사용)
- macOS 메뉴 추가가 다른 OS 빌드 회귀 0 (\`tauri::menu\` API 는 cross-platform)
- 다른 단축키 (Cmd+Enter / Cmd+K 등) 와 충돌 없음 — 단축키 모두 `,` 와 무관