### PR TITLE
chore(warnings): silence 3 dead_code / unused_imports warnings

### DIFF
--- a/src-tauri/src/commands/search/query_expand.rs
+++ b/src-tauri/src/commands/search/query_expand.rs
@@ -50,7 +50,13 @@ pub fn expand_query(query: &str, conn: Option<&Connection>) -> Result<String, Ap
 
 /// Strategy for the outbound Claude call — swappable in tests so we don't need
 /// to manipulate PATH or env vars in parallel test threads.
+///
+/// `Empty` / `Stub` are constructed only from `#[cfg(test)]` call sites; the
+/// production path uses `Real`. Variants stay on the public-ish enum (not
+/// gated behind `cfg(test)`) so the type signature is identical across
+/// test/release builds.
 #[derive(Debug, Clone, Copy)]
+#[allow(dead_code)]
 pub(crate) enum InvokeClaude {
     /// Spawn `claude -p ...` as a subprocess (production path).
     Real,

--- a/src-tauri/src/no_console.rs
+++ b/src-tauri/src/no_console.rs
@@ -32,7 +32,8 @@ impl NoConsole for std::process::Command {
 impl NoConsole for tokio::process::Command {
     #[cfg(windows)]
     fn no_console(&mut self) -> &mut Self {
-        use std::os::windows::process::CommandExt;
+        // `tokio::process::Command::creation_flags` is provided directly by tokio
+        // on Windows — no `std::os::windows::process::CommandExt` import required.
         self.creation_flags(CREATE_NO_WINDOW)
     }
     #[cfg(not(windows))]

--- a/src-tauri/src/notification_stub.rs
+++ b/src-tauri/src/notification_stub.rs
@@ -13,8 +13,12 @@
 
 use serde::Serialize;
 
+/// Auth status mirrors the macOS native enum so the serialized shape stays
+/// identical across platforms. On stub builds (non-macOS) variants are not
+/// constructed — the stub command paths return errors instead.
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
 pub enum NotificationAuthStatus {
     NotDetermined,
     Denied,


### PR DESCRIPTION
## Summary

`cargo check` on Windows surfaced 3 warnings since v0.1.4-beta merges. Pure annotation / unused-import cleanup, no behavior change.

| File | Warning | Fix |
|---|---|---|
| `src-tauri/src/no_console.rs:35` | `unused_imports` — `use std::os::windows::process::CommandExt;` inside `impl NoConsole for tokio::process::Command` | **Remove import** — tokio's own `Command` provides `creation_flags` directly on Windows. The std::process::Command impl above keeps its CommandExt import (actually required). |
| `src-tauri/src/commands/search/query_expand.rs:54-62` | `dead_code` — `InvokeClaude::Empty` / `Stub(&'static str)` never constructed | **`#[allow(dead_code)]`** — variants only constructed from `#[cfg(test)]` call sites; production always uses `Real`. Keeping variants ungated preserves identical type signature across test/release builds. |
| `src-tauri/src/notification_stub.rs:16-22` | `dead_code` — `NotificationAuthStatus::NotDetermined / Denied / Authorized` never constructed | **`#[allow(dead_code)]`** — enum mirrors the macOS native enum so the serialized shape stays cross-platform; on stub builds (Win/Linux) the stub command paths return errors instead, leaving variants as type-only. |

## Invariants

- **INV-1**: macOS unaffected.
  - `no_console.rs` change is inside `#[cfg(windows)]` block.
  - `notification_stub.rs` is `#![cfg(not(target_os = "macos"))]` only — macOS native path untouched.
  - `query_expand.rs` annotation is build-platform-agnostic but adds 0 behavior.
- **INV-4**: single axis (warning silence), 3 files +12/-1.

## Verification (Windows host)

- `cargo check` → **0 warnings** (was 3).
- Worktree-isolated at `D:/privateProject/tunaFlow-warnings` so the developer's main worktree is unaffected.

## Test plan

- [ ] CI rust-check + frontend-check pass
- [ ] mac architect spot-check: no behavior change confirmed (annotation-only + redundant import removal)