### PR TITLE
fix(agents/claude): cli mode session_freshness 적용 — double history 차단 (T9)

### DIFF
--- a/src-tauri/src/agents/claude_sdk_session.rs
+++ b/src-tauri/src/agents/claude_sdk_session.rs
@@ -364,6 +364,55 @@ pub fn has_active_session(conv_id: &str) -> bool {
     SESSIONS.lock().contains_key(&key)
 }
 
+/// claude `-p` cli mode (T9, claudeTransportFlipHardeningPlan 2026-04-30) — finalize 시점에
+/// claude 응답의 새 session_id 를 메모리 RESUME_IDS 에 갱신한다.
+///
+/// sdk-url path 는 `stream_run_sdk` 의 result 이벤트 핸들러에서 RESUME_IDS 에 직접
+/// insert (line 933) 하지만, cli path 는 `claude.rs::stream_run` 외부에서 finalize 가
+/// 진행되므로 별도 hook 이 없다. 이 helper 는 cli path 의 finalize 직전에 호출되어
+/// `session_freshness::current_session_key` 의 다음 lookup 이 새 sid 를 반영하도록 한다.
+///
+/// **Identity 원칙**: RESUME_IDS 는 sdk-url 와 cli mode 가 공유. mode 는 conv lifetime
+/// 동안 고정 (env var 기반) 이므로 충돌 없음. brand:* 는 root main key 로 normalize.
+///
+/// **DO NOT 가드** (T9): 본 helper 는 *additive* — sdk-url path 의 result 핸들러 동작
+/// 변경 0. 단지 cli path 가 RESUME_IDS 에 접근할 수 있는 새 진입점 추가.
+pub fn register_cli_resume_id(conv_id: &str, sid: &str) {
+    let key = session_key_for(conv_id);
+    let prior = RESUME_IDS.lock().insert(key.clone(), sid.to_string());
+    if let Some(p) = prior {
+        if p != sid {
+            // sdk-url path 의 INV-6 와 동일 정책 — sid 가 변하면 LAST_DELIVERED 무효화.
+            // cli path 의 finalize 흐름에서 새 sid 가 들어왔다면 다음 send 를 full 로
+            // 강제해 history 일관성 유지 (사용자가 외부에서 session 재생성한 시나리오).
+            eprintln!(
+                "[cli-session] RESUME_IDS sid changed (prior={} new={}) for conv={} (key={}) — \
+                 invalidating LAST_DELIVERED",
+                p, sid, conv_id, key
+            );
+            crate::commands::agents_helpers::send_common::session_freshness::clear_delivered_key(
+                conv_id,
+            );
+            if key != conv_id {
+                crate::commands::agents_helpers::send_common::session_freshness::clear_delivered_key(
+                    &key,
+                );
+            }
+        }
+    }
+}
+
+/// 테스트 전용 — RESUME_IDS leak 방지.
+///
+/// session_freshness 의 unit test 가 `register_cli_resume_id` 호출 후 정리할 때 사용.
+/// 다른 테스트의 conv_id 와 충돌하지 않도록 unique conv 를 쓰면 strictly 필요하지
+/// 않지만, 안전 마진으로 유지.
+#[cfg(test)]
+pub fn clear_resume_id_for_test(conv_id: &str) {
+    let key = session_key_for(conv_id);
+    RESUME_IDS.lock().remove(&key);
+}
+
 /// ContextPack freshness 판정용 — 현재 활성 세션의 식별 키.
 ///
 /// **Identity 원칙** (sessionContinuityFixPlan.md task-01): 식별자는 claude 자체가

