### PR TITLE
chore(gitignore): exclude /agents/_skills/ vendor snapshot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,12 @@ _stash_recovery/
 # Auto-cloned rawq sidecar source (build-rawq.sh / build-rawq.ps1 fallback)
 vendor/rawq/
 
+# Vendor skills snapshot — fallback source for publish-skills.sh.
+# Real artifact lives in ~/.tunaflow/skills/ after publish; this in-repo
+# folder is a co-located mirror some users keep next to the source tree.
+# Not part of the tunaFlow build.
+/agents/_skills/
+
 # .tunaflow/ — 폐기된 outbox 잔재 + 향후 동적 산출물 차단
 .tunaflow/outbox/
 


### PR DESCRIPTION
## Summary

`publish-skills.sh` lists `/agents/_skills/` as a fallback source candidate when `SKILLS_SRC` is unset and `_research/_skills/` is also missing. Some users keep this co-located mirror; it is **not part of the tunaFlow build**, not authored as repo content, and the runtime artifact lives in `~/.tunaflow/skills/` after publish.

This was producing 6 untracked entries on every `git status` (anthropic / microsoft / openai / remotion / supabase / vercel vendor folders), masking real work-tree noise.

## Change

`.gitignore` gains one block (5 lines) under the existing *Auto-cloned* section:

```gitignore
# Vendor skills snapshot — fallback source for publish-skills.sh.
# Real artifact lives in ~/.tunaflow/skills/ after publish; this in-repo
# folder is a co-located mirror some users keep next to the source tree.
# Not part of the tunaFlow build.
/agents/_skills/
```

Sibling axis to existing `_research/` / `vendor/rawq/` ignores. No code, no docs, no behavior change.

## Verification

- Before: `git status` shows 6 `?? agents/_skills/skills-*` lines.
- After: `git status` clean.

## Invariants

- INV-1: no source change, mac unaffected.
- INV-4: single axis (gitignore noise reduction).