### PR TITLE
fix: cli fresh session 도 compressed_memory drop (T9-b 강제)

### DIFF
--- a/src-tauri/src/commands/agents_helpers/send_common/persistence.rs
+++ b/src-tauri/src/commands/agents_helpers/send_common/persistence.rs
@@ -285,6 +285,21 @@ pub fn prepare_engine_run(
         }
     }
 
+    // T9-b: cli mode (claude-code) 는 *fresh session 첫 send 도* compressed_memory 미inject.
+    // 이유: T9-a (PR #245, 163b1cf) 가 두 번째 send 부터의 minimal mode 만 적용. 첫 send 는
+    // 여전히 compressed-memory inject → paid API trigger → 거부 → retry 도 같은 prompt
+    // 그대로 → 영구 lock (사용자 환경 fact 2026-04-30). cli mode 는 Claude `--resume` 또는
+    // fresh session 자체가 history 보유, anchor 2 turns 의 recent_context 도 keep — 즉
+    // compressed_memory 만 drop 하면 Lite 모드 강제 회피하면서 paid API 영역 회피 가능.
+    // continuation 분기는 이미 둘 다 drop 하므로 영향 X — fresh session 분기에 한정.
+    if engine_key == "claude-code" && !data.is_session_continuation {
+        if data.compressed_memory.is_some() {
+            data.compressed_memory = None;
+            data.compressed_memory_source = None;
+            eprintln!("[session_freshness] claude-code fresh session → drop compressed_memory only (T9-b, paid API trigger 회피)");
+        }
+    }
+
     // Phase B: Pure prompt assembly — no DB lock held
     let (mut enriched_prompt, system_context, ctx_meta) = assemble_prompt(&data, identity_frag);
 


### PR DESCRIPTION
## Summary

T9-a (PR #245 / 163b1cf) 후속 hotfix. 사용자 fact 2026-04-30:
- seCall main (Auto 모드) 재시도 → `[claude-stale-resume]` retry 발동 후에도 동일 거부
- retry 도 같은 prompt (compressed-memory inject) 그대로 → 영구 lock

T9-a 의 cli session_freshness 적용은 *두 번째 send 부터* minimal mode 만 효과. 첫 send 자체가 paid API trigger 로 막혀 영구 lock 회피 못 함.

## Plan SSOT

`docs/plans/claudeTransportFlipHardeningPlan_2026-04-29.md` §4 Task 09-b (보조 가드 강제 적용)

## Change

`src-tauri/src/commands/agents_helpers/send_common/persistence.rs:286+`

```rust
// T9-b: cli mode (claude-code) 는 *fresh session 첫 send 도* compressed_memory 미inject
if engine_key == "claude-code" && !data.is_session_continuation {
    if data.compressed_memory.is_some() {
        data.compressed_memory = None;
        data.compressed_memory_source = None;
        eprintln!("[session_freshness] claude-code fresh session → drop compressed_memory only (T9-b, paid API trigger 회피)");
    }
}
```

+15 / -0 (단일 파일)

## 회귀 가드 (DO NOT 위반 0)

- ✅ `engine_key == "claude-code"` 한정 — 다른 엔진 (codex/gemini/ollama/lmstudio) 영향 0
- ✅ continuation 분기 변경 X — 두 번째 send 부터 minimal mode 정상 (T9-a 효과 유지)
- ✅ `recent_context` keep — anchor 2 turns 의 사용자 history 복구 가치 보존
- ✅ sdk-url path 영향 X (cli mode 한정)
- ✅ frontend / DB schema / settings 변경 0

## Verification

- `cargo check` 통과 (14s)
- 사용자 환경 검증 부탁:
  - `git pull && npm run tauri dev` 후 seCall main (Auto 모드) send
  - backend log 에 `[session_freshness] claude-code fresh session → drop compressed_memory only (T9-b)` 표시
  - 정상 응답 — Lite 모드 강제 회피
  - 두 번째 send → `[memory_policy] skipped=[context:skipped(session-continuation)...]` (T9-a 효과 유지)
  - 다른 프로젝트 / 스크래치패드 회귀 0

## CI 정책

PR + admin merge (Architect 직접 처리, 변경 영역 작고 명확). v0.1.5-beta release blocker 의 마지막 fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)