### PR TITLE
feat(claude+db): rate_limit_event parser + migration v49 (T1+T5)

### DIFF
--- a/src-tauri/src/agents/anthropic_sdk.rs
+++ b/src-tauri/src/agents/anthropic_sdk.rs
@@ -159,6 +159,7 @@ where
         input_tokens,
         output_tokens,
         session_id: None,
+        last_rate_limit: None,
     })
 }
 

--- a/src-tauri/src/agents/claude.rs
+++ b/src-tauri/src/agents/claude.rs
@@ -40,6 +40,36 @@ struct StreamLine {
     /// insightStabilityPlan Subtask 03 (INV-3).
     usage: Option<StreamUsage>,
     session_id: Option<String>,
+    // rate_limit_event fields — claude CLI 2.1.x stream-json 일부 응답에 포함.
+    // (claudeTransportFlipHardeningPlan T1) optional, 미존재 시 graceful 무시.
+    status: Option<String>,
+    resets_at: Option<String>,
+    rate_limit_type: Option<String>,
+    overage_status: Option<String>,
+    overage_disabled_reason: Option<String>,
+    is_using_overage: Option<bool>,
+}
+
+/// claude CLI 의 `rate_limit_event` line 에서 추출된 정보.
+///
+/// SSOT: `docs/plans/claudeTransportFlipHardeningPlan_2026-04-29.md` Task 01.
+/// frontend RuntimeStatusBar 의 indicator + 사용자 가시 안내 (overage rejected,
+/// reset 카운트다운) 의 데이터 소스. 미전송 버전 / line 미수신 시 None.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RateLimitInfo {
+    /// "ok" / "approaching_limit" / "limit_reached" / etc — Anthropic 정의 그대로
+    pub status: Option<String>,
+    /// reset 시점 RFC3339 ISO 문자열
+    pub resets_at: Option<String>,
+    /// "5_hour" / "weekly" / etc
+    pub rate_limit_type: Option<String>,
+    /// "enabled" / "disabled" / "available"
+    pub overage_status: Option<String>,
+    /// "org_level_disabled" 등 disable 사유
+    pub overage_disabled_reason: Option<String>,
+    /// 현재 send 가 overage 사용 중인지
+    pub is_using_overage: Option<bool>,
 }
 
 #[derive(Deserialize)]
@@ -138,6 +168,9 @@ pub struct RunOutput {
     pub input_tokens: i64,
     pub output_tokens: i64,
     pub session_id: Option<String>,
+    /// 가장 최근에 관측된 `rate_limit_event` payload. Anthropic 측에서 미전송이거나
+    /// 구버전 CLI 면 None. claudeTransportFlipHardeningPlan T1.
+    pub last_rate_limit: Option<RateLimitInfo>,
 }
 
 /// Execute `claude -p` with `--output-format stream-json`.
@@ -212,6 +245,9 @@ where
     let reader = BufReader::new(stdout);
     let mut final_output: Option<RunOutput> = None;
     let mut unparsed_lines: Vec<String> = Vec::new();
+    // 마지막으로 관측된 rate_limit_event — result event 시 RunOutput.last_rate_limit
+    // 으로 전달. claudeTransportFlipHardeningPlan T1.
+    let mut last_rate_limit: Option<RateLimitInfo> = None;
 
     // Idle timeout: kill process if no output for 10 minutes.
     // insightStabilityPlan Subtask 04 (INV-4): watchdog 가 `timed_out` 플래그를 set
@@ -309,6 +345,19 @@ where
             "system" => {
                 on_progress("Agent initializing...".into());
             }
