### PR TITLE
feat(workflow): Reviewer verdict → Architect 직행 (PR-2: T05+T01+T02)

### DIFF
--- a/src/components/tunaflow/context-panel/plans/ReviewVerdictCard.tsx
+++ b/src/components/tunaflow/context-panel/plans/ReviewVerdictCard.tsx
@@ -6,6 +6,7 @@ import type { Plan, PlanPhase, PlanStatus } from "@/types";
 import type { ParsedReviewVerdict } from "@/lib/planProposalParser";
 import { processReviewVerdict, approveAndStartImplementation } from "@/lib/workflowOrchestration";
 import * as planApi from "@/lib/api/plans";
+import { dispatchArchitectRedesign } from "@/lib/workflow/architectDispatch";
 import { toast } from "sonner";
 import { invoke } from "@tauri-apps/api/core";
 
@@ -94,29 +95,8 @@ export function ReviewVerdictCard({
         await invoke("update_subtask_status", { id: st.id, status: "pending" }).catch(() => {});
       }
 
-      // 4. Architect에게 findings 포함 재설계 요청 전송
-      const { sendWithEngine, getConversationEngine } = useChatStore.getState();
-      const convId = plan.conversationId;
-      const saved = getConversationEngine(convId);
-      const engine = saved?.engine ?? "claude";
-
-      const findings = verdict.findings.length > 0
-        ? verdict.findings.map((f) => `- ${f}`).join("\n")
-        : t("review.verdict.findings_empty_redesign");
-      const recs = verdict.recommendations.length > 0
-        ? verdict.recommendations.map((r) => `- ${r}`).join("\n")
-        : "";
-      const recsBlock = recs ? t("review.verdict.redesign_recs_block", { recs }) : "";
-      const prompt = t("review.verdict.redesign_prompt", {
-        title: plan.title,
-        revision: plan.revision,
-        verdict: verdict.verdict.toUpperCase(),
-        findings,
-        recsBlock,
-        nextRevision: (plan.revision ?? 1) + 1,
-      });
-
-      await sendWithEngine(engine, prompt);
+      // 4. Architect에게 findings 포함 재설계 요청 전송 (helper 경유 — Task 05)
+      await dispatchArchitectRedesign(plan, { ...verdict, verdict: "fail" }, { reason: "user-redesign" });
 
       onPlanUpdate({ phase: "done" as PlanPhase, status: "abandoned" as PlanStatus });
       toast.success(t("review.verdict.redesign_success"));

--- a/src/lib/workflow/architectDispatch.ts
+++ b/src/lib/workflow/architectDispatch.ts
@@ -1,0 +1,87 @@
+/**
+ * Architect dispatch helpers — review verdict (pass/fail/escalate) 처리 시
+ * Architect 에게 main conv 로 직접 prompt 를 dispatch 하는 단일 진입점.
+ *
+ * **배경**: 기존엔 review-cycle 알림 (review_passed / doom_loop_escalated 등) 이
+ * Meta inbox 로만 가고, 사용자가 *"메타에게 물어보기"* 또는 *"플랜 재설계"* 버튼을
+ * 눌러야 Architect 가 실제 작업했다. 본 helper 가 도입되면서 dispatch 책임이
+ * Meta inbox → Architect main conv 로 이동.
+ *
+ * **호출처**:
+ *  - `processReviewVerdict()` 의 pass 분기 → `dispatchArchitectNextPriority(plan)`
+ *  - `processReviewVerdict()` 의 doom-escalate 분기 → `dispatchArchitectRedesign(plan, verdict, { reason: "doom-escalate" })`
+ *  - `ReviewVerdictCard.handleRedesign()` 사용자 클릭 → `dispatchArchitectRedesign(plan, verdict, { reason: "user-redesign" })`
+ *
+ * **유의**:
+ *  - phase=done / status=abandoned 갱신 + subtask reset 로직은 caller 책임
+ *    (helper 는 *dispatch 만* 담당). 같은 helper 가 자동/수동 양쪽에서 호출되므로
+ *    plan 상태 머신 변경은 caller 쪽에 둔다.
+ *  - i18n key 변경 시 ko/en 동시 갱신.
+ */
+import type { Plan } from "@/types";
+import type { ParsedReviewVerdict } from "../planProposalParser";
+import { useChatStore } from "@/stores/chatStore";
+import i18n from "i18next";
+
+export type ArchitectRedesignReason = "user-redesign" | "doom-escalate";
+
+/** pass 직후 main conv 로 다음 우선순위 제안 prompt 를 dispatch.
+ *  실패해도 throw 하지 않는다 (review pass 처리 자체를 막지 않기 위함). */
+export async function dispatchArchitectNextPriority(plan: Plan): Promise<void> {
+  try {
+    const { sendWithEngine, getConversationEngine } = useChatStore.getState();
+    const saved = getConversationEngine(plan.conversationId);
+    const engine = saved?.engine ?? "claude";
+    const prompt = i18n.t("review.verdict.next_priority_prompt", {
+      ns: "workflow",
+      title: plan.title,
+    });
+    await sendWithEngine(engine, prompt);
+  } catch (e) {
+    console.warn("[architectDispatch] next-priority failed:", e);
+  }
+}
+
+/** fail/escalate 시 main conv 로 plan 재설계 prompt 를 dispatch.
+ *  - reason="user-redesign": ReviewVerdictCard 의 사용자 클릭 경로
+ *  - reason="doom-escalate": review 5회 누적 실패 시 자동 호출 경로
+ *  실패해도 throw 하지 않는다. */
+export async function dispatchArchitectRedesign(
+  plan: Plan,
+  verdict: ParsedReviewVerdict,
+  opts: { reason: ArchitectRedesignReason; failCount?: number },
+): Promise<void> {
+  try {
+    const { sendWithEngine, getConversationEngine } = useChatStore.getState();
+    const saved = getConversationEngine(plan.conversationId);
+    const engine = saved?.engine ?? "claude";
+    const findings = verdict.findings.length > 0
+      ? verdict.findings.map((f) => `- ${f}`).join("\n")
+      : i18n.t("review.verdict.findings_empty_redesign", { ns: "workflow" });
+    const recs = verdict.recommendations.length > 0
+      ? verdict.recommendations.map((r) => `- ${r}`).join("\n")
+      : "";
+    const recsBlock = recs
+      ? i18n.t("review.verdict.redesign_recs_block", { ns: "workflow", recs })
+      : "";
+    const reasonNote = opts.reason === "doom-escalate" && opts.failCount
+      ? i18n.t("review.verdict.redesign_reason_doom_escalate", {
+          ns: "workflow",
+          failCount: opts.failCount,
+        })
+      : "";
+    const prompt = i18n.t("review.verdict.redesign_prompt", {
+      ns: "workflow",
+      title: plan.title,
+      revision: plan.revision,
+      verdict: verdict.verdict.toUpperCase(),
+      findings,
+      recsBlock,
+      nextRevision: (plan.revision ?? 1) + 1,
+    });
+    const finalPrompt = reasonNote ? `${reasonNote}\n\n${prompt}` : prompt;
+    await sendWithEngine(engine, finalPrompt);
+  } catch (e) {
+    console.warn("[architectDispatch] redesign failed:", e);
+  }
+}

--- a/src/lib/workflow/reviewWorkflow.ts
+++ b/src/lib/workflow/reviewWorkflow.ts
@@ -13,7 +13,6 @@ import {
 } from "../manualVerification";
 import * as failureLessonsApi from "../api/failureLessons";
 import * as insightApi from "../api/insight";
-import { dispatchMetaNotification } from "../metaNotifications";
 import { maybeTriggerMetaAnalysis } from "../metaAnalysisTrigger";
 import { dispatchArchitectNextPriority, dispatchArchitectRedesign } from "./architectDispatch";
 import {
@@ -515,16 +514,10 @@ export async function processReviewVerdict(
       // Baton has moved to Architect — review branch is no longer active.
       const { archiveReviewBranchForHandoff } = await import("./implementWorkflow");
       await archiveReviewBranchForHandoff(plan);
-      // projectKey 조회 (meta conv mirror 용).
-      const escProjectKey = await invoke<{ projectKey?: string }>("get_conversation", { id: plan.conversationId })
-        .then((c) => c?.projectKey).catch(() => undefined);
-      dispatchMetaNotification({
-        kind: "doom_loop_escalated",
-        title: `⚠️ Plan "${plan.title}" 재설계 필요`,
-        summary: `Review ${failCount}회 실패로 Architect 재설계가 강제되었습니다. Subtask 범위를 재검토하세요.`,
-        projectKey: escProjectKey,
-        route: { tab: "workflow", stage: "plan-check", planId: plan.id },
-      });
+      // 자동 escalate 시 Architect 가 main conv 에서 재설계 prompt 를 즉시 수신.
+      // 기존 dispatchMetaNotification(doom_loop_escalated) → Meta inbox 의존을 제거.
+      // plan_event_log 에 doom_loop_escalated 이벤트는 보존되어 시스템 자동 결정 흔적 유지.
+      await dispatchArchitectRedesign(plan, verdict, { reason: "doom-escalate", failCount });
     } else if (doom.recommendation === "warn") {
       await planApi.createPlanEvent(
         plan.id,
@@ -532,15 +525,9 @@ export async function processReviewVerdict(
         "system",
         `Review 실패 ${failCount}회 — 설계 재검토를 권장합니다. Architect 재설계 또는 Developer 계속 rework 중 선택하세요.`,
       );
-      const warnProjectKey = await invoke<{ projectKey?: string }>("get_conversation", { id: plan.conversationId })
-        .then((c) => c?.projectKey).catch(() => undefined);
-      dispatchMetaNotification({
-        kind: "doom_loop_warning",
-        title: `⚠️ Plan "${plan.title}" ${failCount}회 실패`,
-        summary: "설계 재검토 권장. 계속 rework 할지 Architect 재설계로 갈지 선택하세요.",
-        projectKey: warnProjectKey,
-        route: { tab: "workflow", stage: "review", planId: plan.id },
-      });
+      // warn 단계는 사용자 결정 (continue rework vs redesign) 으로 유지 — Architect 자동
+      // 호출 없음. plan_event_log 의 doom_loop_warning 이벤트가 ReviewVerdictCard /
+      // DevProgressView 에 표시되어 사용자 결정 UI 가 충족됨.
     }
   } else {
     await planApi.createPlanEvent(plan.id, "review_conditional", "reviewer", detail);

--- a/src/lib/workflow/reviewWorkflow.ts
+++ b/src/lib/workflow/reviewWorkflow.ts
@@ -15,6 +15,7 @@ import * as failureLessonsApi from "../api/failureLessons";
 import * as insightApi from "../api/insight";
 import { dispatchMetaNotification } from "../metaNotifications";
 import { maybeTriggerMetaAnalysis } from "../metaAnalysisTrigger";
+import { dispatchArchitectNextPriority, dispatchArchitectRedesign } from "./architectDispatch";
 import {
   buildPlanContext,
   getOrCreateReviewBranch,
@@ -407,22 +408,13 @@ export async function processReviewVerdict(
     await planApi.updatePlanPhase(plan.id, "done");
     await planApi.updatePlanStatus(plan.id, "done");
     await planApi.createPlanEvent(plan.id, "review_passed", "reviewer", detail);
-    // Notify Meta — plan cycle finished, user may want next-priority suggestion.
-    // projectKey 는 plan 의 메인 conv 경유해서 찾기
+    // projectKey 는 plan 의 메인 conv 경유해서 찾기 — Tier 2 분석 트리거용.
     let projectKey: string | undefined;
     try {
       const conv = await invoke<{ projectKey?: string }>("get_conversation", { id: plan.conversationId });
       projectKey = conv?.projectKey;
     } catch { /* ignore */ }
-    dispatchMetaNotification({
-      kind: "review_passed",
-      title: `✅ Plan "${plan.title}" 리뷰 통과`,
-      summary: verdict.findings.length > 0
-        ? `minor findings ${verdict.findings.length}건. ${verdict.recommendations[0]?.slice(0, 100) ?? ""}`
-        : "모든 검증 통과 — Done 처리됨",
-      projectKey,
-      route: { tab: "workflow", stage: "done", planId: plan.id },
-    });
+    // Tier 2 분석 (Haiku/Flash brief) 은 보존 — 결과 dispatch kind 는 PR-3 에서 tier2_brief 로 분리.
     if (projectKey) {
       maybeTriggerMetaAnalysis(projectKey, "review_passed", { planTitle: plan.title })
         .catch((e) => console.debug("[meta-trigger]", e));
@@ -448,10 +440,11 @@ export async function processReviewVerdict(
       const { useChatStore } = await import("@/stores/chatStore");
       await useChatStore.getState().loadBranches(plan.conversationId);
     } catch (e) { console.debug("[loadBranches after archive]", e); }
-    // Role separation: plan completion goes to Meta inbox only (dispatchMetaNotification
-    // above + maybeTriggerMetaAnalysis for Tier 2 brief). Architect is NOT auto-invoked —
-    // 'what's next?' is Meta's oversight role, not Architect's design role. User asks
-    // via the inbox entry's askMeta button when they want the next-priority suggestion.
+    // Plan 완료 → Architect 가 main conv 에서 다음 우선순위 제안 prompt 를 자동 수신.
+    // 기존엔 Meta inbox 의 review_passed 알림 + 사용자 클릭 (askMeta) 흐름이었지만,
+    // *plan-cycle 결정* 은 Meta 의 read-only 역할보다 Architect 의 design 역할에 속함.
+    // 사용자 의사결정 burden 제거. Tier 2 brief (Haiku/Flash) 는 별 axis 로 inbox 유지.
+    await dispatchArchitectNextPriority(plan);
   } else if (verdict.verdict === "fail") {
     await planApi.updatePlanPhase(plan.id, "rework");
     await planApi.createPlanEvent(plan.id, "review_failed", "reviewer", detail);

--- a/src/locales/en/workflow.json
+++ b/src/locales/en/workflow.json
@@ -334,7 +334,9 @@
       "conditional_prompt": "[Conditional Review] The reviewer requested partial revisions.\n\n**Findings (must fix):{{findings}}\n{{recsBlock}}\n\nAfter fixing, emit the impl-complete marker.",
       "conditional_recs_block": "**Recommendations:{{recs}}",
       "redesign_prompt": "[Plan revision request] \"{{title}}\" (rev.{{revision}}) was abandoned after review failure.\n\n**Reviewer verdict**: {{verdict}}\n\n**Findings (failure causes)**:\n{{findings}}\n{{recsBlock}}\n\nAnalyze the findings above and propose a revised rev.{{nextRevision}} Plan that fixes the failed subtasks, in `<!-- tunaflow:plan-proposal -->` format.\nKeep successful subtasks as-is; only revise the parts that caused the failure.",
-      "redesign_recs_block": "\n**Recommendations**:\n{{recs}}"
+      "redesign_recs_block": "\n**Recommendations**:\n{{recs}}",
+      "redesign_reason_doom_escalate": "[Auto-escalation] Review failed {{failCount}} times in a row, so the system is requesting an Architect redesign.",
+      "next_priority_prompt": "[Next-priority suggestion] Plan \"{{title}}\" has completed review.\n\nLooking at the project's current state, propose the next priority task or a follow-up plan branch. If a new plan is needed, write it in `<!-- tunaflow:plan-proposal -->` format. If it's just guidance, respond in free form."
     }
   }
 }

--- a/src/locales/ko/workflow.json
+++ b/src/locales/ko/workflow.json
@@ -334,7 +334,9 @@
       "conditional_prompt": "[Conditional Review] 리뷰어가 일부 수정을 요청했습니다.\n\n**Findings (수정 필요):{{findings}}\n{{recsBlock}}\n\n수정 후 impl-complete 마커를 출력해 주세요.",
       "conditional_recs_block": "**Recommendations:{{recs}}",
       "redesign_prompt": "[Plan 개정 요청] \"{{title}}\" (rev.{{revision}})이 리뷰 실패로 폐기되었습니다.\n\n**리뷰어 판정**: {{verdict}}\n\n**Findings (실패 원인)**:\n{{findings}}\n{{recsBlock}}\n\n위 findings를 분석하여 실패한 서브태스크를 수정한 rev.{{nextRevision}} Plan을 `<!-- tunaflow:plan-proposal -->` 형식으로 제안해 주세요.\n성공한 서브태스크는 유지하고, 실패 원인이 된 부분만 수정하세요.",
-      "redesign_recs_block": "\n**Recommendations**:\n{{recs}}"
+      "redesign_recs_block": "\n**Recommendations**:\n{{recs}}",
+      "redesign_reason_doom_escalate": "[자동 에스컬레이션] Review 가 {{failCount}}회 연속 실패하여 시스템이 Architect 재설계를 요청합니다.",
+      "next_priority_prompt": "[다음 우선순위 제안] \"{{title}}\" Plan 이 리뷰 통과로 완료되었습니다.\n\n프로젝트의 현재 상태를 보고 다음 우선순위 작업이나 후속 plan 분기를 제안해 주세요. 새 plan 이 필요하다면 `<!-- tunaflow:plan-proposal -->` 형식으로 작성하세요. 단순 안내라면 자유 형식으로 답변해 주세요."
     }
   }
 }


