### PR TITLE
fix(projects): normalize Windows verbatim path before is_dir check

### DIFF
--- a/src-tauri/src/commands/projects.rs
+++ b/src-tauri/src/commands/projects.rs
@@ -46,6 +46,31 @@ pub struct CreateProjectInput {
     pub source: String,
 }
 
+/// Strip the Windows verbatim NT-namespace prefix (`\\?\D:\...` or the UNC
+/// form `\\?\UNC\server\share\...`) from a path string, returning a plain
+/// form that `std::path::Path::is_dir` can resolve.
+///
+/// Why this exists: Rust's `std::fs::canonicalize` on Windows returns the
+/// verbatim form, but `Path::is_dir` returns *false* for those strings even
+/// when the directory exists (platform quirk reproduced on user environment
+/// 2026-04-30 — `proj-1777432893872` / gemento). We round-trip through this
+/// helper on both the read side (`fill_path_valid`) and the write side
+/// (`create_project` after canonicalize) so DB rows and IO checks agree.
+///
+/// Pure string transform — paths without `\\?\` (mac, Linux, plain Windows
+/// `D:\...`) pass through unchanged → cross-platform zero behavior change.
+pub(crate) fn normalize_verbatim_path(s: &str) -> String {
+    if let Some(rest) = s.strip_prefix(r"\\?\UNC\") {
+        // \\?\UNC\server\share\... → \\server\share\...
+        format!(r"\\{}", rest)
+    } else if let Some(rest) = s.strip_prefix(r"\\?\") {
+        // \\?\D:\... → D:\...
+        rest.to_string()
+    } else {
+        s.to_string()
+    }
+}
+
 /// Validate the project's `path` column at runtime: populate `path_valid`
 /// and log a warning when stale. This is the single hook that makes the
 /// "macOS DB ported to Windows" regression visible to the frontend.
