### PR TITLE
feat(ui): claude fresh_fallback toast + rate_limit indicator (T4)

### DIFF
--- a/src/components/tunaflow/AppShell.tsx
+++ b/src/components/tunaflow/AppShell.tsx
@@ -18,6 +18,7 @@ import { MetaFloatingChat } from "./MetaFloatingChat";
 import { ProjectOnboardingModal } from "./ProjectOnboardingModal";
 import { FirstRunDependencyDialog } from "./FirstRunDependencyDialog";
 import { SettingsPanel } from "./SettingsPanel";
+import { ClaudeFallbackEvents } from "./ClaudeFallbackEvents";
 
 // ─── Panel width constraints ─────────────────────────────────────────────────
 const SIDEBAR_MIN = 220;
@@ -238,6 +239,9 @@ export function AppShell() {
   return (
     <FileViewerContext.Provider value={fileViewerCtx}>
     <Toaster position="bottom-right" theme={themeMode} richColors closeButton />
+    {/* claudeTransportFlipHardeningPlan T4 — fresh_fallback 토스트 + rate_limit
+        store 갱신 listener. 시각 출력 0, AppShell 안에서 1회 mount. */}
+    <ClaudeFallbackEvents />
     <div className="flex flex-col h-screen w-screen overflow-hidden bg-sidebar text-foreground font-sans relative">
       {/* ── Title bar (macOS overlay) ── */}
       <TitleBar />

--- a/src/components/tunaflow/ClaudeFallbackEvents.tsx
+++ b/src/components/tunaflow/ClaudeFallbackEvents.tsx
@@ -1,0 +1,110 @@
+/**
+ * Claude transport flip hardening (T4) — UI 가시화.
+ *
+ * SSOT: docs/plans/claudeTransportFlipHardeningPlan_2026-04-29.md Task 04.
+ *
+ * Backend (T2+T3) 가 emit 하는 두 이벤트를 단일 컴포넌트에서 listen:
+ *
+ *  - `claude:fresh_fallback` — stale resume_token detect 후 자동 fresh session
+ *    fallback 발생. 사용자에게 "다음 응답부터 ContextPack revival" 안내 토스트
+ *    1회 (conversation 별 sessionStorage flag 로 spam 차단).
+ *
+ *  - `claude:rate_limit` — Anthropic 측 rate_limit_event payload 도착. 가장
+ *    최근 값을 RuntimeStatusBar 의 indicator (별도 컴포넌트) 가 읽도록 store
+ *    상태로 보관. (status: ok/approaching/limit_reached + reset 시각 + overage
+ *    상태)
+ *
+ * 회귀 가드:
+ *  - 본 컴포넌트는 AppShell 안에 1회 mount → listener 가 앱 lifetime 한 번만 wire.
+ *  - 기존 progress/chunk/completed/error listener (agentStreamHelper) 영향 0.
+ *  - 다른 엔진의 같은 이름 이벤트 없음 (claude 한정 prefix) — 회귀 0.
+ */
+import { useEffect } from "react";
+import { listen } from "@tauri-apps/api/event";
+import { toast } from "sonner";
+import { useTranslation } from "react-i18next";
+import { useClaudeRateLimitStore, type ClaudeRateLimitInfo } from "@/stores/claudeRateLimitStore";
+
+interface FreshFallbackPayload {
+  messageId: string;
+  conversationId: string;
+  engine: string;
+}
+
+interface RateLimitPayload {
+  conversationId: string;
+  engine: string;
+  rateLimit: ClaudeRateLimitInfo;
+}
+
+/** sessionStorage key — 같은 conversation 의 fallback 토스트 재표시 차단. */
+function fallbackToastKey(conversationId: string): string {
+  return `tunaflow.claudeFreshFallbackShown.${conversationId}`;
+}
+
+/**
+ * Claude fallback / rate_limit event listener — AppShell 에 1회 mount.
+ * 시각 출력 없음 (토스트는 sonner, indicator 는 별도 컴포넌트). null 반환.
+ */
+export function ClaudeFallbackEvents(): null {
+  const { t } = useTranslation("runtime");
+  const setRateLimit = useClaudeRateLimitStore((s) => s.setRateLimit);
+
+  useEffect(() => {
+    let unlistenFallback: (() => void) | null = null;
+    let unlistenRateLimit: (() => void) | null = null;
+    let cancelled = false;
+
+    (async () => {
+      unlistenFallback = await listen<FreshFallbackPayload>(
+        "claude:fresh_fallback",
+        (e) => {
+          const { conversationId } = e.payload;
+          // Spam 차단 — 같은 conversation 의 첫 fallback 만 토스트.
+          // sessionStorage 라 앱 재시작 후 reset (다음 세션에서 한 번 더).
+          let alreadyShown = false;
+          try {
+            alreadyShown = sessionStorage.getItem(fallbackToastKey(conversationId)) === "1";
+          } catch {
+            // sessionStorage unavailable (private mode 등) — 무시, 매번 토스트 OK
+          }
+          if (alreadyShown) return;
+          try {
+            sessionStorage.setItem(fallbackToastKey(conversationId), "1");
+          } catch {
+            /* ignore */
+          }
+
+          toast.info(t("claude.freshFallback.title"), {
+            description: t("claude.freshFallback.body"),
+            duration: 8000,
+            action: {
+              label: t("claude.freshFallback.dismiss"),
+              onClick: () => {
+                /* sonner auto-dismiss — explicit 확인 액션만 */
+              },
+            },
+          });
+        },
+      );
+
+      unlistenRateLimit = await listen<RateLimitPayload>(
+        "claude:rate_limit",
+        (e) => {
+          if (cancelled) return;
+          setRateLimit(e.payload.conversationId, e.payload.rateLimit);
+        },
+      );
+    })().catch((err) => {
+      console.warn("[claude-fallback] listener setup failed:", err);
+    });
+
+    return () => {
+      cancelled = true;
+      if (unlistenFallback) unlistenFallback();
+      if (unlistenRateLimit) unlistenRateLimit();
+    };
+  }, [setRateLimit, t]);
+
+  return null;
+}

--- a/src/components/tunaflow/ClaudeRateLimitIndicator.tsx
+++ b/src/components/tunaflow/ClaudeRateLimitIndicator.tsx
@@ -1,0 +1,95 @@
+/**
+ * claudeTransportFlipHardeningPlan T4 — Claude rate_limit_event 의 status 를
+ * RuntimeStatusBar 안에 dot indicator + 텍스트 hint 로 표시.
+ *
+ * 데이터 source: useClaudeRateLimitStore (ClaudeFallbackEvents 가 갱신).
+ * 표시 우선순위: 현재 selected conv 의 정보 → 없으면 latest conv 의 정보 →
+ * 없으면 미표시.
+ *
+ * 색상 규칙 (Anthropic 정의 status 기반):
+ *  - "ok" / 미정의 → 초록 dot, 라벨 미표시 (조용)
+ *  - "approaching_limit" → 노란 dot, "Approaching..." 라벨
+ *  - "limit_reached" + overage_status="disabled" → 빨간 dot, "Overage disabled"
+ *  - "limit_reached" → 주황 dot, "Limit reached"
+ *
+ * 클릭 시 detail tooltip 또는 settings 링크 — 본 minimal 구현은 title 속성만.
+ *
+ * 회귀 가드:
+ *  - 본 컴포넌트는 store data 가 없으면 null 반환 → 기존 RuntimeStatusBar 영향 0.
+ *  - 다른 indicator (rateLimit, gitStatus) 와 영역 분리.
+ */
+import { useTranslation } from "react-i18next";
+import { useChatStore } from "@/stores/chatStore";
+import { useClaudeRateLimitStore, type ClaudeRateLimitInfo } from "@/stores/claudeRateLimitStore";
+import { cn } from "@/lib/utils";
+
+type StatusKind = "ok" | "approaching" | "limitReached" | "overageDisabled";
+
+function selectStatusKind(info: ClaudeRateLimitInfo): StatusKind {
+  const status = info.status ?? null;
+  const overageDisabled = info.overageStatus === "disabled";
+  const isLimitReached = status === "limit_reached";
+
+  if (isLimitReached && overageDisabled) return "overageDisabled";
+  if (isLimitReached) return "limitReached";
+  if (status === "approaching_limit") return "approaching";
+  return "ok";
+}
+
+function dotClassFor(kind: StatusKind): string {
+  switch (kind) {
+    case "overageDisabled": return "bg-red-500";
+    case "limitReached": return "bg-amber-500";
+    case "approaching": return "bg-yellow-400";
+    default: return "bg-status-approved";
+  }
+}
+
+export function ClaudeRateLimitIndicator() {
+  const { t } = useTranslation("runtime");
+  const selectedConvId = useChatStore((s) => s.selectedConversationId);
+  const byConversation = useClaudeRateLimitStore((s) => s.byConversation);
+  const latestConvId = useClaudeRateLimitStore((s) => s.latestConversationId);
+
+  const convId = selectedConvId && byConversation[selectedConvId] ? selectedConvId : latestConvId;
+  const info = convId ? byConversation[convId] : null;
+  if (!info) return null;
+
+  const kind = selectStatusKind(info);
+  // 정상 상태는 자리 차지 안 하게 hide.
+  if (kind === "ok") return null;
+
+  const labelText: string =
+    kind === "approaching" ? t("claude.rateLimit.approaching")
+    : kind === "limitReached" ? t("claude.rateLimit.limitReached")
+    : t("claude.rateLimit.overageDisabled");
+
+  const tooltipParts: string[] = [labelText];
+  if (info.resetsAt) {
+    tooltipParts.push(t("claude.rateLimit.resetsIn", { when: info.resetsAt }));
+  }
+  if (info.rateLimitType) {
+    const typeLabel: string =
+      info.rateLimitType === "5_hour" ? t("claude.rateLimit.fiveHour")
+      : info.rateLimitType === "weekly" ? t("claude.rateLimit.weekly")
+      : info.rateLimitType;
+    tooltipParts.push(typeLabel);
+  }
+  const tooltip = tooltipParts.join(" · ");
+
+  return (
+    <>
+      <span className="w-px h-3 bg-border/30" />
+      <a
+        href="https://claude.ai/settings/usage"
+        target="_blank"
+        rel="noopener noreferrer"
+        title={tooltip}
+        className="flex items-center gap-1 px-2 h-full text-muted-foreground/60 hover:text-muted-foreground transition-colors text-tf-micro"
+      >
+        <span className={cn("w-1.5 h-1.5 rounded-full shrink-0", dotClassFor(kind))} />
+        <span className="truncate max-w-[140px]">{labelText}</span>
+      </a>
+    </>
+  );
+}

--- a/src/components/tunaflow/RuntimeStatusBar.tsx
+++ b/src/components/tunaflow/RuntimeStatusBar.tsx
@@ -6,6 +6,7 @@ import { useChatStore } from "@/stores/chatStore";
 import { usePtyStore } from "@/stores/ptyStore";
 import { Activity, Loader2, Zap, Terminal, Settings, Moon, Sun, Brain } from "lucide-react";
 import { TraceModal } from "./TraceModal";
+import { ClaudeRateLimitIndicator } from "./ClaudeRateLimitIndicator";
 import { getSetting, setSetting } from "@/lib/appStore";
 import { countBackgroundJobs, type BackgroundJobCounts } from "@/lib/api/identityAnalysis";
 
@@ -374,7 +375,7 @@ export function RuntimeStatusBar() {
           </>
         )}
 
-        {/* Rate limit */}
+        {/* Rate limit (ccusage 기반 — 5h/7d %) */}
         {rateLimit && (
           <>
             <span className="w-px h-3 bg-border/30" />
@@ -400,6 +401,11 @@ export function RuntimeStatusBar() {
             </span>
           </>
         )}
+
+        {/* claudeTransportFlipHardeningPlan T4 — claude:rate_limit 이벤트 기반
+            indicator (rate_limit_event payload). 위 ccusage 기반 % 와 다른
+            source. 정상 상태에서는 자동 hide. */}
+        <ClaudeRateLimitIndicator />
 
         {/* Separator */}
         <span className="w-px h-3 bg-border/30" />

--- a/src/locales/en/runtime.json
+++ b/src/locales/en/runtime.json
@@ -1,0 +1,20 @@
+{
+  "claude": {
+    "freshFallback": {
+      "title": "Claude session restarted",
+      "body": "Your previous session expired and was automatically recovered with a fresh one. From the next response, we'll re-attach prior conversation context via ContextPack — the first reply may be slightly slower.",
+      "dismiss": "Got it",
+      "learnMore": "Open Claude usage"
+    },
+    "rateLimit": {
+      "ok": "Claude usage OK",
+      "approaching": "Approaching Claude's 5-hour limit",
+      "limitReached": "Claude 5-hour limit reached",
+      "overageDisabled": "Overage usage is disabled and was rejected",
+      "weekly": "Weekly limit",
+      "fiveHour": "5-hour limit",
+      "resetsIn": "Resets at {{when}}",
+      "openSettings": "Open Anthropic settings"
+    }
+  }
+}

--- a/src/locales/index.ts
+++ b/src/locales/index.ts
@@ -14,6 +14,7 @@ import koInsight from "./ko/insight.json";
 import koQuality from "./ko/quality.json";
 import koSkills from "./ko/skills.json";
 import koHarness from "./ko/harness.json";
+import koRuntime from "./ko/runtime.json";
 import enCommon from "./en/common.json";
 import enError from "./en/error.json";
 import enSettings from "./en/settings.json";
@@ -26,6 +27,7 @@ import enInsight from "./en/insight.json";
 import enQuality from "./en/quality.json";
 import enSkills from "./en/skills.json";
 import enHarness from "./en/harness.json";
+import enRuntime from "./en/runtime.json";
 
 /** Supported locales. Add 'ja', 'zh', etc. in later PRs. */
 export type SupportedLocale = "ko" | "en";
@@ -49,6 +51,7 @@ export const resources = {
     quality: koQuality,
     skills: koSkills,
     harness: koHarness,
+    runtime: koRuntime,
   },
   en: {
     common: enCommon,
@@ -63,6 +66,7 @@ export const resources = {
     quality: enQuality,
     skills: enSkills,
     harness: enHarness,
+    runtime: enRuntime,
   },
 } as const;
 
@@ -76,7 +80,7 @@ i18n
     // 누락 키는 빈 문자열 대신 키 그대로 표시 → 누락 즉시 인지.
     returnEmptyString: false,
     defaultNS: "common",
-    ns: ["common", "error", "settings", "sidebar", "chat", "dialog", "workflow", "branch", "insight", "quality", "skills", "harness"],
+    ns: ["common", "error", "settings", "sidebar", "chat", "dialog", "workflow", "branch", "insight", "quality", "skills", "harness", "runtime"],
     detection: {
       // appStore (IndexedDB) 우선, 그 다음 localStorage/navigator.
       order: ["localStorage", "navigator"],

--- a/src/locales/ko/runtime.json
+++ b/src/locales/ko/runtime.json
@@ -1,0 +1,20 @@
+{
+  "claude": {
+    "freshFallback": {
+      "title": "Claude 세션이 새로 시작됩니다",
+      "body": "이전 세션이 만료되어 자동으로 새 세션으로 회복됐습니다. 다음 응답부터 ContextPack 으로 이전 대화 맥락을 다시 제공합니다 — 첫 응답이 약간 느릴 수 있습니다.",
+      "dismiss": "확인",
+      "learnMore": "Claude 사용량 보기"
+    },
+    "rateLimit": {
+      "ok": "Claude 사용량 정상",
+      "approaching": "Claude 5시간 한도에 가까워졌습니다",
+      "limitReached": "Claude 5시간 한도에 도달했습니다",
+      "overageDisabled": "추가 사용(overage) 이 비활성화되어 거부되었습니다",
+      "weekly": "주간 한도",
+      "fiveHour": "5시간 한도",
+      "resetsIn": "{{when}} 에 리셋",
+      "openSettings": "Anthropic 설정 열기"
+    }
+  }
+}

--- a/src/stores/claudeRateLimitStore.ts
+++ b/src/stores/claudeRateLimitStore.ts
@@ -1,0 +1,48 @@
+/**
+ * claudeTransportFlipHardeningPlan T4 — Claude rate_limit 상태 저장소.
+ *
+ * Backend (claude.rs T1) 가 stream-json 안의 `rate_limit_event` 를 parse 해
+ * `claude:rate_limit` 이벤트로 emit. ClaudeFallbackEvents 컴포넌트가 받아 본
+ * store 에 저장 → RuntimeStatusBar 의 ClaudeRateLimitIndicator 가 read.
+ *
+ * 데이터는 conversation 별로 마지막 1건만 보관. 이전 plan 의 `ccusage` 산출
+ * 기반 rateLimit (5h/7d 비율) 과는 다른 source. 둘 다 RuntimeStatusBar 에
+ * 표시 가능 (영역 분리).
+ */
+import { create } from "zustand";
+
+/** Backend RateLimitInfo struct 의 camelCase JSON. */
+export interface ClaudeRateLimitInfo {
+  status?: string | null;
+  resetsAt?: string | null;
+  rateLimitType?: string | null;
+  overageStatus?: string | null;
+  overageDisabledReason?: string | null;
+  isUsingOverage?: boolean | null;
+}
+
+interface ClaudeRateLimitState {
+  /** conversationId → 가장 최근 rate_limit_event payload. */
+  byConversation: Record<string, ClaudeRateLimitInfo>;
+  /** 가장 최근에 갱신된 conversationId. RuntimeStatusBar 가 selected conv 우선
+   *  사용하다가 없으면 fallback 으로 본 값을 사용. */
+  latestConversationId: string | null;
+  setRateLimit: (conversationId: string, info: ClaudeRateLimitInfo) => void;
+  clear: (conversationId: string) => void;
+}
+
+export const useClaudeRateLimitStore = create<ClaudeRateLimitState>((set) => ({
+  byConversation: {},
+  latestConversationId: null,
+  setRateLimit: (conversationId, info) =>
+    set((s) => ({
+      byConversation: { ...s.byConversation, [conversationId]: info },
+      latestConversationId: conversationId,
+    })),
+  clear: (conversationId) =>
+    set((s) => {
+      const next = { ...s.byConversation };
+      delete next[conversationId];
+      return { byConversation: next };
+    }),
+}));

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -18,6 +18,7 @@ import type koInsight from "../locales/ko/insight.json";
 import type koQuality from "../locales/ko/quality.json";
 import type koSkills from "../locales/ko/skills.json";
 import type koHarness from "../locales/ko/harness.json";
+import type koRuntime from "../locales/ko/runtime.json";
 
 declare module "i18next" {
   interface CustomTypeOptions {
@@ -35,6 +36,7 @@ declare module "i18next" {
       quality: typeof koQuality;
       skills: typeof koSkills;
       harness: typeof koHarness;
+      runtime: typeof koRuntime;
     };
   }
 }


### PR DESCRIPTION
v0.1.5-beta release blocker — claude transport flip hardening Phase 1 의 마지막 (Task 04). 사용자 가시화.

> **Stacked PR**: base = #239 (T2+T3). 머지 순서 = #238 → #239 → 본 PR.

SSOT: [claudeTransportFlipHardeningPlan_2026-04-29.md](docs/plans/claudeTransportFlipHardeningPlan_2026-04-29.md)

## Summary

backend (T2+T3) 가 emit 하는 두 이벤트를 사용자에게 가시화:

- **claude:fresh_fallback** → sonner toast 1회 ("이전 세션이 만료되어 자동으로 새 세션으로 회복됐습니다. 다음 응답부터 ContextPack 으로 이전 대화 맥락을 다시 제공합니다 — 첫 응답이 약간 느릴 수 있습니다.")
  - sessionStorage flag 로 conversation 별 1회 dismiss
- **claude:rate_limit** → \`useClaudeRateLimitStore\` 갱신, \`ClaudeRateLimitIndicator\` (RuntimeStatusBar 안) 가 read
  - 정상 상태 → null 반환 (자리 차지 X)
  - approaching → 노란 dot
  - limit_reached → 주황 dot
  - overage disabled → 빨간 dot + \"Overage disabled\" 라벨
  - 모두 \`claude.ai/settings/usage\` 링크

## 신규 파일

- \`src/components/tunaflow/ClaudeFallbackEvents.tsx\` — AppShell 안에 1회 mount, listener wire
- \`src/components/tunaflow/ClaudeRateLimitIndicator.tsx\` — RuntimeStatusBar 안의 dot indicator
- \`src/stores/claudeRateLimitStore.ts\` — conversation 별 마지막 rate_limit_event 보관
- \`src/locales/{ko,en}/runtime.json\` — 새 namespace, 4 status + 토스트 본문

## 수정 파일

- \`AppShell.tsx\` — ClaudeFallbackEvents mount (메인 return path 만, Project 선택 후)
- \`RuntimeStatusBar.tsx\` — ClaudeRateLimitIndicator import + 자리
- \`locales/index.ts\` — runtime namespace 등록
- \`types/i18next.d.ts\` — runtime 타입 추가

## 회귀 가드

- AppShell 의 메인 return path 만 mount (ProjectStartup 영향 0).
- agentStreamHelper 의 progress/chunk/completed/error listener 영향 0.
- RuntimeStatusBar 의 ccusage 기반 rateLimit indicator 와 별도 영역 — 공존, 충돌 0.
- 정상 status / store 비어있으면 indicator null → status bar 자리 영향 0.
- 새 dependency 0.

## Verification

\`\`\`bash
npx tsc --noEmit                  # ✓
npx vitest run                    # ✓ 388 passed (변동 없음)
cd src-tauri && cargo check       # ✓ (T2+T3 와 동일 backend, 변경 없음)
\`\`\`

## Test plan

- [x] tsc --noEmit
- [x] vitest run
- [ ] dev 모드 manual smoke: stale resume_token simulate → backend 로그 \`claude-stale-resume detected\` → toast \"Claude 세션이 새로 시작됩니다\" 표시 → 다음 send full ContextPack
- [ ] CI macOS / Windows 양쪽 ✓ 후 머지 (frontend 만 변경 — cross-platform 회귀 위험 낮음, admin merge 가능)

## DO NOT 위반 0

- ❌ 다른 엔진 영향 0 (claude:* prefix 한정)
- ❌ 새 dependency 0 (sonner / zustand / react-i18next 모두 기존)
- ❌ tauri.conf.json 변경 0
- ❌ settings store / userProfile 변경 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)