+            // claude CLI 가 stream-json 안에 rate_limit_event line 을 별도 emit 하는
+            // 케이스. T1: 마지막 관측치를 RunOutput.last_rate_limit 으로 전달.
+            // 구버전 CLI 가 미전송이면 last_rate_limit 은 None 으로 유지된다.
+            "rate_limit_event" => {
+                last_rate_limit = Some(RateLimitInfo {
+                    status: parsed.status.clone(),
+                    resets_at: parsed.resets_at.clone(),
+                    rate_limit_type: parsed.rate_limit_type.clone(),
+                    overage_status: parsed.overage_status.clone(),
+                    overage_disabled_reason: parsed.overage_disabled_reason.clone(),
+                    is_using_overage: parsed.is_using_overage,
+                });
+            }
             "assistant" => {
                 if let Some(msg) = &parsed.message {
                     // Thinking → structured step
@@ -375,6 +424,7 @@ where
                         .or_else(|| parsed.usage.as_ref().and_then(|u| u.output_tokens))
                         .unwrap_or(0),
                     session_id: parsed.session_id,
+                    last_rate_limit: last_rate_limit.take(),
                 });
             }
             _ => {}
@@ -482,6 +532,9 @@ pub fn run(input: RunInput) -> Result<RunOutput, AppError> {
             .or_else(|| parsed.usage.as_ref().and_then(|u| u.output_tokens))
             .unwrap_or(0),
         session_id: parsed.session_id,
+        // one-shot json 모드는 rate_limit_event line 을 별도 stream 으로 받지
+        // 못한다 (stream-json 전용). 항상 None.
+        last_rate_limit: None,
     })
 }
 
@@ -575,6 +628,68 @@ mod tests {
             .unwrap_or(0);
         assert_eq!(input, 6);
         assert_eq!(output, 12);
+    }
+
+    /// claudeTransportFlipHardeningPlan T1 — `rate_limit_event` line 의 fields 가
+    /// `StreamLine` 으로 정상 deserialize 되는지 확인. CLI 가 아직 미전송이면
+    /// 본 코드 경로를 안 타지만, deserialize 는 unknown field 무시 정책이라
+    /// graceful.
+    #[test]
+    fn stream_line_parses_rate_limit_event() {
+        let json = r#"{
+            "type": "rate_limit_event",
+            "status": "approaching_limit",
+            "resets_at": "2026-04-29T12:00:00Z",
+            "rate_limit_type": "5_hour",
+            "overage_status": "available",
+            "overage_disabled_reason": null,
+            "is_using_overage": false
+        }"#;
+        let parsed: StreamLine = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.line_type, "rate_limit_event");
+        assert_eq!(parsed.status.as_deref(), Some("approaching_limit"));
+        assert_eq!(parsed.resets_at.as_deref(), Some("2026-04-29T12:00:00Z"));
+        assert_eq!(parsed.rate_limit_type.as_deref(), Some("5_hour"));
+        assert_eq!(parsed.overage_status.as_deref(), Some("available"));
+        assert!(parsed.overage_disabled_reason.is_none());
+        assert_eq!(parsed.is_using_overage, Some(false));
+    }
+
+    #[test]
+    fn stream_line_rate_limit_with_overage_disabled() {
+        let json = r#"{
+            "type": "rate_limit_event",
+            "status": "limit_reached",
+            "resets_at": "2026-04-29T17:00:00Z",
+            "rate_limit_type": "5_hour",
+            "overage_status": "disabled",
+            "overage_disabled_reason": "org_level_disabled",
+            "is_using_overage": false
+        }"#;
+        let parsed: StreamLine = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.line_type, "rate_limit_event");
+        assert_eq!(parsed.status.as_deref(), Some("limit_reached"));
+        assert_eq!(parsed.overage_status.as_deref(), Some("disabled"));
+        assert_eq!(parsed.overage_disabled_reason.as_deref(), Some("org_level_disabled"));
+    }
+
+    #[test]
+    fn rate_limit_info_serializes_camelcase() {
+        // frontend (RuntimeStatusBar) 가 받는 직렬화 — camelCase 필드명 검증.
+        let info = RateLimitInfo {
+            status: Some("approaching_limit".into()),
+            resets_at: Some("2026-04-29T12:00:00Z".into()),
+            rate_limit_type: Some("5_hour".into()),
+            overage_status: Some("available".into()),
+            overage_disabled_reason: None,
+            is_using_overage: Some(false),
+        };
+        let json = serde_json::to_string(&info).unwrap();
+        assert!(json.contains("\"resetsAt\""));
+        assert!(json.contains("\"rateLimitType\""));
+        assert!(json.contains("\"overageStatus\""));
+        assert!(json.contains("\"isUsingOverage\""));
+        assert!(json.contains("\"status\""));
     }
 
     #[test]

