### PR TITLE
feat(installer): first-run dependency consent dialog + auto-install

### DIFF
--- a/src-tauri/src/commands/dependency_install.rs
+++ b/src-tauri/src/commands/dependency_install.rs
@@ -1,0 +1,283 @@
+//! First-run dependency consent install (T4 / windowsDependencyBootstrapPlan_2026-04-29).
+//!
+//! Detects optional sidecars (context-hub via npm, code-review-graph via pip) and,
+//! after explicit user consent, runs `npm install -g` / `pip install` with timeout.
+//!
+//! Invariants
+//! - INV-DEP-A: silent global install 금지. user consent (frontend) 후에만 호출.
+//! - INV-DEP-B: timeout (npm 60s / pip 120s) + graceful failure with manual command hint.
+//! - Q-3: VIRTUAL_ENV 가 set 되어 있고 그 안의 pip 가 실제로 존재하면 venv 안에 설치;
+//!        그렇지 않으면 system pip. silent venv 생성 금지.
+
+use serde::Serialize;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+use tauri::Emitter;
+
+use crate::no_console::NoConsole;
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct DependencyStatus {
+    pub name: String,
+    pub available: bool,
+    pub installer_command: String,
+    pub requires: String,
+    pub version: Option<String>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct InstallResult {
+    pub name: String,
+    pub success: bool,
+    pub message: String,
+    pub manual_command: Option<String>,
+}
+
+const NPM_TIMEOUT: Duration = Duration::from_secs(60);
+const PIP_TIMEOUT: Duration = Duration::from_secs(120);
+
+const NAME_CONTEXT_HUB: &str = "context-hub";
+const NAME_CRG: &str = "code-review-graph";
+const CHUB_INSTALL_CMD: &str = "npm install -g @aisuite/chub";
+
+/// Probe both sidecars and report installer hints (called from first-run dialog
+/// + Settings → Runtime "수동 설치" 버튼).
+#[tauri::command]
+pub async fn list_dependencies() -> Result<Vec<DependencyStatus>, String> {
+    tokio::task::spawn_blocking(move || {
+        let chub = crate::agents::context_hub::health();
+        let crg_avail = crate::agents::crg::is_available();
+        vec![
+            DependencyStatus {
+                name: NAME_CONTEXT_HUB.into(),
+                available: chub.available,
+                installer_command: CHUB_INSTALL_CMD.into(),
+                requires: "Node.js + npm".into(),
+                version: chub.version,
+            },
+            DependencyStatus {
+                name: NAME_CRG.into(),
+                available: crg_avail,
+                installer_command: pip_install_hint(std::env::var("VIRTUAL_ENV").ok().as_deref()),
+                requires: "Python 3 + pip".into(),
+                version: None,
+            },
+        ]
+    })
+    .await
+    .map_err(|e| format!("spawn_blocking: {}", e))
+}
+
+/// Run the install for one named dependency. Always emits
+/// `dependency:install_result` so the dialog can react even when the
+/// invocation Promise is dropped.
+#[tauri::command]
+pub async fn install_dependency(
+    app: tauri::AppHandle,
+    name: String,
+) -> Result<InstallResult, String> {
+    let result = tokio::task::spawn_blocking(move || run_install(&name))
+        .await
+        .map_err(|e| format!("spawn_blocking: {}", e))?;
+    let _ = app.emit("dependency:install_result", &result);
+    Ok(result)
+}
+
+fn run_install(name: &str) -> InstallResult {
+    match name {
+        NAME_CONTEXT_HUB => run_with_timeout(
+            NAME_CONTEXT_HUB,
+            "npm",
+            &["install", "-g", "@aisuite/chub"],
+            NPM_TIMEOUT,
+            CHUB_INSTALL_CMD,
+        ),
+        NAME_CRG => {
+            let venv = std::env::var("VIRTUAL_ENV").ok();
+            let pip = pip_executable_for(venv.as_deref());
+            let manual = pip_install_hint(venv.as_deref());
+            run_with_timeout(
+                NAME_CRG,
+                &pip,
+                &["install", "code-review-graph"],
+                PIP_TIMEOUT,
+                &manual,
+            )
+        }
+        other => InstallResult {
+            name: other.into(),
+            success: false,
+            message: format!("unknown dependency: {}", other),
+            manual_command: None,
+        },
+    }
+}
+
+/// Resolve pip executable, preferring an *active* venv when its pip is
+/// actually present. Pure helper so tests don't mutate process env.
+fn pip_executable_for(virtual_env: Option<&str>) -> String {
+    if let Some(venv) = virtual_env.filter(|s| !s.is_empty()) {
+        let candidate: PathBuf = if cfg!(windows) {
+            PathBuf::from(venv).join("Scripts").join("pip.exe")
+        } else {
+            PathBuf::from(venv).join("bin").join("pip")
+        };
+        if candidate.exists() {
+            return candidate.to_string_lossy().to_string();
+        }
+    }
+    "pip".into()
+}
+
+/// Human-readable install command hint; reflects venv presence.
+fn pip_install_hint(virtual_env: Option<&str>) -> String {
+    if virtual_env.map(|s| !s.is_empty()).unwrap_or(false) {
+        "pip install code-review-graph (active venv)".into()
+    } else {
+        "pip install code-review-graph".into()
+    }
+}
+
+fn run_with_timeout(
+    name: &str,
+    program: &str,
+    args: &[&str],
+    timeout: Duration,
+    manual: &str,
+) -> InstallResult {
+    let mut cmd = Command::new(program);
+    cmd.no_console();
+    cmd.args(args);
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+
+    let mut child = match cmd.spawn() {
+        Ok(c) => c,
+        Err(e) => {
+            return InstallResult {
+                name: name.into(),
+                success: false,
+                message: format!("spawn failed: {}", e),
+                manual_command: Some(manual.into()),
+            };
+        }
+    };
+
+    let start = Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                if status.success() {
+                    return InstallResult {
+                        name: name.into(),
+                        success: true,
+                        message: format!("{} 설치 완료", name),
+                        manual_command: None,
+                    };
+                }
+                let mut stderr_buf = String::new();
+                if let Some(mut e) = child.stderr.take() {
+                    use std::io::Read;
+                    let _ = e.read_to_string(&mut stderr_buf);
+                }
+                let trimmed = stderr_buf.trim();
+                let detail = if trimmed.is_empty() {
+                    format!("exit {}", status)
+                } else {
+                    format!("exit {}: {}", status, truncate(trimmed, 400))
+                };
+                return InstallResult {
+                    name: name.into(),
+                    success: false,
+                    message: detail,
+                    manual_command: Some(manual.into()),
+                };
+            }
+            Ok(None) => {
+                if start.elapsed() > timeout {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return InstallResult {
+                        name: name.into(),
+                        success: false,
+                        message: format!("timeout after {}s", timeout.as_secs()),
+                        manual_command: Some(manual.into()),
+                    };
+                }
+                std::thread::sleep(Duration::from_millis(200));
+            }
+            Err(e) => {
+                return InstallResult {
+                    name: name.into(),
+                    success: false,
+                    message: format!("wait failed: {}", e),
+                    manual_command: Some(manual.into()),
+                };
+            }
+        }
+    }
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.into()
+    } else {
+        let mut out = String::with_capacity(max + 3);
+        out.push_str(&s[..max]);
+        out.push_str("...");
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pip_executable_returns_pip_when_no_venv() {
+        assert_eq!(pip_executable_for(None), "pip");
+        assert_eq!(pip_executable_for(Some("")), "pip");
+    }
+
+    #[test]
+    fn pip_executable_returns_pip_when_venv_path_doesnt_exist() {
+        assert_eq!(
+            pip_executable_for(Some("/definitely/nonexistent/venv/path/__claude_t4__")),
+            "pip"
+        );
+    }
+
+    #[test]
+    fn pip_install_hint_reflects_venv_presence() {
+        assert_eq!(pip_install_hint(None), "pip install code-review-graph");
+        assert_eq!(pip_install_hint(Some("")), "pip install code-review-graph");
+        assert_eq!(
+            pip_install_hint(Some("/some/path")),
+            "pip install code-review-graph (active venv)"
+        );
+    }
+
+    #[test]
+    fn run_install_unknown_dependency_returns_failure() {
+        let r = run_install("not-a-real-thing");
+        assert!(!r.success);
+        assert!(r.message.contains("unknown"));
+        assert_eq!(r.name, "not-a-real-thing");
+    }
+
+    #[test]
+    fn truncate_long_string_appends_ellipsis() {
+        let s = "a".repeat(500);
+        let t = truncate(&s, 400);
+        assert_eq!(t.len(), 403);
+        assert!(t.ends_with("..."));
+    }
+
+    #[test]
+    fn truncate_short_string_unchanged() {
+        assert_eq!(truncate("short", 100), "short");
+    }
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub mod artifacts;
 pub mod branches;
 pub mod capabilities;
 pub mod context_hub;
+pub mod dependency_install;
 pub mod context_queries;
 pub mod conventions_sync;
 pub mod conversation_memory;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -295,6 +295,8 @@ pub fn run() {
             commands::context_hub::context_hub_health,
             commands::context_hub::context_hub_search,
             commands::context_hub::context_hub_get,
+            commands::dependency_install::list_dependencies,
+            commands::dependency_install::install_dependency,
             // Files
             commands::files::list_directory,
             commands::files::list_project_docs,

--- a/src/components/tunaflow/AppShell.tsx
+++ b/src/components/tunaflow/AppShell.tsx
@@ -16,6 +16,7 @@ import { CommandPalette } from "./CommandPalette";
 import { TitleBar } from "./TitleBar";
 import { MetaFloatingChat } from "./MetaFloatingChat";
 import { ProjectOnboardingModal } from "./ProjectOnboardingModal";
+import { FirstRunDependencyDialog } from "./FirstRunDependencyDialog";
 import { SettingsPanel } from "./SettingsPanel";
 
 // ─── Panel width constraints ─────────────────────────────────────────────────
@@ -210,6 +211,7 @@ export function AppShell() {
       <>
         <ProjectStartup />
         <Toaster position="bottom-right" theme={themeMode} richColors closeButton />
+        <FirstRunDependencyDialog />
         {settingsOpen && (
           <SettingsPanel
             onClose={() => { setSettingsOpen(false); setSettingsInitialSection(undefined); }}
@@ -394,6 +396,7 @@ export function AppShell() {
     </div>
     <CommandPalette />
     <ProjectOnboardingModal />
+    <FirstRunDependencyDialog />
     </FileViewerContext.Provider>
   );
 }

--- a/src/components/tunaflow/FirstRunDependencyDialog.tsx
+++ b/src/components/tunaflow/FirstRunDependencyDialog.tsx
@@ -1,0 +1,210 @@
+import { useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import { useTranslation } from "react-i18next";
+import { Loader2, CheckCircle2, AlertCircle } from "lucide-react";
+import { getSetting, setSetting } from "@/lib/appStore";
+
+// Setting key gates whether the dialog ever shows. Pre-set to true to skip
+// (debug toggle for startup-race diagnosis — Q-4 / W-9 of bootstrap plan).
+export const FIRST_RUN_SETTING_KEY = "first_run_dependency_check_done";
+
+interface DependencyStatus {
+  name: string;
+  available: boolean;
+  installerCommand: string;
+  requires: string;
+  version: string | null;
+}
+
+interface InstallResult {
+  name: string;
+  success: boolean;
+  message: string;
+  manualCommand: string | null;
+}
+
+export function FirstRunDependencyDialog() {
+  const { t } = useTranslation("dialog");
+  const [open, setOpen] = useState(false);
+  const [missing, setMissing] = useState<DependencyStatus[]>([]);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [installing, setInstalling] = useState<Set<string>>(new Set());
+  const [results, setResults] = useState<Record<string, InstallResult>>({});
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const done = await getSetting<boolean>(FIRST_RUN_SETTING_KEY, false);
+      if (done || cancelled) return;
+      try {
+        const list = await invoke<DependencyStatus[]>("list_dependencies");
+        if (cancelled) return;
+        const missing = list.filter((d) => !d.available);
+        if (missing.length === 0) {
+          await setSetting(FIRST_RUN_SETTING_KEY, true);
+          return;
+        }
+        setMissing(missing);
+        setSelected(new Set(missing.map((d) => d.name)));
+        setOpen(true);
+      } catch (e) {
+        console.error("[first-run-deps] list_dependencies failed", e);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  useEffect(() => {
+    const u = listen<InstallResult>("dependency:install_result", (e) => {
+      const r = e.payload;
+      setResults((prev) => ({ ...prev, [r.name]: r }));
+      setInstalling((prev) => {
+        if (!prev.has(r.name)) return prev;
+        const next = new Set(prev);
+        next.delete(r.name);
+        return next;
+      });
+    });
+    return () => { u.then((un) => un()).catch(() => {}); };
+  }, []);
+
+  const finish = async () => {
+    await setSetting(FIRST_RUN_SETTING_KEY, true);
+    setOpen(false);
+  };
+
+  const handleInstall = async () => {
+    const targets = missing.filter((d) => selected.has(d.name));
+    if (targets.length === 0) return;
+    setInstalling(new Set(targets.map((d) => d.name)));
+    await Promise.all(targets.map((d) =>
+      invoke<InstallResult>("install_dependency", { name: d.name }).catch((e) => {
+        const r: InstallResult = {
+          name: d.name,
+          success: false,
+          message: String(e),
+          manualCommand: d.installerCommand,
+        };
+        setResults((prev) => ({ ...prev, [d.name]: r }));
+        setInstalling((prev) => {
+          if (!prev.has(d.name)) return prev;
+          const next = new Set(prev);
+          next.delete(d.name);
+          return next;
+        });
+      })
+    ));
+  };
+
+  const toggle = (name: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(name)) next.delete(name);
+      else next.add(name);
+      return next;
+    });
+  };
+
+  const targetCount = missing.filter((d) => selected.has(d.name)).length;
+  const completedCount = missing.filter(
+    (d) => selected.has(d.name) && results[d.name],
+  ).length;
+  const allAttempted = installing.size === 0 && targetCount > 0 && completedCount === targetCount;
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-[110] flex items-center justify-center" data-testid="first-run-deps-dialog">
+      <div className="absolute inset-0 bg-black/50" />
+      <div className="relative z-10 w-[520px] max-h-[85vh] bg-background border border-border rounded-xl shadow-2xl flex flex-col overflow-hidden">
+        <div className="px-6 pt-5 pb-3 border-b border-border">
+          <h2 className="text-sm font-semibold text-foreground">{t("dependency_install.title")}</h2>
+          <p className="text-[11px] text-muted-foreground mt-0.5">{t("dependency_install.lead")}</p>
+        </div>
+
+        <div className="px-6 py-4 space-y-3 flex-1 overflow-y-auto min-h-0">
+          {missing.map((d) => {
+            const r = results[d.name];
+            const isInstalling = installing.has(d.name);
+            const locked = isInstalling || !!r;
+            return (
+              <div key={d.name} className="rounded-md border border-border/60 p-3" data-testid={`dep-card-${d.name}`}>
+                <label className="flex items-start gap-2 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={selected.has(d.name)}
+                    onChange={() => toggle(d.name)}
+                    disabled={locked}
+                    className="w-3.5 h-3.5 mt-0.5"
+                    aria-label={d.name}
+                  />
+                  <div className="flex-1 space-y-0.5">
+                    <div className="flex items-center gap-2">
+                      <span className="text-[12px] font-medium text-foreground">{d.name}</span>
+                      <span className="text-[10px] text-muted-foreground">{d.requires}</span>
+                    </div>
+                    <code className="text-[10px] text-muted-foreground/70 block break-all">{d.installerCommand}</code>
+                    {isInstalling && (
+                      <div className="flex items-center gap-1.5 text-[11px] text-primary mt-1">
+                        <Loader2 className="w-3 h-3 animate-spin" />
+                        {t("dependency_install.installing")}
+                      </div>
+                    )}
+                    {r?.success && (
+                      <div className="flex items-center gap-1.5 text-[11px] text-green-500 mt-1">
+                        <CheckCircle2 className="w-3 h-3" />
+                        {r.message}
+                      </div>
+                    )}
+                    {r && !r.success && (
+                      <div className="flex items-start gap-1.5 text-[11px] text-destructive mt-1">
+                        <AlertCircle className="w-3 h-3 mt-0.5" />
+                        <div>
+                          <div>{r.message}</div>
+                          {r.manualCommand && (
+                            <div className="mt-1 text-muted-foreground">
+                              {t("dependency_install.manual_hint")}{" "}
+                              <code className="text-foreground/70">{r.manualCommand}</code>
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                </label>
+              </div>
+            );
+          })}
+          <p className="text-[10px] text-muted-foreground/60">{t("dependency_install.venv_note")}</p>
+        </div>
+
+        <div className="px-6 py-4 border-t border-border flex justify-between">
+          <button
+            onClick={finish}
+            disabled={installing.size > 0}
+            className="text-[11px] text-muted-foreground hover:text-foreground transition-colors disabled:opacity-40"
+          >
+            {t("dependency_install.skip")}
+          </button>
+          {allAttempted ? (
+            <button
+              onClick={finish}
+              className="px-4 py-1.5 rounded-lg bg-primary text-primary-foreground text-[11px] font-medium hover:bg-primary/90 transition-colors"
+            >
+              {t("dependency_install.close")}
+            </button>
+          ) : (
+            <button
+              onClick={handleInstall}
+              disabled={installing.size > 0 || targetCount === 0}
+              className="px-4 py-1.5 rounded-lg bg-primary text-primary-foreground text-[11px] font-medium hover:bg-primary/90 transition-colors disabled:opacity-40"
+            >
+              {t("dependency_install.install")}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/locales/en/dialog.json
+++ b/src/locales/en/dialog.json
@@ -27,6 +27,16 @@
     "save": "Save",
     "cancel": "Cancel"
   },
+  "dependency_install": {
+    "title": "Install optional sidecars",
+    "lead": "These sidecars enable extra features (context-hub search / code-graph analysis). You can skip and re-run from Settings → Runtime later.",
+    "install": "Install",
+    "skip": "Skip",
+    "close": "Close",
+    "installing": "Installing...",
+    "manual_hint": "Manual command:",
+    "venv_note": "If an active Python venv is detected, install goes into the venv (avoids global system install)."
+  },
   "onboarding": {
     "step_scan": "Scanning project...",
     "step_analyze": "Analyzing existing docs...",

--- a/src/locales/ko/dialog.json
+++ b/src/locales/ko/dialog.json
@@ -27,6 +27,16 @@
     "save": "저장",
     "cancel": "취소"
   },
+  "dependency_install": {
+    "title": "추가 사이드카 설치",
+    "lead": "다음 사이드카는 일부 기능 (context-hub 검색 / 코드 그래프 분석) 에 필요합니다. 설치를 원하지 않으면 건너뛸 수 있고, 나중에 Settings → Runtime 에서 다시 설치할 수 있습니다.",
+    "install": "설치",
+    "skip": "건너뛰기",
+    "close": "닫기",
+    "installing": "설치 중...",
+    "manual_hint": "수동 설치 명령:",
+    "venv_note": "활성 Python venv 가 감지되면 그 안에 설치합니다 (시스템 전역 설치 회피)."
+  },
   "onboarding": {
     "step_scan": "프로젝트 스캔 중...",
     "step_analyze": "기존 문서 분석 중...",

--- a/src/tests/firstRunDependencyDialog.test.tsx
+++ b/src/tests/firstRunDependencyDialog.test.tsx
@@ -1,0 +1,116 @@
+// FirstRunDependencyDialog — first-run consent dialog test (T4 of
+// windowsDependencyBootstrapPlan_2026-04-29). Validates: setting gate
+// suppresses the dialog, missing-deps render, "건너뛰기" persists the
+// done flag, "설치" invokes install_dependency per selected item.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { FirstRunDependencyDialog, FIRST_RUN_SETTING_KEY } from "@/components/tunaflow/FirstRunDependencyDialog";
+
+// react-i18next: identity mock so we assert on key strings.
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "ko", changeLanguage: () => Promise.resolve() },
+  }),
+}));
+
+const mockInvoke = vi.fn<(...a: unknown[]) => unknown>();
+const mockListen = vi.fn<() => Promise<() => void>>(() => Promise.resolve(() => {}));
+vi.mock("@tauri-apps/api/core", () => ({ invoke: (...a: unknown[]) => mockInvoke(...a) }));
+vi.mock("@tauri-apps/api/event", () => ({ listen: () => mockListen() }));
+
+const mockGetSetting = vi.fn<(...a: unknown[]) => unknown>();
+const mockSetSetting = vi.fn<(...a: unknown[]) => Promise<void>>(() => Promise.resolve());
+vi.mock("@/lib/appStore", () => ({
+  getSetting: (...a: unknown[]) => mockGetSetting(...a),
+  setSetting: (...a: unknown[]) => mockSetSetting(...a),
+}));
+
+beforeEach(() => {
+  mockInvoke.mockReset();
+  mockListen.mockClear();
+  mockGetSetting.mockReset();
+  mockSetSetting.mockClear();
+});
+
+describe("FirstRunDependencyDialog", () => {
+  it("renders nothing when first_run_dependency_check_done is true (debug toggle)", async () => {
+    mockGetSetting.mockResolvedValue(true);
+    const { container } = render(<FirstRunDependencyDialog />);
+    // Wait long enough for the effect to settle without state changes.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(container.querySelector('[data-testid="first-run-deps-dialog"]')).toBeNull();
+    expect(mockInvoke).not.toHaveBeenCalled();
+  });
+
+  it("renders nothing and marks done when no dependencies are missing", async () => {
+    mockGetSetting.mockResolvedValue(false);
+    mockInvoke.mockResolvedValue([
+      { name: "context-hub", available: true, installerCommand: "npm install -g @aisuite/chub", requires: "Node.js + npm", version: "0.1.4" },
+      { name: "code-review-graph", available: true, installerCommand: "pip install code-review-graph", requires: "Python 3 + pip", version: null },
+    ]);
+    render(<FirstRunDependencyDialog />);
+    await waitFor(() => expect(mockSetSetting).toHaveBeenCalledWith(FIRST_RUN_SETTING_KEY, true));
+    expect(screen.queryByTestId("first-run-deps-dialog")).toBeNull();
+  });
+
+  it("shows the dialog with cards for each missing dependency", async () => {
+    mockGetSetting.mockResolvedValue(false);
+    mockInvoke.mockResolvedValue([
+      { name: "context-hub", available: false, installerCommand: "npm install -g @aisuite/chub", requires: "Node.js + npm", version: null },
+      { name: "code-review-graph", available: false, installerCommand: "pip install code-review-graph", requires: "Python 3 + pip", version: null },
+    ]);
+    render(<FirstRunDependencyDialog />);
+    await screen.findByTestId("first-run-deps-dialog");
+    expect(screen.getByTestId("dep-card-context-hub")).toBeInTheDocument();
+    expect(screen.getByTestId("dep-card-code-review-graph")).toBeInTheDocument();
+    // checkboxes are pre-selected for missing deps
+    const checkboxes = screen.getAllByRole("checkbox") as HTMLInputElement[];
+    expect(checkboxes).toHaveLength(2);
+    expect(checkboxes.every((c) => c.checked)).toBe(true);
+  });
+
+  it("clicking 건너뛰기 (skip) persists the done flag and unmounts the dialog", async () => {
+    mockGetSetting.mockResolvedValue(false);
+    mockInvoke.mockResolvedValue([
+      { name: "context-hub", available: false, installerCommand: "npm install -g @aisuite/chub", requires: "Node.js + npm", version: null },
+    ]);
+    render(<FirstRunDependencyDialog />);
+    await screen.findByTestId("first-run-deps-dialog");
+    fireEvent.click(screen.getByText("dependency_install.skip"));
+    await waitFor(() => expect(mockSetSetting).toHaveBeenCalledWith(FIRST_RUN_SETTING_KEY, true));
+    await waitFor(() => expect(screen.queryByTestId("first-run-deps-dialog")).toBeNull());
+  });
+
+  it("clicking 설치 invokes install_dependency once per selected item", async () => {
+    mockGetSetting.mockResolvedValue(false);
+    mockInvoke.mockImplementation((...args: unknown[]) => {
+      const cmd = args[0] as string;
+      if (cmd === "list_dependencies") {
+        return Promise.resolve([
+          { name: "context-hub", available: false, installerCommand: "npm install -g @aisuite/chub", requires: "Node.js + npm", version: null },
+          { name: "code-review-graph", available: false, installerCommand: "pip install code-review-graph", requires: "Python 3 + pip", version: null },
+        ]);
+      }
+      if (cmd === "install_dependency") {
+        return Promise.resolve({ name: "context-hub", success: true, message: "ok", manualCommand: null });
+      }
+      return Promise.resolve(null);
+    });
+    render(<FirstRunDependencyDialog />);
+    await screen.findByTestId("first-run-deps-dialog");
+    // Uncheck crg → only context-hub installs.
+    const crgCheckbox = screen.getByLabelText("code-review-graph") as HTMLInputElement;
+    fireEvent.click(crgCheckbox);
+    expect(crgCheckbox.checked).toBe(false);
+
+    fireEvent.click(screen.getByText("dependency_install.install"));
+    await waitFor(() =>
+      expect(mockInvoke).toHaveBeenCalledWith("install_dependency", { name: "context-hub" })
+    );
+    // Only the context-hub install was triggered.
+    const installCalls = mockInvoke.mock.calls.filter((c) => c[0] === "install_dependency");
+    expect(installCalls).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- 첫 실행 시 누락된 사이드카 (context-hub via npm / code-review-graph via pip) 를 감지하고 **사용자 동의 후** 설치하는 다이얼로그 + 자동 설치 경로 추가.
- backend: `list_dependencies` / `install_dependency` Tauri command. timeout (npm 60s / pip 120s), pip 는 활성 venv 가 있으면 venv 안에 설치 (Q-3), 결과 이벤트 `dependency:install_result` emit.
- frontend: `FirstRunDependencyDialog` — setting `first_run_dependency_check_done` 으로 1회성 게이트, 항목별 체크박스, 건너뛰기/설치, 결과 상태 표시.
- i18n: ko/en `dialog.json` 의 `dependency_install` namespace.

## Plan / handoff mapping
- Plan: `docs/plans/windowsDependencyBootstrapPlan_2026-04-29.md`
- Handoff: `docs/prompts/windowsDependencyBootstrapDeveloperHandoff_2026-04-29.md`
- Task: **T4** (Phase 2 / P1)
- Q-3: 활성 venv 자동 활용 + global pip fallback + 1줄 안내 — 반영 (`venv_note` i18n key + pure helper).
- Q-4: 모달 직렬 보장 — 반영 (z-[110] vs onboarding z-[100]).
- W-9: 디버그 토글 (setting 사전 true) — 반영.

## Invariants
- **INV-1** (macOS 영향 0): backend 의 cfg(windows) 분기 (pip executable Scripts/pip.exe) 외 모든 코드는 cross-platform. macOS 측 detection 결과 `available:true` 면 dialog 자체가 안 뜸 → UX 영향 0.
- **INV-3** (macOS-specific 코드 미변경): 확인 (`bootstrap/env.rs` / `scripts/build-rawq.sh` 무변경).
- **INV-4** (단일 axis): T4 만 — 8 파일 (3 신규 + 5 수정).
- **INV-DEP-A** (silent install 금지): consent 버튼 클릭 후에만 invoke.
- **INV-DEP-B** (graceful failure): timeout / spawn fail / exit fail 각각 manual command 힌트와 함께 InstallResult 반환, 다이얼로그 hang 없음.

## Verification (Windows host)
- `cargo check --lib` ok
- `cargo test --lib commands::dependency_install` → **6 passed** (pip_executable_for 2건, pip_install_hint 1건, unknown dependency 1건, truncate 2건)
- `cargo test --lib` (full) → **575 passed / 4 failed**
  - 실패 4건은 본 PR 무관: `commands::files::tests::*` Windows path-separator 회귀 (R-W-7) — architect 가 별 worktree `fix/win-path-separator-grep-audit` 에서 hotfix 진행 중.
  - 본 PR axis 회귀 0 (T4 +6 신규 → pre-T4 569 + 6 = 575, 일치).
- `npx tsc --noEmit` ok
- `npx vitest run` → **386 passed** (pre-T4 381 + 5 신규)

## Test plan
- [ ] Linux self-hosted CI ✓
- [ ] dev mode 첫 실행 (setting clear) → dialog 노출 → "건너뛰기" → 다음 실행에는 dialog 없음
- [ ] dialog 에서 "설치" → context-hub / crg ready 로 전환 (architect 수동 검증)
- [ ] VIRTUAL_ENV 활성 상태 → pip 가 venv 안에 설치 (W-7)