### PR TITLE
docs(claude): transport flip hardening v0.1.5-beta — README/INSTALL/CHANGELOG (T8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,50 @@ All notable changes to tunaFlow are recorded here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 versioning follows [SemVer](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.5-beta] - 2026-04-29 (예정)
+
+🛡️ **claude transport flip hardening** — v0.1.4-beta 의 transport flip
+(`-p --resume`) 후 발견된 stale resume_token 부작용 차단. 외부 사용자
+v0.1.4-beta 업그레이드 직후 첫 send 좌절 시나리오 해소.
+
+### Fixed
+
+- **stale resume_token 자동 회복**
+  ([claudeTransportFlipHardeningPlan_2026-04-29.md](docs/plans/claudeTransportFlipHardeningPlan_2026-04-29.md))
+  - 한동안 미사용 conversation 의 resume_token 이 (a) 과거 sdk-url 시점
+    session id 이거나 (b) Anthropic 측 TTL 만료 → `--resume <id>` 시도가
+    "out of extra usage" 형태로 거부되던 문제. 사용자 액션 0 자동 회복.
+  - **T1**: claude.rs `stream_run` 이 `rate_limit_event` line 을 parse →
+    `RunOutput.last_rate_limit` 로 노출 (RuntimeStatusBar indicator 데이터
+    소스).
+  - **T2**: `stream_run` wrapper 가 result.is_error 의 keyword 패턴 detect
+    → `--resume` 제거 후 1회 retry. false positive 차단 (정상 인증 실패 /
+    한도 초과 / 네트워크 에러는 retry 트리거 X).
+  - **T3**: retry 성공 시 `session_freshness::clear_delivered_key` →
+    다음 send 부터 `is_session_continuation=false` → ContextPack revival
+    자동 (full mode + anchor 2 turns). frontend 에 `claude:fresh_fallback`
+    이벤트 emit.
+  - **T4**: 사용자 가시화 — fresh_fallback toast 1회 + RuntimeStatusBar 의
+    Claude rate_limit indicator (정상 시 hide, approaching/limit_reached/
+    overage_disabled 상태별 색상). claude.ai/settings/usage 링크.
+  - **T5**: DB migration v49 — 7일+ idle conversation 의 stale claude
+    resume_token 일괄 NULL. idempotent (schema_version 가드). 활성 사용
+    conversation 영향 0.
+  - **T6**: Conversation 우클릭 메뉴에 "Claude 세션 재시작" 항목 추가.
+    backend `restart_sdk_session` 호출 + 토스트.
+  - **T7**: claude API 에러 6 종 분류 (\`stale_resume_token\` /
+    \`auth_failure\` / \`rate_limited\` / \`quota_exceeded\` /
+    \`model_unavailable\` / \`unknown\`). agent:error event 의 errorKind
+    payload 에 노출.
+
+### Anthropic billing 안내
+
+tunaFlow 가 `claude -p` headless mode 사용 — Pro/Max plan 의 5시간 rolling
+한도 + overage 정책 동일 적용. 한동안 미사용 conversation 의 resume_token
+이 stale 일 수 있음 — v0.1.5-beta 가 자동 fallback. 수동 재시작은
+conversation 우클릭 메뉴 (T6). claude.ai/settings/usage 에서 한도 / overage
+/ "extra usage" 옵션 확인 권장.
+
 ## [0.1.4-beta] - 2026-04-29
 
 🚨 **긴급 패치** — claude CLI 2.1.121 (2026-04-28 자동 update) 의 `--sdk-url`

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -151,6 +151,19 @@ open -a tunaFlow
 open ~/Library/Logs/tunaFlow/
 ```
 
+### Claude 응답이 "out of extra usage" 등으로 거부될 때 (v0.1.4-beta 업그레이드 직후)
+
+v0.1.4-beta 의 transport flip (`-p --resume`) 이후 한동안 미사용 conversation 의 `resume_token` 이 stale 일 수 있습니다. 증상:
+
+- "out of extra usage" / "session not found" / "404" 등의 에러
+- 같은 사용자/계정의 다른 conversation (스크래치패드 등) 은 정상
+
+**해결 (v0.1.5-beta+ 자동)**: tunaFlow 가 stale 패턴을 감지해 `--resume` 제거 후 1회 retry. 다음 send 부터 ContextPack 이 full mode 로 다시 붙습니다. 토스트로 안내됩니다.
+
+**수동 재시작**: conversation 우클릭 → "Claude 세션 재시작". 다음 send 가 fresh session 으로 시작.
+
+**그래도 안 되면**: [claude.ai/settings/usage](https://claude.ai/settings/usage) 에서 5시간 한도 / 주간 한도 / "extra usage" (overage) 옵션 확인.
+
 ### rawq 가 인식 안 될 때 (footer "rawq sidecar 없음")
 
 원인 별 분기:

--- a/README.ko.md
+++ b/README.ko.md
@@ -204,6 +204,13 @@ tunaFlow 를 만들면서 Claude Opus 가 쓴 개발기입니다. 설계 결정 
 - **JSONL 완료 감지 실패 (P1)** — PTY 세션에서 응답이 UI 에 반영되지 않는 경우 간헐적 발생 (sdk-session WebSocket 경로로 이동 중).
 - **Windows / Linux 빌드** — 미지원. 패키징 파이프라인 준비 중.
 
+### Anthropic billing & Claude 세션 동작
+
+- **Claude `-p` headless mode**: tunaFlow 는 v0.1.4-beta 이후 `claude -p --resume <id>` CLI path 를 사용합니다 (upstream `--sdk-url` 정책 변경 대응). Pro/Max plan 의 5시간 rolling 한도 + 주간 한도 + overage 정책이 `claude.ai` 와 동일하게 적용됩니다.
+- **Stale resume_token 자동 회복 (v0.1.5-beta+)**: 한동안 미사용 conversation 의 `resume_token` 이 upstream 측에서 만료되어 있을 수 있습니다. tunaFlow 는 거부 패턴 (`out of extra usage`, `404 session not found` 등) 을 감지해 `--resume` 을 제거하고 1회 retry. 다음 send 부터 ContextPack 이 full mode + 2-turn anchor 로 다시 붙습니다. 발생 시 토스트 1회 안내.
+- **수동 재시작**: conversation 우클릭 → "Claude 세션 재시작" 으로 다음 send 를 fresh session 으로 강제 가능 (자동 회복과 별개).
+- **사용량 확인**: [claude.ai/settings/usage](https://claude.ai/settings/usage) — 5시간 한도 / 주간 한도 / "extra usage" (overage) 옵션을 확인하세요.
+
 ### 설계상 / Beta 단계
 
 - **ad-hoc 서명** — Beta 에서는 Apple Developer ID 서명 없음. Gatekeeper 경고 해제 필요 (`xattr -cr /Applications/tunaFlow.app`). DMG 를 drag-install 만 하면 `.app` 에 quarantine 속성이 붙어 번들 안 사이드카 (rawq) 가 조용히 차단됩니다 — 증상/원인 표는 [INSTALL.md → "rawq 가 인식 안 될 때"](./INSTALL.md#rawq-가-인식-안-될-때-footer-rawq-sidecar-없음) 참조.

--- a/README.md
+++ b/README.md
@@ -217,6 +217,13 @@ If this trade-off is unacceptable for your workflow, run Claude Code directly in
 - **JSONL Completion Detection Failure (P1)** — Occasional issues where PTY session responses are not reflected in the UI (transitioning to `sdk-session` WebSocket path).
 - **Windows / Linux builds** — Not yet supported; packaging pipeline in progress.
 
+### Anthropic billing & Claude session behavior
+
+- **Claude `-p` headless mode**: tunaFlow uses the `claude -p --resume <id>` CLI path (since v0.1.4-beta, after the upstream `--sdk-url` policy change). Pro/Max plan limits — 5-hour rolling window + weekly cap + overage policy — apply the same as in `claude.ai`.
+- **Stale resume_token auto-recovery (v0.1.5-beta+)**: idle conversations may carry a `resume_token` that the upstream session store has rolled off. tunaFlow detects the rejection pattern (`out of extra usage`, `404 session not found`, etc.), clears `--resume`, and retries once. From the next send, `ContextPack` is re-attached in full mode + 2-turn anchor. A toast informs the user when this happens.
+- **Manual restart**: right-click any conversation → "Restart Claude session" forces a fresh session for the next send (works alongside the auto-recovery above).
+- **Where to check usage**: [claude.ai/settings/usage](https://claude.ai/settings/usage) — verify your 5-hour limit, weekly cap, and "extra usage" (overage) toggle.
+
 ### By design / Beta stage
 
 - **Ad-hoc Signature** — No Apple Developer ID signing in Beta. Requires Gatekeeper bypass (`xattr -cr /Applications/tunaFlow.app`). Drag-installing the DMG without running `install.sh` leaves a quarantine attribute on the `.app`, which silently blocks the bundled sidecars (rawq) — see [INSTALL.md → "rawq 가 인식 안 될 때"](./INSTALL.md#rawq-가-인식-안-될-때-footer-rawq-sidecar-없음) for the symptom-cause table.


### PR DESCRIPTION
v0.1.5-beta release blocker — claude transport flip hardening Phase 2 마지막 (Task 08).

> **Stacked PR**: base = #241 (T6+T7). 머지 순서 = #238 → #239 → #240 → #241 → 본 PR.

SSOT: [claudeTransportFlipHardeningPlan_2026-04-29.md](docs/plans/claudeTransportFlipHardeningPlan_2026-04-29.md)

## Summary

T1~T7 의 변경 요약 + Anthropic billing 안내 + 사용자 troubleshooting 안내.

- **CHANGELOG.md**: \`[0.1.5-beta]\` (예정) 섹션 신규. T1~T7 모든 변경 요약 + Anthropic billing 안내.
- **README.md / README.ko.md**: \"Anthropic billing & Claude session behavior\" 섹션 (Known Constraints 안). 자동 회복 + 수동 재시작 + \`claude.ai/settings/usage\` 링크.
- **INSTALL.md**: 문제 해결 섹션에 \"Claude 응답이 'out of extra usage' 등으로 거부될 때\" 항목 추가. 자동 회복 (T2+T3) + 수동 재시작 (T6) + 사용량 확인 링크로 분기.

## 회귀 가드

- 다른 README / INSTALL / CHANGELOG 섹션 변경 0
- 코드 변경 0 — 문서만

## Verification

\`\`\`bash
npx tsc --noEmit                  # ✓ (코드 변경 없으나 sanity check)
\`\`\`

## DO NOT 위반 0

- ❌ 코드 / locale / settings 변경 0
- ❌ Anthropic 정책 부정확 표현 없음 (사용자 행동 안내만)

🤖 Generated with [Claude Code](https://claude.com/claude-code)