### PR TITLE
chore(meta): askMeta UX 폐지 — Reviewer verdict→Architect 직행 plan PR-1

### DIFF
--- a/src/components/tunaflow/MetaFloatingChat.tsx
+++ b/src/components/tunaflow/MetaFloatingChat.tsx
@@ -196,30 +196,6 @@ export function MetaFloatingChat({ projectKey }: MetaFloatingChatProps) {
     if (!pinned) setOpen(false);
   }, [pinned]);
 
-  /** C — "메타에게 물어보기": 알림 하나를 선택해 메타 채팅 패널을 열면서
-   *  해당 맥락을 input 에 자동 주입. 사용자는 엔터만 누르거나 질문을 덧붙여 전송.
-   *  실제 메타 LLM 호출은 사용자가 전송할 때 (원칙: 자동 실행 금지). */
-  const askMetaAbout = useCallback((notif: MetaNotification) => {
-    // 읽음 처리
-    setNotifs((prev) => {
-      const next = prev.map((n) => (n.id === notif.id ? { ...n, read: true } : n));
-      saveNotifs(next);
-      return next;
-    });
-    invoke("mark_meta_notification_read", { id: notif.id }).catch(() => {});
-    // 메타 채팅 탭으로 전환 + 컨텍스트 질문 prompt 주입
-    const prompt = [
-      t("meta_chat.ask_about_header", { title: notif.title }),
-      notif.summary ? t("meta_chat.ask_about_summary", { summary: notif.summary }) : "",
-      "",
-      t("meta_chat.ask_about_instruction"),
-    ].filter(Boolean).join("\n");
-    setInput(prompt);
-    setActiveTab("chat");
-    setOpen(true);
-    setTimeout(() => inputRef.current?.focus(), 50);
-  }, []);
-
   // Close popup on outside click (pinned stays open)
   useEffect(() => {
     if (!open || pinned) return;
@@ -576,9 +552,6 @@ export function MetaFloatingChat({ projectKey }: MetaFloatingChatProps) {
                             </p>
                           </div>
                           <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                            <button onClick={() => askMetaAbout(n)} className="p-1 rounded hover:bg-primary/10 text-primary" title={t("meta_chat.action_ask_meta")}>
-                              <Bot className="w-3 h-3" />
-                            </button>
                             {n.route && (
                               <button onClick={() => routeTo(n)} className="p-1 rounded hover:bg-primary/10 text-primary" title={t("meta_chat.action_navigate")}>
                                 <ChevronRight className="w-3 h-3" />

--- a/src/locales/en/dialog.json
+++ b/src/locales/en/dialog.json
@@ -114,14 +114,10 @@
     "inbox_clear_all": "Clear all",
     "inbox_count": "{{count}}",
     "inbox_empty": "No notifications",
-    "action_ask_meta": "Ask meta",
     "action_navigate": "Go to related location",
     "action_dismiss": "Dismiss",
     "empty_state_primary": "I can help analyze project status, detect issues, and suggest priorities.",
     "empty_state_secondary": "Try starting with \"Check project status\"",
-    "input_placeholder": "Ask Meta...",
-    "ask_about_header": "Notification: **{{title}}**",
-    "ask_about_summary": "Summary: {{summary}}",
-    "ask_about_instruction": "Please analyze the event above and suggest the next recommended actions."
+    "input_placeholder": "Ask Meta..."
   }
 }

--- a/src/locales/ko/dialog.json
+++ b/src/locales/ko/dialog.json
@@ -114,14 +114,10 @@
     "inbox_clear_all": "전체 삭제",
     "inbox_count": "{{count}}개",
     "inbox_empty": "알림 없음",
-    "action_ask_meta": "메타에게 물어보기",
     "action_navigate": "관련 위치로 이동",
     "action_dismiss": "닫기",
     "empty_state_primary": "프로젝트 상태 분석, 이슈 감지, 우선순위 제안을 도와드립니다.",
     "empty_state_secondary": "\"프로젝트 상태 확인해줘\" 로 시작해보세요",
-    "input_placeholder": "Meta에게 물어보기...",
-    "ask_about_header": "알림: **{{title}}**",
-    "ask_about_summary": "요약: {{summary}}",
-    "ask_about_instruction": "위 이벤트에 대해 분석해주시고, 다음 권장 액션을 제안해주세요."
+    "input_placeholder": "Meta에게 물어보기..."
   }
 }


### PR DESCRIPTION
## Summary

Plan: [reviewerVerdictDirectArchitectPlan_2026-05-04](../blob/main/docs/plans/reviewerVerdictDirectArchitectPlan_2026-05-04.md)
Handoff: [reviewerVerdictDirectArchitectDeveloperHandoff_2026-05-04](../blob/main/docs/prompts/reviewerVerdictDirectArchitectDeveloperHandoff_2026-05-04.md)

**Task 04** — askMeta UX 폐지. 메타 알림 inbox 의 *"메타에게 물어보기"* 버튼 + `askMetaAbout` callback + i18n 키 (`action_ask_meta`, `ask_about_*`) 제거.

3 PR 시리즈의 1번 — UX 표면, 단독 axis. PR-2 (verdict→Architect 직행) / PR-3 (Tier 2 kind 분리) 와 같은 release cycle (v0.1.6-beta) 에 함께 머지 권장.

## 변경

- `src/components/tunaflow/MetaFloatingChat.tsx` — `askMetaAbout` callback 23줄 제거 + inbox 항목의 Bot 아이콘 버튼 제거
- `src/locales/{ko,en}/dialog.json` — `action_ask_meta` / `ask_about_header` / `ask_about_summary` / `ask_about_instruction` 4 키 제거

## DO NOT 영역 미침범

- ReviewVerdictCard / handleSendToDevDirect 영역 미변경 (INV-RVA-4)
- Meta floating chat 자체 보존 — 폐지는 askMeta 버튼 + callback + i18n 한정 (INV-RVA-7)
- 알림 카드 표시 / 읽음 / route navigation / dismiss 동작 보존
- src-tauri/ / DB schema / 다른 i18n 미변경

## 검증

- `npx tsc --noEmit` PASS
- `npx vitest run` → 401/401 (변동 없음)
- `cd src-tauri && cargo test --lib` → 613 passed + 1 pre-existing fail (`audit_enabled_default_true`, FE 변경 영향 0)

## 회귀 grep

```
rg "askMeta|action_ask_meta|ask_about_" src/ src/locales/
# → src/lib/workflow/reviewWorkflow.ts:454 의 stale comment 1건만
#   (PR-2 에서 dispatchMetaNotification 제거와 함께 같이 갱신됨)
```

## Test plan

- [ ] Meta floating chat 열기 → inbox 항목 우측에 "메타에게 물어보기" 버튼 비존재
- [ ] 알림 본문 클릭 → route navigation (탭/stage/planId 포커스) 정상 동작
- [ ] 알림 dismiss / clear-all / mark-read 동작 보존
- [ ] 채팅 탭 직접 열고 입력창에서 메시지 송신 → 정상 동작
- [ ] PlansPanel / InsightPanel / ReviewVerdictCard 등 다른 UI 정상 렌더 (i18n 누락 에러 0)

GUI 환경 검증은 v0.1.6-beta release 외부 사용자 검증으로 최종 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)