### PR TITLE
feat(titlebar): unified custom controls + left-align (Win/Mac)

### DIFF
--- a/src-tauri/src/bootstrap/window.rs
+++ b/src-tauri/src/bootstrap/window.rs
@@ -10,6 +10,18 @@ pub fn restore_window_state(app: &tauri::App) -> Result<(), Box<dyn std::error::
         return Ok(());
     };
 
+    // Windows: drop native decorations so the custom TitleBar + WindowControls
+    // own the caption area (mac parity — `titleBarStyle: "Overlay"` +
+    // `hiddenTitle: true` are macOS-only). Done while the window is still
+    // hidden (`visible: false` in tauri.conf.json) so the user never sees the
+    // native chrome flicker out. cfg-gated → mac/Linux untouched.
+    #[cfg(target_os = "windows")]
+    {
+        if let Err(e) = window.set_decorations(false) {
+            eprintln!("[bootstrap/window] set_decorations(false) failed: {}", e);
+        }
+    }
+
     // window-state plugin restores position/size BEFORE setup runs.
     // Log actual state to diagnose restoration issues.
     let pos = window.outer_position().unwrap_or_default();

--- a/src/components/tunaflow/TitleBar.tsx
+++ b/src/components/tunaflow/TitleBar.tsx
@@ -1,10 +1,22 @@
 import { useState, useEffect } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { isWindows as detectIsWindows } from "@/lib/platform";
 import { useChatStore } from "@/stores/chatStore";
+import { WindowControls } from "./WindowControls";
+
+const isWindows = detectIsWindows();
 
 /**
- * Custom title bar — overlays the macOS traffic light area.
- * Shows: tunaFlow / projectName / gitBranch
+ * Unified title bar (mac / Windows).
+ * - mac: traffic-light overlay (`titleBarStyle: "Overlay"` + `hiddenTitle:
+ *   true` in tauri.conf.json) — left padding reserves the traffic-light area.
+ * - Windows: native decorations dropped in `bootstrap/window.rs` (T-WT-1);
+ *   custom `<WindowControls />` rendered top-right; left padding is minimal.
+ *
+ * Information row (tunaFlow / projectName / gitBranch) is **left-aligned on
+ * both OSes** (Q-WT-4) — center is reserved as drag-region for window move.
+ *
+ * Plan: docs/plans/windowsTitlebarUnificationPlan_2026-04-29.md (§3.3, T-WT-3)
  */
 export function TitleBar() {
   const selectedProjectKey = useChatStore((s) => s.selectedProjectKey);
@@ -30,9 +42,16 @@ export function TitleBar() {
   return (
     <div
       data-tauri-drag-region
-      className="h-[28px] shrink-0 flex items-center justify-center select-none bg-sidebar"
+      className="h-[32px] shrink-0 flex items-center select-none bg-sidebar"
     >
-      <div data-tauri-drag-region className="flex items-center gap-0">
+      {/* Left padding — reserves traffic-light area on mac, minimal on Windows */}
+      <div
+        data-tauri-drag-region
+        className={isWindows ? "w-[12px] shrink-0" : "w-[72px] shrink-0"}
+      />
+
+      {/* Info row — left-aligned on both OSes (Q-WT-4) */}
+      <div data-tauri-drag-region className="flex items-center gap-0 shrink-0">
         <span data-tauri-drag-region className="text-[11px] font-bold text-foreground/70 tracking-wide">
           tunaFlow
         </span>
@@ -55,6 +74,12 @@ export function TitleBar() {
           </>
         )}
       </div>
+
+      {/* Center — large drag region */}
+      <div data-tauri-drag-region className="flex-1" />
+
+      {/* Right side: Windows custom controls / mac empty padding */}
+      {isWindows ? <WindowControls /> : <div className="w-[72px] shrink-0" />}
     </div>
   );
 }

