### PR TITLE
fix(claude-sdk): make Windows no-op explicit in kill_orphan_sdk_processes

### DIFF
--- a/src-tauri/src/agents/claude_sdk_session.rs
+++ b/src-tauri/src/agents/claude_sdk_session.rs
@@ -1005,6 +1005,11 @@ pub fn shutdown_all_sessions() {
 
 /// Kill any orphaned `claude --sdk-url` processes from previous app runs.
 /// Called on app startup to prevent zombie processes that consume rate limit quota.
+///
+/// Unix path uses `pgrep -f` + `ps -o ppid=` to detect PPID=1 orphans, then
+/// `kill <pid>`. Windows would need WMIC / PowerShell parent-PID +
+/// command-line introspection — deferred (see windows variant below).
+#[cfg(unix)]
 pub fn kill_orphan_sdk_processes() {
     use std::process::Command;
     let output = match Command::new("pgrep").no_console().args(["-f", "claude.*--sdk-url"]).output() {
@@ -1034,6 +1039,28 @@ pub fn kill_orphan_sdk_processes() {
     if killed > 0 {
         eprintln!("[sdk-session] cleaned up {} orphan sdk-url process(es)", killed);
     }
+}
+
+/// Windows variant — intentional no-op for now.
+///
+/// The Unix path relies on `pgrep` / `ps -o ppid=` which do not exist on
+/// Windows. Spawning them previously failed silently (`Err(_) => return` on
+/// the first call), making the no-op non-obvious — this `cfg(windows)` stub
+/// makes the absence explicit.
+///
+/// Why deferred:
+/// - Random per-session port (`127.0.0.1:0`) + UUID session_id mean orphaned
+///   `claude.exe --sdk-url` processes do not collide with new sessions or
+///   directly saturate user-visible quota in practice.
+/// - Proper Windows orphan detection requires WMIC / PowerShell command-line
+///   + parent-PID introspection — deferred to a separate
+///   `windowsOrphanProcessHardeningPlan` (P3, post-beta).
+/// - The §D watchdog `taskkill` patch (PR #231) already handles the more
+///   common in-session idle-timeout kill path; this stub covers only the
+///   cross-app-restart leak path, which is rarer.
+#[cfg(windows)]
+pub fn kill_orphan_sdk_processes() {
+    // intentional no-op — see doc comment above for rationale and follow-up plan.
 }
 
 // ─── Tests ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`kill_orphan_sdk_processes()` uses `pgrep -f` / `ps -o ppid=` / `kill <pid>` — all Unix-only. On Windows the first `pgrep` spawn fails (`Err(_) => return`) which silently no-ops, but the absence of an explicit `cfg(windows)` made the Windows behavior easy to misread as "actually working".

This PR makes the no-op explicit: wrap the Unix path in `cfg(unix)` and add a `cfg(windows)` stub with rationale + follow-up plan reference. Behavior unchanged on Windows (still no-op). macOS / Linux unchanged (still `cfg(unix)`).

## Plan / handoff mapping

- Discovered during developer's Track 2 (windowsBetaHardening §B startup race) static analysis as a "Bonus" finding — separate axis from §B itself.
- Sibling axis to PR #231 (`claude.rs` watchdog Windows compat). Same category (Unix-only kill on Windows), different hot-spot.
- Real Windows implementation deferred to `windowsOrphanProcessHardeningPlan` (P3, post-beta).

## Why no real Windows implementation now

- Random per-session port (`127.0.0.1:0`) + UUID session_id mean orphaned `claude.exe --sdk-url` processes do not collide with new sessions or directly saturate user-visible quota in practice.
- Proper Windows detection requires WMIC / PowerShell command-line + parent-PID introspection — significant complexity, marginal value for beta.
- §D watchdog `taskkill` patch (PR #231) already handles the more common in-session idle-timeout kill path; this stub only covers the cross-app-restart leak path, which is rarer.

## Invariants

- **INV-1**: macOS / Linux unaffected — Unix path now under `cfg(unix)` (same code, same activation set).
- **INV-3**: only `claude_sdk_session.rs:kill_orphan_sdk_processes` touched.
- **INV-4**: single axis (Windows kill no-op explicit). 1 file, +27 insertions.

## Verification (Windows host)

- `cargo check` → 0 warnings.
- Worktree-isolated at `D:/privateProject/tunaFlow-bonus`.
- Behavior on Windows unchanged (was implicit no-op via `Err(_) => return`, now explicit `cfg(windows)` no-op).

## Test plan

- [ ] CI rust-check + frontend-check pass
- [ ] mac architect spot-check: `cfg(unix)` activation set unchanged on macOS, behavior identical