### PR TITLE
feat(claude): stale resume_token auto fallback + ContextPack revival (T2+T3)

### DIFF
--- a/src-tauri/src/agents/anthropic_sdk.rs
+++ b/src-tauri/src/agents/anthropic_sdk.rs
@@ -160,6 +160,7 @@ where
         output_tokens,
         session_id: None,
         last_rate_limit: None,
+        fresh_fallback: false,
     })
 }
 

--- a/src-tauri/src/agents/claude.rs
+++ b/src-tauri/src/agents/claude.rs
@@ -171,6 +171,38 @@ pub struct RunOutput {
     /// 가장 최근에 관측된 `rate_limit_event` payload. Anthropic 측에서 미전송이거나
     /// 구버전 CLI 면 None. claudeTransportFlipHardeningPlan T1.
     pub last_rate_limit: Option<RateLimitInfo>,
+    /// `true` = stale resume_token detect → `--resume` 제거 후 1회 retry 로 fresh
+    /// session 으로 응답을 받았다. 호출자 (start_claude_stream / finalize_engine_run)
+    /// 가 이 flag 보고 (a) DB resume_token 갱신 (이미 새 session_id 가 들어옴), (b)
+    /// `session_freshness::clear_delivered_key()` 호출 → 다음 send 부터
+    /// `is_session_continuation=false` → full mode + anchor 2 turns ContextPack
+    /// revival 자동 발동, (c) frontend 에 `claude:fresh_fallback` event emit.
+    /// claudeTransportFlipHardeningPlan T2 + T3.
+    pub fresh_fallback: bool,
+}
+
+/// claude CLI 의 result.is_error 메시지가 stale resume_token 을 의미하는지 판정.
+///
+/// claudeTransportFlipHardeningPlan T2 — `--resume <id>` 동반 send 가 다음 패턴
+/// 으로 거부되면 stale resume_token 으로 보고 `--resume` 제거 후 retry 1회.
+///
+/// 정확한 keyword 조합으로 false positive 차단:
+/// - 정상 인증 실패 (401, invalid api key) → match X
+/// - 정상 한도 초과 (5h rolling) → match X (Anthropic 측 다른 status code/메시지)
+/// - 일시적 네트워크 에러 → match X
+///
+/// 매칭 keyword (사용자 보고 + Anthropic 정의):
+/// - "out of extra usage" — 사용자 보고 패턴 (resume_token 무효화 시점)
+/// - "session not found" / "404" — Anthropic 측 session_id 만료
+/// - "invalid_request_error" + "session" — invalid session id reject
+///
+/// **caller 책임**: 본 함수가 true 라도 retry 는 stream_run 내부에서 1회만.
+/// 두 번째 stale → caller 가 raw error 그대로 사용자에게 가시화 (escalate).
+fn looks_like_stale_resume_error(error_msg: &str) -> bool {
+    let lower = error_msg.to_ascii_lowercase();
+    lower.contains("out of extra usage")
+        || (lower.contains("session not found") || (lower.contains("404") && lower.contains("session")))
+        || (lower.contains("invalid_request_error") && lower.contains("session"))
 }
 
 /// Execute `claude -p` with `--output-format stream-json`.