--- a/src/components/tunaflow/WindowControls.tsx
+++ b/src/components/tunaflow/WindowControls.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState } from "react";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { Minus, Square, X, Copy } from "lucide-react";
+
+/**
+ * Custom Window Controls — Windows 11 native parity (46×32 sq buttons).
+ * Rendered only on Windows by `TitleBar.tsx` (platform-detect gate); the
+ * component itself has no `cfg` so unit tests can exercise it on any host.
+ *
+ * Plan: docs/plans/windowsTitlebarUnificationPlan_2026-04-29.md (§3.2, T-WT-2)
+ * Decisions: Q-WT-1 (Windows native shape) / Q-WT-2 (status-rejected close hover)
+ */
+export function WindowControls() {
+  const [isMaximized, setIsMaximized] = useState(false);
+
+  useEffect(() => {
+    let cleanup: (() => void) | undefined;
+    const w = getCurrentWindow();
+    w.isMaximized().then(setIsMaximized).catch(() => {});
+    w.onResized(() => {
+      w.isMaximized().then(setIsMaximized).catch(() => {});
+    })
+      .then((un) => { cleanup = un; })
+      .catch(() => {});
+    return () => { if (cleanup) cleanup(); };
+  }, []);
+
+  const onMinimize = () => { getCurrentWindow().minimize().catch(() => {}); };
+  const onToggleMax = () => { getCurrentWindow().toggleMaximize().catch(() => {}); };
+  const onClose = () => { getCurrentWindow().close().catch(() => {}); };
+
+  return (
+    <div
+      className="flex items-center h-full shrink-0"
+      data-tauri-drag-region={false}
+      data-testid="window-controls"
+    >
+      <button
+        type="button"
+        aria-label="Minimize"
+        onClick={onMinimize}
+        className="h-full w-[46px] flex items-center justify-center text-foreground/70 hover:bg-foreground/10 hover:text-foreground focus-visible:outline-none focus-visible:bg-foreground/10"
+      >
+        <Minus size={14} />
+      </button>
+      <button
+        type="button"
+        aria-label={isMaximized ? "Restore" : "Maximize"}
+        onClick={onToggleMax}
+        className="h-full w-[46px] flex items-center justify-center text-foreground/70 hover:bg-foreground/10 hover:text-foreground focus-visible:outline-none focus-visible:bg-foreground/10"
+      >
+        {isMaximized ? <Copy size={12} /> : <Square size={12} />}
+      </button>
+      <button
+        type="button"
+        aria-label="Close"
+        onClick={onClose}
+        className="h-full w-[46px] flex items-center justify-center text-foreground/70 hover:bg-status-rejected hover:text-white focus-visible:outline-none focus-visible:bg-status-rejected focus-visible:text-white"
+      >
+        <X size={14} />
+      </button>
+    </div>
+  );
+}

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -12,14 +12,20 @@
  * Windows/Linux on `tauri-plugin-notification` (zero behavior change).
  */
 