--- a/src-tauri/src/agents/claude_sdk_session.rs
+++ b/src-tauri/src/agents/claude_sdk_session.rs
@@ -968,6 +968,8 @@ where
                     input_tokens: final_input,
                     output_tokens: final_output,
                     session_id: parsed.session_id,
+                    // sdk-session path 는 본 plan scope 외 — 호환성만 유지.
+                    last_rate_limit: None,
                 });
             }
             "control_request" => {

--- a/src-tauri/src/agents/codex.rs
+++ b/src-tauri/src/agents/codex.rs
@@ -210,6 +210,7 @@ pub fn run(input: RunInput) -> Result<RunOutput, AppError> {
         input_tokens,
         output_tokens,
         session_id: None,
+        last_rate_limit: None,
     })
 }
 
@@ -409,6 +410,7 @@ where
         input_tokens,
         output_tokens,
         session_id: None,
+        last_rate_limit: None,
     })
 }
 

--- a/src-tauri/src/agents/codex_app_server.rs
+++ b/src-tauri/src/agents/codex_app_server.rs
@@ -354,6 +354,7 @@ where
                     input_tokens,
                     output_tokens,
                     session_id: Some(thread_id),
+                    last_rate_limit: None,
                 });
             }
             // wire format: "error" (NOT "errorNotification"; codex v2 protocol common.rs:978)

--- a/src-tauri/src/agents/gemini.rs
+++ b/src-tauri/src/agents/gemini.rs
@@ -99,6 +99,7 @@ pub fn run(input: RunInput) -> Result<RunOutput, AppError> {
         input_tokens: 0,
         output_tokens: 0,
         session_id: None,
+        last_rate_limit: None,
     })
 }
 
@@ -317,5 +318,6 @@ where
         input_tokens: total_in,
         output_tokens: total_out,
         session_id,
+        last_rate_limit: None,
     })
 }

--- a/src-tauri/src/agents/gemini_sdk.rs
+++ b/src-tauri/src/agents/gemini_sdk.rs
@@ -161,6 +161,7 @@ where
         input_tokens,
         output_tokens,
         session_id: None,
+        last_rate_limit: None,
     })
 }
 

--- a/src-tauri/src/agents/openai_compat.rs
+++ b/src-tauri/src/agents/openai_compat.rs
@@ -379,6 +379,7 @@ where
         input_tokens,
         output_tokens,
         session_id: None,
+        last_rate_limit: None,
     })
 }
 

--- a/src-tauri/src/agents/openai_sdk.rs
+++ b/src-tauri/src/agents/openai_sdk.rs
@@ -164,6 +164,7 @@ where
         input_tokens,
         output_tokens,
         session_id: None,
+        last_rate_limit: None,
     })
 }
 

--- a/src-tauri/src/agents/opencode.rs
+++ b/src-tauri/src/agents/opencode.rs
@@ -133,5 +133,6 @@ pub fn run(input: RunInput) -> Result<RunOutput, AppError> {
         input_tokens: 0,
         output_tokens: 0,
         session_id: None,
+        last_rate_limit: None,
     })
 }

--- a/src-tauri/src/db/migrations.rs
+++ b/src-tauri/src/db/migrations.rs
@@ -169,6 +169,9 @@ pub fn run(conn: &mut Connection) -> Result<(), AppError> {
     if current < 48 {
         apply_v48(conn)?;
     }
+    if current < 49 {
+        apply_v49(conn)?;
+    }
     Ok(())
 }
 
@@ -1267,6 +1270,63 @@ fn apply_v48(conn: &Connection) -> Result<(), AppError> {
     Ok(())
 }
 