--- a/src-tauri/src/commands/agents_helpers/send_common/persistence.rs
+++ b/src-tauri/src/commands/agents_helpers/send_common/persistence.rs
@@ -325,6 +325,28 @@ pub fn finalize_engine_run(
     let now = now_epoch_ms();
     match result {
         Ok(out) => {
+            // T9 (claudeTransportFlipHardeningPlan, 2026-04-30):
+            // claude cli mode (`-p --resume`) 의 finalize 흐름 — 응답에 새 session_id 가
+            // 들어오면 메모리 RESUME_IDS 를 즉시 갱신해 다음 promote_pending_to_delivered
+            // 의 live key lookup 이 새 sid 를 반영하게 한다.
+            //
+            // **scope 좁힘**: sdk-url path 는 `claude_sdk_session::stream_run_sdk` 의
+            // result 핸들러가 stream 도중 RESUME_IDS 를 직접 갱신 + INV-6 무효화
+            // (claude_sdk_session.rs:931-952). 본 helper 호출은 cli mode 에서만 — DO NOT
+            // 가드 (sdk-url path 동작 보존) 의 정신에 맞춰 미진입 보장.
+            //
+            // 다른 엔진 (codex/gemini/ollama/lmstudio) 은 engine_key 가 "claude-code" /
+            // "claude" 일 때만 분기 진입.
+            if matches!(engine_key, "claude-code" | "claude") {
+                if session_freshness::is_claude_cli_mode_external(conversation_id) {
+                    if let Some(ref sid) = out.session_id {
+                        crate::agents::claude_sdk_session::register_cli_resume_id(
+                            conversation_id, sid,
+                        );
+                    }
+                }
+            }
+
             // Session freshness: 성공 시 pending → delivered 승격
             session_freshness::promote_pending_to_delivered(msg_id, conversation_id, engine_key);
 

--- a/src-tauri/src/commands/agents_helpers/send_common/session_freshness.rs
+++ b/src-tauri/src/commands/agents_helpers/send_common/session_freshness.rs
@@ -1,17 +1,18 @@
 //! ContextPack 세션 신선도(freshness) 판정.
 //!
 //! 핵심 규칙: 같은 (engine, session_id) 튜플로 연속 send → 에이전트가 이미
-//! `--replay-user-messages`/codex thread 내부에 히스토리를 가지고 있으므로
+//! `--replay-user-messages`/`--resume`/codex thread 내부에 히스토리를 가지고 있으므로
 //! ContextPack은 minimal(user prompt 위주)로 충분.
 //!
 //! 다른 튜플 → 새 에이전트 프로세스(엔진 전환, 세션 crash, 첫 send) → full ContextPack.
 //!
 //! 적용 대상:
-//! - claude `--sdk-url` (claude_sdk_session::SESSIONS)
+//! - claude `--sdk-url` (claude_sdk_session::SESSIONS) — key: `claude-ws:{sid}`
+//! - claude `-p` cli `--resume` (claudeTransportFlipHardeningPlan T9, 2026-04-30)
+//!   — key: `claude-cli:{sid}` (sdk-url path 와 prefix 분리해 충돌 차단)
 //! - codex app-server (codex_app_server::CONV_THREADS)
 //!
 //! 적용 제외 (항상 full):
-//! - claude `-p` CLI 모드 (start_claude_stream의 비-sdk 경로)
 //! - codex CLI exec fallback
 //! - gemini, opencode (one-shot)
 //! - Roundtable participants
@@ -65,9 +66,39 @@ pub fn discard_pending(msg_id: &str) {
 /// 현재 conversation에 대해 활성화된 세션 키를 반환.
 /// WS/app-server 지속 세션을 사용하지 않는 엔진은 None을 반환하며,
 /// 이 경우 호출자는 항상 full ContextPack 경로를 사용해야 한다.
+///
+/// claude 분기 (T9, 2026-04-30 — claudeTransportFlipHardeningPlan):
+/// - sdk-url mode (`TUNAFLOW_USE_SDK_URL=1`) 또는 anthropic_sdk + branch path
+///   → `claude_sdk_session::current_session_key` 위임 (`claude-ws:{sid}` 형식)
+/// - cli mode (default since 2026-04-29) → `claude-cli:{sid}` 형식. cli 와 sdk-url
+///   양쪽이 같은 conv 에 LAST_DELIVERED 등록할 일은 없지만 (mode 는 conv lifetime 동안
+///   고정), prefix 분리로 mode 전환 시 stale key 충돌도 차단.
+///
+/// **router fallback 처리**: cli/sdk-url 모두 RESUME_IDS 가 비어있는 첫 send 에서는
+/// `claude_sdk_session::current_session_key` 가 router UUID fallback 을 반환할 수 있음
+/// (`claude-ws:router:{uuid}`). cli mode 에서는 router fallback 의미가 없으므로
+/// (cli 는 SESSIONS 자체를 채우지 않음) `None` 으로 정규화 — 첫 send 의 LAST_DELIVERED
+/// 미등록을 보장.
 pub fn current_session_key(conv_id: &str, engine: &str) -> Option<String> {
     match engine {
-        "claude" | "claude-code" => crate::agents::claude_sdk_session::current_session_key(conv_id),
+        "claude" | "claude-code" => {
+            if is_claude_cli_mode(conv_id) {
+                // cli mode: RESUME_IDS 의 sid 를 cli prefix 로 wrapping.
+                // sdk_session 의 current_session_key 를 호출하되 결과를 변환.
+                let raw = crate::agents::claude_sdk_session::current_session_key(conv_id)?;
+                // router fallback (`claude-ws:router:...`) 은 cli 에 무의미 → None.
+                // SESSIONS 가 cli path 에서 채워지지 않으므로 router fallback 자체가
+                // 도달하기 어렵지만, 방어적으로 차단.
+                if raw.starts_with("claude-ws:router:") {
+                    return None;
+                }
+                let sid = raw.strip_prefix("claude-ws:")?;
+                Some(format!("claude-cli:{}", sid))
+            } else {
+                // sdk-url mode (또는 branch + anthropic_sdk path): 기존 동작 그대로.
+                crate::agents::claude_sdk_session::current_session_key(conv_id)
+            }
+        }
         "codex" => {
             // codex는 OpenAI SDK > app-server > CLI 순으로 fallback.
             // app-server 모드일 때만 thread key 존재.
@@ -75,6 +106,25 @@ pub fn current_session_key(conv_id: &str, engine: &str) -> Option<String> {
         }
         _ => None,
     }
+}
+
+/// claude `-p` cli mode 활성 여부.
+///
+/// `agents.rs::resolve_claude_mode` 와 동일 로직 (env var `TUNAFLOW_USE_SDK_URL=1`
+/// + branch + anthropic_sdk::is_available). 본 함수는 session_freshness 내부에서만
+/// 사용해 cli/sdk-url path 의 key prefix 를 분리한다.
+///
+/// resolve_claude_mode 자체를 pub 으로 노출하면 외부 의존이 늘어나므로, 같은 정책을
+/// 좁은 범위로 inline 한다. 정책 변경 시 양쪽 sync 필수 (현재 단일 env var 라 부담 적음).
+fn is_claude_cli_mode(conv_id: &str) -> bool {
+    let is_branch = conv_id.starts_with("branch:");
+    if crate::agents::anthropic_sdk::is_available() && is_branch {
+        return false; // sdk path
+    }
+    if std::env::var("TUNAFLOW_USE_SDK_URL").as_deref() == Ok("1") {
+        return false; // sdk-url path
+    }
+    true // cli (default since 2026-04-29)
 }
 
 /// 마지막으로 기록된 전달 키.
@@ -170,5 +220,75 @@ mod tests {
         record_delivered_key(&conv, "claude-ws:xyz");
         assert!(!is_session_continuation(&conv, "unknown-engine"),
             "current_session_key가 None인 엔진은 continuation 판정 false여야 함");
+    }
+
+    /// T9 (claudeTransportFlipHardeningPlan, 2026-04-30):
+    /// cli mode 와 sdk-url mode 의 session key prefix 가 분리되어야 한다.
+    /// 같은 RESUME_IDS sid 라도 cli/sdk 양쪽이 같은 conv 에 충돌하지 않도록 검증.
+    #[test]
+    fn cli_and_sdk_url_session_key_prefixes_never_collide() {
+        // env var 미설정 + non-branch conv → cli mode
+        let conv_cli = unique_conv("non-branch-cli");
+        // RESUME_IDS 에 sid 직접 주입 — sdk_session 공유 메모리지만 cli mode 에서도 조회됨.
+        // sdk_session 의 RESUME_IDS 는 module-private 이라 직접 주입 대신,
+        // claude_sdk_session 이 노출하는 register_cli_resume_id pub helper 를 사용.
+        crate::agents::claude_sdk_session::register_cli_resume_id(&conv_cli, "sid-abc-123");
+
+        // env var 미설정 → cli mode 활성
+        std::env::remove_var("TUNAFLOW_USE_SDK_URL");
+        let cli_key = current_session_key(&conv_cli, "claude-code")
+            .expect("cli mode 에서 RESUME_IDS sid 가 있으면 Some");
+        assert!(
+            cli_key.starts_with("claude-cli:"),
+            "cli mode 의 key 는 claude-cli: prefix 를 사용해야 함: {}",
+            cli_key
+        );
+        assert!(
+            !cli_key.starts_with("claude-ws:"),
+            "cli mode 의 key 는 sdk-url 의 claude-ws: prefix 와 충돌하면 안 됨: {}",
+            cli_key
+        );
+
+        // 정리 — RESUME_IDS leak 방지 (다른 테스트 영향 차단)
+        crate::agents::claude_sdk_session::clear_resume_id_for_test(&conv_cli);
+    }
+
+    /// T9: cli mode 의 첫 send (RESUME_IDS 비어있음) 는 None 반환 — LAST_DELIVERED
+    /// 미등록 → 다음 send 도 full mode. SESSIONS 가 cli path 에서 채워지지 않으므로
+    /// router fallback (`claude-ws:router:`) 이 도달해도 None 으로 정규화.
+    #[test]
+    fn cli_mode_first_send_returns_none_for_router_fallback() {
+        let conv = unique_conv("cli-first-send");
+        std::env::remove_var("TUNAFLOW_USE_SDK_URL");
+        // RESUME_IDS 미설정, SESSIONS 도 없음 → claude_sdk_session::current_session_key None
+        // → cli wrapper 도 None.
+        assert!(
+            current_session_key(&conv, "claude-code").is_none(),
+            "cli mode 첫 send 는 None 이어야 함 (LAST_DELIVERED 미등록)"
+        );
+    }
+
+    /// T9: sdk-url mode 일 때 기존 동작 보존 — claude-ws: prefix 그대로.
+    #[test]
+    fn sdk_url_mode_preserves_existing_claude_ws_prefix() {
+        let conv = unique_conv("sdk-url-preserve");
+        crate::agents::claude_sdk_session::register_cli_resume_id(&conv, "sid-sdk-url-XYZ");
+        // env var 활성 → sdk-url mode (cli mode 가 아님)
+        std::env::set_var("TUNAFLOW_USE_SDK_URL", "1");
+        let key = current_session_key(&conv, "claude-code")
+            .expect("RESUME_IDS sid 가 있으면 Some");
+        assert!(
+            key.starts_with("claude-ws:"),
+            "sdk-url mode 는 기존 claude-ws: prefix 를 보존해야 함: {}",
+            key
+        );
+        assert!(
+            !key.starts_with("claude-cli:"),
+            "sdk-url mode 가 cli prefix 를 쓰면 안 됨: {}",
+            key
+        );
+        // 정리
+        std::env::remove_var("TUNAFLOW_USE_SDK_URL");
+        crate::agents::claude_sdk_session::clear_resume_id_for_test(&conv);
     }
 }

--- a/src-tauri/src/commands/agents_helpers/send_common/session_freshness.rs
+++ b/src-tauri/src/commands/agents_helpers/send_common/session_freshness.rs
@@ -127,6 +127,13 @@ fn is_claude_cli_mode(conv_id: &str) -> bool {
     true // cli (default since 2026-04-29)
 }
 
+/// `is_claude_cli_mode` 의 pub wrapper — `persistence::finalize_engine_run` 이 cli mode
+/// 에서만 RESUME_IDS 갱신을 trigger 하기 위해 사용. session_freshness 모듈 안에서
+/// 정책을 단일 진실로 유지하기 위해 외부 호출은 본 함수로 통일.
+pub fn is_claude_cli_mode_external(conv_id: &str) -> bool {
+    is_claude_cli_mode(conv_id)
+}
+
 /// 마지막으로 기록된 전달 키.
 pub fn last_delivered_key(conv_id: &str) -> Option<String> {
     LAST_DELIVERED_KEY.lock().get(conv_id).cloned()

--- a/src-tauri/src/commands/agents_helpers/send_common/session_freshness.rs
+++ b/src-tauri/src/commands/agents_helpers/send_common/session_freshness.rs
@@ -80,9 +80,22 @@ pub fn discard_pending(msg_id: &str) {
 /// (cli 는 SESSIONS 자체를 채우지 않음) `None` 으로 정규화 — 첫 send 의 LAST_DELIVERED
 /// 미등록을 보장.
 pub fn current_session_key(conv_id: &str, engine: &str) -> Option<String> {
+    current_session_key_with_mode(conv_id, engine, is_claude_cli_mode(conv_id))
+}
+
+/// `current_session_key` 의 inner — mode flag 를 외부 인자로 받는 testable form.
+///
+/// production code 는 `current_session_key` 만 호출 (flag 자동 detect).
+/// test 는 본 함수에 명시 flag 를 주입 → process-wide env var mutation 회피로
+/// CI 병렬 실행 race 차단.
+fn current_session_key_with_mode(
+    conv_id: &str,
+    engine: &str,
+    cli_mode_active: bool,
+) -> Option<String> {
     match engine {
         "claude" | "claude-code" => {
-            if is_claude_cli_mode(conv_id) {
+            if cli_mode_active {
                 // cli mode: RESUME_IDS 의 sid 를 cli prefix 로 wrapping.
                 // sdk_session 의 current_session_key 를 호출하되 결과를 변환.
                 let raw = crate::agents::claude_sdk_session::current_session_key(conv_id)?;
@@ -232,18 +245,18 @@ mod tests {
     /// T9 (claudeTransportFlipHardeningPlan, 2026-04-30):
     /// cli mode 와 sdk-url mode 의 session key prefix 가 분리되어야 한다.
     /// 같은 RESUME_IDS sid 라도 cli/sdk 양쪽이 같은 conv 에 충돌하지 않도록 검증.
+    ///
+    /// **CI race 차단**: env var (`TUNAFLOW_USE_SDK_URL`) 를 process-wide 로 mutate
+    /// 하면 병렬 테스트 사이 leak 발생 (실제로 첫 PR push CI rust-check 에서 fail).
+    /// 따라서 mode flag 는 `current_session_key_with_mode` 에 직접 주입한다.
     #[test]
     fn cli_and_sdk_url_session_key_prefixes_never_collide() {
-        // env var 미설정 + non-branch conv → cli mode
         let conv_cli = unique_conv("non-branch-cli");
-        // RESUME_IDS 에 sid 직접 주입 — sdk_session 공유 메모리지만 cli mode 에서도 조회됨.
-        // sdk_session 의 RESUME_IDS 는 module-private 이라 직접 주입 대신,
-        // claude_sdk_session 이 노출하는 register_cli_resume_id pub helper 를 사용.
+        // RESUME_IDS 에 sid 직접 주입 — claude_sdk_session 의 pub helper 사용.
         crate::agents::claude_sdk_session::register_cli_resume_id(&conv_cli, "sid-abc-123");
 
-        // env var 미설정 → cli mode 활성
-        std::env::remove_var("TUNAFLOW_USE_SDK_URL");
-        let cli_key = current_session_key(&conv_cli, "claude-code")
+        // mode=true (cli) 명시 주입.
+        let cli_key = current_session_key_with_mode(&conv_cli, "claude-code", true)
             .expect("cli mode 에서 RESUME_IDS sid 가 있으면 Some");
         assert!(
             cli_key.starts_with("claude-cli:"),
@@ -266,11 +279,10 @@ mod tests {
     #[test]
     fn cli_mode_first_send_returns_none_for_router_fallback() {
         let conv = unique_conv("cli-first-send");
-        std::env::remove_var("TUNAFLOW_USE_SDK_URL");
         // RESUME_IDS 미설정, SESSIONS 도 없음 → claude_sdk_session::current_session_key None
-        // → cli wrapper 도 None.
+        // → cli wrapper 도 None. mode=true (cli) 명시 주입.
         assert!(
-            current_session_key(&conv, "claude-code").is_none(),
+            current_session_key_with_mode(&conv, "claude-code", true).is_none(),
             "cli mode 첫 send 는 None 이어야 함 (LAST_DELIVERED 미등록)"
         );
     }
@@ -280,9 +292,8 @@ mod tests {
     fn sdk_url_mode_preserves_existing_claude_ws_prefix() {
         let conv = unique_conv("sdk-url-preserve");
         crate::agents::claude_sdk_session::register_cli_resume_id(&conv, "sid-sdk-url-XYZ");
-        // env var 활성 → sdk-url mode (cli mode 가 아님)
-        std::env::set_var("TUNAFLOW_USE_SDK_URL", "1");
-        let key = current_session_key(&conv, "claude-code")
+        // mode=false (sdk-url) 명시 주입.
+        let key = current_session_key_with_mode(&conv, "claude-code", false)
             .expect("RESUME_IDS sid 가 있으면 Some");
         assert!(
             key.starts_with("claude-ws:"),
@@ -295,7 +306,6 @@ mod tests {
             key
         );
         // 정리
-        std::env::remove_var("TUNAFLOW_USE_SDK_URL");
         crate::agents::claude_sdk_session::clear_resume_id_for_test(&conv);
     }
 }


### PR DESCRIPTION
## Summary

claudeTransportFlipHardeningPlan §4 Task 09 — claude `-p` cli mode 의 session_freshness 적용 회복. v0.1.4-beta transport flip 후속 — cli mode 가 \"적용 제외\" 에 박혀 있어 secall main (Auto 모드) 에서 double history (Claude `--resume` session + tunaFlow ContextPack 의 compressed-memory 동시 inject) → paid API trigger → Lite 모드 강제 회피되는 회귀.

**v0.1.5-beta release blocker.**

## SSOT

- Plan: [docs/plans/claudeTransportFlipHardeningPlan_2026-04-29.md §4 Task 09](../blob/main/docs/plans/claudeTransportFlipHardeningPlan_2026-04-29.md)
- Handoff: [docs/prompts/cliModeSessionFreshnessDeveloperHandoff_2026-04-30.md](../blob/main/docs/prompts/cliModeSessionFreshnessDeveloperHandoff_2026-04-30.md)

## Sub-step 변경 요약

### T9-a — `current_session_key` cli 분기 + 적용 제외 목록 제거 (commit `a83eb79`)
- `session_freshness.rs:1-18` doc — cli mode 를 적용 제외 → 적용 대상으로 이동.
- `session_freshness.rs:current_session_key` — cli/sdk-url 분기. cli mode 일 때 RESUME_IDS sid 를 `claude-cli:{sid}` prefix 로 wrap. router fallback (`claude-ws:router:`) 은 cli 의미 없음 → None 정규화. sdk-url path 는 `claude_sdk_session::current_session_key` 위임 그대로 (`claude-ws:` prefix 보존).
- `session_freshness.rs:is_claude_cli_mode` — `agents.rs::resolve_claude_mode` 와 동일 정책 inline (env var TUNAFLOW_USE_SDK_URL + branch + anthropic_sdk).
- `claude_sdk_session.rs:register_cli_resume_id` — additive pub helper. cli path 의 finalize 가 RESUME_IDS 를 새 sid 로 갱신할 때 사용. INV-6 정책 (sid 변경 시 LAST_DELIVERED 무효화) 동일 적용. sdk-url path 동작 변경 0.
- `claude_sdk_session.rs:clear_resume_id_for_test` — test 전용 cleanup helper (#cfg(test)).
- 변경 라인: ~177줄 (2 files insertion 173 / deletion 4).

### T9-b — finalize 직전 RESUME_IDS 갱신 (commit `9f9c64a`)
- `persistence.rs:finalize_engine_run` — Ok 분기 진입 직후 cli mode + claude-code 엔진 + `out.session_id` Some 일 때만 `register_cli_resume_id` 호출. 이로써 다음 promote_pending_to_delivered 의 live key lookup 이 새 sid 정확히 capture → 두 번째 send 부터 minimal mode 발동.
- `session_freshness.rs:is_claude_cli_mode_external` — `is_claude_cli_mode` 의 pub wrapper. 정책 단일 진실 유지.
- 변경 라인: ~29줄 (2 files insertion 29).

### T9-c (보조 가드 — 미적용 결정)
첫 send 의 compressed-memory 미inject 정책은 본 PR 에 포함 안 함. 이유:
1. T9-a + T9-b 만으로 두 번째 send 부터 minimal mode 자동 발동 → 사용자 보고의 결정적 trigger (반복 send 시 Lite 강제) 차단.
2. 첫 send 의 compressed-memory 차단은 anchor 2 turns 만으로 응답 품질 저하 가능 — 후속 cycle (`v0.1.6-beta`) 에서 사용자 피드백 확인 후 결정.
3. 단순성 우선 — 구조 변경 최소화로 회귀 위험 차단.

T2 stale resume detect → fresh fallback path 와 결합되어 첫 send 의 paid API trigger 가 발생해도 자동 회복. 사용자 가시화는 기존 `claude:fresh_fallback` 이벤트.

## Verification

- `cargo check --message-format=short` PASS (warnings 0)
- `cargo test --lib` — **602/602 PASS** (baseline 599 + T9 신규 unit test 3건)
  - `cli_and_sdk_url_session_key_prefixes_never_collide`
  - `cli_mode_first_send_returns_none_for_router_fallback`
  - `sdk_url_mode_preserves_existing_claude_ws_prefix`
- `npx tsc --noEmit` PASS
- `npx vitest run` — **394/394 PASS** (baseline 동일, frontend 영향 0)

## DO NOT 위반 0 — 회귀 가드 grep

- `git diff main --name-only` →
  - `src-tauri/src/agents/claude_sdk_session.rs` (additive pub helper 만)
  - `src-tauri/src/commands/agents_helpers/send_common/persistence.rs`
  - `src-tauri/src/commands/agents_helpers/send_common/session_freshness.rs`
- 다른 엔진 (`agents/codex/gemini/ollama/lmstudio/opencode`) 변경 0 ✅
- frontend 변경 0 (`src/`) ✅
- `agents.rs::resolve_claude_mode` 변경 0 ✅
- `claude_sdk_session.rs::current_session_key` / `stream_run_sdk` / `get_or_create_session` 변경 0 — sdk-url path 동작 보존 ✅
- session key namespace 충돌 0 — cli (`claude-cli:`) ↔ sdk-url (`claude-ws:`) 명시 분리 ✅

## 동작 변화

- **cli mode 의 두 번째 send 부터**: `is_session_continuation = true` → `[session_freshness] continuation conv=... engine=claude-code → drop recent_context + compressed_memory (rely on Claude session)` 로그 발동 → minimal ContextPack → paid API trigger 회피.
- **첫 send**: 기존 동작 (full mode + anchor 2 turns) 그대로. 단 RESUME_IDS 가 finalize 직후 새 sid 로 채워져 다음 send 가 즉시 continuation 인식.
- **sdk-url mode**: 변경 0 (claude-ws: prefix + 기존 INV-6 정책 그대로).
- **secall main (Auto 모드)**: 두 번째 send 부터 minimal 모드 → Lite 모드 강제 회피 회귀 해소.

## Test plan

- [x] cargo check PASS
- [x] cargo test --lib (Rust 602/602 PASS)
- [x] npx tsc --noEmit PASS
- [x] npx vitest run (FE 394/394 PASS)
- [ ] CI macOS ✓
- [ ] CI Windows ✓
- [ ] manual smoke: secall main (큰 history) Auto 모드 두 번째 send 에서 `[session_freshness] continuation` 로그 발동 (사용자 환경 한정, dev rebuild 권장)

## Next

T9 머지 = v0.1.5-beta release publish 가능 상태 진입. release tag push 만 남음 (architect 영역).

🤖 Generated with [Claude Code](https://claude.com/claude-code)