### PR TITLE
feat(runtime-settings): manual install trigger for context-hub

### DIFF
--- a/src/components/tunaflow/settings/RuntimeSection.tsx
+++ b/src/components/tunaflow/settings/RuntimeSection.tsx
@@ -2,8 +2,9 @@ import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { copyToClipboard } from "@/lib/clipboard";
 import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
 import { cn, errorMessage } from "@/lib/utils";
-import { X, Search, FileText, ChevronRight, Copy, Send, Archive, ChevronDown } from "lucide-react";
+import { X, Search, FileText, ChevronRight, Copy, Send, Archive, ChevronDown, Download, Loader2, AlertCircle } from "lucide-react";
 import { useChatStore } from "@/stores/chatStore";
 import { getSetting, setSetting } from "@/lib/appStore";
 import { SKILL_SETS, expandSkillRefs } from "@/lib/skillSets";
@@ -417,7 +418,15 @@ interface HubHealth { available: boolean; version: string | null; message: strin
 interface HubSearchResult { id: string; title: string; source: string; snippet: string; score: number }
 interface HubDocument { id: string; title: string; content: string; source: string }
 
-function ContextHubPanel({ hubHealth }: { hubHealth: HubHealth | null }) {
+interface DependencyInstallResult {
+  name: string;
+  success: boolean;
+  message: string;
+  manualCommand: string | null;
+}
+
+function ContextHubPanel({ hubHealth, onRefresh }: { hubHealth: HubHealth | null; onRefresh: () => void }) {
+  const { t } = useTranslation("settings");
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<HubSearchResult[]>([]);
   const [searching, setSearching] = useState(false);
@@ -426,8 +435,37 @@ function ContextHubPanel({ hubHealth }: { hubHealth: HubHealth | null }) {
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
   const [sentToContext, setSentToContext] = useState(false);
+  const [installing, setInstalling] = useState(false);
+  const [installResult, setInstallResult] = useState<DependencyInstallResult | null>(null);
 
   const isAvailable = hubHealth?.available ?? false;
+
+  useEffect(() => {
+    const u = listen<DependencyInstallResult>("dependency:install_result", (e) => {
+      if (e.payload.name !== "context-hub") return;
+      setInstallResult(e.payload);
+      setInstalling(false);
+      if (e.payload.success) onRefresh();
+    });
+    return () => { u.then((un) => un()).catch(() => {}); };
+  }, [onRefresh]);
+
+  const handleInstall = async () => {
+    setInstalling(true);
+    setInstallResult(null);
+    try {
+      await invoke<DependencyInstallResult>("install_dependency", { name: "context-hub" });
+      // The dependency:install_result listener handles result + state.
+    } catch (e) {
+      setInstallResult({
+        name: "context-hub",
+        success: false,
+        message: errorMessage(e),
+        manualCommand: "npm install -g @aisuite/chub",
+      });
+      setInstalling(false);
+    }
+  };
 
   const handleSearch = async () => {
     if (!query.trim() || !isAvailable) return;
@@ -470,6 +508,40 @@ function ContextHubPanel({ hubHealth }: { hubHealth: HubHealth | null }) {
           <div className="flex items-center gap-2"><span className="text-muted-foreground w-[80px]">Policy</span><span className="text-foreground/80">bundled / local / private only</span></div>
         </div>
       ) : <p className="text-[12px] text-muted-foreground/50">Checking...</p>}
+
+      {!isAvailable && hubHealth && (
+        <div className="rounded-md border border-border/40 bg-accent/20 p-2.5 space-y-1.5" data-testid="context-hub-install-panel">
+          <div className="flex items-center gap-2">
+            <button
+              onClick={handleInstall}
+              disabled={installing}
+              className="flex items-center gap-1.5 px-3 py-1 rounded-md bg-primary/10 text-primary hover:bg-primary/20 transition-colors disabled:opacity-40 text-[11px] font-medium"
+            >
+              {installing ? <Loader2 className="w-3 h-3 animate-spin" /> : <Download className="w-3 h-3" />}
+              {installing ? t("runtime.context_hub_install.installing") : t("runtime.context_hub_install.button")}
+            </button>
+            <code className="text-[10px] text-muted-foreground/70">npm install -g @aisuite/chub</code>
+          </div>
+          {installResult?.success && (
+            <p className="text-[11px] text-status-approved">✓ {t("runtime.context_hub_install.success")}</p>
+          )}
+          {installResult && !installResult.success && (
+            <div className="flex items-start gap-1.5 text-[11px] text-destructive">
+              <AlertCircle className="w-3 h-3 mt-0.5" />
+              <div>
+                <div>{installResult.message}</div>
+                {installResult.manualCommand && (
+                  <div className="mt-1 text-muted-foreground">
+                    {t("runtime.context_hub_install.manual_hint")}{" "}
+                    <code className="text-foreground/70">{installResult.manualCommand}</code>
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+          <p className="text-[10px] text-muted-foreground/60">{t("runtime.context_hub_install.venv_note")}</p>
+        </div>
+      )}
 
       <div className="flex gap-1.5">
         <div className="flex-1 relative">
@@ -592,7 +664,11 @@ export function RuntimeSection() {
   const [rebuilding, setRebuilding] = useState(false);
   const [hubHealth, setHubHealth] = useState<HubHealth | null>(null);
 
-  useEffect(() => { invoke<HubHealth>("context_hub_health").then(setHubHealth).catch((e) => console.debug("[hub-health]", e)); }, []);
+  const refreshHubHealth = () => {
+    invoke<HubHealth>("context_hub_health").then(setHubHealth).catch((e) => console.debug("[hub-health]", e));
+  };
+
+  useEffect(() => { refreshHubHealth(); }, []);
 
   const handleRefreshModels = async () => { setRefreshing(true); await loadEngineModels(true); setRefreshing(false); };
 
@@ -682,7 +758,7 @@ export function RuntimeSection() {
       <ContextBudgetControl />
       <WorkflowSkillsConfig />
       <InsightAgentConfig />
-      <ContextHubPanel hubHealth={hubHealth} />
+      <ContextHubPanel hubHealth={hubHealth} onRefresh={refreshHubHealth} />
 
       {/* Background / Daemon */}
       <div className="rounded-lg border border-border/30 bg-background/50 p-4 space-y-2">

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -252,6 +252,13 @@
   "runtime": {
     "heading": "Runtime",
     "description": "Inspect and manage the runtime environment.",
+    "context_hub_install": {
+      "button": "Install via npm",
+      "installing": "Installing...",
+      "manual_hint": "Manual command:",
+      "success": "Installed — restart to mark as ready",
+      "venv_note": "The Python sidecar (code-review-graph) is installed via the first-run dialog or with an active venv."
+    },
     "workflow_skills": {
       "heading": "Workflow Skills",
       "description": "Skill sets per workflow phase. Combined with manual selection.",

--- a/src/locales/ko/settings.json
+++ b/src/locales/ko/settings.json
@@ -252,6 +252,13 @@
   "runtime": {
     "heading": "Runtime",
     "description": "런타임 환경 상태를 확인하고 관리합니다.",
+    "context_hub_install": {
+      "button": "npm 으로 설치",
+      "installing": "설치 중...",
+      "manual_hint": "수동 명령:",
+      "success": "설치 완료, 재시작 후 ready 로 전환",
+      "venv_note": "Python 측 사이드카 (code-review-graph) 는 첫 실행 다이얼로그 또는 venv 활성 상태에서 별도 설치하세요."
+    },
     "workflow_skills": {
       "heading": "Workflow Skills",
       "description": "워크플로우 단계별 스킬 세트. 수동 선택과 합산됩니다.",

--- a/src/tests/runtimeSection-contextHubInstall.test.tsx
+++ b/src/tests/runtimeSection-contextHubInstall.test.tsx
@@ -1,0 +1,89 @@
+// RuntimeSection ContextHubPanel — manual install trigger (T5 of
+// windowsDependencyBootstrapPlan_2026-04-29). Verifies the install
+// button is rendered only when context-hub is unavailable, and that
+// clicking it dispatches install_dependency.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+// react-i18next: identity mock — assertions go against keys.
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "ko", changeLanguage: () => Promise.resolve() },
+  }),
+}));
+
+const mockInvoke = vi.fn<(...a: unknown[]) => unknown>();
+const mockListen = vi.fn<() => Promise<() => void>>(() => Promise.resolve(() => {}));
+vi.mock("@tauri-apps/api/core", () => ({ invoke: (...a: unknown[]) => mockInvoke(...a) }));
+vi.mock("@tauri-apps/api/event", () => ({ listen: () => mockListen() }));
+
+vi.mock("@/lib/clipboard", () => ({ copyToClipboard: vi.fn() }));
+vi.mock("@/lib/skillSets", () => ({ SKILL_SETS: [], expandSkillRefs: () => [] }));
+vi.mock("@/lib/appStore", () => ({
+  getSetting: vi.fn((_key: string, fallback: unknown) => Promise.resolve(fallback)),
+  setSetting: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@/stores/chatStore", () => {
+  const baseStoreState = {
+    rawqStatus: null,
+    selectedProjectKey: null,
+    engineModels: [],
+    loadEngineModels: vi.fn(),
+    workflowSkills: {},
+    saveWorkflowSkills: vi.fn(),
+    setHandoffSource: vi.fn(),
+    selectedConversationId: null,
+  };
+  const useChatStore = Object.assign(
+    vi.fn((selector?: (s: typeof baseStoreState) => unknown) =>
+      selector ? selector(baseStoreState) : baseStoreState,
+    ),
+    { getState: () => baseStoreState },
+  );
+  return { useChatStore };
+});
+
+import { RuntimeSection } from "@/components/tunaflow/settings/RuntimeSection";
+
+beforeEach(() => {
+  mockInvoke.mockReset();
+  mockListen.mockClear();
+});
+
+describe("RuntimeSection — context-hub manual install (T5)", () => {
+  it("does not render install button when context-hub is ready", async () => {
+    mockInvoke.mockImplementation((...args: unknown[]) => {
+      if (args[0] === "context_hub_health") {
+        return Promise.resolve({ available: true, version: "0.1.4", message: "context-hub 0.1.4 ready" });
+      }
+      return Promise.resolve(null);
+    });
+    render(<RuntimeSection />);
+    await waitFor(() =>
+      expect(mockInvoke).toHaveBeenCalledWith("context_hub_health"),
+    );
+    expect(screen.queryByTestId("context-hub-install-panel")).toBeNull();
+  });
+
+  it("shows install button when context-hub is unavailable and triggers install_dependency on click", async () => {
+    mockInvoke.mockImplementation((...args: unknown[]) => {
+      const cmd = args[0] as string;
+      if (cmd === "context_hub_health") {
+        return Promise.resolve({ available: false, version: null, message: "context-hub not installed" });
+      }
+      if (cmd === "install_dependency") {
+        return Promise.resolve({ name: "context-hub", success: true, message: "ok", manualCommand: null });
+      }
+      return Promise.resolve(null);
+    });
+    render(<RuntimeSection />);
+    await screen.findByTestId("context-hub-install-panel");
+    fireEvent.click(screen.getByText("runtime.context_hub_install.button"));
+    await waitFor(() =>
+      expect(mockInvoke).toHaveBeenCalledWith("install_dependency", { name: "context-hub" }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Settings → Runtime 의 context-hub 카드가 `unavailable` 상태일 때 "npm 으로 설치" 버튼을 노출.
- 클릭 시 T4 의 `install_dependency` Tauri command 를 호출하고, `dependency:install_result` 이벤트로 결과를 받아 `context_hub_health` 재호출 → ready 로 자동 전환.
- 설치 중 스피너 / 실패 시 manual 명령 힌트 / venv 안내 동봉.
- macOS 사용자는 보통 `available:true` → 패널 hidden → UX 영향 0.

## Plan / handoff mapping
- Plan: `docs/plans/windowsDependencyBootstrapPlan_2026-04-29.md`
- Handoff: `docs/prompts/windowsDependencyBootstrapDeveloperHandoff_2026-04-29.md`
- Task: **T5** (Phase 2 / P1)

## Invariants
- **INV-1** (macOS 영향 0): hubHealth.available true → install panel 자체가 hidden. 코드 add-only.
- **INV-3** (macOS-specific 코드 미변경): 확인.
- **INV-4** (단일 axis): T5 만 — 4 파일 (1 테스트 신규 + 3 수정).

## Verification
- `npx tsc --noEmit` clean
- `npx vitest run src/tests/runtimeSection-contextHubInstall.test.tsx` → **2 passed**
  - ready 상태에서 install panel 미노출
  - unavailable 상태에서 클릭 → `install_dependency({name:"context-hub"})` invoke
- `npx vitest run` (full) → **388 passed** (pre-T5 386 + 2 신규)

## CRG 보류 사유
plan §3 T5 가 *"if there's a CRG section"* 으로 옵션 규정. 현재 RuntimeSection 에 CRG 전용 패널이 없어 본 PR 외 axis. 사용자는 T4 의 첫 실행 다이얼로그에서 CRG 도 함께 설치할 수 있음. CRG 패널 신설은 별 PR 권장.

## Test plan
- [ ] Linux self-hosted CI ✓
- [ ] dev mode 에서 chub 미설치 상태로 Settings 열기 → "npm 으로 설치" 버튼 노출, 클릭 → 약 5~30s 후 ready 로 전환 (architect 수동 검증)