### PR TITLE
feat(docs): docs panel scope toggle — Plan E (P3-Lite)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -463,6 +463,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1994,6 +2004,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "gobject-sys"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2451,6 +2474,22 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -6631,6 +6670,7 @@ dependencies = [
  "chrono",
  "dirs 5.0.1",
  "futures-util",
+ "ignore",
  "keyring",
  "lazy_static",
  "lindera",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -69,6 +69,9 @@ ndarray = "0.16"
 # OS keychain access (macOS Keychain, Windows Credential Vault, Linux Secret Service).
 # Used for persisting user-supplied secrets (future API keys etc.) outside the SQLite DB.
 keyring = "3"
+# Used by `list_project_docs` (scope='all') to honor .gitignore + auto-skip
+# heavy build dirs (node_modules/, target/, dist/, ...). Plan E (2026-04-29).
+ignore = "0.4"
 
 [profile.release]
 panic = "abort"

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -1,6 +1,8 @@
+use ignore::WalkBuilder;
 use serde::Serialize;
+use std::collections::BTreeMap;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::errors::AppError;
 
@@ -47,6 +49,288 @@ pub fn list_directory(path: String) -> Result<Vec<DirEntry>, AppError> {
     });
 
     Ok(entries)
+}
+
+// ─── list_project_docs (Plan E — docs panel scope policy) ───────────────────
+
+/// Tree entry returned to the docs panel. `children` is `Some` for dirs,
+/// `None` for files. We use `BTreeMap`-derived ordering on the way up so the
+/// panel renders consistently across runs.
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct DocsEntry {
+    pub name: String,
+    pub path: String,
+    pub is_dir: bool,
+    pub children: Option<Vec<DocsEntry>>,
+}
+
+const DOCS_MAX_DEPTH: usize = 5;
+/// Hard ceiling so that a runaway repo can't lock the panel render. Combined
+/// with the frontend toast at 200, the user is warned before getting close.
+const DOCS_HARD_LIMIT: usize = 5_000;
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DocsScanResult {
+    pub entries: Vec<DocsEntry>,
+    /// Total file count (.md only). Used by frontend to show a perf toast at
+    /// >200 — see Task 03 of docsPanelScopePolicyPlan_2026-04-29.
+    pub file_count: usize,
+    /// True if traversal stopped at `DOCS_HARD_LIMIT`. Frontend can hint at
+    /// switching scopes.
+    pub truncated: bool,
+}
+
+/// Scan a project root for `.md` documents according to a scope policy.
+///
+/// - `scope = "tunaflow"` → legacy behavior: top-level `.md` files + immediate
+///   children of `docs/` and `.github/` (recursive within those subtrees, max
+///   depth 3 like `scanDocsDir` did before).
+/// - `scope = "all"` → recursive walk under `<project_root>` honoring
+///   `.gitignore` (via the `ignore` crate). Depth-capped at `DOCS_MAX_DEPTH`.
+///
+/// Returns a tree (dirs + files) sorted dirs-first, then alphabetical within
+/// each level. Hidden entries (`.foo`) are skipped — except `.github` for the
+/// tunaflow scope, kept for parity with the previous TS-side scan.
+#[tauri::command]
+pub fn list_project_docs(project_path: String, scope: String) -> Result<DocsScanResult, AppError> {
+    let root = Path::new(&project_path);
+    if !root.is_dir() {
+        return Err(AppError::NotFound(format!("Not a directory: {}", project_path)));
+    }
+    match scope.as_str() {
+        "tunaflow" => Ok(scan_tunaflow(root)),
+        "all" => Ok(scan_all(root)),
+        other => Err(AppError::Agent(format!("Unknown docs scope: {}", other))),
+    }
+}
+
+// ─── scope='tunaflow' (legacy parity) ──────────────────────────────────────
+
+fn scan_tunaflow(root: &Path) -> DocsScanResult {
+    let mut tree: Vec<DocsEntry> = Vec::new();
+    let mut file_count = 0usize;
+
+    let Ok(read) = fs::read_dir(root) else {
+        return DocsScanResult { entries: tree, file_count, truncated: false };
+    };
+
+    for entry in read.flatten() {
+        let name = entry.file_name().to_string_lossy().to_string();
+        let is_dir = entry.file_type().map(|t| t.is_dir()).unwrap_or(false);
+        let full_path = entry.path();
+
+        if is_dir {
+            // Mirror legacy TS behavior: only `docs/` and `.github/` are scanned
+            // (everything else under the project root is ignored in tunaflow scope).
+            if name == "docs" || name == ".github" {
+                let (children, count) = scan_tunaflow_subdir(&full_path, 0);
+                if !children.is_empty() {
+                    file_count += count;
+                    tree.push(DocsEntry {
+                        name,
+                        path: full_path.to_string_lossy().to_string(),
+                        is_dir: true,
+                        children: Some(children),
+                    });
+                }
+            }
+        } else if name.ends_with(".md") && !name.starts_with('.') {
+            // Hidden files (".env.md") were filtered by the previous TS scanner
+            // via `list_directory`. Preserve that for parity.
+            file_count += 1;
+            tree.push(DocsEntry {
+                name,
+                path: full_path.to_string_lossy().to_string(),
+                is_dir: false,
+                children: None,
+            });
+        }
+    }
+
+    sort_tree_inplace(&mut tree);
+    DocsScanResult { entries: tree, file_count, truncated: false }
+}
+
+fn scan_tunaflow_subdir(dir: &Path, depth: usize) -> (Vec<DocsEntry>, usize) {
+    if depth > 3 {
+        return (Vec::new(), 0);
+    }
+    let mut out: Vec<DocsEntry> = Vec::new();
+    let mut count = 0usize;
+    let Ok(read) = fs::read_dir(dir) else { return (out, 0); };
+    for entry in read.flatten() {
+        let name = entry.file_name().to_string_lossy().to_string();
+        // Skip hidden files/dirs to mirror the legacy TS `list_directory` filter.
+        if name.starts_with('.') {
+            continue;
+        }
+        let is_dir = entry.file_type().map(|t| t.is_dir()).unwrap_or(false);
+        let full_path = entry.path();
+        if is_dir {
+            let (children, sub_count) = scan_tunaflow_subdir(&full_path, depth + 1);
+            if !children.is_empty() {
+                count += sub_count;
+                out.push(DocsEntry {
+                    name,
+                    path: full_path.to_string_lossy().to_string(),
+                    is_dir: true,
+                    children: Some(children),
+                });
+            }
+        } else if name.ends_with(".md") {
+            count += 1;
+            out.push(DocsEntry {
+                name,
+                path: full_path.to_string_lossy().to_string(),
+                is_dir: false,
+                children: None,
+            });
+        }
+    }
+    sort_tree_inplace(&mut out);
+    (out, count)
+}
+
+// ─── scope='all' (walkdir + ignore) ────────────────────────────────────────
+
+/// Build a tree by inserting each `.md` file path into a nested `BTreeMap`.
+/// Sub-trees are converted to `Vec<DocsEntry>` afterwards. Dirs first,
+/// alphabetical within each level.
+fn scan_all(root: &Path) -> DocsScanResult {
+    let mut root_node = Node::default();
+    let mut file_count = 0usize;
+    let mut truncated = false;
+
+    // `ignore::WalkBuilder` honors `.gitignore` files automatically. We also
+    // register `.gitignore` as a custom ignore filename so that projects that
+    // are *not* a git repo (no `.git/` directory) still get the same filtering
+    // behavior — important because users sometimes open a worktree or extract
+    // a tarball without `.git/`. `hidden(true)` skips `.git/`, `.cache/`, etc.
+    let walker = WalkBuilder::new(root)
+        .max_depth(Some(DOCS_MAX_DEPTH))
+        .hidden(true)
+        .git_ignore(true)
+        .git_exclude(true)
+        .git_global(true)
+        .parents(true)
+        .add_custom_ignore_filename(".gitignore")
+        .build();
+
+    for result in walker {
+        let dent = match result {
+            Ok(d) => d,
+            Err(_) => continue, // permission denied / IO — silently skip
+        };
+        // Skip the root dir entry itself.
+        let path = dent.path();
+        if path == root {
+            continue;
+        }
+        let is_file = dent.file_type().map(|t| t.is_file()).unwrap_or(false);
+        if !is_file {
+            continue;
+        }
+        let name = match path.file_name().and_then(|n| n.to_str()) {
+            Some(n) => n,
+            None => continue,
+        };
+        if !name.ends_with(".md") {
+            continue;
+        }
+
+        // Hard ceiling — defensive guard. Frontend toast warns at 200.
+        if file_count >= DOCS_HARD_LIMIT {
+            truncated = true;
+            break;
+        }
+        file_count += 1;
+
+        // Insert into tree using path components relative to root.
+        let rel = match path.strip_prefix(root) {
+            Ok(r) => r,
+            Err(_) => continue,
+        };
+        let comps: Vec<String> = rel
+            .components()
+            .filter_map(|c| c.as_os_str().to_str().map(String::from))
+            .collect();
+        if comps.is_empty() {
+            continue;
+        }
+
+        let mut cursor = &mut root_node;
+        let last_idx = comps.len() - 1;
+        for (i, comp) in comps.iter().enumerate() {
+            let entry = cursor.children.entry(comp.clone()).or_default();
+            if i == last_idx {
+                entry.is_file = true;
+                entry.full_path = Some(path.to_path_buf());
+            }
+            cursor = entry;
+        }
+    }
+
+    let entries = node_to_entries(&root_node, root);
+    DocsScanResult { entries, file_count, truncated }
+}
+
+fn node_to_entries(node: &Node, base: &Path) -> Vec<DocsEntry> {
+    let mut out: Vec<DocsEntry> = Vec::new();
+    for (name, child) in node.children.iter() {
+        if child.is_file {
+            let full = child
+                .full_path
+                .as_ref()
+                .map(|p| p.to_string_lossy().to_string())
+                .unwrap_or_else(|| base.join(name).to_string_lossy().to_string());
+            out.push(DocsEntry {
+                name: name.clone(),
+                path: full,
+                is_dir: false,
+                children: None,
+            });
+        } else {
+            // Directory node — recurse.
+            let sub_base = base.join(name);
+            let children = node_to_entries(child, &sub_base);
+            // Skip empty dirs (no .md descendants).
+            if children.is_empty() {
+                continue;
+            }
+            out.push(DocsEntry {
+                name: name.clone(),
+                path: sub_base.to_string_lossy().to_string(),
+                is_dir: true,
+                children: Some(children),
+            });
+        }
+    }
+    sort_tree_inplace(&mut out);
+    out
+}
+
+#[derive(Default)]
+struct Node {
+    children: BTreeMap<String, Node>,
+    is_file: bool,
+    full_path: Option<PathBuf>,
+}
+
+// ─── shared helpers ────────────────────────────────────────────────────────
+
+fn sort_tree_inplace(items: &mut Vec<DocsEntry>) {
+    items.sort_by(|a, b| {
+        b.is_dir
+            .cmp(&a.is_dir)
+            .then(a.name.to_lowercase().cmp(&b.name.to_lowercase()))
+    });
+    for it in items.iter_mut() {
+        if let Some(children) = it.children.as_mut() {
+            sort_tree_inplace(children);
+        }
+    }
 }
 
 /// Read file content as UTF-8 string. Used by Docs viewer popup.
