### PR TITLE
fix(commands/files): normalize test path comparison to forward-slash on Windows

### DIFF
--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -443,7 +443,10 @@ mod tests {
                     flatten_md_paths(children, out);
                 }
             } else {
-                out.push(e.path.clone());
+                // Normalize Windows backslash to forward-slash so assertions like
+                // `ends_with("docs/foo.md")` / `contains("/.git/")` remain portable.
+                // Production `e.path` keeps OS-native separators — this is test-only.
+                out.push(e.path.replace('\\', "/"));
             }
         }
     }
@@ -468,9 +471,12 @@ mod tests {
 
         let mut paths: Vec<String> = Vec::new();
         flatten_md_paths(&result.entries, &mut paths);
+        // root_prefix is normalized to forward-slash to match `paths` (already
+        // normalized inside `flatten_md_paths`).
+        let root_prefix = root.to_string_lossy().replace('\\', "/");
         let names: Vec<String> = paths
             .iter()
-            .map(|p| p.replace(&format!("{}/", root.to_string_lossy()), ""))
+            .map(|p| p.replace(&format!("{}/", root_prefix), ""))
             .collect();
 
         assert!(names.contains(&"README.md".to_string()));


### PR DESCRIPTION
## Summary

- T2 escalate-1~4 (`commands::files::tests::*`) regressions caused by `Path::display()` / `to_string_lossy()` emitting backslash on Windows; assertions like `p.ends_with(\"docs/foo.md\")` fail.
- **Test-only fix** — `flatten_md_paths` (test helper) and the root-prefix transform in `tunaflow_scope_returns_root_md_and_docs_only` normalize `\` → `/`. Production `DocsEntry.path` keeps OS-native separators (UI consumers unaffected).

## Plan / handoff mapping

- Plan: `docs/plans/windowsCiPipelinePlan_2026-04-29.md` §W-CI-3 (R-W-7) — separate hotfix axis from `windowsBetaHardeningPlan §C/§D`.
- Sister PR pattern: PR #213 (`fix(conventions): normalize @import path …`) — same root cause class.

## R-W-7 grep audit results

| Pattern | Hits | Action |
|---|---|---|
| `\.ends_with\(\"[^\"]*/[^\"]*\"\)` | 9 | 7 in files.rs **fixed** (this PR); 1 in `agent_detect.rs:135` (URL, not path); 1 in `skills.rs:569` (git tree blob — always forward-slash) |
| `\.contains\(\"/[^\"]+/[^\"]+\"\)` | 0 | none |
| `Path::new\(\"[^\"]*/[^\"]*\"\)` | 0 | none |
| `rawq.*Command\|crg.*Command` | 0 | no placeholder binary call sites — W-CI-1 sidecar placeholder safe |

## Invariants

- **INV-1**: macOS/Linux unaffected — `replace('\\', \"/\")` is no-op on already-slash paths.
- **INV-4**: single axis (path-separator test normalization). 1 file changed, +8/-2.
- Production code untouched.

## Verification (Windows host)

- `cargo test --lib commands::files` → **7/7 passed** (escalate-1~4 + 3 pre-existing tests).
- `cargo test --lib` (full) → **573 passed / 0 failed** (was 569 passed + 4 failed = 573).
- Architect worktree at `D:/privateProject/tunaFlow-architect` (git worktree isolation, no impact on developer's `feat/first-run-dependency-dialog` working copy).

## Test plan

- [ ] CI Linux self-hosted ✓ (existing rust-check / frontend-check)
- [ ] Windows manual verification confirmed pre-merge (this PR description)
- [ ] After windowsCiPipelinePlan W-CI-1 lands, this PR's regression guard becomes automated on subsequent main pushes