### PR TITLE
fix(branch): preserve chat input across plan revision (#255)

### DIFF
--- a/src/components/tunaflow/BranchThreadPanel.tsx
+++ b/src/components/tunaflow/BranchThreadPanel.tsx
@@ -354,8 +354,12 @@ export function BranchThreadPanel() {
         )}
       </div>
 
-      {/* Input — hidden for read-only branches */}
-      {!isReadOnly && <NewMessageInput threadMode />}
+      {/* Input — hidden only for adopted branches.
+          archived 는 plan revision 후 link 끊김(MergeBranchButton/PlanProposalCard)으로
+          status 가 archived 가 되는 케이스가 있어 input 을 그대로 보존한다.
+          INV-1~5 (branchSessionPolicy) 보존 — branch session = main session 공유이므로
+          archived 에서도 send 시 동일 main session 으로 안전하게 전달된다. (#255) */}
+      {threadBranch?.status !== "adopted" && <NewMessageInput threadMode />}
 
       {/* RT creation dialog for branching from thread messages */}
       <CreateRoundtableDialog


### PR DESCRIPTION
## Summary

- Issue #255 (devbug, 2026-05-02) — plan A 진행 중 plan revision 후 plan A 의 dev branch 를 다시 열면 chat input 이 사라지던 회귀.
- Frontend hotfix: `BranchThreadPanel.tsx` 의 input mount 분기를 `status !== "adopted"` 로 좁혀 `archived` branch 에서도 input 노출.
- INV-1~5 (branchSessionPolicy) 보존 — branch session = main session 공유이므로 archived 에서도 send 안전.

## Root cause (Task 01 진단)

`PlanProposalCard.autoMerge` (line 257-263) 와 `handleOverwrite` (line 176-179) 가 plan revision 머지 시 plan A 의 `implementationBranchId` 를 `archive_branch` 호출 → DB `branches.status = 'archived'` 로 만든다 (`linkPlanBranch(..., null)` 도 같이 호출하므로 `findPlanByBranch` 도 `null` 리턴).

이후 사용자가 그 archived impl branch 를 사이드바에서 다시 열면 `BranchThreadPanel.tsx:73` 의 `isReadOnly = status === "adopted" || status === "archived"` 분기로 input mount 가 막힘.

가설 매칭:
- (a) phase reset: input 분기는 phase 무관 ❌
- (b) conv_id race: 무관 ❌
- **(c) UI conditional render: ✅** — `isReadOnly` 분기
- **(d) status 변경 path: ✅** — plan revision 머지가 archived 로 변경

## Fix scope

- 파일 1개 / 의미 분기 1줄 (주석 포함 +6/-2)
- `BranchThreadPanel.tsx` input mount 분기만 좁힘 (`adopted` 만 readonly)
- 다른 readonly 분기 (status badge / Adopt / Delete / 메시지 액션) 는 `isReadOnly` 그대로 — 의미 변경 최소

## DO NOT 가드 (모두 0 diff 확인)

- `docs/reference/branchSessionPolicy.md` — diff 0
- `src-tauri/src/commands/branch_sync.rs` — 파일 없음 (frontend `branchSync.ts`만 존재, 미수정)
- `src-tauri/src/commands/plans.rs` — diff 0
- DB / store schema — 변경 0
- 새 dependency — 0

## Verification

| 항목 | 결과 |
|---|---|
| `npx tsc --noEmit` | PASS (no output) |
| `npx vitest run` | PASS — 39 files / 401 tests |
| protected file diff | 0 (branchSessionPolicy.md / plans.rs) |

## Test plan (e2e 수동, merge 후 next release 에서 사용자 검증)

- [ ] 회귀 시나리오: plan A 진행 중 → plan revision 요청 → 새 plan-proposal 머지 → plan A 의 archived dev branch 다시 열기 → chat input 노출 ✅
- [ ] 회귀 가드 1: 정상 plan 진행 (revision 없이 dev → review → completed) — 정책 변화 0
- [ ] 회귀 가드 2: 새 plan 단독 — chat input 정상
- [ ] 회귀 가드 3: branch 직접 review 진입 — chat input 정상
- [ ] 회귀 가드 4: adopted branch 의 input hide 정책 보존

## 관련 문서

- Plan: `docs/plans/branchChatInputRegressionPlan_2026-05-03.md`
- 핸드오프: `docs/prompts/branchChatInputRegressionDeveloperHandoff_2026-05-03.md`
- 보존된 정책: `docs/reference/branchSessionPolicy.md` (INV-1~5)

Closes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)