+/// v49 — claude transport flip 후속: 7일+ idle conversation 의 stale
+/// `resume_token` 일괄 NULL 처리 (claudeTransportFlipHardeningPlan T5).
+///
+/// 배경: v0.1.4-beta 의 transport default flip (`-p --resume`) 으로 cli mode 가
+/// DB 의 `resume_token` 을 그대로 사용. 한동안 미사용 conversation 은 (a) 과거
+/// sdk-url 시점 session id 이거나 (b) Anthropic 측 TTL 만료 — `--resume` 시도
+/// 시 "out of extra usage" 형태로 거부됨. 본 migration 은 외부 사용자가
+/// v0.1.5-beta 로 업그레이드한 직후 그 stale token 을 일괄 클리어해 첫 send
+/// 부터 fresh session 으로 시작하도록 한다.
+///
+/// 정책:
+/// - 영향 범위: `conversations` 의 `resume_token IS NOT NULL` AND
+///   `resume_token_engine IN ('claude', 'claude-code')`.
+/// - 기준: 그 conversation 의 가장 최근 메시지가 **7일 이상** 지난 경우만.
+///   messages.timestamp 단위는 epoch ms (now_epoch_ms() 출력과 동일).
+/// - idempotent: schema_version 47 ↔ 49 marker 로 1회만 실행. 재기동 / partial
+///   upgrade 케이스에 활성 conversation 의 valid token 이 잘려나가지 않게 보호.
+/// - 다른 엔진 (codex / gemini / ollama / lmstudio) 의 resume_token 영향 0 —
+///   claude 한정. (애초에 다른 엔진은 cli `--resume` 의미 없거나 다른 모델)
+fn apply_v49(conn: &Connection) -> Result<(), AppError> {
+    // 7일 ms cutoff. messages.timestamp 는 now_epoch_ms() 결과와 동일 단위.
+    let now_ms = now_epoch_ms();
+    let cutoff_ms = now_ms - 7 * 24 * 60 * 60 * 1000;
+
+    // 1) 후보 conversation_id 조회 — claude resume_token 보유 + 마지막 메시지가 7일+ idle.
+    //    HAVING 의 MAX(timestamp) < cutoff 가 0건이면 affected = 0.
+    //    NULL safe: subquery 의 GROUP BY 는 messages 가 있는 conv 만 결과로 낸다 →
+    //    메시지 한 건도 없는 conv 는 영향 0 (resume_token 의미가 거의 없는 상태).
+    let affected = conn.execute(
+        "UPDATE conversations
+            SET resume_token = NULL
+          WHERE resume_token IS NOT NULL
+            AND resume_token_engine IN ('claude', 'claude-code')
+            AND id IN (
+                SELECT conversation_id
+                  FROM messages
+                 GROUP BY conversation_id
+                HAVING MAX(timestamp) < ?1
+            )",
+        rusqlite::params![cutoff_ms],
+    )?;
+
+    // 2) 1회 console log — 외부 사용자가 업그레이드 직후 콘솔에서 확인 가능.
+    //    Tauri release build 의 stderr 는 일반적으로 안 보이지만, dev / debug
+    //    환경에서 진단용. silent 보다 1회 흔적이 운영 가치 높음.
+    eprintln!(
+        "[migration v49] cleared {} stale resume_tokens (>7 days idle, claude only)",
+        affected
+    );
+
+    conn.execute(
+        "INSERT INTO schema_version (version, applied_at) VALUES (49, ?1)",
+        [now_epoch_ms()],
+    )?;
+    Ok(())
+}
+
 /// Milliseconds since Unix epoch (for Message.timestamp)
 pub fn now_epoch_ms() -> i64 {
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -1946,5 +2006,133 @@ mod tests {
         .unwrap();
         // apply_v48 가 ALTER 실패 없이 통과해야 함.
         apply_v48(&conn).expect("apply_v48 should be idempotent");
+    }
+
+    // ─── v49 — stale claude resume_token 7일+ NULL ──────────────────────────
+
+    /// `conversations` + `messages` 의 v49 SQL 이 의존하는 컬럼만 갖춘 minimal
+    /// fixture. 다른 컬럼은 v49 가 안 건드리므로 schema drift 영향 0.
+    fn open_with_resume_token_fixture() -> Connection {
+        let conn = Connection::open_in_memory().expect("open");
+        conn.execute_batch(schema::CREATE_SCHEMA_VERSION).expect("schema_version");
+        conn.execute_batch(
+            "CREATE TABLE conversations (
+                id                   TEXT PRIMARY KEY,
+                resume_token         TEXT,
+                resume_token_engine  TEXT
+            );
+             CREATE TABLE messages (
+                id              TEXT PRIMARY KEY,
+                conversation_id TEXT NOT NULL,
+                timestamp       INTEGER NOT NULL
+            );",
+        )
+        .expect("create fixture");
+        conn
+    }
+
+    /// 7일+ idle conversation 의 claude resume_token 만 NULL 처리되는지 확인.
+    /// 7일 미만 idle 이거나 다른 엔진의 token 은 보존.
+    #[test]
+    fn v49_clears_only_stale_claude_resume_tokens() {
+        let conn = open_with_resume_token_fixture();
+        let now_ms = now_epoch_ms();
+        let eight_days_ms = 8 * 24 * 60 * 60 * 1000_i64;
+        let three_days_ms = 3 * 24 * 60 * 60 * 1000_i64;
+
+        // c1: claude, 8일 idle → NULL 대상
+        // c2: claude, 3일 idle → 보존
+        // c3: codex, 8일 idle → 보존 (다른 엔진)
+        // c4: claude, 메시지 없음 → 보존 (subquery 가 결과 안 냄)
+        conn.execute_batch(
+            "INSERT INTO conversations (id, resume_token, resume_token_engine) VALUES
+                ('c1', 'token-stale', 'claude'),
+                ('c2', 'token-fresh', 'claude'),
+                ('c3', 'token-codex', 'codex'),
+                ('c4', 'token-no-msg', 'claude-code');",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO messages (id, conversation_id, timestamp) VALUES
+                ('m1', 'c1', ?1),
+                ('m2', 'c2', ?2),
+                ('m3', 'c3', ?1);",
+            rusqlite::params![now_ms - eight_days_ms, now_ms - three_days_ms],
+        )
+        .unwrap();
+
+        apply_v49(&conn).expect("apply_v49");
+
+        let token_c1: Option<String> = conn
+            .query_row("SELECT resume_token FROM conversations WHERE id='c1'", [], |r| r.get(0))
+            .unwrap();
+        let token_c2: Option<String> = conn
+            .query_row("SELECT resume_token FROM conversations WHERE id='c2'", [], |r| r.get(0))
+            .unwrap();
+        let token_c3: Option<String> = conn
+            .query_row("SELECT resume_token FROM conversations WHERE id='c3'", [], |r| r.get(0))
+            .unwrap();
+        let token_c4: Option<String> = conn
+            .query_row("SELECT resume_token FROM conversations WHERE id='c4'", [], |r| r.get(0))
+            .unwrap();
+
+        assert!(token_c1.is_none(), "8일 idle claude token 은 NULL 처리되어야 함");
+        assert_eq!(token_c2.as_deref(), Some("token-fresh"), "3일 idle 은 보존");
+        assert_eq!(token_c3.as_deref(), Some("token-codex"), "다른 엔진 token 은 보존");
+        assert_eq!(token_c4.as_deref(), Some("token-no-msg"), "메시지 없는 conv 는 보존");
+    }
+
+    #[test]
+    fn v49_records_schema_version() {
+        let conn = open_with_resume_token_fixture();
+        apply_v49(&conn).expect("apply_v49");
+        let v: i64 = conn
+            .query_row("SELECT MAX(version) FROM schema_version", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(v, 49);
+    }
+
+    /// idempotent 검증: schema_version 가드 (run() 의 `if current < 49`) 에 의해
+    /// 같은 DB 에서 두 번 호출되지 않도록 보호된다. 본 테스트는 first apply 후
+    /// `current_version()` 이 49 이상으로 올라갔을 때 run() 이 v49 를 다시 호출
+    /// 하지 않는 의미를 검증한다. (다른 migration 들도 같은 패턴이며, 직접 두
+    /// 번 apply 시 schema_version PK 위반은 의도된 안전 가드)
+    #[test]
+    fn v49_guarded_by_schema_version_check() {
+        let conn = open_with_resume_token_fixture();
+        let now_ms = now_epoch_ms();
+        let eight_days_ms = 8 * 24 * 60 * 60 * 1000_i64;
+        conn.execute_batch(
+            "INSERT INTO conversations (id, resume_token, resume_token_engine)
+             VALUES ('c1', 'token-stale', 'claude');",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO messages (id, conversation_id, timestamp)
+             VALUES ('m1', 'c1', ?1);",
+            rusqlite::params![now_ms - eight_days_ms],
+        )
+        .unwrap();
+
+        apply_v49(&conn).expect("first apply_v49");
+
+        // run() 진입점 시뮬: current_version >= 49 이면 v49 skip.
+        let cur = current_version(&conn).expect("current_version");
+        assert!(cur >= 49, "schema_version 가 v49 이상이어야 함");
+        // 실제 run 가 if current < 49 가드로 skip 하므로 두 번째 호출이 발생하지 않는다.
+        // 본 testcase 는 그 invariant 를 명시 — apply_v49 자체의 SQL idempotency
+        // 는 codebase 정책상 schema_version 가드에 위임.
+
+        let token: Option<String> = conn
+            .query_row("SELECT resume_token FROM conversations WHERE id='c1'", [], |r| r.get(0))
+            .unwrap();
+        assert!(token.is_none(), "first apply 가 stale token 을 NULL 로 만들었어야");
+    }
+
+    #[test]
+    fn v49_no_messages_no_op() {
+        let conn = open_with_resume_token_fixture();
+        // empty conversations / messages — 안전하게 통과해야.
+        apply_v49(&conn).expect("apply_v49 on empty DB");
     }
 }