-function detect(): "macos" | "other" {
+function detect(): "macos" | "windows" | "other" {
   if (typeof navigator === "undefined") return "other";
   const ua = navigator.userAgent || "";
-  return /Mac|Macintosh|MacIntel/i.test(ua) ? "macos" : "other";
+  if (/Mac|Macintosh|MacIntel/i.test(ua)) return "macos";
+  if (/Win/i.test(ua)) return "windows";
+  return "other";
 }
 
 const cached = detect();
 
 export function isMacOS(): boolean {
   return cached === "macos";
+}
+
+export function isWindows(): boolean {
+  return cached === "windows";
 }

--- a/src/tests/windowControls.test.tsx
+++ b/src/tests/windowControls.test.tsx
@@ -1,0 +1,73 @@
+// WindowControls — Windows custom window controls (T-WT-2 of
+// windowsTitlebarUnificationPlan_2026-04-29). Verifies the three buttons
+// render with proper ARIA labels, dispatch the right Tauri window APIs,
+// and toggle the maximize/restore icon based on `isMaximized`.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+const minimize = vi.fn(() => Promise.resolve());
+const toggleMaximize = vi.fn(() => Promise.resolve());
+const close = vi.fn(() => Promise.resolve());
+const isMaximized = vi.fn(() => Promise.resolve(false));
+const onResized = vi.fn(() => Promise.resolve(() => {}));
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({
+    minimize,
+    toggleMaximize,
+    close,
+    isMaximized,
+    onResized,
+  }),
+}));
+
+import { WindowControls } from "@/components/tunaflow/WindowControls";
+
+beforeEach(() => {
+  minimize.mockClear();
+  toggleMaximize.mockClear();
+  close.mockClear();
+  isMaximized.mockClear().mockResolvedValue(false);
+  onResized.mockClear().mockResolvedValue(() => {});
+});
+
+describe("WindowControls", () => {
+  it("renders Min / Max / Close buttons with correct ARIA labels", () => {
+    render(<WindowControls />);
+    expect(screen.getByRole("button", { name: "Minimize" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Maximize" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Close" })).toBeInTheDocument();
+  });
+
+  it("dispatches minimize() when Minimize is clicked", async () => {
+    render(<WindowControls />);
+    fireEvent.click(screen.getByRole("button", { name: "Minimize" }));
+    await waitFor(() => expect(minimize).toHaveBeenCalledTimes(1));
+  });
+
+  it("dispatches toggleMaximize() when Maximize is clicked", async () => {
+    render(<WindowControls />);
+    fireEvent.click(screen.getByRole("button", { name: "Maximize" }));
+    await waitFor(() => expect(toggleMaximize).toHaveBeenCalledTimes(1));
+  });
+
+  it("dispatches close() when Close is clicked", async () => {
+    render(<WindowControls />);
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    await waitFor(() => expect(close).toHaveBeenCalledTimes(1));
+  });
+
+  it("renders Restore label when initially maximized", async () => {
+    isMaximized.mockResolvedValue(true);
+    render(<WindowControls />);
+    await screen.findByRole("button", { name: "Restore" });
+    expect(screen.queryByRole("button", { name: "Maximize" })).toBeNull();
+  });
+
+  it("opts out of drag region", () => {
+    render(<WindowControls />);
+    const root = screen.getByTestId("window-controls");
+    expect(root.getAttribute("data-tauri-drag-region")).toBe("false");
+  });
+});


### PR DESCRIPTION
## Summary
- Windows 사용자 보고 *3 라인* (native title bar + TitleBar.tsx + AppShell 헤더) → mac 과 동일한 *1 라인* 통합으로 정렬.
- 본 PR 은 windowsTitlebarUnificationPlan §3 / T-WT-1+2+3 (P0 베타 hotfix) 묶음. axis 작고 T-WT-2 단독은 UX 효과 0 (T-WT-3 가 import 후에야 마운트), T-WT-3 가 T-WT-1 의 native chrome 제거에 의존하므로 **단일 PR 묶음**.
- T-WT-4/5/6 (a11y / snap layouts overlay / 디자인 토큰) 은 Q-WT-6 결정으로 v0.1.5 묶음.

## Plan / handoff mapping
- Plan: `docs/plans/windowsTitlebarUnificationPlan_2026-04-29.md`
- 직전 인계 (architect → developer 2026-04-29): "Track 1 — windowsTitlebarUnification T-WT-1~3"
- 결정 incorporate: Q-WT-1 (Win11 native 46×32) / Q-WT-2 (status-rejected close hover) / Q-WT-4 (좌측 정렬 통일) / Q-WT-6 (T-WT-4~6 v0.1.5 보류). Q-WT-3 (snap layouts) / Q-WT-5 (Linux) 본 PR 범위 외.

## Changes
**T-WT-1** `src-tauri/src/bootstrap/window.rs`
- `#[cfg(target_os = "windows")] { window.set_decorations(false) }` — visible:false 시작 직후 호출, native chrome flicker 0.

