### PR TITLE
fix(context-hub): Windows resolve_bin candidate paths (npm global)

### DIFF
--- a/src-tauri/src/agents/context_hub.rs
+++ b/src-tauri/src/agents/context_hub.rs
@@ -79,6 +79,26 @@ fn is_source_allowed(source: &str) -> bool {
     ALLOWED_SOURCE_PREFIXES.iter().any(|prefix| source.starts_with(prefix))
 }
 
+/// Build candidate paths for chub on Windows npm global install dirs.
+/// Pure function — env values are passed in so tests don't mutate process env.
+#[cfg(target_os = "windows")]
+fn windows_chub_candidates(appdata: Option<&str>, userprofile: Option<&str>) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    if let Some(a) = appdata {
+        out.push(PathBuf::from(a).join("npm").join("chub.cmd"));
+    }
+    if let Some(u) = userprofile {
+        out.push(
+            PathBuf::from(u)
+                .join("AppData")
+                .join("Roaming")
+                .join("npm")
+                .join("chub.cmd"),
+        );
+    }
+    out
+}
+
 /// Resolve the context-hub binary path.
 /// Searches for both "context-hub" and "chub" (the actual CLI binary name).
 fn resolve_bin() -> Result<PathBuf, HubError> {
@@ -97,6 +117,17 @@ fn resolve_bin() -> Result<PathBuf, HubError> {
             if let Ok(fnm) = std::env::var("FNM_MULTISHELL_PATH") {
                 c.push(PathBuf::from(&fnm).join("bin").join("chub"));
             }
+        }
+        #[cfg(target_os = "windows")]
+        {
+            // Windows native process: HOME is usually unset, npm globals live under
+            // %APPDATA%\npm. Add explicit candidates so we don't rely solely on PATH.
+            let appdata = std::env::var("APPDATA").ok();
+            let userprofile = std::env::var("USERPROFILE").ok();
+            c.extend(windows_chub_candidates(
+                appdata.as_deref(),
+                userprofile.as_deref(),
+            ));
         }
         c.push(PathBuf::from("/usr/local/bin/chub"));
         c.push(PathBuf::from("/opt/homebrew/bin/chub"));
@@ -287,5 +318,31 @@ mod tests {
         assert!(!is_source_allowed("npm:react"));
         assert!(!is_source_allowed("public:pypi"));
         assert!(!is_source_allowed("registry:crates.io"));
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_candidates_include_appdata_npm_chub() {
+        let v = windows_chub_candidates(Some(r"C:\Users\u\AppData\Roaming"), None);
+        assert_eq!(v.len(), 1);
+        let s = v[0].to_string_lossy().to_string();
+        assert!(s.ends_with(r"npm\chub.cmd"), "got: {}", s);
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_candidates_include_userprofile_appdata_roaming_npm_chub() {
+        let v = windows_chub_candidates(None, Some(r"C:\Users\u"));
+        assert_eq!(v.len(), 1);
+        let s = v[0].to_string_lossy().to_string();
+        assert!(s.contains("AppData"), "got: {}", s);
+        assert!(s.contains("Roaming"), "got: {}", s);
+        assert!(s.ends_with("chub.cmd"), "got: {}", s);
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_candidates_empty_when_no_env() {
+        assert!(windows_chub_candidates(None, None).is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- Windows 머신에서 `chub.cmd` (npm global) 가 `%APPDATA%\npm\chub.cmd` 에 설치되지만, 기존 `resolve_bin()` 의 첫 candidate 블록은 `HOME` env var 에 의존해서 Windows native process 에서는 통째로 skip 되었다. PATH fallback 으로 동작 *가능*하지만 명시적 candidate 가 더 빠르고 안정적.
- `windows_chub_candidates()` pure helper 추가 후 `resolve_bin()` 에 `#[cfg(target_os = "windows")]` 블록으로 격리. macOS / Linux 코드는 무변경.
- 단위 테스트 3개 추가 (모두 cfg(windows) gated).

## Plan / handoff mapping
- Plan: `docs/plans/windowsDependencyBootstrapPlan_2026-04-29.md`
- Handoff: `docs/prompts/windowsDependencyBootstrapDeveloperHandoff_2026-04-29.md`
- Task: **T1** (Phase 1 / P0)

## Invariants
- **INV-1** (macOS 영향 0): 모든 신규 코드 `#[cfg(target_os = "windows")]` 격리, 기존 HOME / unix abs path 분기 무변경.
- **INV-3** (macOS-specific 코드 미변경): 확인.
- **INV-4** (단일 axis): T1 만 — context_hub.rs 1 파일.

## Verification (Windows host)
- `cargo test --lib agents::context_hub` → 5 passed (기존 2 + 신규 3)
  - `windows_candidates_include_appdata_npm_chub` ✓
  - `windows_candidates_include_userprofile_appdata_roaming_npm_chub` ✓
  - `windows_candidates_empty_when_no_env` ✓
- `cargo test --lib` (full suite) → 560 passed / 1 failed
  - 실패 1건은 `commands::agents_helpers::send_common::agent_session_tx::tests::audit_enabled_default_true` — isolation 시 ✓ 통과 확인. 사전 존재하던 env-var leak flake로 본 PR 무관.
- baseline 비교: PR #213 직후 558 passed → 본 PR 후 560 passed (+3 신규 테스트, 일치).

## Test plan
- [ ] macOS CI ✓
- [ ] Windows CI ✓ (실 chub search 수동 검증은 머지 전후 architect 가 dev 모드에서 chub 카드 ready 여부 확인)