### PR TITLE
feat(claude-sdk): surface SDK session stderr for diagnostics

### DIFF
--- a/src-tauri/src/agents/claude_sdk_session.rs
+++ b/src-tauri/src/agents/claude_sdk_session.rs
@@ -492,7 +492,12 @@ async fn spawn_session(
         // stdin/stdout piped — stdin: 메시지 전달, stdout: 이벤트 수신(HTTP POST 병행)
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::null())
+        // stderr 를 piped 로 surface — 첫 메시지 stuck (Defender first-spawn /
+        // connection refused / version 불일치 등) 의 root cause 가 invisible 인
+        // 회귀 차단. 별 task 에서 line 단위 drain (drain 실패 시 buffer full 로
+        // claude 가 hang 함).
+        // PR #222 codex stderr surface 와 동등 패턴.
+        .stderr(std::process::Stdio::piped())
         .kill_on_drop(true);
 
     // `--session-id` vs `--resume` 상호배타 (claude CLI 2.1.x 제약).
@@ -522,6 +527,23 @@ async fn spawn_session(
         .stdout
         .take()
         .ok_or_else(|| AppError::Agent("sdk-session: could not get child stdout".into()))?;
+
+    // stderr 핸들 추출 + drain 태스크 — claude 의 startup 실패 (Defender freeze /
+    // connection refused / version 미스매치 등) 가 backend stderr 로 즉시 표면화
+    // 되도록 한다. WS connect 30s timeout 도달 전 claude 가 stderr 로 무엇을
+    // 토했는지가 가장 빠른 root-cause 신호. 30s 안에 connect 못 하는 케이스라도
+    // 이 태스크는 분리되어 있어 timeout 처리 흐름을 막지 않는다.
+    if let Some(child_stderr) = child.stderr.take() {
+        let conv_id_for_log = conv_id.to_string();
+        tokio::spawn(async move {
+            use tokio::io::{AsyncBufReadExt, BufReader};
+            let mut lines = BufReader::new(child_stderr).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                if line.trim().is_empty() { continue; }
+                eprintln!("[sdk-session-stderr] conv={} {}", conv_id_for_log, line);
+            }
+        });
+    }
 
     // claude WS 연결 대기 (최대 30초)
     tokio::time::timeout(


### PR DESCRIPTION
## Summary
- windowsBetaHardeningPlan §B (P1 startup race) 진단 도구.
- `claude --sdk-url` 자식 프로세스의 stderr 가 통째로 버려져 첫 메시지 stuck 의 root cause (Defender first-spawn / connection refused / version mismatch 등) 가 **invisible** 인 회귀 차단.
- `Stdio::null()` → `Stdio::piped()` + 별 tokio task 에서 line 단위 drain → `eprintln!("[sdk-session-stderr] conv={} {}", conv_id, line)` 로 backend stderr 에 즉시 표면화.
- PR #222 (codex stderr surface) 와 동등 패턴.

## Plan / handoff mapping
- Plan: `docs/plans/windowsBetaHardeningPlan_2026-04-26.md` §B (가설 검증용 진단 도구)
- 직전 인계 (architect → developer 2026-04-29): "A 안 + 트랙 3 병렬 진행"

## Invariants
- **INV-1** (macOS 영향 0): stderr surface 는 cross-platform. macOS 에서도 동일하게 surface 되며, 동작 변경 없음 (기존 시스템은 stderr 를 단순히 무시했었음).
- **INV-3** (macOS-specific 코드 미변경): 확인.
- **INV-4** (단일 axis): claude_sdk_session.rs 1 파일.
- 진단 도구라 fix-policy 무관.

## Verification
- `cargo check --lib` ok
- `cargo test --lib agents::claude_sdk_session` → **20 passed / 0 failed**
- `cargo test --lib` (예상) → 기존 baseline 그대로 (테스트 추가 없음, 진단 도구 axis)
- PR #222 패턴과 일관성 확인: codex.rs 의 stderr drain 과 동등 (string read vs line stream — 본 PR 은 long-running session 이라 line stream 채택)

## Diagnostic 시나리오 (architect 머지 후 재현 검증)
- cold start (fresh boot 또는 process kill 후 재시작)
- 첫 메시지 즉시 전송
- backend stderr 에 다음 중 하나가 나타나야 함:
  1. `[sdk-session-stderr] conv=... claude: connecting to ws://...` 류 (정상 시작)
  2. `[sdk-session-stderr] conv=... Error: connection refused` (가설 a — WS race)
  3. `[sdk-session-stderr] conv=... <verbose AV scan delay>` 또는 timeout 부재 (가설 b — Defender)
  4. 그 외 모든 stderr 라인 = root cause 단서

## Test plan
- [ ] Linux self-hosted CI ✓
- [ ] architect cold start 재현 → stderr 캡처 → 트랙 2 fix axis 결정