**T-WT-2** `src/components/tunaflow/WindowControls.tsx` (신규, 64 lines)
- Windows 11 native 사각 46×32 buttons: Min / Max-Restore / Close.
- close hover: `status-rejected` 토큰 (oklch theme derived → light/dark 자동 대응).
- Tauri 2 `getCurrentWindow().{minimize,toggleMaximize,close}` + `onResized` listener 로 Maximize↔Restore icon 상태 동기화.
- ARIA labels (Minimize / Maximize / Restore / Close), focus-visible ring, `data-tauri-drag-region={false}`.

**T-WT-3** `src/components/tunaflow/TitleBar.tsx`
- mac/Win 정보 영역 좌측 통일 (Q-WT-4): left padding (mac 72px traffic light reserve / Win 12px) → 정보 row → flex-1 중앙 drag-region → 우측 (Win WindowControls / mac 72px padding).
- 높이 28→32px (Win11 caption 표준).
- 텍스트 컴포넌트 (tunaFlow / projectName / gitBranch) 자체 변경 0 (INV-3).

**plugin-os 회피** `src/lib/platform.ts`
- 기존 isMacOS() 패턴 그대로, `isWindows()` 추가 (navigator.userAgent sniff). `@tauri-apps/plugin-os` 신설 없이 동일 효과 — plugin bundle 회피 + capabilities 추가 회피.

## Invariants
- **INV-1** (mac 영향 0): set_decorations cfg(windows) 격리 / WindowControls mac 미렌더 / TitleBar 좌측 정렬은 layout-only (텍스트 컴포넌트 동일). 단 mac 사용자에게도 *정보 위치 중앙 → 좌측* 변경 발생 — Q-WT-4 의도된 변경, B-WT-1 검증 의무 (PR description 의 dev 모드 smoke 항목 참조).
- **INV-3** (macOS-specific 파일 미변경): `bootstrap/env.rs` / `scripts/build-rawq.sh` 무변경 git diff 확인.
- **INV-4** (단일 axis): titlebar unification 1 axis, 5 파일 (3 신규/수정 컴포넌트 + 1 platform helper + 1 test).
- **INV-WT-A 부분**: native double-click maximize / Aero snap / Win+↑↓ / Alt+space 는 OS 가 default 처리. snap layouts overlay (Q-WT-3) 는 v0.1.5 / T-WT-5.

## Verification
- `npx tsc --noEmit` clean
- `cargo check --lib` ok
- `cargo test --lib` (full) → **584 passed / 0 failed** (T-WT-1 의 cfg 분기 1줄, 신규 테스트 X — baseline 그대로)
- `npx vitest run src/tests/windowControls.test.tsx` → **6 passed**
  - Min/Max/Close ARIA label 노출
  - 각 button click → Tauri API 1 호출 검증 (mock spy)
  - 초기 isMaximized:true 시 "Restore" label 으로 렌더
  - root data-tauri-drag-region="false" 확인
- `npx vitest run` (full) → **394 passed** (pre-baseline 388 + 신규 6, 일치)

## Test plan (수동 smoke — architect 검증 영역)
- [ ] Linux self-hosted CI ✓
- [ ] Windows dev 모드 (`npm run tauri dev`)
  - native title bar 사라짐, 1 라인 통합 (32px) ✓
  - 우상단 WindowControls — Min/Max/Close 동작
  - Maximize 후 Restore icon 으로 변경 (Square → Copy)
  - TitleBar 영역 드래그로 창 이동
  - **WT-13** light mode 에서 Close 버튼 hover white text 가독성 (axe-core 또는 시각, 대비비 ≥ 4.5:1) — B-WT-2 / R-WT-1
- [ ] **mac dev 모드 smoke (B-WT-1)**: traffic light 옆 좌측 정보 표시 자연스러운지, 회귀 0 확인
- [ ] (v0.1.5 영역, 본 PR 범위 외) Win11 22H2+ snap layouts overlay 동작 검증 — T-WT-5

## 추후 trace
- T-WT-4 (a11y testing-library) / T-WT-5 (snap layouts) / T-WT-6 (디자인 토큰): v0.1.5 정식 release 묶음 (Q-WT-6).