@@ -181,7 +213,67 @@ pub struct RunOutput {
 ///
 /// Returns the final `RunOutput` when the `result` line arrives.
 /// Caller must NOT hold the DbState lock while calling this function.
+///
+/// claudeTransportFlipHardeningPlan T2 — `--resume <id>` 가 stale 로 거부되면
+/// 자동으로 `--resume` 없이 1회 retry. retry 성공 시 RunOutput.fresh_fallback=true
+/// 로 표기. retry 도 fail 이면 raw error 그대로 반환 (다른 원인). 무한 loop 차단.
 pub fn stream_run<F, G, C>(input: RunInput, mut on_progress: G, mut on_chunk: F, is_cancelled: C) -> Result<RunOutput, AppError>
+where
+    F: FnMut(String),
+    G: FnMut(String),
+    C: Fn() -> bool,
+{
+    // 1회차 시도 — 사용자의 resume_token 그대로 사용.
+    let had_resume = input.resume_token.is_some();
+    let first_input = RunInput {
+        prompt: input.prompt.clone(),
+        model: input.model.clone(),
+        system_prompt: input.system_prompt.clone(),
+        resume_token: input.resume_token.clone(),
+        project_path: input.project_path.clone(),
+        image_paths: input.image_paths.clone(),
+    };
+    let first_result = stream_run_once(first_input, &mut on_progress, &mut on_chunk, &is_cancelled);
+
+    match first_result {
+        Ok(out) => Ok(out),
+        Err(AppError::Agent(msg)) if had_resume && looks_like_stale_resume_error(&msg) => {
+            // Stale resume_token detect — `--resume` 제거 후 1회 retry.
+            // false positive 차단: had_resume 가 true 인 경우만 (resume 동반 send).
+            // 무한 loop 차단: stream_run_once 직접 호출 (재귀 없음).
+            eprintln!(
+                "[claude-stale-resume] detected stale resume_token, retrying without --resume (msg: {})",
+                msg.chars().take(120).collect::<String>()
+            );
+            let retry_input = RunInput {
+                prompt: input.prompt,
+                model: input.model,
+                system_prompt: input.system_prompt,
+                // resume_token 제거 — fresh session 으로 시작.
+                resume_token: None,
+                project_path: input.project_path,
+                image_paths: input.image_paths,
+            };
+            match stream_run_once(retry_input, &mut on_progress, &mut on_chunk, &is_cancelled) {
+                Ok(mut out) => {
+                    out.fresh_fallback = true;
+                    Ok(out)
+                }
+                Err(e) => Err(e),
+            }
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// `stream_run` 의 inner 구현 — `--resume` 가 있는 그대로 1회 시도.
+/// retry 는 stream_run wrapper 가 담당 (T2 stale detect path).
+fn stream_run_once<F, G, C>(
+    input: RunInput,
+    on_progress: &mut G,
+    on_chunk: &mut F,
+    is_cancelled: &C,
+) -> Result<RunOutput, AppError>
 where
     F: FnMut(String),
     G: FnMut(String),
@@ -425,6 +517,8 @@ where
                         .unwrap_or(0),
                     session_id: parsed.session_id,
                     last_rate_limit: last_rate_limit.take(),
+                    // T2: stream_run wrapper 가 retry 후 true 로 set. 1회 시도 자체는 false.
+                    fresh_fallback: false,
                 });
             }
             _ => {}
@@ -535,6 +629,7 @@ pub fn run(input: RunInput) -> Result<RunOutput, AppError> {
         // one-shot json 모드는 rate_limit_event line 을 별도 stream 으로 받지
         // 못한다 (stream-json 전용). 항상 None.
         last_rate_limit: None,
+        fresh_fallback: false,
     })
 }
 
@@ -671,6 +766,49 @@ mod tests {
         assert_eq!(parsed.status.as_deref(), Some("limit_reached"));
         assert_eq!(parsed.overage_status.as_deref(), Some("disabled"));
         assert_eq!(parsed.overage_disabled_reason.as_deref(), Some("org_level_disabled"));
+    }
+
+    /// claudeTransportFlipHardeningPlan T2 — stale resume detect keyword.
+    /// false positive 차단 검증 (정상 인증 실패 / 한도 초과 / 네트워크 에러는
+    /// match X). retry trigger 정확성이 사용자 회복 핵심.
+    #[test]
+    fn looks_like_stale_resume_matches_user_reported_pattern() {
+        // 사용자 보고 — "out of extra usage"
+        assert!(looks_like_stale_resume_error("Anthropic API: out of extra usage"));
+        // case insensitive
+        assert!(looks_like_stale_resume_error("Out Of Extra Usage"));
+    }
+
+    #[test]
+    fn looks_like_stale_resume_matches_session_404() {
+        assert!(looks_like_stale_resume_error("404 session not found"));
+        assert!(looks_like_stale_resume_error("Session not found"));
+    }
+
+    #[test]
+    fn looks_like_stale_resume_matches_invalid_session_request() {
+        assert!(looks_like_stale_resume_error("invalid_request_error: invalid session id"));
+    }
+
+    #[test]
+    fn looks_like_stale_resume_does_not_match_auth_failure() {
+        // 401 / invalid api key 는 retry 트리거하지 않음 (사용자가 재로그인 필요)
+        assert!(!looks_like_stale_resume_error("401 Unauthorized"));
+        assert!(!looks_like_stale_resume_error("invalid api key"));
+        assert!(!looks_like_stale_resume_error("authentication failed"));
+    }
+
+    #[test]
+    fn looks_like_stale_resume_does_not_match_rate_limit() {
+        // 429 / true rate limit 은 retry 무의미 — Anthropic 측 한도 초과
+        assert!(!looks_like_stale_resume_error("429 Too Many Requests"));
+        assert!(!looks_like_stale_resume_error("rate_limit_exceeded"));
+    }
+
+    #[test]
+    fn looks_like_stale_resume_does_not_match_network_error() {
+        assert!(!looks_like_stale_resume_error("connection timed out"));
+        assert!(!looks_like_stale_resume_error("dns resolution failed"));
     }
 
     #[test]

