### PR TITLE
fix(bootstrap): project path validate + fallback (Windows P1)

### DIFF
--- a/src-tauri/src/commands/projects.rs
+++ b/src-tauri/src/commands/projects.rs
@@ -46,6 +46,28 @@ pub struct CreateProjectInput {
     pub source: String,
 }
 
+/// Validate the project's `path` column at runtime: populate `path_valid`
+/// and log a warning when stale. This is the single hook that makes the
+/// "macOS DB ported to Windows" regression visible to the frontend.
+///
+/// Side effect: `eprintln!` only — DB row is preserved so the user can
+/// later re-map the path manually.
+fn fill_path_valid(p: &mut Project) {
+    p.path_valid = match p.path.as_deref() {
+        Some(s) if !s.trim().is_empty() => {
+            let ok = std::path::Path::new(s).is_dir();
+            if !ok {
+                eprintln!(
+                    "[projects] stale path detected — key={} path={} (DB row preserved; user can re-map)",
+                    p.key, s
+                );
+            }
+            Some(ok)
+        }
+        _ => None,
+    };
+}
+
 #[tauri::command]
 pub fn list_projects(state: State<DbState>) -> Result<Vec<Project>, AppError> {
     let conn = state.read.lock().map_err(|_| AppError::Lock)?;
@@ -53,7 +75,7 @@ pub fn list_projects(state: State<DbState>) -> Result<Vec<Project>, AppError> {
         "SELECT key, name, path, type, default_engine, workspace_root, source, updated_at
          FROM projects WHERE COALESCE(hidden, 0) = 0 ORDER BY updated_at DESC",
     )?;
-    let rows = stmt
+    let mut rows = stmt
         .query_map([], |row| {
             Ok(Project {
                 key: row.get(0)?,
@@ -64,9 +86,13 @@ pub fn list_projects(state: State<DbState>) -> Result<Vec<Project>, AppError> {
                 workspace_root: row.get(5)?,
                 source: row.get(6)?,
                 updated_at: row.get(7)?,
+                path_valid: None,
             })
         })?
         .collect::<Result<Vec<_>, _>>()?;
+    for p in rows.iter_mut() {
+        fill_path_valid(p);
+    }
     Ok(rows)
 }
 
@@ -93,7 +119,7 @@ pub fn list_recent_projects(
          ORDER BY last_opened_at DESC, updated_at DESC
          LIMIT ?1",
     )?;
-    let rows = stmt
+    let mut rows = stmt
         .query_map(params![lim], |row| {
             Ok(Project {
                 key: row.get(0)?,
@@ -104,9 +130,13 @@ pub fn list_recent_projects(
                 workspace_root: row.get(5)?,
                 source: row.get(6)?,
                 updated_at: row.get(7)?,
+                path_valid: None,
             })
         })?
         .collect::<Result<Vec<_>, _>>()?;
+    for p in rows.iter_mut() {
+        fill_path_valid(p);
+    }
     Ok(rows)
 }
 
@@ -175,6 +205,7 @@ pub fn create_project(
                         key: row.get(0)?, name: row.get(1)?, path: row.get(2)?,
                         project_type: row.get(3)?, default_engine: row.get(4)?,
                         workspace_root: row.get(5)?, source: row.get(6)?, updated_at: row.get(7)?,
+                        path_valid: None,
                     }),
                 ).map_err(|_| AppError::NotFound("restored project not found".into()));
             }
@@ -218,7 +249,7 @@ pub fn create_project(
         scaffold_project_dir(path, &input.name);
     }
 
-    Ok(Project {
+    let mut project = Project {
         key: input.key,
         name: input.name,
         path: store_path,
@@ -227,7 +258,10 @@ pub fn create_project(
         workspace_root: input.workspace_root,
         source: input.source,
         updated_at: now,
-    })
+        path_valid: None,
+    };
+    fill_path_valid(&mut project);
+    Ok(project)
 }
 
 /// Create minimal project directory structure and convention files.
