### PR TITLE
fix(menu): macOS Edit submenu — Cmd+C/V/X/A/Z 등 standard clipboard shortcut 회복

### DIFF
--- a/src-tauri/src/bootstrap/menu.rs
+++ b/src-tauri/src/bootstrap/menu.rs
@@ -62,6 +62,30 @@ pub fn install(app: &App) -> Result<(), Box<dyn std::error::Error>> {
         .item(&PredefinedMenuItem::quit(handle, None)?)
         .build()?;
 
+    // Edit submenu — macOS native standard shortcuts 회복 (Cmd+C/V/X/A/Z/Shift+Cmd+Z).
+    //
+    // Tauri 2 macOS 정책: app.set_menu() 가 register 한 menu 는 *전체 menu set*
+    // 이 됨. Edit submenu 가 PredefinedMenuItem 으로 등록 안 되면 WKWebView 의
+    // Cmd+C/V 자체 처리도 menu 가 가로챈 후 fallthrough 안 함 → standard
+    // clipboard shortcut 모두 dead. 사용자 보고 (2026-05-02): "앱 내 Cmd+C/V
+    // 잘 안된다."
+    //
+    // 위 doc comment 의 "deliberately small" 정책은 Win/Linux 한정 유효 — 그쪽은
+    // webview 가 자체 처리. macOS 는 Edit menu 필수.
+    #[cfg(target_os = "macos")]
+    let edit_submenu = SubmenuBuilder::new(handle, "Edit")
+        .item(&PredefinedMenuItem::undo(handle, None)?)
+        .item(&PredefinedMenuItem::redo(handle, None)?)
+        .separator()
+        .item(&PredefinedMenuItem::cut(handle, None)?)
+        .item(&PredefinedMenuItem::copy(handle, None)?)
+        .item(&PredefinedMenuItem::paste(handle, None)?)
+        .item(&PredefinedMenuItem::select_all(handle, None)?)
+        .build()?;
+
+    #[cfg(target_os = "macos")]
+    let menu = MenuBuilder::new(handle).item(&app_submenu).item(&edit_submenu).build()?;
+    #[cfg(not(target_os = "macos"))]
     let menu = MenuBuilder::new(handle).item(&app_submenu).build()?;
 
     // Tauri 2.x: app-level set_menu so it applies to all windows + macOS bar.


### PR DESCRIPTION
## Summary

PR #217 (Plan C T01) 의 macOS 한정 회귀 hotfix.

사용자 보고 2026-05-02: "앱 내 Cmd+V (붙여넣기), Cmd+C (복사) 가 잘 안된다."

## Root cause

`src-tauri/src/bootstrap/menu.rs::install()` 가 *App submenu (Settings/About/Quit) 만 등록* + **Edit submenu 누락**. Tauri 2 macOS 정책: `app.set_menu()` 가 register 한 menu 는 *전체 menu set*. Edit submenu 미등록 시 WKWebView 의 Cmd+C/V 자체 처리도 menu 가 가로챈 후 fallthrough 안 함 → standard clipboard shortcut 모두 dead.

기존 doc comment "deliberately keep the menu small" 정책은 Win/Linux 한정 유효. macOS 는 Edit menu 필수.

## Change

`menu.rs` 에 `#[cfg(target_os = "macos")]` 분기로 Edit submenu 추가:
- `PredefinedMenuItem::undo / redo / cut / copy / paste / select_all` 6 항목

Win/Linux 는 기존 동작 그대로.

+24 / -1

## 회귀 가드

- ✅ macOS 외 영향 0 (cfg 격리)
- ✅ 기존 App submenu (Settings/About/Quit) 변경 0
- ✅ Cmd+, (Settings) shortcut 영향 0
- ✅ 다른 menu_event handler 영향 0

## Verification

- `cargo check` 통과 (11.7s)
- 사용자 dev rebuild 후 macOS 에서:
  - Cmd+C / Cmd+V / Cmd+X / Cmd+A / Cmd+Z / Shift+Cmd+Z 정상 동작
  - menu bar 의 Edit menu 노출 (undo/redo/cut/copy/paste/select all)
  - Cmd+, (Settings) 기존 동작 유지

## CI 정책

PR + admin merge (Architect 직접 처리, 변경 영역 작고 명확, macOS UX 회귀 hotfix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)