--- a/src-tauri/src/agents/claude_sdk_session.rs
+++ b/src-tauri/src/agents/claude_sdk_session.rs
@@ -970,6 +970,7 @@ where
                     session_id: parsed.session_id,
                     // sdk-session path 는 본 plan scope 외 — 호환성만 유지.
                     last_rate_limit: None,
+                    fresh_fallback: false,
                 });
             }
             "control_request" => {

--- a/src-tauri/src/agents/codex.rs
+++ b/src-tauri/src/agents/codex.rs
@@ -211,6 +211,7 @@ pub fn run(input: RunInput) -> Result<RunOutput, AppError> {
         output_tokens,
         session_id: None,
         last_rate_limit: None,
+        fresh_fallback: false,
     })
 }
 
@@ -411,6 +412,7 @@ where
         output_tokens,
         session_id: None,
         last_rate_limit: None,
+        fresh_fallback: false,
     })
 }
 

--- a/src-tauri/src/agents/codex_app_server.rs
+++ b/src-tauri/src/agents/codex_app_server.rs
@@ -355,6 +355,7 @@ where
                     output_tokens,
                     session_id: Some(thread_id),
                     last_rate_limit: None,
+                    fresh_fallback: false,
                 });
             }
             // wire format: "error" (NOT "errorNotification"; codex v2 protocol common.rs:978)

--- a/src-tauri/src/agents/gemini.rs
+++ b/src-tauri/src/agents/gemini.rs
@@ -100,6 +100,7 @@ pub fn run(input: RunInput) -> Result<RunOutput, AppError> {
         output_tokens: 0,
         session_id: None,
         last_rate_limit: None,
+        fresh_fallback: false,
     })
 }
 
@@ -319,5 +320,6 @@ where
         output_tokens: total_out,
         session_id,
         last_rate_limit: None,
+        fresh_fallback: false,
     })
 }

--- a/src-tauri/src/agents/gemini_sdk.rs
+++ b/src-tauri/src/agents/gemini_sdk.rs
@@ -162,6 +162,7 @@ where
         output_tokens,
         session_id: None,
         last_rate_limit: None,
+        fresh_fallback: false,
     })
 }
 

--- a/src-tauri/src/agents/openai_compat.rs
+++ b/src-tauri/src/agents/openai_compat.rs
@@ -380,6 +380,7 @@ where
         output_tokens,
         session_id: None,
         last_rate_limit: None,
+        fresh_fallback: false,
     })
 }
 

--- a/src-tauri/src/agents/openai_sdk.rs
+++ b/src-tauri/src/agents/openai_sdk.rs
@@ -165,6 +165,7 @@ where
         output_tokens,
         session_id: None,
         last_rate_limit: None,
+        fresh_fallback: false,
     })
 }
 

--- a/src-tauri/src/agents/opencode.rs
+++ b/src-tauri/src/agents/opencode.rs
@@ -134,5 +134,6 @@ pub fn run(input: RunInput) -> Result<RunOutput, AppError> {
         output_tokens: 0,
         session_id: None,
         last_rate_limit: None,
+        fresh_fallback: false,
     })
 }

--- a/src-tauri/src/commands/agents_helpers/send_common/persistence.rs
+++ b/src-tauri/src/commands/agents_helpers/send_common/persistence.rs
@@ -360,6 +360,37 @@ pub fn finalize_engine_run(
                     params![sid, engine_key, conversation_id],
                 );
             }
