### PR TITLE
fix(crg): Windows PATH fallback for code-review-graph binary

### DIFF
--- a/src-tauri/src/agents/crg.rs
+++ b/src-tauri/src/agents/crg.rs
@@ -31,7 +31,24 @@ fn resolve_bin() -> Result<String, CrgError> {
             return Ok(c.clone());
         }
     }
-    // Fallback: PATH lookup via `which`
+    // Windows: `which` is not a builtin binary on Windows. Probe the PATH directly
+    // by attempting to spawn `code-review-graph --version`. cfg-gated so macOS/Linux
+    // behavior is unchanged (still goes through `which` below).
+    #[cfg(target_os = "windows")]
+    {
+        if Command::new("code-review-graph")
+            .no_console()
+            .arg("--version")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+        {
+            return Ok("code-review-graph".to_string());
+        }
+    }
+    // Fallback: PATH lookup via `which` (Unix)
     let output = Command::new("which")
         .no_console()
         .arg("code-review-graph")


### PR DESCRIPTION
## Summary
- Windows 에는 `which` 가 builtin 바이너리로 없다. 기존 unix candidate paths (`~/.local/bin/code-review-graph`, `/opt/homebrew/...`, `/usr/local/bin/...`) 가 모두 miss 하면 `which` spawn 도 실패해 `NotFound` 로 빠진다.
- `#[cfg(target_os = "windows")]` 격리 PATH fallback 추가: `Command::new("code-review-graph").arg("--version")` 직접 spawn, 성공 시 bare name 반환 (이후 `Command::new(&bin)` 가 PATH 재조회).
- macOS / Linux 는 기존 `which` 경로 그대로.

## Plan / handoff mapping
- Plan: `docs/plans/windowsDependencyBootstrapPlan_2026-04-29.md`
- Handoff: `docs/prompts/windowsDependencyBootstrapDeveloperHandoff_2026-04-29.md`
- Task: **T2** (Phase 1 / P0)

## Invariants
- **INV-1** (macOS 영향 0): cfg(target_os="windows") 격리. macOS / Linux 는 `which` fallback 그대로 사용.
- **INV-3** (macOS-specific 코드 미변경): 확인.
- **INV-4** (단일 axis): T2 만 — crg.rs 1 파일.

## Verification (Windows host)
- `cargo check --lib` → ok
- `cargo test --lib agents::crg` → 0 passed (기존에도 단위 테스트 0건; subprocess 의존성 회피)
- `cargo test --lib` → 569 passed / 4 failed
  - **실패 4건은 본 PR 무관**: `commands::files::tests::*` 4건 모두 Windows path-separator 회귀 (`paths.iter().any(|p| p.ends_with("docs/a.md"))` 가 Windows backslash 에 매치 안 됨). 본 main HEAD 기준 사전 존재 — PR #219 `feat(docs)` 도입 가능성. 별도 axis 로 별 PR 처리 권장 (architect 에 보고 완료 예정).
- baseline 비교: 본 PR 의 axis (`agents::crg`) 에 회귀 0. 사전 4 failures 가 없을 때 main = 569 + 4 = 573 passed (PR #213 baseline 558 → 신규 PR 들에서 +15).

## Test plan
- [ ] macOS CI ✓
- [ ] Windows CI ✓
- [ ] dev mode 재시작 후 Settings → Runtime 의 code-review-graph 카드가 ready 로 표기되는지 (architect 수동 검증)