@@ -638,24 +672,28 @@ pub fn hide_project(key: String, state: State<DbState>) -> Result<(), AppError> 
 #[tauri::command]
 pub fn get_project(key: String, state: State<DbState>) -> Result<Project, AppError> {
     let conn = state.read.lock().map_err(|_| AppError::Lock)?;
-    conn.query_row(
-        "SELECT key, name, path, type, default_engine, workspace_root, source, updated_at
-         FROM projects WHERE key = ?1",
-        [&key],
-        |row| {
-            Ok(Project {
-                key: row.get(0)?,
-                name: row.get(1)?,
-                path: row.get(2)?,
-                project_type: row.get(3)?,
-                default_engine: row.get(4)?,
-                workspace_root: row.get(5)?,
-                source: row.get(6)?,
-                updated_at: row.get(7)?,
-            })
-        },
-    )
-    .map_err(|_| AppError::NotFound(format!("Project '{}' not found", key)))
+    let mut project = conn
+        .query_row(
+            "SELECT key, name, path, type, default_engine, workspace_root, source, updated_at
+             FROM projects WHERE key = ?1",
+            [&key],
+            |row| {
+                Ok(Project {
+                    key: row.get(0)?,
+                    name: row.get(1)?,
+                    path: row.get(2)?,
+                    project_type: row.get(3)?,
+                    default_engine: row.get(4)?,
+                    workspace_root: row.get(5)?,
+                    source: row.get(6)?,
+                    updated_at: row.get(7)?,
+                    path_valid: None,
+                })
+            },
+        )
+        .map_err(|_| AppError::NotFound(format!("Project '{}' not found", key)))?;
+    fill_path_valid(&mut project);
+    Ok(project)
 }
 
 /// Validate a project path before creation.
@@ -704,5 +742,71 @@ pub fn validate_project_path(path: String) -> Result<PathValidation, AppError> {
         normalized_path: trimmed.to_string(),
         error: None,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::models::Project;
+
+    fn project_with_path(path: Option<String>) -> Project {
+        Project {
+            key: "test-key".into(),
+            name: "test".into(),
+            path,
+            project_type: "project".into(),
+            default_engine: None,
+            workspace_root: None,
+            source: "configured".into(),
+            updated_at: 0,
+            path_valid: None,
+        }
+    }
+
+    #[test]
+    fn fill_path_valid_marks_existing_directory_as_true() {
+        // 환경에 의존성 없는 path: cargo manifest dir 은 항상 존재.
+        let manifest = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR");
+        let mut p = project_with_path(Some(manifest));
+        fill_path_valid(&mut p);
+        assert_eq!(p.path_valid, Some(true));
+    }
+
+    #[test]
+    fn fill_path_valid_marks_nonexistent_path_as_false() {
+        let mut p = project_with_path(Some(
+            "/this/path/__definitely_does_not_exist__/__claude_t3__".into(),
+        ));
+        fill_path_valid(&mut p);
+        assert_eq!(p.path_valid, Some(false));
+    }
+
+    #[test]
+    fn fill_path_valid_returns_none_when_path_unset() {
+        let mut p = project_with_path(None);
+        fill_path_valid(&mut p);
+        assert!(p.path_valid.is_none());
+    }
+
+    #[test]
+    fn fill_path_valid_returns_none_when_path_empty_or_whitespace() {
+        let mut p = project_with_path(Some(String::new()));
+        fill_path_valid(&mut p);
+        assert!(p.path_valid.is_none());
+
+        let mut p = project_with_path(Some("   ".into()));
+        fill_path_valid(&mut p);
+        assert!(p.path_valid.is_none());
+    }
+
+    #[test]
+    fn fill_path_valid_marks_file_as_false() {
+        // is_dir() 는 directory 만 true. file 은 false.
+        let manifest = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR");
+        let cargo_toml = std::path::Path::new(&manifest).join("Cargo.toml");
+        let mut p = project_with_path(Some(cargo_toml.to_string_lossy().to_string()));
+        fill_path_valid(&mut p);
+        assert_eq!(p.path_valid, Some(false));
+    }
 }
 

--- a/src-tauri/src/db/models.rs
+++ b/src-tauri/src/db/models.rs
@@ -6,6 +6,10 @@ use serde::{Deserialize, Serialize};
 /// - `path`: 로컬 프로젝트 디렉토리. 에이전트의 cwd + rawq 검색 대상.
 ///   향후 git repo 여부 판별의 기준 경로 (path 내 .git 존재 확인).
 /// - `workspace_root`: multi-root workspace 확장용 (현재 미사용).
+/// - `path_valid`: startup-time path 존재 여부. DB 미저장 — `list_*`/`get_project`
+///   가 채우는 runtime-only field. macOS DB 가 Windows 로 이식되어 `/Users/...`
+///   경로가 무효해진 회귀를 frontend 가 감지/차단할 수 있도록 한다.
+///   None = path 미설정, Some(true) = directory 존재, Some(false) = stale.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Project {
@@ -19,6 +23,8 @@ pub struct Project {
     pub workspace_root: Option<String>,
     pub source: String,
     pub updated_at: i64,
+    #[serde(default, skip_deserializing)]
+    pub path_valid: Option<bool>,
 }
 
 /// DATA_MODEL.md §1.3 Conversation