+
+            // claudeTransportFlipHardeningPlan T3 — fresh session fallback 처리.
+            // claude.rs::stream_run wrapper 가 stale resume_token detect → 1회 retry
+            // (without `--resume`) 성공 시 fresh_fallback=true 로 표기. 본 분기에서
+            // (a) session_freshness LAST_DELIVERED_KEY clear → 다음 send 의
+            // is_session_continuation=false → ContextPack revival 자동 (full mode +
+            // anchor 2 turns), (b) frontend 에 `claude:fresh_fallback` 이벤트 emit.
+            // 다른 엔진은 fresh_fallback 항상 false 라 분기 진입 X — 회귀 0.
+            if out.fresh_fallback {
+                session_freshness::clear_delivered_key(conversation_id);
+                eprintln!(
+                    "[session_freshness] T3 fresh_fallback for conv={} engine={} → cleared LAST_DELIVERED, next send uses full ContextPack",
+                    &conversation_id[..conversation_id.len().min(12)],
+                    engine_key
+                );
+                let _ = app.emit("claude:fresh_fallback", serde_json::json!({
+                    "messageId": msg_id,
+                    "conversationId": conversation_id,
+                    "engine": engine_key,
+                }));
+            }
+
+            // T1 + T4 — last_rate_limit 이 있으면 frontend RuntimeStatusBar 가 받도록
+            // 별도 이벤트로 emit. UI 가 dismiss 처리. 미관측 시 emit 안 함.
+            if let Some(ref rl) = out.last_rate_limit {
+                let _ = app.emit("claude:rate_limit", serde_json::json!({
+                    "conversationId": conversation_id,
+                    "engine": engine_key,
+                    "rateLimit": rl,
+                }));
+            }
             insert_trace_log_with_context(conn, conversation_id, out.input_tokens, out.output_tokens, out.cost_usd, now,
                 &SpanInfo { trace_id: &new_trace_id(), span_id: new_span_id(), parent_span_id: None,
                     operation: "agent.stream", engine: engine_key, duration_ms: duration_ms as i64, status: "ok" },


### PR DESCRIPTION
v0.1.5-beta release blocker — claude transport flip hardening Phase 1 의 **핵심** (Task 02 + Task 03).

> **Stacked PR**: base = #238 (T1+T5). 머지 순서 = #238 → 본 PR.

SSOT: [claudeTransportFlipHardeningPlan_2026-04-29.md](docs/plans/claudeTransportFlipHardeningPlan_2026-04-29.md)

## Summary

**T2** — \`stream_run\` wrapper 가 stale resume_token 패턴 detect → \`--resume\` 제거 후 1회 retry. RunOutput.fresh_fallback=true 표기. 사용자 액션 0 자동 회복.

**T3** — \`finalize_engine_run\` 이 fresh_fallback flag 보고:
1. \`session_freshness::clear_delivered_key()\` → 다음 send 의 \`is_session_continuation=false\` → ContextPack revival 자동 (full mode + anchor 2 turns)
2. frontend 에 \`claude:fresh_fallback\` event emit (T4 가 토스트로 가시화)
3. T1 \`last_rate_limit\` 있으면 \`claude:rate_limit\` event 도 emit

## False positive 차단

retry 트리거 keyword 조합:
- \`out of extra usage\` (사용자 보고 패턴)
- \`404\` + \`session\` 또는 \`session not found\`
- \`invalid_request_error\` + \`session\`

retry 차단:
- 정상 인증 실패 (401, invalid api key) — escalate 필요
- 정상 한도 초과 (429, rate_limit_exceeded) — retry 무의미
- 네트워크 에러 — 다른 처리 경로

## ContextPack revival 옵션

옵션 A (retry same prompt, revival 다음 send 부터) 채택. 옵션 B (retry 직전 재assemble) 는 latency 위험 + 본 batch scope 외 — plan §9 escalate 조건 명시.

## 회귀 가드

- claude.rs cli mode 분기 안 (stream_run wrapper). sdk-session path 영향 0.
- 다른 엔진 RunOutput 변경: \`fresh_fallback: false\` 호환성 fill 만.
- looks_like_stale_resume_error 는 \`had_resume=true\` 일 때만 호출.
- retry 1회 한정 (stream_run_once 직접 호출, 재귀 X).
- 메모리 RESUME_IDS / 다른 엔진 / DB 다른 컬럼 영향 0.

## Verification

\`\`\`bash
cd src-tauri && cargo check         # ✓
cd src-tauri && cargo test --lib    # ✓ 597 passed (T1+T5 591 → +6: T2 stale detect 6 tests)
npx tsc --noEmit                    # ✓
\`\`\`

baseline 대비 회귀 0. macOS 로컬 검증 PASS.

## Test plan

- [x] cargo test --lib agents::claude (33 passed, T2 6건 신규)
- [x] cargo test --lib (전체 597, baseline +13: T1 3 + T5 4 + T2 6)
- [x] tsc --noEmit
- [ ] Manual smoke: DB의 conversation resume_token 을 invalid 값으로 set → tunaFlow dev 모드 send → backend log \`[claude-stale-resume] detected\` + \`[session_freshness] T3 fresh_fallback\` + 다음 send \`new session\` ContextPack revival
- [ ] CI macOS / Windows 양쪽 ✓ 후 머지

## DO NOT 위반 0

- ❌ 다른 엔진 동작 변경 0
- ❌ \`agents.rs::resolve_claude_mode\` 변경 0
- ❌ \`claude_sdk_session.rs\` 동작 변경 0 (호환성 fill)
- ❌ ContextPack 다른 분기 변경 0 (Task 03 은 LAST_DELIVERED clear 만)
- ❌ DB schema 변경 0 (T5 와 분리, 본 PR 은 logic only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)