### PR TITLE
fix(onboarding): surface codex stderr on exit != 0

### DIFF
--- a/src-tauri/src/commands/project_onboarding.rs
+++ b/src-tauri/src/commands/project_onboarding.rs
@@ -540,7 +540,18 @@ async fn await_cli_with_cancel(
         match rx.try_recv() {
             Ok(Ok(output)) => {
                 if !output.status.success() {
-                    return Err(format!("{engine} 분석 실패 (exit: {:?})", output.status.code()));
+                    let stderr_body = String::from_utf8_lossy(&output.stderr);
+                    let stderr_trimmed = stderr_body.trim();
+                    let detail = if stderr_trimmed.is_empty() {
+                        "(no stderr)".to_string()
+                    } else {
+                        stderr_trimmed.to_string()
+                    };
+                    return Err(format!(
+                        "{engine} 분석 실패 (exit: {:?}): {}",
+                        output.status.code(),
+                        detail
+                    ));
                 }
                 return Ok(String::from_utf8_lossy(&output.stdout).into_owned());
             }
@@ -580,7 +591,11 @@ async fn call_cli_agent(
         }
         _ => return Err(format!("지원하지 않는 CLI 엔진: {engine}")),
     }
-    cmd.stdout(Stdio::piped()).stderr(Stdio::null());
+    // stderr is piped so failure diagnostics surface to the user/log via
+    // await_cli_with_cancel (Plan B Task 02 follow-up — codex exit 1 root cause
+    // identification). wait_with_output() drains the pipe automatically; success
+    // path behavior is unchanged (stderr discarded).
+    cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
 
     let spawn_res = cmd.spawn();
     let mut child = spawn_res


### PR DESCRIPTION
## Summary

- onboarding 의 `call_cli_agent` 가 stderr 를 `Stdio::null()` 로 버려서 codex exit 1 root cause 가 어디에도 표면화되지 않던 문제 (batmania52 보고, Plan B Task 02 진단) 의 1차 진단 가능성 회복.
- `cmd.stderr(Stdio::null())` → `Stdio::piped()`. `await_cli_with_cancel` 내부의 `wait_with_output()` 가 자동 drain.
- exit != 0 시 에러 메시지에 stderr 본문 포함 (empty 시 `(no stderr)` fallback). 다음 사용자 보고 시 H1~H4 가설 (skip-git-repo-check / color=never / current_dir / 인자 순서) 즉시 확정 가능.

## Scope

- 변경 파일: `src-tauri/src/commands/project_onboarding.rs` (1 파일, +17/-2 LoC)
- production `agents/codex.rs` 변경 0 — `git diff src-tauri/src/agents/codex.rs` 무출력 확인.
- 정상 path (exit 0) 동작 변경 0 — stderr piped 는 wait_with_output 이 자동 drain.
- F2~F5 (skip-git-repo-check 누락 / color=never / current_dir / 인자 순서) 가설 기반 fix 는 본 PR 비대상 — 별 PR 분리.

## SSOT

- `docs/plans/onboardingCodexStderrSurfacePlan_2026-04-29.md` (Layer A)
- Plan B Task 02 follow-up: `docs/plans/onboardingAnalysisFailureAndSkipUiPlan_2026-04-29.md`

## Test plan

- [x] `cd src-tauri && cargo check` — clean
- [x] `cd src-tauri && cargo test --lib` — 566 passed (baseline 대비 회귀 0)
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 381 passed (FE baseline 동일)
- [x] `git diff src-tauri/src/agents/codex.rs` — 무출력 (production 변경 0 확인)

## Invariants

- INV-1: onboarding codex 호출 exit != 0 시 stderr 본문이 에러 메시지에 포함됨.
- INV-2: stderr 가 비어 있을 때 `(no stderr)` graceful fallback.
- INV-3: 정상 종료 (exit 0) path 동작 변경 0.
- INV-4: production `agents/codex.rs` path 변경 0.
- INV-5: F2~F5 가설 기반 fix 는 본 PR 비대상.

🤖 Generated with [Claude Code](https://claude.com/claude-code)