### PR TITLE
feat(projects): recent projects DB migration + UI (Plan C Task 02)

### DIFF
--- a/src-tauri/src/commands/projects.rs
+++ b/src-tauri/src/commands/projects.rs
@@ -70,6 +70,60 @@ pub fn list_projects(state: State<DbState>) -> Result<Vec<Project>, AppError> {
     Ok(rows)
 }
 
+/// 최근 열었던 프로젝트 목록 — `last_opened_at DESC` 순.
+///
+/// `globalSettingsAndRecentProjectsPlan_2026-04-29.md` Task 02 의 G3.
+/// `list_projects` 와 동일한 hidden 필터 + Project shape 를 유지하지만,
+/// `last_opened_at = 0` (한 번도 열지 않은 프로젝트) 은 결과에서 제외 —
+/// "최근" 의 정의에 부합. 정렬은 last_opened_at DESC, tie-break 으로
+/// updated_at DESC.
+///
+/// `limit` 은 UI 측 (5 권장) 에서 제어. 0 또는 음수면 기본값 5 적용.
+#[tauri::command]
+pub fn list_recent_projects(
+    limit: Option<i64>,
+    state: State<DbState>,
+) -> Result<Vec<Project>, AppError> {
+    let conn = state.read.lock().map_err(|_| AppError::Lock)?;
+    let lim = limit.filter(|n| *n > 0).unwrap_or(5);
+    let mut stmt = conn.prepare(
+        "SELECT key, name, path, type, default_engine, workspace_root, source, updated_at
+         FROM projects
+         WHERE COALESCE(hidden, 0) = 0 AND COALESCE(last_opened_at, 0) > 0
+         ORDER BY last_opened_at DESC, updated_at DESC
+         LIMIT ?1",
+    )?;
+    let rows = stmt
+        .query_map(params![lim], |row| {
+            Ok(Project {
+                key: row.get(0)?,
+                name: row.get(1)?,
+                path: row.get(2)?,
+                project_type: row.get(3)?,
+                default_engine: row.get(4)?,
+                workspace_root: row.get(5)?,
+                source: row.get(6)?,
+                updated_at: row.get(7)?,
+            })
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(rows)
+}
+
+/// 프로젝트 선택 시 `last_opened_at` 을 현재 시각(ms) 으로 갱신.
+///
+/// `selectProject` 가 호출하므로 idempotent 해야 한다 — 동일 프로젝트
+/// 재선택 시 단순히 timestamp 만 갱신. 알 수 없는 key 는 no-op (UPDATE rows = 0).
+#[tauri::command]
+pub fn touch_project_opened_at(key: String, state: State<DbState>) -> Result<(), AppError> {
+    let conn = state.write.lock().map_err(|_| AppError::Lock)?;
+    conn.execute(
+        "UPDATE projects SET last_opened_at = ?1 WHERE key = ?2",
+        params![crate::db::migrations::now_epoch_ms(), key],
+    )?;
+    Ok(())
+}
+
 #[tauri::command]
 pub fn create_project(
     input: CreateProjectInput,

--- a/src-tauri/src/db/migrations.rs
+++ b/src-tauri/src/db/migrations.rs
@@ -166,6 +166,9 @@ pub fn run(conn: &mut Connection) -> Result<(), AppError> {
     if current < 47 {
         apply_v47(conn)?;
     }
+    if current < 48 {
+        apply_v48(conn)?;
+    }
     Ok(())
 }
 
@@ -1234,6 +1237,36 @@ fn apply_v47(conn: &Connection) -> Result<(), AppError> {
     result
 }
 
+/// v48: `projects` 에 `last_opened_at` 컬럼 추가 (recent projects UX).
+///
+/// `globalSettingsAndRecentProjectsPlan_2026-04-29.md` Task 02. 사용자가
+/// 프로젝트를 선택할 때마다 `selectProject` (Rust: `touch_project_opened_at`)
+/// 가 unix-ms 단위로 갱신한다. ProjectStartup 화면이 "최근 열었던 프로젝트"
+/// 섹션을 이 컬럼 DESC 순으로 보여준다.
+///
+/// - 기존 row: DEFAULT 0 — UI 는 0 인 row 도 정상 표시 (단지 우선순위가
+///   낮을 뿐). NULL 회피 위해 NOT NULL DEFAULT 0.
+/// - 인덱스: list_recent_projects 의 ORDER BY last_opened_at DESC 가
+///   index 활용하도록 명시. updated_at 인덱스와 동등 비용.
+/// - idempotent: `add_column_if_missing` + `CREATE INDEX IF NOT EXISTS`.
+fn apply_v48(conn: &Connection) -> Result<(), AppError> {
+    add_column_if_missing(
+        conn,
+        "projects",
+        "last_opened_at",
+        "INTEGER NOT NULL DEFAULT 0",
+    )?;
+    conn.execute_batch(
+        "CREATE INDEX IF NOT EXISTS idx_projects_last_opened_at
+         ON projects(last_opened_at DESC);",
+    )?;
+    conn.execute(
+        "INSERT INTO schema_version (version, applied_at) VALUES (48, ?1)",
+        [now_epoch_ms()],
+    )?;
+    Ok(())
+}
+
 /// Milliseconds since Unix epoch (for Message.timestamp)
 pub fn now_epoch_ms() -> i64 {
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -1823,5 +1856,95 @@ mod tests {
             )
             .unwrap();
         assert_eq!(c, 1);
+    }
+
+    /// Open an in-memory connection with `projects` table at the v1 shape so
+    /// `apply_v48` can operate. We don't run the full migration chain (some
+    /// earlier migrations need sqlite-vec), only the bits v48 depends on.
+    fn open_with_projects_v1() -> Connection {
+        let conn = Connection::open_in_memory().expect("open");
+        conn.execute_batch(schema::CREATE_SCHEMA_VERSION).expect("schema_version");
+        // projects table — same shape as v1 schema.
+        conn.execute_batch(
+            "CREATE TABLE projects (
+                key            TEXT    PRIMARY KEY,
+                name           TEXT    NOT NULL,
+                path           TEXT,
+                type           TEXT    NOT NULL DEFAULT 'project',
+                default_engine TEXT,
+                workspace_root TEXT,
+                source         TEXT    NOT NULL DEFAULT 'configured',
+                updated_at     INTEGER NOT NULL,
+                hidden         INTEGER NOT NULL DEFAULT 0
+            );",
+        )
+        .expect("create projects");
+        conn
+    }
+
+    #[test]
+    fn v48_adds_last_opened_at_column() {
+        let conn = open_with_projects_v1();
+        apply_v48(&conn).expect("apply_v48");
+        // PRAGMA 로 컬럼 존재 확인
+        assert!(column_exists(&conn, "projects", "last_opened_at"));
+    }
+
+    #[test]
+    fn v48_records_schema_version() {
+        let conn = open_with_projects_v1();
+        apply_v48(&conn).expect("apply_v48");
+        let v: i64 = conn
+            .query_row("SELECT MAX(version) FROM schema_version", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(v, 48);
+    }
+
+    #[test]
+    fn v48_creates_last_opened_index() {
+        let conn = open_with_projects_v1();
+        apply_v48(&conn).expect("apply_v48");
+        let c: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='idx_projects_last_opened_at'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(c, 1);
+    }
+
+    #[test]
+    fn v48_existing_rows_default_to_zero() {
+        let conn = open_with_projects_v1();
+        // 마이그레이션 전 row 삽입
+        conn.execute(
+            "INSERT INTO projects (key, name, type, source, updated_at)
+             VALUES ('p1', 'Pre-v48', 'project', 'configured', 1234)",
+            [],
+        )
+        .unwrap();
+        apply_v48(&conn).expect("apply_v48");
+        let v: i64 = conn
+            .query_row(
+                "SELECT last_opened_at FROM projects WHERE key='p1'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(v, 0, "기존 row 는 DEFAULT 0 적용");
+    }
+
+    #[test]
+    fn v48_idempotent_when_column_already_exists() {
+        let conn = open_with_projects_v1();
+        // 미리 컬럼 추가 — schema drift 시뮬
+        conn.execute(
+            "ALTER TABLE projects ADD COLUMN last_opened_at INTEGER NOT NULL DEFAULT 0",
+            [],
+        )
+        .unwrap();
+        // apply_v48 가 ALTER 실패 없이 통과해야 함.
+        apply_v48(&conn).expect("apply_v48 should be idempotent");
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -142,6 +142,8 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             // Project
             commands::projects::list_projects,
+            commands::projects::list_recent_projects,
+            commands::projects::touch_project_opened_at,
             commands::projects::create_project,
             commands::projects::get_project,
             commands::projects::hide_project,

--- a/src/components/tunaflow/ProjectStartup.tsx
+++ b/src/components/tunaflow/ProjectStartup.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { FolderOpen, Plus, Clock } from "lucide-react";
 import { useChatStore } from "@/stores/chatStore";
 import { open } from "@tauri-apps/plugin-dialog";
@@ -6,6 +6,9 @@ import { invoke } from "@tauri-apps/api/core";
 import { toast } from "sonner";
 import { setSetting } from "@/lib/appStore";
 import { basename } from "@/lib/utils";
+import type { Project } from "@/types";
+
+const RECENT_LIMIT = 5;
 
 export function ProjectStartup() {
   const projects = useChatStore((s) => s.projects);
@@ -13,6 +16,25 @@ export function ProjectStartup() {
   const createProject = useChatStore((s) => s.createProject);
   const loadProjects = useChatStore((s) => s.loadProjects);
   const [adding, setAdding] = useState(false);
+
+  // 최근 열었던 프로젝트 — last_opened_at DESC. v48 마이그레이션 이전 사용자
+  // 의 프로젝트는 last_opened_at=0 이라 본 list 에 안 잡힌다 → fallback 으로
+  // store 의 `projects` (updated_at DESC) 를 사용. 처음 한 번 열고나면
+  // 이후부터는 정상 recent list.
+  const [recent, setRecent] = useState<Project[] | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    invoke<Project[]>("list_recent_projects", { limit: RECENT_LIMIT })
+      .then((r) => { if (!cancelled) setRecent(r); })
+      .catch(() => { if (!cancelled) setRecent([]); });
+    return () => { cancelled = true; };
+  }, [projects.length]);
+
+  // recent 가 비어있으면 (신규 사용자 또는 v48 이전 사용자) projects 슬라이스
+  // 의 updated_at 정렬 결과를 fallback 으로 사용. fallback 도 비면 섹션 미노출.
+  const displayProjects: Project[] = recent && recent.length > 0
+    ? recent
+    : projects.slice(0, RECENT_LIMIT);
 
   const handleOpenFolder = async () => {
     setAdding(true);
@@ -65,14 +87,14 @@ export function ProjectStartup() {
         </button>
 
         {/* Recent projects */}
-        {projects.length > 0 && (
+        {displayProjects.length > 0 && (
           <div className="space-y-2">
             <div className="flex items-center gap-2 px-1">
               <Clock className="w-3.5 h-3.5 text-muted-foreground/40" />
               <span className="text-[11px] font-medium text-muted-foreground/50 uppercase tracking-wider">Recent Projects</span>
             </div>
             <div className="space-y-1">
-              {projects.slice(0, 5).map((p) => (
+              {displayProjects.map((p) => (
                 <button
                   key={p.key}
                   onClick={() => handleSelectRecent(p.key)}

--- a/src/lib/bootstrap/project.ts
+++ b/src/lib/bootstrap/project.ts
@@ -103,6 +103,12 @@ export function setInitialState(
   import("@/lib/appStore")
     .then(({ setSetting }) => setSetting("lastProjectKey", key))
     .catch((e) => console.debug("[bootstrap/project] persist last key:", e));
+  // recent-projects ordering 을 위해 last_opened_at 갱신 (fire-and-forget).
+  // ProjectStartup 화면의 "최근 열었던 프로젝트" 섹션은 이 timestamp 의
+  // DESC 순으로 노출 (Plan C Task 02). 갱신 실패는 UX 영향만 — bootstrap
+  // 체인을 막지 않는다.
+  invoke("touch_project_opened_at", { key })
+    .catch((e) => console.debug("[bootstrap/project] touch last_opened_at:", e));
 }
 
 /**


### PR DESCRIPTION
## Summary

batmania52 보고 처리 — ProjectStartup 화면의 \"Recent Projects\" 섹션이 정확한 \"마지막으로 연 시각\" 으로 정렬되도록 한다.

기존: \`projects.updated_at DESC\` — 메타데이터 변경(이름 수정 등) 으로도 정렬이 흔들림.
변경: \`projects.last_opened_at DESC\` — 사용자가 실제로 프로젝트를 연 timestamp 기반.

## 변경

- **DB v48 migration** — \`projects.last_opened_at INTEGER NOT NULL DEFAULT 0\` + \`idx_projects_last_opened_at\` 인덱스. \`add_column_if_missing\` 으로 idempotent (이미 컬럼 있으면 skip).
- **\`touch_project_opened_at(key)\`** — selectProject 의 \`setInitialState\` 단계에서 fire-and-forget 호출. 갱신 실패는 부트스트랩 체인에 영향 없음.
- **\`list_recent_projects(limit)\`** — \`last_opened_at DESC\`, tie-break \`updated_at DESC\`. \`last_opened_at=0\` (한 번도 열지 않은 row) 은 결과에서 제외.
- **ProjectStartup** — \`useEffect\` 로 recent list 가져오고, 비어있을 때만 store 의 \`projects\` 슬라이스를 fallback (v48 이전 사용자 경험 보존).

Plan: \`docs/plans/globalSettingsAndRecentProjectsPlan_2026-04-29.md\` (Task 02)

## Verification

- [x] \`npx tsc --noEmit\` — PASS
- [x] \`npx vitest run\` — 381 passed (baseline 381)
- [x] \`cargo check\` — PASS
- [x] \`cargo test --lib\` — 564 passed (baseline 559 + 5 v48 신규)
  - \`v48_adds_last_opened_at_column\`
  - \`v48_records_schema_version\`
  - \`v48_creates_last_opened_index\`
  - \`v48_existing_rows_default_to_zero\`
  - \`v48_idempotent_when_column_already_exists\`

## Test plan

- [ ] dev 실행: 프로젝트 1~3개 만들고 닫았다 다시 열기
- [ ] ProjectStartup 화면에서 \"Recent Projects\" 섹션이 last_opened 순으로 정렬 확인
- [ ] v48 이전 DB 시뮬: \`last_opened_at\` 컬럼 없는 상태로 시작 → migration 적용 후 기존 row 가 default 0 으로 fallback (store projects 사용)
- [ ] 신규 사용자 (project 0 개): 섹션 미노출 확인

## 회귀 가드 (확인됨)

- migration 은 v48 만 추가 — 다른 v1~v47 변경 0
- \`Project\` model (models.rs) 변경 0 — \`last_opened_at\` 은 backend-only metadata
- \`commands/projects.rs\` 의 다른 명령 (list_projects/create/get/hide/validate) 변경 0
- \`ProjectOnboardingModal\` 변경 0 (다른 분기 영향 없음)
- migration idempotent — 컬럼 이미 있으면 ALTER skip (테스트로 검증)

## CI 정책 (handoff §3)

Plan C Task 02 (DB migration) — CI watch 필수. CI green 확인 후 admin merge 진행.