### PR TITLE
fix: cli fresh session 도 current_messages + parent_messages drop (T12)

### DIFF
--- a/src-tauri/src/commands/agents_helpers/send_common/persistence.rs
+++ b/src-tauri/src/commands/agents_helpers/send_common/persistence.rs
@@ -335,8 +335,22 @@ pub fn prepare_engine_run(
             data.cross_session_data.clear();
             dropped.push("cross_session");
         }
+        // T12 (사용자 통찰 2026-04-30): scratchpad 정상 = main chat 의 current_messages 미인용
+        // = anchor 2 turns 안의 specific content 가 paid API trigger 결정적. T11 적용 후
+        // (plan/artifacts/findings drop) 도 거부 = recent_context (anchor 2 turns) cause.
+        // prompt_assembly.rs:421-422 에 "anchor 는 budget 초과여도 무조건 포함" 정책이라
+        // size cap 으로 회피 불가 — current_messages + parent_messages 자체 clear.
+        // agent 가 필요 시 tool-request:recent_turns:N 으로 on-demand 검색.
+        if !data.current_messages.is_empty() {
+            data.current_messages.clear();
+            dropped.push("recent_context");
+        }
+        if !data.parent_messages.is_empty() {
+            data.parent_messages.clear();
+            dropped.push("parent_messages");
+        }
         if !dropped.is_empty() {
-            eprintln!("[session_freshness] claude-code fresh session → drop large layers (T11): {} (paid API trigger 회피, agent 가 tool-request 로 on-demand 검색)",
+            eprintln!("[session_freshness] claude-code fresh session → drop large layers (T11+T12): {} (paid API trigger 회피, agent 가 tool-request 로 on-demand 검색)",
                 dropped.join("+"));
         }
     }


### PR DESCRIPTION
## Summary

T11 (PR #247) 후속. 사용자 통찰 2026-04-30: scratchpad 정상 + 다른 프로젝트 정상 = size 가 아니라 *main chat 의 anchor 2 turns content* 가 trigger.

`prompt_assembly.rs:421-422` 의 결정적 정책:
> "anchor 는 budget 초과여도 무조건 포함 (품질 우선)"

→ anchor 2 turns 의 content 는 어떤 cap 으로도 회피 불가. T11 적용 후도 거부 = recent_context (current_messages) cause 확정.

## Change

`persistence.rs` T11 분기 확장 — `data.current_messages.clear() + data.parent_messages.clear()`. cli mode + fresh session 한정.

+12 / -2

## 회귀 가드

- ✅ `engine_key == "claude-code" && !is_session_continuation` 한정
- ✅ 다른 엔진 / sdk-url path / continuation 분기 영향 0
- ✅ branch 의 parent_messages 가치 — cli mode + fresh session 한정이라 영향 미미

## Verification

- `cargo check` 통과
- 사용자 환경 검증 부탁: `git pull && npm run tauri dev` 후 seCall main (Auto) send → backend log `drop large layers (T11+T12): ... +recent_context+parent_messages` 표시 + 정상 응답 기대

🤖 Generated with [Claude Code](https://claude.com/claude-code)