@@ -55,11 +80,14 @@ pub struct CreateProjectInput {
 fn fill_path_valid(p: &mut Project) {
     p.path_valid = match p.path.as_deref() {
         Some(s) if !s.trim().is_empty() => {
-            let ok = std::path::Path::new(s).is_dir();
+            // Strip Windows verbatim NT-namespace prefix before `is_dir` —
+            // see `normalize_verbatim_path` for rationale.
+            let normalized = normalize_verbatim_path(s);
+            let ok = std::path::Path::new(&normalized).is_dir();
             if !ok {
                 eprintln!(
-                    "[projects] stale path detected — key={} path={} (DB row preserved; user can re-map)",
-                    p.key, s
+                    "[projects] stale path detected — key={} path={} (normalized={}; DB row preserved; user can re-map)",
+                    p.key, s, normalized
                 );
             }
             Some(ok)
@@ -161,9 +189,15 @@ pub fn create_project(
 ) -> Result<Project, AppError> {
     let conn = state.write.lock().map_err(|_| AppError::Lock)?;
 
-    // Normalize path for duplicate check (canonicalize resolves symlinks, case, slashes)
+    // Normalize path for duplicate check (canonicalize resolves symlinks, case, slashes).
+    // Strip the Windows verbatim NT-namespace prefix that `std::fs::canonicalize`
+    // emits on Windows (`\\?\D:\...`) — that form is what makes its way into the
+    // `projects.path` column and later breaks `Path::is_dir`. See
+    // `normalize_verbatim_path` for the round-trip rationale.
     let normalized_path = input.path.as_ref().and_then(|p| {
-        std::fs::canonicalize(p).ok().map(|c| c.to_string_lossy().to_string())
+        std::fs::canonicalize(p)
+            .ok()
+            .map(|c| normalize_verbatim_path(&c.to_string_lossy()))
     });
 
     // Duplicate path check — restore hidden project or reject active duplicate
@@ -807,6 +841,57 @@ mod tests {
         let mut p = project_with_path(Some(cargo_toml.to_string_lossy().to_string()));
         fill_path_valid(&mut p);
         assert_eq!(p.path_valid, Some(false));
+    }
+
+    // ─── normalize_verbatim_path ─────────────────────────────────────────────
+
+    #[test]
+    fn normalize_verbatim_strips_disk_prefix() {
+        assert_eq!(
+            normalize_verbatim_path(r"\\?\D:\privateProject\gemento"),
+            r"D:\privateProject\gemento"
+        );
+        assert_eq!(normalize_verbatim_path(r"\\?\C:\"), r"C:\");
+    }
+
+    #[test]
+    fn normalize_verbatim_rewrites_unc_form() {
+        // \\?\UNC\server\share\dir → \\server\share\dir
+        assert_eq!(
+            normalize_verbatim_path(r"\\?\UNC\server\share\dir"),
+            r"\\server\share\dir"
+        );
+    }
+
+    #[test]
+    fn normalize_verbatim_passes_plain_paths_through() {
+        // No `\\?\` prefix — string returned unchanged on every OS.
+        assert_eq!(
+            normalize_verbatim_path("/Users/alice/projects/foo"),
+            "/Users/alice/projects/foo"
+        );
+        assert_eq!(
+            normalize_verbatim_path(r"D:\privateProject\gemento"),
+            r"D:\privateProject\gemento"
+        );
+        assert_eq!(normalize_verbatim_path(""), "");
+        assert_eq!(
+            normalize_verbatim_path(r"\\server\share"),
+            r"\\server\share"
+        );
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn fill_path_valid_handles_windows_verbatim_path() {
+        // Reproduces the user-environment regression (proj-1777432893872):
+        // a real, existing directory wrapped in the verbatim NT-namespace
+        // form must still resolve to `Some(true)`.
+        let manifest = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR");
+        let verbatim = format!(r"\\?\{}", manifest);
+        let mut p = project_with_path(Some(verbatim));
+        fill_path_valid(&mut p);
+        assert_eq!(p.path_valid, Some(true));
     }
 }
 


### PR DESCRIPTION
## Summary
- **Symptom** (사용자 환경 2026-04-30): gemento (key `proj-1777432893872`) 가 sidebar 에서 누락 + AppShell auto-select skip. DB row 의 path 가 Windows verbatim NT-namespace form (`\?\D:\privateProject\gemento`) 으로 저장된 케이스. `Path::is_dir(r"\?\D:\...")` 가 실제 디렉토리 존재에도 **false** 반환 (Rust std platform quirk) → PR #234 의 `fill_path_valid` 가 false-positive `pathValid: false` 마킹 → AppShell 의 `pathValid !== false` 게이팅 우회.
- **Root cause** (T-VP-2 grep): `create_project:166` 의 `std::fs::canonicalize` 가 Windows 에서 verbatim form 반환 → 그대로 DB INSERT. 이후 `list_projects` 가 read 시 그 verbatim 문자열을 그대로 `is_dir` 에 넘기면서 false 회귀.
- **Fix**: `normalize_verbatim_path` pure helper 도입. read 측 (`fill_path_valid`) + write 측 (`create_project` canonicalize 결과) 양쪽에 적용 → 신규 row 부터 verbatim form 진입 차단 + 기존 verbatim row 도 read 시 정상 resolve.

## Plan / handoff mapping
- 직전 인계 (architect → developer 2026-04-30): "Windows path verbatim normalization fix" — T-VP-1 + T-VP-2 본 PR 묶음.
- T-VP-3 (DB migration v50) 는 architect 결정 (옵션/P3) 그대로 **본 PR 외** — 사용자 환경 1 row 는 architect 가 SQL UPDATE 로 즉시 fix 완료. 추가 사례 누적 시 별 PR.
- 관련 PR: #234 (Track 3 DB path stale fallback) 의 read-side 회귀 차단 + write-side root cause fix.

## Changes
**`src-tauri/src/commands/projects.rs`** (단일 파일, +90 / -5)

- `normalize_verbatim_path(s: &str) -> String` pure helper (pub(crate)):
  - `\?\D:\...` → `D:\...`
  - `\?\UNC\server\share\...` → `\server\share\...`
  - prefix 부재 시 입력 그대로 반환 (mac / Linux / plain Windows `D:\...`).
- `fill_path_valid`: `is_dir` 호출 전 normalize. 실패 시 stderr log 에 `normalized=` 추가 (재현/진단 용이).
- `create_project`: `std::fs::canonicalize` 결과를 normalize_verbatim_path 로 통과 시킨 후 DB 저장.

## Invariants
- **INV-1** (cross-platform 안전): helper 는 pure string strip. mac/Linux 는 `\?\` prefix 부재 → 그대로 통과 → 동작 0 변화. 단위 테스트 (`normalize_verbatim_passes_plain_paths_through`) 가 회귀 가드.
- **INV-3** (macOS-specific 파일 미변경): 확인.
- **INV-4** (단일 axis): verbatim path normalization, 1 파일.

## Verification
- `cargo test --lib commands::projects` → **9 passed** (기존 5 + 신규 4)
  - `normalize_verbatim_strips_disk_prefix`
  - `normalize_verbatim_rewrites_unc_form`
  - `normalize_verbatim_passes_plain_paths_through` (mac/Linux/plain Win/empty/UNC non-verbatim)
  - `fill_path_valid_handles_windows_verbatim_path` (cfg(windows) — 사용자 환경 회귀 재현)
- `cargo test --lib` (full) → **606 passed / 0 failed**
- `npx tsc --noEmit` clean
- `npx vitest run` → **394 passed** (frontend 변경 없음, baseline 그대로)

## Test plan (수동 smoke)
- [ ] CI ✓
- [ ] Windows dev 모드: 기존 verbatim row 가 있는 DB (또는 임시 INSERT `path = '\?\D:\test'` 후 디렉토리 생성) → list_projects → sidebar 정상 표시 + `pathValid: true`
- [ ] Windows dev 모드: 새 프로젝트 생성 → DB 의 `projects.path` 가 plain form (`D:\...`) 으로 저장되는지 SQL 확인
- [ ] mac dev 모드: 기존 path (`/Users/...`) 회귀 0 — `pathValid: true` 유지