### PR DESCRIPTION
v0.1.5-beta release blocker — claude transport flip hardening Phase 1 (Task 01 + Task 05).

SSOT: [claudeTransportFlipHardeningPlan_2026-04-29.md](docs/plans/claudeTransportFlipHardeningPlan_2026-04-29.md)

## Summary

- **T1 (claude.rs)**: \`rate_limit_event\` parser 추가 — claude CLI stream-json 에 포함되는 rate_limit payload 를 \`StreamLine\` 으로 deserialize, \`RunOutput.last_rate_limit\` 으로 노출. T4 의 RuntimeStatusBar indicator + 사용자 가시 안내 데이터 소스.
- **T5 (db/migrations.rs)**: migration v49 — 7일+ idle conversation 의 stale claude \`resume_token\` 일괄 NULL. v0.1.4-beta transport flip 후 발견된 \`out of extra usage\` 거부 차단. idempotent (schema_version 가드).

## 회귀 가드

- claude.rs 변경은 cli mode 분기 안 (stream_run reader). sdk-session path 영향 0.
- 다른 엔진 (codex/gemini/ollama/lmstudio) RunOutput 변경은 \`last_rate_limit: None\` 호환성 fill 만. 동작 변경 0.
- migration v49 는 \`resume_token_engine IN ('claude', 'claude-code')\` 명시 — 다른 엔진 영향 0.
- 활성 conv (7일 이내 메시지) 의 valid token 영향 0.

## Verification

\`\`\`bash
cd src-tauri && cargo check       # ✓
cd src-tauri && cargo test --lib  # ✓ 591 passed (baseline 584 → +7: T1 3 + T5 4)
npx tsc --noEmit                  # ✓
\`\`\`

baseline 대비 회귀 0. macOS 로컬 검증 PASS.

## Test plan

- [x] cargo test --lib agents::claude (27 passed, 새 3건 포함)
- [x] cargo test --lib db::migrations::tests::v49 (4/4 passed)
- [x] cargo test --lib 전체 591 passed
- [x] tsc --noEmit
- [ ] CI macOS / Windows 양쪽 ✓ 후 머지

## DO NOT 위반 0

- 다른 엔진 동작 변경 0
- claude_sdk_session.rs 의 동작 변경 0 (호환성 fill 만)
- ContextPack / settings / tauri.conf 변경 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)