### PR DESCRIPTION
## Summary

Plan: [reviewerVerdictDirectArchitectPlan_2026-05-04](../blob/main/docs/plans/reviewerVerdictDirectArchitectPlan_2026-05-04.md)
Handoff: [reviewerVerdictDirectArchitectDeveloperHandoff_2026-05-04](../blob/main/docs/prompts/reviewerVerdictDirectArchitectDeveloperHandoff_2026-05-04.md)

3 PR 시리즈의 본체. Reviewer pass / fail-escalate 시점에 Meta inbox dispatch 를 제거하고 Architect 가 main conv 에서 자동으로 다음 행동 prompt 를 수신하도록 변경. 사용자 의사결정 burden (askMeta 클릭 → Meta 채팅 → Architect 명시 호출) 제거.

PR-1 (#260, askMeta UX 폐지) 머지됨. PR-3 (Tier 2 kind 분리 + test) 후속.

## 3 commit (의존 순서)

1. **T05 — Architect dispatch helper 추출** (refactor)
   - 신규 `src/lib/workflow/architectDispatch.ts`: `dispatchArchitectNextPriority(plan)` / `dispatchArchitectRedesign(plan, verdict, opts)`
   - 신규 i18n 키: `next_priority_prompt`, `redesign_reason_doom_escalate` (ko/en)
   - `ReviewVerdictCard.handleRedesign` inline dispatch 26줄 → helper 호출 1줄

2. **T01 — Reviewer pass → Architect 직행** (feat)
   - `reviewWorkflow.ts` pass 분기: `dispatchMetaNotification(review_passed)` 제거 → `dispatchArchitectNextPriority(plan)` 호출
   - `maybeTriggerMetaAnalysis(review_passed)` 호출은 보존 (INV-RVA-5)

3. **T02 — doom-escalate → Architect 직행 + warn → 자동 호출 안 함** (feat)
   - escalate: `dispatchMetaNotification(doom_loop_escalated)` 제거 → `dispatchArchitectRedesign(plan, verdict, { reason: "doom-escalate", failCount })` 호출
   - warn: `dispatchMetaNotification(doom_loop_warning)` 제거 → plan_event_log 만 남김 (사용자 결정 UI 유지)
   - `dispatchMetaNotification` import 제거 (사용처 0건)

## DO NOT 영역 미침범 (회귀 가드 grep 결과)

```
$ rg "dispatchMetaNotification" src/lib/workflow/reviewWorkflow.ts
# → 주석 내 reference 1건만 (정의/호출 0건)

$ git diff src/lib/metaAnalysisTrigger.ts        # 빈 출력 (PR-3 영역)
$ git diff src/lib/workflow/services/doomLoopDetector.ts   # 빈 출력 (INV-RVA-3)
$ git diff src/components/tunaflow/context-panel/plans/ReviewVerdictCard.tsx | grep -E "handleSendToDevDirect|conditional"   # 0건 (INV-RVA-4)
$ git diff src-tauri/                            # 빈 출력 (INV-RVA-6 — Rust meta_agent 미변경)
```

기타 보존:
- archive_branch (impl + review) 시퀀스 + loadBranches 시점 보존 (INV-RVA-1/2)
- design_review_suggested event 보존
- saveFailureLessons / createReworkReasonArtifact / createVerdictArtifact 호출 보존
- conditional 분기 (`reviewWorkflow.ts:552~554`) 미변경 (Task 03 옵션 (i) default)
- Architect persona / system prompt 미변경
- doom-loop 임계값 (warn ≥3 / escalate ≥5) 미변경

## 검증

- `npx tsc --noEmit` PASS
- `npx vitest run` → 401/401 (변동 없음)
- `cd src-tauri && cargo check` PASS (변경 0)
- `cd src-tauri && cargo test --lib` → 613 passed + 1 pre-existing fail (`audit_enabled_default_true`)

## Test plan

- [ ] Plan A pass → main conv 에 Architect "다음 우선순위 제안" prompt 자동 도착
- [ ] Plan B fail 5회 누적 → main conv 에 Architect "재설계" prompt 자동 도착 + plan phase=`subtask_review`
- [ ] handleRedesign 버튼 클릭 → 기존 동작 유지 (회귀 0)
- [ ] doom warn (3회) → Architect 자동 호출 없음 + plan_event_log 에 `doom_loop_warning` 만 표시
- [ ] conditional → Architect 자동 호출 없음 + Developer 직행 / 사용자 결정 UI 정상
- [ ] archive_branch (impl + review) 양쪽 정상 + 사이드바 stale 없음
- [ ] Tier 2 brief 알림 inbox 도착 (config off 가 아닌 경우)

GUI 환경 검증은 v0.1.6-beta release 외부 사용자 검증으로 최종 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)