### PR TITLE
fix(convEngineMap): sync stale conv overrides on agent profile model change

### DIFF
--- a/src/components/tunaflow/NewMessageInput.tsx
+++ b/src/components/tunaflow/NewMessageInput.tsx
@@ -99,6 +99,7 @@ export function NewMessageInput({ threadMode = false, onCreateRT }: NewMessageIn
           profileId: defaultProfile.id,
           engine: defaultProfile.engine,
           model: defaultProfile.model,
+          source: "profile-derived",
         });
       }
     }
@@ -127,6 +128,7 @@ export function NewMessageInput({ threadMode = false, onCreateRT }: NewMessageIn
         profileId,
         engine: targetEngine,
         model: targetModel,
+        source: "profile-derived",
       });
     }
   };
@@ -470,10 +472,12 @@ export function NewMessageInput({ threadMode = false, onCreateRT }: NewMessageIn
                     if (currentProfile && currentProfile.engine !== e) {
                       useChatStore.setState({ personaFragment: null, personaLabel: null });
                     }
-                    // Save to per-conversation map
+                    // Save to per-conversation map — engine pick is an
+                    // explicit user choice; freeze the model so subsequent
+                    // profile edits don't silently overwrite it.
                     const target = threadMode ? threadBranchConvIdForRestore : selectedConversationId;
                     if (target) {
-                      saveConversationEngine(target, { profileId: null, engine: e, model: selectedModel || undefined });
+                      saveConversationEngine(target, { profileId: null, engine: e, model: selectedModel || undefined, source: "user-explicit" });
                     }
                   }} />
                   {ptyRespawning && isPtyEngine(engine) && (
@@ -486,10 +490,11 @@ export function NewMessageInput({ threadMode = false, onCreateRT }: NewMessageIn
                     selectedModel={selectedModel}
                     setSelectedModel={async (m) => {
                       setSelectedModel(m);
-                      // Persist model change to convEngineMap
+                      // Persist model change to convEngineMap — explicit
+                      // user pick, must survive future profile edits.
                       const target = threadMode ? threadBranchConvIdForRestore : selectedConversationId;
                       if (target) {
-                        saveConversationEngine(target, { profileId: selectedProfileId, engine, model: m || undefined });
+                        saveConversationEngine(target, { profileId: selectedProfileId, engine, model: m || undefined, source: "user-explicit" });
                       }
                       // Respawn PTY session on model change — only if PTY mode is enabled.
                       // Main chat routes through SDK / `-p` CLI by default.

--- a/src/components/tunaflow/context-panel/DevProgressView.tsx
+++ b/src/components/tunaflow/context-panel/DevProgressView.tsx
@@ -136,7 +136,7 @@ export function DevProgressView({ plan, onPlanUpdate }: DevProgressViewProps) {
         plan, `${roundLabel}: ${plan.title.slice(0, 25)}`, "chat",
       );
       if (reused) console.debug("[handleStartReview] reusing branch:", branch.id);
-      saveConversationEngine(shadowConvId, { profileId: selectedReviewerId, engine: selectedProfile.engine, model: selectedProfile.model });
+      saveConversationEngine(shadowConvId, { profileId: selectedReviewerId, engine: selectedProfile.engine, model: selectedProfile.model, source: "profile-derived" });
 
       const slug = getPlanSlug(plan);
 

--- a/src/components/tunaflow/context-panel/SubtaskReviewView.tsx
+++ b/src/components/tunaflow/context-panel/SubtaskReviewView.tsx
@@ -129,7 +129,7 @@ export function SubtaskReviewView({ plan, onPlanUpdate, onSwitchToChat }: Subtas
       const input = { conversationId: plan.conversationId, label: branchLabel, mode: "chat" };
       const branch = await invoke<Branch>("create_branch", { input });
       const shadowConvId = await invoke<string>("open_branch_stream", { branchId: branch.id });
-      saveConversationEngine(shadowConvId, { profileId: null, engine: mainEngine, model: mainModel });
+      saveConversationEngine(shadowConvId, { profileId: null, engine: mainEngine, model: mainModel, source: "user-explicit" });
       await loadBranches(plan.conversationId);
       await openThread(branch.id);
 
@@ -164,7 +164,7 @@ export function SubtaskReviewView({ plan, onPlanUpdate, onSwitchToChat }: Subtas
       const shadowConvId = await invoke<string>("open_branch_stream", { branchId: branch.id });
 
       // Save same agent as main chat
-      saveConversationEngine(shadowConvId, { profileId: null, engine: mainEngine, model: mainModel });
+      saveConversationEngine(shadowConvId, { profileId: null, engine: mainEngine, model: mainModel, source: "user-explicit" });
 
       await loadBranches(plan.conversationId);
       await openThread(branch.id);
@@ -215,7 +215,7 @@ export function SubtaskReviewView({ plan, onPlanUpdate, onSwitchToChat }: Subtas
       const input = { conversationId: plan.conversationId, label: branchLabel, mode: "chat" };
       const branch = await invoke<Branch>("create_branch", { input });
       const shadowConvId = await invoke<string>("open_branch_stream", { branchId: branch.id });
-      saveConversationEngine(shadowConvId, { profileId: null, engine: mainEngine, model: mainModel });
+      saveConversationEngine(shadowConvId, { profileId: null, engine: mainEngine, model: mainModel, source: "user-explicit" });
       await loadBranches(plan.conversationId);
       await openThread(branch.id);
 
@@ -247,7 +247,7 @@ export function SubtaskReviewView({ plan, onPlanUpdate, onSwitchToChat }: Subtas
       const branch = await invoke<Branch>("create_branch", { input });
       const shadowConvId = await invoke<string>("open_branch_stream", { branchId: branch.id });
 
-      saveConversationEngine(shadowConvId, { profileId: null, engine: mainEngine, model: mainModel });
+      saveConversationEngine(shadowConvId, { profileId: null, engine: mainEngine, model: mainModel, source: "user-explicit" });
 
       await loadBranches(plan.conversationId);
       await openThread(branch.id);

--- a/src/components/tunaflow/context-panel/plans/ApprovalGate.tsx
+++ b/src/components/tunaflow/context-panel/plans/ApprovalGate.tsx
@@ -47,7 +47,7 @@ export function ApprovalGate({
       await loadBranches(plan.conversationId);
 
       const shadowConvId = `branch:${branch.id}`;
-      saveConversationEngine(shadowConvId, { profileId: selectedProfileId, engine, model: selectedProfile?.model });
+      saveConversationEngine(shadowConvId, { profileId: selectedProfileId, engine, model: selectedProfile?.model, source: "profile-derived" });
 
       await openThread(branch.id);
       await sendThreadMessage(prompt, engine, selectedProfile?.model);

--- a/src/lib/bootstrap/project.ts
+++ b/src/lib/bootstrap/project.ts
@@ -55,7 +55,7 @@ export interface BootstrapCallbacks {
     | null;
   saveConversationEngine: (
     convId: string,
-    engine: { engine: string; model?: string; profileId: string | null },
+    engine: { engine: string; model?: string; profileId: string | null; source?: "profile-derived" | "user-explicit" },
   ) => void;
   getAgentProfiles: () => AgentProfile[];
   loadWorkflowSkills: () => Promise<void>;
@@ -155,6 +155,7 @@ export async function ensureMainConversation(
     profileId: defaultProfile.id,
     engine: defaultProfile.engine,
     model: defaultProfile.model,
+    source: "profile-derived",
   });
 }
 

--- a/src/lib/workflow/reviewWorkflow.ts
+++ b/src/lib/workflow/reviewWorkflow.ts
@@ -311,6 +311,9 @@ export async function startReviewRT(
           profileId: null,
           engine: first.engine,
           model: first.model,
+          // profileId is null (RT participant pick), so saveProfiles sync
+          // never touches this entry regardless of source — tag for clarity.
+          source: "user-explicit",
         });
       } catch (e) { console.warn("[startReviewRT] saveConversationEngine failed:", e); }
     }

--- a/src/stores/slices/assetSlice.ts
+++ b/src/stores/slices/assetSlice.ts
@@ -22,11 +22,67 @@ const DEFAULT_PROFILES: AgentProfile[] = [
   { id: "general-ollama", label: "General Ollama", engine: "ollama", defaultSkills: [], personaId: "persona_implementer" },
 ];
 
-/** Per-conversation engine/profile snapshot */
+/**
+ * Per-conversation engine/profile snapshot.
+ *
+ * `source` discriminates how the model field was decided so the assetSlice
+ * `saveProfiles` sync can update *only* derived entries when an agent
+ * profile's model changes — explicit user selections must be protected.
+ *
+ * - `"profile-derived"` — model came from `agentProfiles[].model` (or the
+ *   recommended fallback when the profile had no model). Auto-syncable.
+ * - `"user-explicit"` — user picked the model in the ModelSelector or the
+ *   engine selector. Never auto-overwritten on profile change.
+ * - `undefined` — legacy entries written before this discriminator existed.
+ *   Treated conservatively as user-explicit by `saveProfiles` (skipped
+ *   during sync) to preserve user intent. Going forward all writers tag.
+ */
+export type ConversationEngineSource = "profile-derived" | "user-explicit";
+
 export interface ConversationEngineState {
   profileId: string | null;
   engine: string;
   model?: string;
+  source?: ConversationEngineSource;
+}
+
+/**
+ * Pure helper extracted from `saveProfiles` so the sync logic can be unit
+ * tested without spinning a Zustand store.
+ *
+ * Walks `currentMap`, updates `model` on entries whose `profileId` matches a
+ * profile whose model changed AND `source === "profile-derived"`. All other
+ * entries (user-explicit, legacy without source, non-matching profileId)
+ * are returned unchanged.
+ */
+export function syncConvMapForProfileChanges(
+  prev: AgentProfile[],
+  next: AgentProfile[],
+  currentMap: Record<string, ConversationEngineState>,
+): { nextMap: Record<string, ConversationEngineState>; changed: boolean } {
+  const prevModelById = new Map(prev.map((p) => [p.id, p.model]));
+  const changedProfileIds = new Set<string>();
+  for (const profile of next) {
+    if (prevModelById.get(profile.id) !== profile.model) {
+      changedProfileIds.add(profile.id);
+    }
+  }
+  if (changedProfileIds.size === 0) {
+    return { nextMap: currentMap, changed: false };
+  }
+
+  const newModelById = new Map(next.map((p) => [p.id, p.model]));
+  const nextMap: Record<string, ConversationEngineState> = { ...currentMap };
+  let changed = false;
+  for (const [convId, state] of Object.entries(currentMap)) {
+    if (!state.profileId || !changedProfileIds.has(state.profileId)) continue;
+    if (state.source !== "profile-derived") continue;
+    const newModel = newModelById.get(state.profileId);
+    if (newModel === state.model) continue;
+    nextMap[convId] = { ...state, model: newModel };
+    changed = true;
+  }
+  return { nextMap, changed };
 }
 
 export interface AssetSlice {
@@ -101,13 +157,14 @@ export const createAssetSlice = (set: SetState, get: GetState): AssetSlice => ({
   loadProfiles: async () => {
     const profiles = await getSetting<AgentProfile[]>("agentProfiles", DEFAULT_PROFILES);
     const convMap = await getSetting<Record<string, ConversationEngineState>>("convEngineMap", {});
-    // Backfill: if any conversation has a profile but no model, fill from profile default
+    // Backfill: if any conversation has a profile but no model, fill from profile default.
+    // Tagged "profile-derived" so a later `saveProfiles` model change keeps these entries in sync.
     let updated = false;
     for (const [convId, state] of Object.entries(convMap)) {
       if (state.profileId && !state.model) {
         const profile = profiles.find((p) => p.id === state.profileId);
         if (profile?.model) {
-          convMap[convId] = { ...state, model: profile.model };
+          convMap[convId] = { ...state, model: profile.model, source: "profile-derived" };
           updated = true;
         }
       }
@@ -117,8 +174,16 @@ export const createAssetSlice = (set: SetState, get: GetState): AssetSlice => ({
   },
 
   saveProfiles: (profiles: AgentProfile[]) => {
-    set({ agentProfiles: profiles });
+    // Sync convEngineMap entries that were derived from a profile whose model
+    // just changed. User-explicit entries (and legacy entries without a
+    // `source` tag) are protected. See `ConversationEngineSource`.
+    const prev = get().agentProfiles;
+    const currentMap = get()._convEngineMap;
+    const { nextMap, changed } = syncConvMapForProfileChanges(prev, profiles, currentMap);
+
+    set({ agentProfiles: profiles, _convEngineMap: changed ? nextMap : currentMap });
     setSetting("agentProfiles", profiles);
+    if (changed) setSetting("convEngineMap", nextMap);
   },
 
   saveConversationEngine: (conversationId: string, state: ConversationEngineState) => {

--- a/src/stores/slices/types.ts
+++ b/src/stores/slices/types.ts
@@ -112,11 +112,11 @@ export interface ChatState {
   /** Agent profiles — shared between Settings and NewMessageInput */
   agentProfiles: AgentProfile[];
   /** Per-conversation engine/profile memory */
-  _convEngineMap: Record<string, { profileId: string | null; engine: string; model?: string }>;
+  _convEngineMap: Record<string, { profileId: string | null; engine: string; model?: string; source?: "profile-derived" | "user-explicit" }>;
   loadProfiles: () => Promise<void>;
   saveProfiles: (profiles: AgentProfile[]) => void;
-  saveConversationEngine: (conversationId: string, state: { profileId: string | null; engine: string; model?: string }) => void;
-  getConversationEngine: (conversationId: string) => { profileId: string | null; engine: string; model?: string } | null;
+  saveConversationEngine: (conversationId: string, state: { profileId: string | null; engine: string; model?: string; source?: "profile-derived" | "user-explicit" }) => void;
+  getConversationEngine: (conversationId: string) => { profileId: string | null; engine: string; model?: string; source?: "profile-derived" | "user-explicit" } | null;
 
   setHandoffSource: (source: { type: string; content: string } | null) => void;
   _startRun: (threadId: string) => void;

--- a/src/tests/convEngineMap-profileSync.test.ts
+++ b/src/tests/convEngineMap-profileSync.test.ts
@@ -1,0 +1,114 @@
+// convEngineMap profile-sync — assetSlice's `saveProfiles` sync helper.
+// Verifies that an agent profile's `model` change propagates to matching
+// "profile-derived" conversation entries while leaving user-explicit
+// (and legacy untagged) entries alone — the regression that motivated the
+// fix in user environment 2026-04-30 (architect-claude 4-6 stale stuck on
+// 8 conversations after profile bumped to 4-7).
+
+import { describe, it, expect } from "vitest";
+import {
+  syncConvMapForProfileChanges,
+  type ConversationEngineState,
+} from "@/stores/slices/assetSlice";
+import type { AgentProfile } from "@/types";
+
+const profile = (id: string, engine: string, model?: string): AgentProfile => ({
+  id,
+  label: id,
+  engine,
+  model,
+  defaultSkills: [],
+});
+
+describe("syncConvMapForProfileChanges", () => {
+  it("updates profile-derived entries to the new model", () => {
+    const prev = [profile("architect-claude", "claude", "claude-opus-4-6")];
+    const next = [profile("architect-claude", "claude", "claude-opus-4-7")];
+    const map: Record<string, ConversationEngineState> = {
+      conv1: { profileId: "architect-claude", engine: "claude", model: "claude-opus-4-6", source: "profile-derived" },
+      conv2: { profileId: "architect-claude", engine: "claude", model: "claude-opus-4-6", source: "profile-derived" },
+    };
+    const { nextMap, changed } = syncConvMapForProfileChanges(prev, next, map);
+    expect(changed).toBe(true);
+    expect(nextMap.conv1.model).toBe("claude-opus-4-7");
+    expect(nextMap.conv2.model).toBe("claude-opus-4-7");
+  });
+
+  it("protects user-explicit entries", () => {
+    const prev = [profile("architect-claude", "claude", "claude-opus-4-6")];
+    const next = [profile("architect-claude", "claude", "claude-opus-4-7")];
+    const map: Record<string, ConversationEngineState> = {
+      explicit: { profileId: "architect-claude", engine: "claude", model: "claude-sonnet-4-5", source: "user-explicit" },
+    };
+    const { nextMap, changed } = syncConvMapForProfileChanges(prev, next, map);
+    expect(changed).toBe(false);
+    expect(nextMap.explicit.model).toBe("claude-sonnet-4-5");
+  });
+
+  it("treats legacy entries without `source` as user-explicit (skipped)", () => {
+    const prev = [profile("architect-claude", "claude", "claude-opus-4-6")];
+    const next = [profile("architect-claude", "claude", "claude-opus-4-7")];
+    const map: Record<string, ConversationEngineState> = {
+      legacy: { profileId: "architect-claude", engine: "claude", model: "claude-opus-4-6" },
+    };
+    const { nextMap, changed } = syncConvMapForProfileChanges(prev, next, map);
+    expect(changed).toBe(false);
+    expect(nextMap.legacy.model).toBe("claude-opus-4-6");
+    expect(nextMap.legacy.source).toBeUndefined();
+  });
+
+  it("ignores entries whose profileId does not match a changed profile", () => {
+    const prev = [
+      profile("architect-claude", "claude", "claude-opus-4-6"),
+      profile("reviewer-codex", "codex", "gpt-5-codex"),
+    ];
+    const next = [
+      profile("architect-claude", "claude", "claude-opus-4-7"),
+      profile("reviewer-codex", "codex", "gpt-5-codex"),
+    ];
+    const map: Record<string, ConversationEngineState> = {
+      reviewer: { profileId: "reviewer-codex", engine: "codex", model: "gpt-5-codex", source: "profile-derived" },
+    };
+    const { nextMap, changed } = syncConvMapForProfileChanges(prev, next, map);
+    expect(changed).toBe(false);
+    expect(nextMap.reviewer.model).toBe("gpt-5-codex");
+  });
+
+  it("ignores entries with profileId=null (free-form selection)", () => {
+    const prev = [profile("architect-claude", "claude", "claude-opus-4-6")];
+    const next = [profile("architect-claude", "claude", "claude-opus-4-7")];
+    const map: Record<string, ConversationEngineState> = {
+      freeform: { profileId: null, engine: "claude", model: "claude-opus-4-6", source: "profile-derived" },
+    };
+    const { nextMap, changed } = syncConvMapForProfileChanges(prev, next, map);
+    expect(changed).toBe(false);
+    expect(nextMap.freeform.model).toBe("claude-opus-4-6");
+  });
+
+  it("returns unchanged map when no profile model changed", () => {
+    const prev = [profile("architect-claude", "claude", "claude-opus-4-7")];
+    const next = [profile("architect-claude", "claude", "claude-opus-4-7", )];
+    const map: Record<string, ConversationEngineState> = {
+      conv1: { profileId: "architect-claude", engine: "claude", model: "claude-opus-4-7", source: "profile-derived" },
+    };
+    const { nextMap, changed } = syncConvMapForProfileChanges(prev, next, map);
+    expect(changed).toBe(false);
+    expect(nextMap).toBe(map);
+  });
+
+  it("reproduces the user-environment regression (8-conv architect-claude 4-6 → 4-7)", () => {
+    // Original symptom: agentProfiles.architect-claude.model = 4-7, UI 표시 4-7,
+    // but send time used stale 4-6 because convEngineMap entries were never updated.
+    const prev = [profile("architect-claude", "claude", "claude-opus-4-6")];
+    const next = [profile("architect-claude", "claude", "claude-opus-4-7")];
+    const map: Record<string, ConversationEngineState> = {};
+    for (let i = 0; i < 8; i++) {
+      map[`conv-${i}`] = { profileId: "architect-claude", engine: "claude", model: "claude-opus-4-6", source: "profile-derived" };
+    }
+    const { nextMap, changed } = syncConvMapForProfileChanges(prev, next, map);
+    expect(changed).toBe(true);
+    for (const conv of Object.values(nextMap)) {
+      expect(conv.model).toBe("claude-opus-4-7");
+    }
+  });
+});


### PR DESCRIPTION
## Symptom
사용자 환경 (2026-04-30):
- `agentProfiles.architect-claude.model` = `claude-opus-4-7` (사용자 변경)
- 채팅 입력창 / Settings UI 도 `4-7` 표시
- 그러나 send 시 model arg = `claude-opus-4-6` (DB 응답 `message.model` 도 `4-6` 기록)
- architect 환경에서 매핑된 8 conversation 전부 stale
- 사용자 보고: *"채팅입력창, 설정에서는 아키텍트의 모델이 오퍼스4.7인데 대답하는건 4.6으로 나옴"*

## Root cause
`convEngineMap` (per-conversation engine/model override) 가 agent profile 의 *저장 시점* model 값을 그대로 snapshot. 사용자가 나중에 `profile.model` 을 변경해도 기존 conv entries 는 그대로 남고, `resolveModel` 이 `_convEngineMap[convId].model` 을 우선 사용 (`agentProfiles[*].model` 보다 먼저) → stale 값이 send 흐름에 진입.

## Fix
**T-CEM-1+2** 묶음. T-CEM-3 (UI indicator) / T-CEM-4 (one-shot migration) 는 별 PR.

### T-CEM-1 — `ConversationEngineState.source` discriminator
- `"profile-derived"`: profile 기반 자동 매핑 (handleProfileSelect / 기본 profile auto-save / loadProfiles backfill / DevProgressView / ApprovalGate / bootstrap/project default).
- `"user-explicit"`: 명시적 사용자 선택 (ModelSelector / EngineSelector / SubtaskReview shadow inherit / reviewRT participant pick).
- legacy entries (`source` 미설정): conservative 로 sync 시 skip (사용자 의도 보존).

### T-CEM-2 — `saveProfiles` 의 sync 로직
- 순수 helper `syncConvMapForProfileChanges(prev, next, currentMap)` 추출 (assetSlice export, 단위 테스트 가능).
- 변경 profile.id 집합 계산 → currentMap 순회 → `state.profileId` 매칭 AND `state.source === "profile-derived"` 인 entry 만 새 model 적용.
- 그 외 (user-explicit / legacy / null profileId / 비매칭) 모두 미변경.
- 변경 발생 시 _convEngineMap state set + `setSetting("convEngineMap", nextMap)` 영속화.

## Plan / handoff mapping
- 직전 인계 (architect → developer 2026-04-30): "convEngineMap stale model 회귀 fix"
- T-CEM-3 (UI indicator) / T-CEM-4 (one-shot migration) 본 PR 외, 후속 별 PR 가능.

## Invariants
- **INV-1** (cross-platform 안전): pure TS, OS 분기 없음. macOS / Linux / Windows 동일 동작.
- **INV-3** (macOS-specific 파일 미변경): 확인.
- **INV-4** (단일 axis): convEngineMap profile-sync, 9 파일 (1 신규 테스트 + 8 수정).

## Verification
- `npx tsc --noEmit` clean
- `npx vitest run src/tests/convEngineMap-profileSync.test.ts` → **7 passed**
  - profile-derived bulk update
  - user-explicit protection
  - legacy 엔트리 (source 미설정) skip
  - 비매칭 profileId 무영향
  - profileId:null free-form 무영향
  - model unchanged 시 same-ref reuse (불필요한 set/persist 회피)
  - 사용자 환경 회귀 재현: 8 conv architect-claude 4-6 → 4-7 일괄 sync
- `npx vitest run` (full) → **401 passed** (pre-baseline 394 + 신규 7, 일치)
- `cargo test --lib` (full) → **606 passed / 0 failed** (frontend-only 변경, baseline 그대로)

## Test plan (수동 smoke)
- [ ] CI ✓
- [ ] dev 모드: Settings → Agents 에서 architect-claude.model 4-6 → 4-7 변경 → 다음 send 의 model arg 가 4-7
- [ ] dev 모드: Conv 의 ModelSelector 로 명시적 변경 (예: sonnet-4-5) → profile.model 변경해도 그 conv 만은 sonnet-4-5 유지
- [ ] dev 모드: 신규 conv 생성 → profile-derived 로 저장되는지 (settings.json 의 source 필드 확인)

## 후속 axis
- **T-CEM-3** (P2): convEngineMap 과 profile.model 가 diverge 한 conv 의 visual indicator
- **T-CEM-4** (P3): one-shot migration command — *모든* profile-derived entries 를 현재 profile.model 로 강제 sync (architect environments 정리용)