### PR TITLE
feat(macos): native UNUserNotificationCenter bridge (Plan D)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3563,6 +3563,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-web-kit"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6667,6 +6679,7 @@ dependencies = [
  "alacritty_terminal",
  "axum",
  "base64 0.22.1",
+ "block2",
  "chrono",
  "dirs 5.0.1",
  "futures-util",
@@ -6675,6 +6688,9 @@ dependencies = [
  "lazy_static",
  "lindera",
  "ndarray",
+ "objc2",
+ "objc2-foundation",
+ "objc2-user-notifications",
  "ort",
  "parking_lot",
  "portable-pty",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -79,3 +79,13 @@ codegen-units = 1
 lto = true
 opt-level = "s"
 strip = true
+
+[target.'cfg(target_os = "macos")'.dependencies]
+# Direct ObjC bridge to UNUserNotificationCenter (replaces tauri-plugin-notification's
+# osascript-based macOS path that surfaces Script Editor on click — see
+# docs/plans/nativeNotificationPlan_2026-04-29.md). macOS-only target gate keeps
+# Windows/Linux paths unchanged (existing tauri-plugin-notification used there).
+objc2 = "0.6"
+objc2-foundation = { version = "0.3", features = ["NSString", "NSError", "NSDate"] }
+objc2-user-notifications = { version = "0.3.2", default-features = false, features = ["std", "alloc", "bitflags", "block2", "UNUserNotificationCenter", "UNNotificationContent", "UNNotificationRequest", "UNNotificationSound", "UNNotificationSettings", "UNNotificationTrigger", "UNError"] }
+block2 = "0.6"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,17 @@ mod guardrail;
 mod http_api;
 pub mod no_console;
 
+// Native macOS notification bridge (Path B, Plan
+// `docs/plans/nativeNotificationPlan_2026-04-29.md`). Replaces the
+// `tauri-plugin-notification` osascript fallback that surfaces Script Editor
+// on click. Non-macOS OS keeps the existing plugin-notification path —
+// `notification_stub` is only used so command registration compiles cleanly.
+#[cfg(target_os = "macos")]
+mod notification;
+#[cfg(not(target_os = "macos"))]
+#[path = "notification_stub.rs"]
+mod notification;
+
 /// Thread-aware cooperative **stream abort** registry.
 ///
 /// 의미 (옵션 X, `docs/plans/branchCancelSemanticsPlan_2026-04-25.md`):
@@ -402,6 +413,12 @@ pub fn run() {
             commands::document_index::get_document_index_status,
             // Mobile pairing
             commands::mobile::get_api_connection_info,
+            // Native notification bridge (macOS UNUserNotificationCenter — Plan D)
+            // Non-macOS builds register stubs that return Err; frontend
+            // (`notificationStore.ts`) routes only macOS to these commands.
+            notification::notification_send_native,
+            notification::notification_request_permission,
+            notification::notification_get_status,
         ])
         .on_window_event(|window, event| {
             if let tauri::WindowEvent::CloseRequested { .. } = event {

--- a/src-tauri/src/notification.rs
+++ b/src-tauri/src/notification.rs
@@ -1,0 +1,246 @@
+//! Native macOS notification bridge — direct UNUserNotificationCenter path.
+//!
+//! `tauri-plugin-notification` v2.3.3 의 macOS path 는 내부적으로 `notify_rust` 의
+//! osascript fallback 을 호출해, 알림 클릭 시 macOS 가 Script Editor (또는
+//! osascript) 를 frontmost 로 띄운다 (외부 사용자 batmania52 보고 #6, 2026-04-29).
+//! Codesigned/Notarized release 이전까지는 plugin 내부 분기 (`is_dev()`) 만으로는
+//! 회귀가 풀리지 않아 정공법 직접 ObjC bridge 로 전환한다.
+//!
+//! - macOS: `objc2-user-notifications` 로 `UNUserNotificationCenter` 직접 호출.
+//! - Windows / Linux: 이 모듈은 컴파일되지 않으며, frontend 가 기존
+//!   `tauri-plugin-notification` path 를 그대로 사용한다.
+//!
+//! SSOT: `docs/plans/nativeNotificationPlan_2026-04-29.md` (Path B, 권한 UX 옵션 D).
+
+#![cfg(target_os = "macos")]
+
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, Mutex,
+};
+use std::time::Duration;
+
+use block2::RcBlock;
+use objc2::rc::Retained;
+use objc2::runtime::Bool;
+use objc2_foundation::{NSError, NSString};
+use objc2_user_notifications::{
+    UNAuthorizationOptions, UNAuthorizationStatus, UNMutableNotificationContent,
+    UNNotificationRequest, UNNotificationSettings, UNUserNotificationCenter,
+};
+use serde::Serialize;
+
+/// Tauri command 응답에 그대로 직렬화되는 권한 상태.
+///
+/// macOS 의 `UNAuthorizationStatus` 는 5종 (notDetermined / denied / authorized /
+/// provisional / ephemeral) 이지만, frontend UX (옵션 D) 는 3-state 로 충분하다.
+/// `provisional` 과 `ephemeral` 는 사실상 알림이 동작하므로 `authorized` 로 묶는다.
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum NotificationAuthStatus {
+    NotDetermined,
+    Denied,
+    Authorized,
+}
+
+impl From<UNAuthorizationStatus> for NotificationAuthStatus {
+    fn from(s: UNAuthorizationStatus) -> Self {
+        match s {
+            UNAuthorizationStatus::NotDetermined => Self::NotDetermined,
+            UNAuthorizationStatus::Denied => Self::Denied,
+            // Authorized / Provisional / Ephemeral 모두 알림 발송 가능.
+            _ => Self::Authorized,
+        }
+    }
+}
+
+/// completion handler 가 비동기로 호출되므로, 각 호출마다 짧은 대기 (≤ 5s) 로
+/// 결과를 polling 한다. UI hot path 가 아니라 권한 요청 (사용자 dialog) /
+/// 알림 발송 ack 수신 — 둘 다 사용자가 수 초 내 응답할 영역.
+const COMPLETION_TIMEOUT: Duration = Duration::from_secs(5);
+const COMPLETION_POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+/// 현재 알림 권한 상태를 조회한다 (`getNotificationSettingsWithCompletionHandler:`).
+pub fn notification_authorization_status() -> Result<NotificationAuthStatus, String> {
+    let result: Arc<Mutex<Option<NotificationAuthStatus>>> = Arc::new(Mutex::new(None));
+    let done = Arc::new(AtomicBool::new(false));
+
+    let result_for_block = Arc::clone(&result);
+    let done_for_block = Arc::clone(&done);
+
+    // SAFETY: completion handler 는 background queue 에서 호출되며 `settings`
+    // 는 valid pointer 임이 Apple API 계약상 보장된다.
+    let block = RcBlock::new(move |settings: std::ptr::NonNull<UNNotificationSettings>| {
+        let status = unsafe { settings.as_ref() }.authorizationStatus();
+        if let Ok(mut guard) = result_for_block.lock() {
+            *guard = Some(NotificationAuthStatus::from(status));
+        }
+        done_for_block.store(true, Ordering::SeqCst);
+    });
+
+    let center = UNUserNotificationCenter::currentNotificationCenter();
+    center.getNotificationSettingsWithCompletionHandler(&block);
+
+    wait_for_done(&done)?;
+
+    let guard = result
+        .lock()
+        .map_err(|e| format!("notification auth status mutex poisoned: {e}"))?;
+    guard
+        .ok_or_else(|| "notification auth status: handler did not set value".into())
+}
+
+/// 알림 권한을 요청한다. `notDetermined` 일 때 macOS native dialog 가 표시되고,
+/// 사용자가 응답하면 granted bool 이 돌아온다. 이미 결정된 (denied/authorized) 경우
+/// dialog 없이 즉시 현재 상태에 맞는 bool 만 돌아온다.
+pub fn request_notification_authorization() -> Result<bool, String> {
+    let result: Arc<Mutex<Option<bool>>> = Arc::new(Mutex::new(None));
+    let done = Arc::new(AtomicBool::new(false));
+
+    let result_for_block = Arc::clone(&result);
+    let done_for_block = Arc::clone(&done);
+
+    let block = RcBlock::new(move |granted: Bool, _err: *mut NSError| {
+        if let Ok(mut guard) = result_for_block.lock() {
+            *guard = Some(granted.as_bool());
+        }
+        done_for_block.store(true, Ordering::SeqCst);
+    });
+
+    let options = UNAuthorizationOptions::Alert | UNAuthorizationOptions::Sound;
+    let center = UNUserNotificationCenter::currentNotificationCenter();
+    center.requestAuthorizationWithOptions_completionHandler(options, &block);
+
+    wait_for_done(&done)?;
+
+    let guard = result
+        .lock()
+        .map_err(|e| format!("notification auth request mutex poisoned: {e}"))?;
+    guard
+        .ok_or_else(|| "notification auth request: handler did not set value".into())
+}
+
+/// 알림 1건을 즉시 (no trigger) 발송한다.
+///
+/// `add(request:withCompletionHandler:)` 의 completion handler 는 OS 가 alert
+/// 을 schedule 한 직후 호출되며, 사용자 클릭과는 무관하다. handler 의 `NSError`
+/// 가 nil 이면 schedule 성공으로 간주한다.
+pub fn send_native_notification(title: &str, body: &str) -> Result<(), String> {
+    let title_ns = NSString::from_str(title);
+    let body_ns = NSString::from_str(body);
+    let identifier_ns = NSString::from_str(&format!("tunaflow.{}", uuid::Uuid::new_v4()));
+
+    let content: Retained<UNMutableNotificationContent> = UNMutableNotificationContent::new();
+    content.setTitle(&title_ns);
+    content.setBody(&body_ns);
+    // sound 는 default — `UNNotificationSound::default()` retain 비용 회피하고 nil
+    // 로 두면 기본 알림음 사용 (macOS 표준).
+
+    // trigger = nil → 즉시 발송.
+    let request = UNNotificationRequest::requestWithIdentifier_content_trigger(
+        &identifier_ns,
+        &content,
+        None,
+    );
+
+    let err_holder: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let done = Arc::new(AtomicBool::new(false));
+
+    let err_for_block = Arc::clone(&err_holder);
+    let done_for_block = Arc::clone(&done);
+
+    let block = RcBlock::new(move |err: *mut NSError| {
+        if !err.is_null() {
+            // SAFETY: Apple API 가 non-null err 를 valid NSError pointer 로
+            // 호출하는 계약을 따른다. block 의 lifetime 동안 retain 됨.
+            let err_ref = unsafe { &*err };
+            let desc = err_ref.localizedDescription();
+            if let Ok(mut g) = err_for_block.lock() {
+                *g = Some(desc.to_string());
+            }
+        }
+        done_for_block.store(true, Ordering::SeqCst);
+    });
+
+    let center = UNUserNotificationCenter::currentNotificationCenter();
+    center.addNotificationRequest_withCompletionHandler(&request, Some(&block));
+
+    wait_for_done(&done)?;
+
+    let guard = err_holder
+        .lock()
+        .map_err(|e| format!("notification send mutex poisoned: {e}"))?;
+    if let Some(msg) = guard.as_ref() {
+        return Err(format!("UNUserNotificationCenter add failed: {msg}"));
+    }
+    Ok(())
+}
+
+/// completion handler 가 끝날 때까지 짧게 polling 한다. timeout 이면 Err.
+fn wait_for_done(done: &Arc<AtomicBool>) -> Result<(), String> {
+    let start = std::time::Instant::now();
+    while !done.load(Ordering::SeqCst) {
+        if start.elapsed() > COMPLETION_TIMEOUT {
+            return Err(format!(
+                "notification operation timed out after {:?}",
+                COMPLETION_TIMEOUT
+            ));
+        }
+        std::thread::sleep(COMPLETION_POLL_INTERVAL);
+    }
+    Ok(())
+}
+
+// ─── Tauri commands ──────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub async fn notification_send_native(title: String, body: String) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || send_native_notification(&title, &body))
+        .await
+        .map_err(|e| format!("notification_send_native join error: {e}"))?
+}
+
+#[tauri::command]
+pub async fn notification_request_permission() -> Result<bool, String> {
+    tauri::async_runtime::spawn_blocking(request_notification_authorization)
+        .await
+        .map_err(|e| format!("notification_request_permission join error: {e}"))?
+}
+
+#[tauri::command]
+pub async fn notification_get_status() -> Result<NotificationAuthStatus, String> {
+    tauri::async_runtime::spawn_blocking(notification_authorization_status)
+        .await
+        .map_err(|e| format!("notification_get_status join error: {e}"))?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn auth_status_provisional_collapses_to_authorized() {
+        // 옵션 D — frontend UX 는 3-state 로 충분하므로 provisional/ephemeral 도
+        // authorized 로 묶는다.
+        assert_eq!(
+            NotificationAuthStatus::from(UNAuthorizationStatus::Provisional),
+            NotificationAuthStatus::Authorized
+        );
+        assert_eq!(
+            NotificationAuthStatus::from(UNAuthorizationStatus::Authorized),
+            NotificationAuthStatus::Authorized
+        );
+    }
+
+    #[test]
+    fn auth_status_denied_and_not_determined_preserved() {
+        assert_eq!(
+            NotificationAuthStatus::from(UNAuthorizationStatus::Denied),
+            NotificationAuthStatus::Denied
+        );
+        assert_eq!(
+            NotificationAuthStatus::from(UNAuthorizationStatus::NotDetermined),
+            NotificationAuthStatus::NotDetermined
+        );
+    }
+}

--- a/src-tauri/src/notification_stub.rs
+++ b/src-tauri/src/notification_stub.rs
@@ -1,0 +1,40 @@
+//! Non-macOS stub for native notification commands.
+//!
+//! macOS 외 OS 에서는 frontend 의 platform 분기 (notificationStore.ts) 가
+//! 기존 `tauri-plugin-notification` path 를 사용하므로 이 stub 은 호출되지
+//! 않는다. 그러나 Tauri command registration 은 OS 와 무관하게 컴파일 단계에서
+//! resolve 되므로, lib.rs 가 unconditionally `notification::*` 를 참조하도록
+//! 같은 이름의 stub 을 제공한다.
+//!
+//! stub 호출 = macOS 가 아닌데 frontend 가 잘못 invoke 한 경우 → Err 반환으로
+//! 표면화. silent ok 금지 (코드베이스 error visibility 정책).
+
+#![cfg(not(target_os = "macos"))]
+
+use serde::Serialize;
+
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum NotificationAuthStatus {
+    NotDetermined,
+    Denied,
+    Authorized,
+}
+
+const NOT_MACOS_MSG: &str =
+    "native notification commands are macOS-only; use tauri-plugin-notification on this OS";
+
+#[tauri::command]
+pub async fn notification_send_native(_title: String, _body: String) -> Result<(), String> {
+    Err(NOT_MACOS_MSG.into())
+}
+
+#[tauri::command]
+pub async fn notification_request_permission() -> Result<bool, String> {
+    Err(NOT_MACOS_MSG.into())
+}
+
+#[tauri::command]
+pub async fn notification_get_status() -> Result<NotificationAuthStatus, String> {
+    Err(NOT_MACOS_MSG.into())
+}

--- a/src/components/tunaflow/SettingsPanel.tsx
+++ b/src/components/tunaflow/SettingsPanel.tsx
@@ -1,20 +1,21 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
-import { X, Bot, UserCircle, Zap, Cpu, Terminal, Smartphone, User, HelpCircle, Globe, Brain, FileText } from "lucide-react";
+import { X, Bot, UserCircle, Zap, Cpu, Terminal, Smartphone, User, HelpCircle, Globe, Brain, FileText, Bell } from "lucide-react";
 import { SkillsPanel } from "./context-panel/SkillsPanel";
 import { AgentsSection } from "./settings/AgentsSection";
 import { PersonasSection } from "./settings/PersonasSection";
 import { RuntimeSection } from "./settings/RuntimeSection";
 import { TerminalSection } from "./settings/TerminalSection";
 import { MobileSection } from "./settings/MobileSection";
+import { NotificationsSection } from "./settings/NotificationsSection";
 import { ProfileSection } from "./settings/ProfileSection";
 import { HelpSection } from "./settings/HelpSection";
 import { WorldviewSettings } from "./settings/WorldviewSettings";
 import { IdentityAnalysisSettings } from "./settings/IdentityAnalysisSettings";
 import { DocsScopeSection } from "./settings/DocsScopeSection";
 
-type SettingsSection = "profile" | "worldview" | "identity" | "agents" | "personas" | "skills" | "runtime" | "terminal" | "mobile" | "docs_scope" | "help";
+type SettingsSection = "profile" | "worldview" | "identity" | "agents" | "personas" | "skills" | "runtime" | "terminal" | "mobile" | "docs_scope" | "notifications" | "help";
 
 /** Section labels come from `settings.section.*` i18n keys. The order is visual
  *  layout, not config — 새 섹션 추가 시 JSON 키 + 이 배열 양쪽에 등록. */
@@ -29,6 +30,7 @@ const SECTION_CONFIG: { id: SettingsSection; icon: React.ReactNode }[] = [
   { id: "terminal", icon: <Terminal className="w-4 h-4" /> },
   { id: "mobile", icon: <Smartphone className="w-4 h-4" /> },
   { id: "docs_scope", icon: <FileText className="w-4 h-4" /> },
+  { id: "notifications", icon: <Bell className="w-4 h-4" /> },
   { id: "help", icon: <HelpCircle className="w-4 h-4" /> },
 ];
 
@@ -38,7 +40,7 @@ interface SettingsPanelProps {
 }
 
 export function SettingsPanel({ onClose, initialSection }: SettingsPanelProps) {
-  const valid: SettingsSection[] = ["profile", "worldview", "identity", "agents", "personas", "skills", "runtime", "terminal", "mobile", "docs_scope", "help"];
+  const valid: SettingsSection[] = ["profile", "worldview", "identity", "agents", "personas", "skills", "runtime", "terminal", "mobile", "docs_scope", "notifications", "help"];
   const initial = (initialSection && valid.includes(initialSection as SettingsSection))
     ? (initialSection as SettingsSection)
     : "profile";
@@ -94,6 +96,7 @@ export function SettingsPanel({ onClose, initialSection }: SettingsPanelProps) {
               {activeSection === "terminal" && <TerminalSection />}
               {activeSection === "mobile" && <MobileSection />}
               {activeSection === "docs_scope" && <DocsScopeSection />}
+              {activeSection === "notifications" && <NotificationsSection />}
               {activeSection === "help" && <HelpSection />}
             </div>
           </div>

--- a/src/components/tunaflow/settings/NotificationsSection.tsx
+++ b/src/components/tunaflow/settings/NotificationsSection.tsx
@@ -1,0 +1,148 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import { invoke } from "@tauri-apps/api/core";
+import { useNotificationStore } from "@/stores/notificationStore";
+import { isMacOS } from "@/lib/platform";
+
+/**
+ * Notifications settings — macOS native bridge 의 권한 상태 표시 + 수동 prompt.
+ *
+ * 옵션 D 권한 UX (`docs/plans/nativeNotificationPlan_2026-04-29.md`):
+ * - 첫 알림 시 자동 prompt (notify() 안에서) + Settings 토글 병행
+ * - denied 시 macOS 시스템 설정 deep link 안내
+ *
+ * macOS 외 OS 에서는 hint message 만 보이고 컨트롤은 비활성화 — 기존
+ * tauri-plugin-notification path 가 OS 권한을 자체 처리.
+ */
+export function NotificationsSection() {
+  const { t } = useTranslation("settings");
+  const permissionStatus = useNotificationStore((s) => s.permissionStatus);
+  const refreshPermissionStatus = useNotificationStore((s) => s.refreshPermissionStatus);
+  const requestPermissionFromUI = useNotificationStore((s) => s.requestPermissionFromUI);
+
+  const macOS = isMacOS();
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    if (!macOS) return;
+    void refreshPermissionStatus();
+  }, [macOS, refreshPermissionStatus]);
+
+  const onRequest = async () => {
+    setBusy(true);
+    try {
+      await requestPermissionFromUI();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onOpenSystemSettings = async () => {
+    try {
+      const { openUrl } = await import("@tauri-apps/plugin-opener");
+      await openUrl("x-apple.systempreferences:com.apple.preference.notifications");
+    } catch (e) {
+      console.error("[notify] failed to open system settings", e);
+    }
+  };
+
+  const onSendTest = async () => {
+    setBusy(true);
+    try {
+      if (macOS) {
+        await invoke("notification_send_native", {
+          title: "tunaFlow",
+          body: t("notifications.toast.test_sent"),
+        });
+      } else {
+        const { sendNotification, isPermissionGranted, requestPermission } = await import(
+          "@tauri-apps/plugin-notification"
+        );
+        let granted = await isPermissionGranted();
+        if (!granted) {
+          granted = (await requestPermission()) === "granted";
+        }
+        if (granted) {
+          sendNotification({ title: "tunaFlow", body: t("notifications.toast.test_sent") });
+        }
+      }
+      toast.success(t("notifications.toast.test_sent"));
+    } catch (e) {
+      toast.error(t("notifications.toast.test_failed", { error: String(e) }));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const statusLabel =
+    permissionStatus === "authorized"
+      ? t("notifications.status.authorized")
+      : permissionStatus === "denied"
+        ? t("notifications.status.denied")
+        : t("notifications.status.notDetermined");
+
+  const statusColor =
+    permissionStatus === "authorized"
+      ? "text-emerald-500"
+      : permissionStatus === "denied"
+        ? "text-red-500"
+        : "text-amber-500";
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+          {t("notifications.heading")}
+        </h3>
+        <p className="text-[12px] text-muted-foreground mt-1">{t("notifications.description")}</p>
+      </div>
+
+      {/* Status row */}
+      <div className="flex items-center justify-between rounded-md border border-border/40 px-3 py-2">
+        <span className="text-xs text-muted-foreground">{t("notifications.status.label")}</span>
+        <span className={`text-xs font-medium ${statusColor}`}>{statusLabel}</span>
+      </div>
+
+      {/* Actions */}
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          onClick={onRequest}
+          disabled={!macOS || busy || permissionStatus === "authorized"}
+          className="text-xs px-3 py-1.5 rounded-md border border-border/40 hover:bg-accent disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        >
+          {t("notifications.actions.request")}
+        </button>
+        <button
+          type="button"
+          onClick={onSendTest}
+          disabled={busy}
+          className="text-xs px-3 py-1.5 rounded-md border border-border/40 hover:bg-accent disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        >
+          {t("notifications.actions.test")}
+        </button>
+        {macOS && permissionStatus === "denied" && (
+          <button
+            type="button"
+            onClick={onOpenSystemSettings}
+            disabled={busy}
+            className="text-xs px-3 py-1.5 rounded-md border border-border/40 hover:bg-accent disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            {t("notifications.actions.open_system_settings")}
+          </button>
+        )}
+      </div>
+
+      {permissionStatus === "denied" && (
+        <p className="text-[11px] text-muted-foreground">{t("notifications.denied_help")}</p>
+      )}
+
+      {!macOS && (
+        <p className="text-[11px] text-muted-foreground/70">
+          {t("notifications.status.macos_only_hint")}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -1,0 +1,25 @@
+/**
+ * Lightweight platform detection cached at module load.
+ *
+ * Avoids pulling in `@tauri-apps/plugin-os` (extra plugin = bundle bloat) by
+ * sniffing `navigator.userAgent` once. The Tauri webview reliably surfaces a
+ * "Mac" / "Macintosh" token on macOS. Any false positive is harmless — the
+ * macOS-only Tauri command (`notification_send_native`) returns Err on other
+ * OS, so the worst case is a single extra invoke that surfaces in the console.
+ *
+ * Used by `notificationStore.ts` to route macOS to the native ObjC bridge
+ * (`docs/plans/nativeNotificationPlan_2026-04-29.md` Path B) while keeping
+ * Windows/Linux on `tauri-plugin-notification` (zero behavior change).
+ */
+
+function detect(): "macos" | "other" {
+  if (typeof navigator === "undefined") return "other";
+  const ua = navigator.userAgent || "";
+  return /Mac|Macintosh|MacIntel/i.test(ua) ? "macos" : "other";
+}
+
+const cached = detect();
+
+export function isMacOS(): boolean {
+  return cached === "macos";
+}

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -11,7 +11,30 @@
     "terminal": "Terminal",
     "mobile": "Mobile",
     "docs_scope": "Docs Panel",
+    "notifications": "Notifications",
     "help": "Help"
+  },
+  "notifications": {
+    "heading": "Notifications",
+    "description": "Manage desktop notification permissions and behavior.",
+    "status": {
+      "label": "Current permission",
+      "notDetermined": "Not yet decided",
+      "denied": "Denied",
+      "authorized": "Allowed",
+      "macos_only_hint": "These controls only apply on macOS (Windows / Linux use the OS default path)."
+    },
+    "actions": {
+      "request": "Request permission now",
+      "open_system_settings": "Open macOS System Settings",
+      "test": "Send a test notification"
+    },
+    "denied_help": "Permission was denied — enable it manually in System Settings → Notifications → tunaFlow.",
+    "toast": {
+      "denied": "Notification permission denied. You can enable it later in macOS System Settings.",
+      "test_sent": "Test notification sent.",
+      "test_failed": "Test notification failed: {{error}}"
+    }
   },
   "skills_description": "Manage the skills applied to agents.",
   "profile": {

--- a/src/locales/ko/settings.json
+++ b/src/locales/ko/settings.json
@@ -11,7 +11,30 @@
     "terminal": "Terminal",
     "mobile": "Mobile",
     "docs_scope": "Docs Panel",
+    "notifications": "알림",
     "help": "Help"
+  },
+  "notifications": {
+    "heading": "알림",
+    "description": "데스크톱 알림 권한과 동작을 관리합니다.",
+    "status": {
+      "label": "현재 권한",
+      "notDetermined": "미결정",
+      "denied": "거부됨",
+      "authorized": "허용됨",
+      "macos_only_hint": "이 설정은 macOS 에서만 동작합니다 (Windows / Linux 는 OS 기본 알림)."
+    },
+    "actions": {
+      "request": "지금 권한 요청",
+      "open_system_settings": "macOS 시스템 설정 열기",
+      "test": "테스트 알림 보내기"
+    },
+    "denied_help": "거부된 상태에서는 시스템 설정 → 알림 → tunaFlow 에서 직접 허용해 주세요.",
+    "toast": {
+      "denied": "알림 권한이 거부되었습니다. macOS 시스템 설정에서 활성화할 수 있습니다.",
+      "test_sent": "테스트 알림을 보냈습니다.",
+      "test_failed": "테스트 알림 발송 실패: {{error}}"
+    }
   },
   "skills_description": "에이전트에게 적용할 스킬을 관리합니다.",
   "profile": {

--- a/src/stores/notificationStore.ts
+++ b/src/stores/notificationStore.ts
@@ -1,5 +1,7 @@
 import { create } from "zustand";
+import { invoke } from "@tauri-apps/api/core";
 import { getSetting, setSetting } from "@/lib/appStore";
+import { isMacOS } from "@/lib/platform";
 
 export type NotificationType = "completed" | "error" | "info";
 
@@ -22,15 +24,29 @@ export interface NotifyMeta {
   preview?: string;
 }
 
+/** Mirrors `src-tauri/src/notification.rs::NotificationAuthStatus`. */
+export type NotificationAuthStatus = "notDetermined" | "denied" | "authorized";
+
 interface NotificationState {
   notifications: AppNotification[];
   unreadCount: number;
   soundEnabled: boolean;
+  /** macOS native bridge 의 권한 상태 캐시. macOS 외 OS 에서는 항상 'authorized'
+   *  로 두고 (기존 plugin path 가 OS 권한을 자체 처리). */
+  permissionStatus: NotificationAuthStatus;
+  /** denied 안내 토스트는 세션당 1회만 — 사용자가 매 알림마다 spam 받지 않도록. */
+  deniedToastShownThisSession: boolean;
   addNotification: (n: Omit<AppNotification, "id" | "timestamp" | "read">) => void;
   markAllRead: () => void;
   clearAll: () => void;
   toggleSound: () => void;
   loadSoundSetting: () => void;
+  setPermissionStatus: (s: NotificationAuthStatus) => void;
+  markDeniedToastShown: () => void;
+  /** macOS Settings 섹션의 "지금 권한 요청" 버튼이 호출. Returns final status. */
+  requestPermissionFromUI: () => Promise<NotificationAuthStatus>;
+  /** Settings 섹션이 마운트될 때 현재 status 를 가져온다. */
+  refreshPermissionStatus: () => Promise<NotificationAuthStatus>;
 }
 
 const MAX_NOTIFICATIONS = 50;
@@ -39,6 +55,9 @@ export const useNotificationStore = create<NotificationState>((set, get) => ({
   notifications: [],
   unreadCount: 0,
   soundEnabled: true,
+  // macOS 외에서는 권한 검사 path 자체가 안 돌아가므로 'authorized' 로 시작.
+  permissionStatus: isMacOS() ? "notDetermined" : "authorized",
+  deniedToastShownThisSession: false,
 
   addNotification: (n) => {
     const notification: AppNotification = {
@@ -69,6 +88,35 @@ export const useNotificationStore = create<NotificationState>((set, get) => ({
 
   loadSoundSetting: () => {
     getSetting("notificationSound", true).then((v) => set({ soundEnabled: v }));
+  },
+
+  setPermissionStatus: (s) => set({ permissionStatus: s }),
+
+  markDeniedToastShown: () => set({ deniedToastShownThisSession: true }),
+
+  requestPermissionFromUI: async () => {
+    if (!isMacOS()) return get().permissionStatus;
+    try {
+      const granted = await invoke<boolean>("notification_request_permission");
+      const status: NotificationAuthStatus = granted ? "authorized" : "denied";
+      set({ permissionStatus: status });
+      return status;
+    } catch (e) {
+      console.error("[notify] permission request failed", e);
+      return get().permissionStatus;
+    }
+  },
+
+  refreshPermissionStatus: async () => {
+    if (!isMacOS()) return "authorized";
+    try {
+      const status = await invoke<NotificationAuthStatus>("notification_get_status");
+      set({ permissionStatus: status });
+      return status;
+    } catch (e) {
+      console.error("[notify] status fetch failed", e);
+      return get().permissionStatus;
+    }
   },
 }));
 
@@ -110,6 +158,59 @@ function playNotificationSound(type: NotificationType) {
 
 // ─── Central notify function ─────────────────────────────────────────────────
 
+/**
+ * 옵션 D 권한 UX: 첫 알림 시 native dialog 자동 prompt.
+ *
+ *  - `notDetermined` → request_permission 호출 → 응답에 따라 발송 또는 silent skip
+ *  - `denied` → silent skip + 세션당 1회 토스트
+ *  - `authorized` → 즉시 발송
+ *
+ * macOS 외 OS 는 기존 `tauri-plugin-notification` path 그대로.
+ */
+async function ensureMacOSPermissionAndSend(title: string, body: string): Promise<void> {
+  const store = useNotificationStore.getState();
+  let status = store.permissionStatus;
+
+  if (status === "notDetermined") {
+    // refresh 한 번 먼저 — 다른 세션에서 결정됐을 수도 있음.
+    status = await store.refreshPermissionStatus();
+  }
+  if (status === "notDetermined") {
+    // 사용자가 처음 보는 알림 → native dialog 띄움.
+    status = await store.requestPermissionFromUI();
+  }
+
+  if (status === "authorized") {
+    await invoke("notification_send_native", { title, body });
+    return;
+  }
+
+  if (status === "denied") {
+    // 세션당 1회 토스트 — sonner 동적 import 로 store 가 UI lib 와 결합되지 않게.
+    const after = useNotificationStore.getState();
+    if (!after.deniedToastShownThisSession) {
+      after.markDeniedToastShown();
+      try {
+        const { toast } = await import("sonner");
+        const { default: i18n } = await import("@/locales");
+        toast.error(i18n.t("notifications.toast.denied", { ns: "settings" }));
+      } catch (e) {
+        // i18n 또는 sonner 초기화 전이면 console fallback.
+        console.warn(
+          "[notify] OS notification denied — enable in System Settings → Notifications.",
+          e,
+        );
+      }
+    } else {
+      console.debug("[notify] OS notification denied (toast already shown).");
+    }
+    return;
+  }
+
+  // notDetermined 가 다시 떨어지는 비상 case → silent skip.
+  console.debug("[notify] permission still notDetermined; skipping send.");
+}
+
 /** Send OS notification (if app not focused) + add to history + play sound. */
 export async function notify(
   type: NotificationType,
@@ -134,10 +235,15 @@ export async function notify(
   // OS notification only when app is not focused
   if (document.hidden) {
     try {
-      const { sendNotification, isPermissionGranted } = await import("@tauri-apps/plugin-notification");
-      const granted = await isPermissionGranted();
-      if (granted) {
-        sendNotification({ title, body });
+      if (isMacOS()) {
+        // Native UNUserNotificationCenter bridge — no osascript / Script Editor.
+        await ensureMacOSPermissionAndSend(title, body);
+      } else {
+        const { sendNotification, isPermissionGranted } = await import("@tauri-apps/plugin-notification");
+        const granted = await isPermissionGranted();
+        if (granted) {
+          sendNotification({ title, body });
+        }
       }
     } catch (e) {
       console.debug("[notify]", e);


### PR DESCRIPTION
## Summary

- 알림 클릭 시 Script Editor / osascript 가 frontmost 로 뜨는 회귀 (batmania52 #6) 를 macOS native bridge 정공법 (Path B) 으로 해소.
- `objc2-user-notifications` 0.3.2 직접 호출 — `UNUserNotificationCenter` 의 `requestAuthorization` / `addNotificationRequest` / `getNotificationSettings`. macOS-only target gate 로 Windows / Linux 의존성 트리 변경 0.
- 권한 UX = 옵션 D (첫 알림 시 자동 prompt + Settings → Notifications 토글 병행). denied 시 1회 토스트 + 시스템 설정 deep link.

Plan SSOT: `docs/plans/nativeNotificationPlan_2026-04-29.md` (status=ready, Path B 채택)

## Why Path B (not A')

`tauri-plugin-notification` v2.3.3 의 macOS path = `notify_rust` → osascript fallback. dev 일 때는 `set_application("com.apple.Terminal")`, release 일 때는 `set_application(&self.identifier)` 로 분기되지만, codesigned/Notarized 가 아닌 release DMG 도 fallback 으로 osascript 가 사용돼 회귀가 풀리지 않음. is_dev() 분기 제거 (Path A') 는 dev 한정 fix 라 외부 사용자 release DMG 무관 — 정공법 직접 ObjC bridge 로 진행.

## Task breakdown (3 commits)

| Commit | Task | Scope |
|---|---|---|
| `82cd567` | Task 02 prep | `objc2`, `objc2-foundation`, `objc2-user-notifications`, `block2` 추가 (macOS-only target gate) |
| `a4908b4` | Task 02 | `notification.rs` (~250 LoC) + `notification_stub.rs` + 3 Tauri commands + `notificationStore.ts` macOS 분기 + `lib/platform.ts` |
| `23297e9` | Task 03 | `NotificationsSection.tsx` + i18n ko/en + Settings 등록 + 권한 UX (옵션 D) |

## Files

- `src-tauri/Cargo.toml` (+10 lines, macOS-only `[target.'cfg(target_os = "macos")'.dependencies]`)
- `src-tauri/src/notification.rs` (new, ~230 LoC)
- `src-tauri/src/notification_stub.rs` (new, non-macOS Err stub)
- `src-tauri/src/lib.rs` (+17, mod include + 3 commands register)
- `src/lib/platform.ts` (new, navigator.userAgent macOS detection cached)
- `src/stores/notificationStore.ts` (+114, macOS native bridge routing + 권한 state + 옵션 D)
- `src/components/tunaflow/settings/NotificationsSection.tsx` (new)
- `src/components/tunaflow/SettingsPanel.tsx` (+9, Bell section register)
- `src/locales/{ko,en}/settings.json` (+23 each)

## Verification

- Rust: `cargo check` clean (notification 모듈 warning 0). `cargo test --lib` = **561 passed** (baseline 559+ → +2 새 unit test for `NotificationAuthStatus::from`).
- Frontend: `npx tsc --noEmit` clean. `npx vitest run` = **381 passed** (baseline 381 → 회귀 0). `npx vite build` 성공.

## DO NOT regression check

- macOS 외 path 변경 0 (`#![cfg(target_os = "macos")]` 격리, frontend `isMacOS()` 분기, stub commands return Err).
- `tauri-plugin-notification` 자체 제거 / 다운그레이드 X — Windows/Linux 와 macOS-non-focused-test 는 그대로 사용.
- 새 Tauri plugin 추가 X (objc2 외 0).
- 다른 Settings 섹션 / 다른 store 변경 X — `grep` 으로 확인.
- 권한 요청은 첫 알림 시 또는 Settings 명시 클릭 시에만. 앱 시작 시 spam 0.

## Test plan

- [ ] macOS dev 빌드: 알림 1회 발송 → 클릭 → tunaFlow frontmost (Script Editor 안 뜸)
- [ ] macOS dev 빌드: 권한 거부 시나리오 → silent skip + 토스트 1회 (UI hang 0)
- [ ] macOS dev 빌드: Settings → Notifications → "지금 권한 요청" / "테스트 알림" / denied 시 시스템 설정 link 동작
- [ ] Windows / Linux CI 빌드 통과 (cross-platform 회귀 0)
- [ ] macOS release (DMG) 빌드 후 같은 시나리오 — 회귀 0

## Plan / cross-reference

- Plan: `docs/plans/nativeNotificationPlan_2026-04-29.md`
- Hand-off: `docs/prompts/communityFollowupBatchDeveloperHandoff_2026-04-29.md` §2 Plan D
- 외부 보고: batmania52 (#6, 2026-04-29)

🤖 Generated with [Claude Code](https://claude.com/claude-code)