@@ -126,4 +410,218 @@ pub fn read_text_file(file_path: String, project_path: String) -> Result<FileCon
         language,
         line_count,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    //! Plan E (docsPanelScopePolicyPlan_2026-04-29) — scope-aware traversal.
+    //!
+    //! Targets:
+    //! - scope='tunaflow' parity with previous TS-side scan (docs/ + .github/
+    //!   + root .md only).
+    //! - scope='all' walks the project root recursively, honors .gitignore,
+    //!   skips hidden dirs.
+    //! - scope='all' applies max depth (5).
+    //! - scope='all' file count > 0 reflects total .md count for the toast.
+    use super::*;
+    use std::fs::{self, File};
+    use std::io::Write;
+    use tempfile::tempdir;
+
+    fn touch(path: &Path) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        let mut f = File::create(path).unwrap();
+        writeln!(f, "# {}", path.display()).unwrap();
+    }
+
+    fn flatten_md_paths(entries: &[DocsEntry], out: &mut Vec<String>) {
+        for e in entries {
+            if e.is_dir {
+                if let Some(children) = &e.children {
+                    flatten_md_paths(children, out);
+                }
+            } else {
+                out.push(e.path.clone());
+            }
+        }
+    }
+
+    #[test]
+    fn tunaflow_scope_returns_root_md_and_docs_only() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        touch(&root.join("README.md"));
+        touch(&root.join("CHANGELOG.md"));
+        touch(&root.join("docs/guide.md"));
+        touch(&root.join("docs/sub/deep.md"));
+        // Should NOT appear in tunaflow scope.
+        touch(&root.join("packages/lib/docs/x.md"));
+        touch(&root.join("scripts/build.md"));
+
+        let result = list_project_docs(
+            root.to_string_lossy().to_string(),
+            "tunaflow".to_string(),
+        )
+        .unwrap();
+
+        let mut paths: Vec<String> = Vec::new();
+        flatten_md_paths(&result.entries, &mut paths);
+        let names: Vec<String> = paths
+            .iter()
+            .map(|p| p.replace(&format!("{}/", root.to_string_lossy()), ""))
+            .collect();
+
+        assert!(names.contains(&"README.md".to_string()));
+        assert!(names.contains(&"CHANGELOG.md".to_string()));
+        assert!(names.iter().any(|n| n.ends_with("docs/guide.md")));
+        assert!(names.iter().any(|n| n.ends_with("docs/sub/deep.md")));
+        // Out of scope:
+        assert!(!names.iter().any(|n| n.contains("packages/")));
+        assert!(!names.iter().any(|n| n.contains("scripts/")));
+
+        assert_eq!(result.file_count, 4);
+        assert!(!result.truncated);
+    }
+
+    #[test]
+    fn all_scope_walks_recursively_and_respects_gitignore() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        // git-tracked docs.
+        touch(&root.join("README.md"));
+        touch(&root.join("docs/guide.md"));
+        touch(&root.join("packages/lib/docs/x.md"));
+        touch(&root.join("scripts/build.md"));
+        // node_modules content + .gitignore should hide it.
+        touch(&root.join("node_modules/foo/README.md"));
+        // Build dir excluded via .gitignore (not a built-in skip otherwise).
+        touch(&root.join("dist/output.md"));
+        // .gitignore tells walker to skip these:
+        let mut gi = File::create(root.join(".gitignore")).unwrap();
+        writeln!(gi, "node_modules/").unwrap();
+        writeln!(gi, "dist/").unwrap();
+
+        let result = list_project_docs(
+            root.to_string_lossy().to_string(),
+            "all".to_string(),
+        )
+        .unwrap();
+
+        let mut paths: Vec<String> = Vec::new();
+        flatten_md_paths(&result.entries, &mut paths);
+
+        assert!(paths.iter().any(|p| p.ends_with("README.md")));
+        assert!(paths.iter().any(|p| p.ends_with("docs/guide.md")));
+        assert!(paths.iter().any(|p| p.ends_with("packages/lib/docs/x.md")));
+        assert!(paths.iter().any(|p| p.ends_with("scripts/build.md")));
+        // gitignored:
+        assert!(!paths.iter().any(|p| p.contains("node_modules")));
+        assert!(!paths.iter().any(|p| p.contains("dist")));
+
+        assert_eq!(result.file_count, 4);
+        assert!(!result.truncated);
+    }
+
+    #[test]
+    fn all_scope_skips_hidden_dirs() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        touch(&root.join("docs/a.md"));
+        // Hidden directory — should be skipped by the ignore walker.
+        touch(&root.join(".git/HEAD.md"));
+        touch(&root.join(".cache/tmp.md"));
+
+        let result = list_project_docs(
+            root.to_string_lossy().to_string(),
+            "all".to_string(),
+        )
+        .unwrap();
+
+        let mut paths: Vec<String> = Vec::new();
+        flatten_md_paths(&result.entries, &mut paths);
+        assert!(paths.iter().any(|p| p.ends_with("docs/a.md")));
+        assert!(!paths.iter().any(|p| p.contains("/.git/")));
+        assert!(!paths.iter().any(|p| p.contains("/.cache/")));
+    }
+
+    #[test]
+    fn all_scope_caps_depth_at_5() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        // `WalkBuilder::max_depth(Some(5))` counts the root as depth 0, so a
+        // file at `a/b/c/d/within.md` sits at depth 5 (4 dirs + 1 file). The
+        // first file beyond the cap is `a/b/c/d/e/beyond.md` (depth 6).
+        touch(&root.join("a/b/c/d/within.md"));      // depth 5 — included
+        touch(&root.join("a/b/c/d/e/beyond.md"));    // depth 6 — excluded
+        let result = list_project_docs(
+            root.to_string_lossy().to_string(),
+            "all".to_string(),
+        )
+        .unwrap();
+        let mut paths: Vec<String> = Vec::new();
+        flatten_md_paths(&result.entries, &mut paths);
+        assert!(paths.iter().any(|p| p.ends_with("within.md")));
+        assert!(!paths.iter().any(|p| p.ends_with("beyond.md")));
+    }
+
+    #[test]
+    fn unknown_scope_returns_error() {
+        let tmp = tempdir().unwrap();
+        let res = list_project_docs(
+            tmp.path().to_string_lossy().to_string(),
+            "custom".to_string(),
+        );
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn tunaflow_scope_includes_dot_github_and_skips_hidden_md() {
+        // Regression guard for `'tunaflow'` parity with legacy TS scanner:
+        // - `.github/` dir is scanned (legacy behavior).
+        // - `.foo.md` (hidden file) is excluded.
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        touch(&root.join("README.md"));
+        touch(&root.join(".secret.md"));               // hidden — excluded
+        touch(&root.join(".github/PULL_REQUEST_TEMPLATE.md"));
+        touch(&root.join("docs/.draft.md"));           // hidden inside docs — excluded
+
+        let result = list_project_docs(
+            root.to_string_lossy().to_string(),
+            "tunaflow".to_string(),
+        )
+        .unwrap();
+        let mut paths: Vec<String> = Vec::new();
+        flatten_md_paths(&result.entries, &mut paths);
+
+        assert!(paths.iter().any(|p| p.ends_with("README.md")));
+        assert!(paths.iter().any(|p| p.ends_with(".github/PULL_REQUEST_TEMPLATE.md")));
+        assert!(!paths.iter().any(|p| p.ends_with(".secret.md")));
+        assert!(!paths.iter().any(|p| p.ends_with(".draft.md")));
+    }
+
+    #[test]
+    fn dirs_sorted_before_files_alphabetical() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        touch(&root.join("zeta.md"));
+        touch(&root.join("alpha.md"));
+        touch(&root.join("docs/a.md"));
+        touch(&root.join("docs/b.md"));
+
+        let result = list_project_docs(
+            root.to_string_lossy().to_string(),
+            "tunaflow".to_string(),
+        )
+        .unwrap();
+        // dir 'docs/' first, then 'alpha.md', then 'zeta.md'.
+        assert_eq!(result.entries.len(), 3);
+        assert!(result.entries[0].is_dir);
+        assert_eq!(result.entries[0].name, "docs");
+        assert!(!result.entries[1].is_dir);
+        assert_eq!(result.entries[1].name, "alpha.md");
+        assert_eq!(result.entries[2].name, "zeta.md");
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -277,6 +277,7 @@ pub fn run() {
             commands::context_hub::context_hub_get,
             // Files
             commands::files::list_directory,
+            commands::files::list_project_docs,
             commands::files::read_file_content,
             commands::files::read_text_file,
             // Tracing

--- a/src/components/tunaflow/SettingsPanel.tsx
+++ b/src/components/tunaflow/SettingsPanel.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
-import { X, Bot, UserCircle, Zap, Cpu, Terminal, Smartphone, User, HelpCircle, Globe, Brain } from "lucide-react";
+import { X, Bot, UserCircle, Zap, Cpu, Terminal, Smartphone, User, HelpCircle, Globe, Brain, FileText } from "lucide-react";
 import { SkillsPanel } from "./context-panel/SkillsPanel";
 import { AgentsSection } from "./settings/AgentsSection";
 import { PersonasSection } from "./settings/PersonasSection";
@@ -12,8 +12,9 @@ import { ProfileSection } from "./settings/ProfileSection";
 import { HelpSection } from "./settings/HelpSection";
 import { WorldviewSettings } from "./settings/WorldviewSettings";
 import { IdentityAnalysisSettings } from "./settings/IdentityAnalysisSettings";
+import { DocsScopeSection } from "./settings/DocsScopeSection";
 
-type SettingsSection = "profile" | "worldview" | "identity" | "agents" | "personas" | "skills" | "runtime" | "terminal" | "mobile" | "help";
+type SettingsSection = "profile" | "worldview" | "identity" | "agents" | "personas" | "skills" | "runtime" | "terminal" | "mobile" | "docs_scope" | "help";
 
 /** Section labels come from `settings.section.*` i18n keys. The order is visual
  *  layout, not config — 새 섹션 추가 시 JSON 키 + 이 배열 양쪽에 등록. */
@@ -27,6 +28,7 @@ const SECTION_CONFIG: { id: SettingsSection; icon: React.ReactNode }[] = [
   { id: "runtime", icon: <Cpu className="w-4 h-4" /> },
   { id: "terminal", icon: <Terminal className="w-4 h-4" /> },
   { id: "mobile", icon: <Smartphone className="w-4 h-4" /> },
+  { id: "docs_scope", icon: <FileText className="w-4 h-4" /> },
   { id: "help", icon: <HelpCircle className="w-4 h-4" /> },
 ];
 
@@ -36,7 +38,7 @@ interface SettingsPanelProps {
 }
 
 export function SettingsPanel({ onClose, initialSection }: SettingsPanelProps) {
-  const valid: SettingsSection[] = ["profile", "worldview", "identity", "agents", "personas", "skills", "runtime", "terminal", "mobile", "help"];
+  const valid: SettingsSection[] = ["profile", "worldview", "identity", "agents", "personas", "skills", "runtime", "terminal", "mobile", "docs_scope", "help"];
   const initial = (initialSection && valid.includes(initialSection as SettingsSection))
     ? (initialSection as SettingsSection)
     : "profile";
@@ -91,6 +93,7 @@ export function SettingsPanel({ onClose, initialSection }: SettingsPanelProps) {
               {activeSection === "runtime" && <RuntimeSection />}
               {activeSection === "terminal" && <TerminalSection />}
               {activeSection === "mobile" && <MobileSection />}
+              {activeSection === "docs_scope" && <DocsScopeSection />}
               {activeSection === "help" && <HelpSection />}
             </div>
           </div>

--- a/src/components/tunaflow/settings/DocsScopeSection.tsx
+++ b/src/components/tunaflow/settings/DocsScopeSection.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { cn } from "@/lib/utils";
+import { getSetting, setSetting } from "@/lib/appStore";
+
+/** Settings 키 상수 — DocsSection 과 공유. */
+export const DOCS_PANEL_SCOPE_KEY = "docsPanel.scope";
+export type DocsPanelScope = "all" | "tunaflow";
+export const DOCS_PANEL_SCOPE_DEFAULT: DocsPanelScope = "all";
+
+/** 외부 사용자(특히 모노레포) 의 docs 가시성 향상을 위해 default = 'all'.
+ *  기존 사용자는 settings.json 에 키가 없으면 자동으로 'all' fallback. */
+export function DocsScopeSection() {
+  const { t } = useTranslation("settings");
+  const [scope, setScope] = useState<DocsPanelScope>(DOCS_PANEL_SCOPE_DEFAULT);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    let alive = true;
+    getSetting<DocsPanelScope>(DOCS_PANEL_SCOPE_KEY, DOCS_PANEL_SCOPE_DEFAULT).then((v) => {
+      if (alive) {
+        // 잘못된 값(이전 실험으로 'custom' 등) 들어와도 default 로 폴백.
+        const safe: DocsPanelScope = v === "tunaflow" ? "tunaflow" : "all";
+        setScope(safe);
+        setLoaded(true);
+      }
+    });
+    return () => { alive = false; };
+  }, []);
+
+  const choose = async (next: DocsPanelScope) => {
+    if (next === scope) return;
+    setScope(next);
+    await setSetting(DOCS_PANEL_SCOPE_KEY, next);
+    // DocsSection 이 invoke 시점에 새 scope 를 다시 읽도록 이벤트 한번 흘림.
+    window.dispatchEvent(new CustomEvent("tf:docs-scope-changed", { detail: { scope: next } }));
+  };
+
+  if (!loaded) return null;
+
+  const OPTIONS = [
+    { id: "all" as const, labelKey: "docs_scope.option.all_label" as const, descKey: "docs_scope.option.all_desc" as const },
+    { id: "tunaflow" as const, labelKey: "docs_scope.option.tunaflow_label" as const, descKey: "docs_scope.option.tunaflow_desc" as const },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-[14px] font-[550] text-foreground mb-1">{t("docs_scope.heading")}</h2>
+        <p className="text-[12px] text-muted-foreground mb-4">{t("docs_scope.description")}</p>
+      </div>
+
+      <div className="rounded-lg border border-border/30 bg-background/50 p-4 space-y-2">
+        {OPTIONS.map((opt) => {
+          const active = scope === opt.id;
+          return (
+            <button
+              key={opt.id}
+              type="button"
+              onClick={() => choose(opt.id)}
+              className={cn(
+                "w-full text-left rounded-md border p-3 transition-colors",
+                active
+                  ? "border-primary/40 bg-primary/5"
+                  : "border-border/20 hover:border-border/40 hover:bg-accent/20",
+              )}
+            >
+              <div className="flex items-center gap-2">
+                <span
+                  className={cn(
+                    "w-3.5 h-3.5 rounded-full border flex items-center justify-center shrink-0",
+                    active ? "border-primary" : "border-border/50",
+                  )}
+                  aria-hidden
+                >
+                  {active && <span className="w-1.5 h-1.5 rounded-full bg-primary" />}
+                </span>
+                <span className="text-[13px] font-medium text-foreground">{t(opt.labelKey)}</span>
+              </div>
+              <p className="text-[11px] text-muted-foreground/70 mt-1 pl-5.5" style={{ paddingLeft: "22px" }}>
+                {t(opt.descKey)}
+              </p>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/tunaflow/sidebar/DocsSection.tsx
+++ b/src/components/tunaflow/sidebar/DocsSection.tsx
@@ -1,6 +1,7 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { invoke } from "@tauri-apps/api/core";
+import { toast } from "sonner";
 import { FileText, ChevronRight, ChevronDown, Folder, FolderOpen, Copy } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useFileViewer } from "../chat/fileViewerContext";
@@ -25,6 +26,10 @@ interface DocsScanResult {
   fileCount: number;
   truncated: boolean;
 }
+
+/** Plan E (2026-04-29) — file count >200 시 1회 toast.
+ *  Threshold 는 plan SSOT 고정. lazy load 는 Phase 2. */
+const DOCS_PANEL_WARNING_THRESHOLD = 200;
 
 const EMPTY_RESULT: DocsScanResult = { entries: [], fileCount: 0, truncated: false };
 
@@ -60,11 +65,14 @@ interface DocsSectionProps {
 
 export function DocsSection({ projectPath }: DocsSectionProps) {
   const { t } = useTranslation("sidebar");
+  const { t: tSettings } = useTranslation("settings");
   const [docs, setDocs] = useState<DocEntry[]>([]);
   const [scope, setScope] = useState<DocsPanelScope>(DOCS_PANEL_SCOPE_DEFAULT);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [ctxMenu, setCtxMenu] = useState<ContextMenuState | null>(null);
   const fileViewer = useFileViewer();
+  /** Toast 1회만 — 같은 (project,scope) 조합에서 재표시 X. */
+  const warnedRef = useRef<Set<string>>(new Set());
 
   // 1) 초기 scope 로드 + scope 변경 이벤트 구독.
   useEffect(() => {
@@ -97,9 +105,22 @@ export function DocsSection({ projectPath }: DocsSectionProps) {
     scanDocs(projectPath, scope).then((result) => {
       if (!alive) return;
       setDocs(result.entries);
+      // Task 03 — perf toast (Plan E 명시 threshold = 200, 1회).
+      const warnKey = `${projectPath}::${scope}`;
+      if (
+        scope === "all" &&
+        result.fileCount > DOCS_PANEL_WARNING_THRESHOLD &&
+        !warnedRef.current.has(warnKey)
+      ) {
+        warnedRef.current.add(warnKey);
+        toast.warning(
+          tSettings("docs_scope.performance_warning", { count: result.fileCount }),
+          { duration: 6000 },
+        );
+      }
     });
     return () => { alive = false; };
-  }, [projectPath, scope]);
+  }, [projectPath, scope, tSettings]);
 
   const toggle = useCallback((path: string) => {
     setExpanded((prev) => {

--- a/src/components/tunaflow/sidebar/DocsSection.tsx
+++ b/src/components/tunaflow/sidebar/DocsSection.tsx
@@ -6,6 +6,12 @@ import { cn } from "@/lib/utils";
 import { useFileViewer } from "../chat/fileViewerContext";
 import { SidebarContextMenu, type ContextMenuState } from "./SidebarContextMenu";
 import { copyToClipboard } from "@/lib/clipboard";
+import { getSetting } from "@/lib/appStore";
+import {
+  DOCS_PANEL_SCOPE_KEY,
+  DOCS_PANEL_SCOPE_DEFAULT,
+  type DocsPanelScope,
+} from "../settings/DocsScopeSection";
 
 interface DocEntry {
   name: string;
@@ -14,52 +20,26 @@ interface DocEntry {
   children?: DocEntry[];
 }
 
-/** Scan project for .md files, return a tree structure */
-async function scanDocs(projectPath: string): Promise<DocEntry[]> {
-  try {
-    const entries = await invoke<{ name: string; isDir: boolean; path: string }[]>(
-      "list_directory", { path: projectPath }
-    );
-
-    const tree: DocEntry[] = [];
-    for (const entry of entries) {
-      if (entry.isDir) {
-        if (["docs", ".github"].includes(entry.name)) {
-          const children = await scanDocsDir(entry.path, 0);
-          if (children.length > 0) {
-            tree.push({ name: entry.name, path: entry.path, isDir: true, children });
-          }
-        }
-      } else if (entry.name.endsWith(".md")) {
-        tree.push({ name: entry.name, path: entry.path, isDir: false });
-      }
-    }
-    return tree;
-  } catch {
-    return [];
-  }
+interface DocsScanResult {
+  entries: DocEntry[];
+  fileCount: number;
+  truncated: boolean;
 }
 
-async function scanDocsDir(dirPath: string, depth: number): Promise<DocEntry[]> {
-  if (depth > 3) return [];
+const EMPTY_RESULT: DocsScanResult = { entries: [], fileCount: 0, truncated: false };
+
+async function scanDocs(projectPath: string, scope: DocsPanelScope): Promise<DocsScanResult> {
   try {
-    const entries = await invoke<{ name: string; isDir: boolean; path: string }[]>(
-      "list_directory", { path: dirPath }
-    );
-    const result: DocEntry[] = [];
-    for (const entry of entries) {
-      if (entry.isDir) {
-        const children = await scanDocsDir(entry.path, depth + 1);
-        if (children.length > 0) {
-          result.push({ name: entry.name, path: entry.path, isDir: true, children });
-        }
-      } else if (entry.name.endsWith(".md")) {
-        result.push({ name: entry.name, path: entry.path, isDir: false });
-      }
-    }
+    const result = await invoke<DocsScanResult>("list_project_docs", {
+      projectPath,
+      scope,
+    });
+    // Defensive: tests / stub envs may resolve to undefined.
+    if (!result || !Array.isArray(result.entries)) return EMPTY_RESULT;
     return result;
-  } catch {
-    return [];
+  } catch (e) {
+    console.warn("[docs] list_project_docs failed:", e);
+    return EMPTY_RESULT;
   }
 }
 
@@ -81,14 +61,45 @@ interface DocsSectionProps {
 export function DocsSection({ projectPath }: DocsSectionProps) {
   const { t } = useTranslation("sidebar");
   const [docs, setDocs] = useState<DocEntry[]>([]);
+  const [scope, setScope] = useState<DocsPanelScope>(DOCS_PANEL_SCOPE_DEFAULT);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [ctxMenu, setCtxMenu] = useState<ContextMenuState | null>(null);
   const fileViewer = useFileViewer();
 
+  // 1) 초기 scope 로드 + scope 변경 이벤트 구독.
   useEffect(() => {
-    if (!projectPath) { setDocs([]); return; }
-    scanDocs(projectPath).then(setDocs);
-  }, [projectPath]);
+    let alive = true;
+    getSetting<DocsPanelScope>(DOCS_PANEL_SCOPE_KEY, DOCS_PANEL_SCOPE_DEFAULT).then((v) => {
+      if (alive) {
+        setScope(v === "tunaflow" ? "tunaflow" : "all");
+      }
+    });
+    const onScopeChange = (e: Event) => {
+      const detail = (e as CustomEvent<{ scope: DocsPanelScope }>).detail;
+      if (detail?.scope) {
+        setScope(detail.scope === "tunaflow" ? "tunaflow" : "all");
+      }
+    };
+    window.addEventListener("tf:docs-scope-changed", onScopeChange);
+    return () => {
+      alive = false;
+      window.removeEventListener("tf:docs-scope-changed", onScopeChange);
+    };
+  }, []);
+
+  // 2) projectPath / scope 변경 시 다시 스캔.
+  useEffect(() => {
+    if (!projectPath) {
+      setDocs([]);
+      return;
+    }
+    let alive = true;
+    scanDocs(projectPath, scope).then((result) => {
+      if (!alive) return;
+      setDocs(result.entries);
+    });
+    return () => { alive = false; };
+  }, [projectPath, scope]);
 
   const toggle = useCallback((path: string) => {
     setExpanded((prev) => {
@@ -158,6 +169,9 @@ export function DocsSection({ projectPath }: DocsSectionProps) {
 
   return (
     <div className="py-1">
+      <div className="px-3 pb-1 text-[10px] text-sidebar-foreground/30 select-none">
+        {t(scope === "all" ? "docs_scope.all" : "docs_scope.tunaflow")}
+      </div>
       {docs.length === 0 ? (
         <p className="px-3 text-[10px] text-sidebar-foreground/25 italic">{t("empty.no_docs")}</p>
       ) : (

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -10,6 +10,7 @@
     "runtime": "Runtime",
     "terminal": "Terminal",
     "mobile": "Mobile",
+    "docs_scope": "Docs Panel",
     "help": "Help"
   },
   "skills_description": "Manage the skills applied to agents.",
@@ -281,6 +282,21 @@
         "no_path": "Project path not found."
       }
     }
+  },
+  "docs_scope": {
+    "heading": "Docs Panel Scope",
+    "description": "Choose which .md files appear in the left sidebar docs panel.",
+    "option": {
+      "all_label": "All docs",
+      "all_desc": "Every .md file under the project root (.gitignore respected, max depth 5). Recommended for monorepos / workspaces.",
+      "tunaflow_label": "tunaFlow only",
+      "tunaflow_desc": "Only docs/ and root-level .md files (legacy behavior)."
+    },
+    "scope_label": {
+      "all": "All docs",
+      "tunaflow": "tunaFlow only"
+    },
+    "performance_warning": "Found {{count}} docs. If the panel feels heavy, switch to 'tunaFlow only' in Settings."
   },
   "conventions": {
     "heading": "Conventions Context Sync",

--- a/src/locales/en/sidebar.json
+++ b/src/locales/en/sidebar.json
@@ -42,6 +42,10 @@
     "no_scratchpads": "No scratchpads yet",
     "no_docs": "No docs found"
   },
+  "docs_scope": {
+    "all": "All docs",
+    "tunaflow": "tunaFlow only"
+  },
   "error": {
     "path_required": "Enter a path",
     "invalid_path": "Invalid path"

--- a/src/locales/ko/settings.json
+++ b/src/locales/ko/settings.json
@@ -10,6 +10,7 @@
     "runtime": "Runtime",
     "terminal": "Terminal",
     "mobile": "Mobile",
+    "docs_scope": "Docs Panel",
     "help": "Help"
   },
   "skills_description": "에이전트에게 적용할 스킬을 관리합니다.",
@@ -281,6 +282,21 @@
         "no_path": "프로젝트 경로를 찾을 수 없습니다."
       }
     }
+  },
+  "docs_scope": {
+    "heading": "문서 패널 범위",
+    "description": "좌측 사이드바 문서 패널이 표시할 .md 파일 범위를 설정합니다.",
+    "option": {
+      "all_label": "전체 문서",
+      "all_desc": "프로젝트 루트 아래 모든 .md 파일 (.gitignore 존중, 최대 5단계 깊이). 모노레포/워크스페이스 권장.",
+      "tunaflow_label": "tunaFlow 산출물",
+      "tunaflow_desc": "docs/ 폴더와 루트의 .md 파일만 표시 (기존 동작)."
+    },
+    "scope_label": {
+      "all": "전체 문서",
+      "tunaflow": "tunaFlow 산출물"
+    },
+    "performance_warning": "전체 문서 {{count}}개. 패널이 무거우면 Settings에서 'tunaFlow 산출물'로 전환할 수 있습니다."
   },
   "conventions": {
     "heading": "Conventions Context Sync",

--- a/src/locales/ko/sidebar.json
+++ b/src/locales/ko/sidebar.json
@@ -42,6 +42,10 @@
     "no_scratchpads": "스크래치패드 없음",
     "no_docs": "문서 없음"
   },
+  "docs_scope": {
+    "all": "전체 문서",
+    "tunaflow": "tunaFlow 산출물"
+  },
   "error": {
     "path_required": "경로를 입력하세요",
     "invalid_path": "유효하지 않은 경로"


### PR DESCRIPTION
## Summary

Plan E (`docsPanelScopePolicyPlan_2026-04-29.md`) — P3-Lite 채택분 그대로 구현.

좌측 사이드바 문서 패널이 `<project_root>/docs/` 와 루트 `*.md` 만 보여주던 한계를 해소. batmania52 의 모노레포/워크스페이스 보고에 대응.

- **Settings 토글**: `docsPanel.scope` = `'all'` (default) / `'tunaflow'` (legacy 동작). \`'custom'\` 은 Phase 2 격하라 본 PR 비대상.
- **scope='all'**: \`ignore::WalkBuilder\` 로 \`.gitignore\` 자동 처리 (git repo 가 아니어도 \`add_custom_ignore_filename\` 으로 적용), \`hidden(true)\` 로 \`.git/.cache\` skip, depth ≤ 5, hard ceiling 5_000.
- **scope='tunaflow'**: 기존 TS 측 \`scanDocs\` 와 1:1 동일 (docs/ + .github/ + 루트 .md, hidden filter 포함). 회귀 0 시각 가드.
- **성능 토스트**: \`'all'\` scope file count > 200 시 sonner warning 1회, 동일 (project, scope) 에서 재표시 X.

## Commits (3)

- \`feat(settings): docs panel scope toggle (Task 01)\` — Settings UI + state 영구화
- \`feat(docs): scope-aware traversal — all|tunaflow (Task 02)\` — Rust \`list_project_docs\` + DocsSection 분기
- \`feat(docs): performance toast for >200 files (Task 03)\` — sonner warning

## Verification

- \`npx tsc --noEmit\` PASS
- \`npx vitest run\` 381 passed (35 files), errors 0
- \`cd src-tauri && cargo check\` PASS (warning 1 — 기존 \`InvokeClaude\` dead-code, 무관)
- \`cd src-tauri && cargo test --lib\` 565 passed (baseline 559 + 6 신규 \`commands::files::tests\`)
- \`cd src-tauri && cargo test --lib commands::files\` 7 passed (Task 02 회귀 가드)
- \`npx vite build\` PASS

## Regression guards

- \`scope='tunaflow'\` path 는 hidden 필터까지 포함해 기존 TS 동작과 동일 (\`tunaflow_scope_includes_dot_github_and_skips_hidden_md\` test).
- 기존 \`list_directory\` 코드 변경 0 (다른 호출처 영향 없음).
- 다른 sidebar 패널 / Settings 섹션 변경 0.
- 기존 사용자 (settings.json 에 \`docsPanel.scope\` 키 없음) 자동 \`'all'\` fallback.

## Phase 2 (out-of-scope, deferred)

Plan SSOT §"Phase 2" 그대로:
- \`'custom'\` 폴더 화이트리스트
- lazy load (50개씩 + 더 보기)
- 비-md 확장자 (\`.rst\`, \`.txt\`)
- 폴더 즐겨찾기 / pin
- realtime watcher (FS 이벤트)

## Test plan

- [ ] tunaFlow 자체 (모노레포 X) 에서 \`'all'\` 토글 → docs/ + 루트 + scripts/ 의 \`.md\` 가시
- [ ] 모노레포 (예: tunaInsight) 에서 \`'all'\` → \`packages/*/docs/\` 가시. \`node_modules/\` 안 .md 미가시 (.gitignore 효과)
- [ ] \`'tunaflow'\` 토글 → 현재 동작과 동일 (회귀 0)
- [ ] 큰 모노레포 (200+ .md) 진입 → 성능 토스트 1회

🤖 Generated with [Claude Code](https://claude.com/claude-code)