--- a/src/components/tunaflow/AppShell.tsx
+++ b/src/components/tunaflow/AppShell.tsx
@@ -82,9 +82,22 @@ export function AppShell() {
         const { projects, selectProject } = useChatStore.getState();
 
         const lastKey = await getSetting<string>("lastProjectKey", "");
-        let proj = lastKey ? projects.find((p) => p.key === lastKey) : null;
-        if (!proj) proj = projects[0];
-        // No auto-create: if no projects, show ProjectStartup instead
+        // Auto-select must skip projects whose `path` no longer exists on
+        // this machine — stale rows (e.g. macOS `/Users/...` ported to
+        // Windows) hang `selectProject` on file IO. `pathValid === false`
+        // is the explicit signal from backend; `undefined` (no path set)
+        // is fine for non-filesystem project types (chat / channel).
+        const stale = projects.filter((p) => p.pathValid === false);
+        if (stale.length > 0) {
+          console.warn(
+            "[AppShell] skipping auto-select for stale-path projects:",
+            stale.map((p) => `${p.key} (${p.path})`).join(", "),
+          );
+        }
+        const selectable = projects.filter((p) => p.pathValid !== false);
+        let proj = lastKey ? selectable.find((p) => p.key === lastKey) : null;
+        if (!proj) proj = selectable[0];
+        // No auto-create: if no projects (or all stale), show ProjectStartup instead
         if (proj) {
           setLoadingStep(`프로젝트 열기: ${proj.name ?? proj.key}...`);
           await selectProject(proj.key);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,6 +7,15 @@ export interface Project {
   workspaceRoot?: string;
   source: "configured" | "discovered";
   updatedAt: number;
+  /**
+   * Runtime-only field populated by `list_projects` / `get_project` —
+   * `true` when the path exists as a directory on this machine, `false`
+   * when stale (typical regression: macOS DB ported to Windows where
+   * `/Users/...` is invalid). `undefined` when the path is unset/empty.
+   * Use this to gate auto-select on cold start so the app does not hang
+   * on stale paths.
+   */
+  pathValid?: boolean;
 }
 
 export interface Conversation {


### PR DESCRIPTION
## Summary
- macOS DB 가 Windows 로 이식된 베타 사용자 시나리오에서 `projects.path` 가 `/Users/<user>/...` 처럼 무효해진 row 가 cold-start auto-select 되면 `selectProject` 가 file IO 로 hang 하던 회귀를 차단.
- backend: `Project::path_valid: Option<bool>` runtime-only field 추가. `list_projects` / `list_recent_projects` / `get_project` / `create_project` 가 모두 채움. invalid 시 stderr 로 한 줄 경고 (`[projects] stale path detected — key=... path=...`). DB row 는 보존해서 사용자가 나중에 매핑 가능.
- frontend: AppShell init 에서 `pathValid === false` 인 프로젝트는 lastKey/first auto-select 후보에서 제외. 모두 stale 이면 ProjectStartup 화면으로 fallback.

## Plan / handoff mapping
- Plan: `docs/plans/windowsBetaHardeningPlan_2026-04-26.md` §C / §96 option A
- 직전 인계 (architect → developer 2026-04-29): "Track 3 — DB path stale fix (P1)"
- 같은 인계의 트랙 2 (startup race 진단) A 안 = PR #233 (별 axis 병행 진행)

## Invariants
- **INV-1** (macOS 영향 0): cross-platform fallback. macOS 의 valid path 는 `Some(true)` → 기존 auto-select 동작 100% 유지. Windows 에서 stale `/Users/...` 만 `Some(false)` 로 분류됨. unit test (`fill_path_valid_marks_existing_directory_as_true`, manifest dir 사용) 가 macOS 회귀 가드.
- **INV-3** (macOS-specific 파일 미변경): 확인.
- **INV-4** (단일 axis): path validation, 4 파일 (backend 2 + frontend 2).

## Verification
- `cargo check --lib` ok
- `cargo test --lib commands::projects` → **5 passed** (신규 unit test 5)
  - existing directory → Some(true)
  - nonexistent path → Some(false)
  - path None → None
  - empty/whitespace path → None
  - file (not directory) → Some(false)
- `cargo test --lib` (full) → **584 passed / 0 failed** (pre-baseline 579 + 신규 5, 일치)
- `npx tsc --noEmit` clean
- `npx vitest run` → **388 passed** (변경 없음)

## DB / migration 영향
- DB 스키마 변경 없음 (`path_valid` 는 `#[serde(skip_deserializing)]` runtime field).
- 마이그레이션 불필요.
- 기존 stale row 는 *DB 에 그대로 보존* — 사용자가 나중에 path 재선택 또는 hide 처리 가능.

## Test plan
- [ ] Linux self-hosted CI ✓
- [ ] dev 모드 manual smoke (architect 검증)
  - macOS: 정상 path 로 last project auto-select 동작 확인 (기존 동작 그대로)
  - Windows: stale `/Users/...` row 가 있는 DB 로 시작 → ProjectStartup 화면 + console.warn / backend stderr `[projects] stale path detected` 로그