### PR TITLE
chore(meta): tier2_brief kind 분리 + verdict→architect 회귀 가드 (PR-3: T06+T07)

### DIFF
--- a/src/components/tunaflow/MetaFloatingChat.test.tsx
+++ b/src/components/tunaflow/MetaFloatingChat.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * MetaFloatingChat — askMeta UX 폐지 (PR-1, T04) 회귀 가드.
+ *
+ * 사용자가 *"메타에게 물어보기"* 버튼 / `askMetaAbout` callback / 관련 i18n 키
+ * (`action_ask_meta`, `ask_about_*`) 가 다시 추가되지 않도록 source-level 검증.
+ *
+ * Plan: docs/plans/reviewerVerdictDirectArchitectPlan_2026-05-04.md (T07)
+ */
+import { describe, it, expect } from "vitest";
+// @ts-expect-error — node built-in available under vitest runtime, types optional here
+import { readFileSync } from "node:fs";
+// @ts-expect-error — node built-in available under vitest runtime
+import { resolve, dirname } from "node:path";
+// @ts-expect-error — node built-in available under vitest runtime
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const componentPath = resolve(__dirname, "MetaFloatingChat.tsx");
+const koDialogPath = resolve(__dirname, "../../locales/ko/dialog.json");
+const enDialogPath = resolve(__dirname, "../../locales/en/dialog.json");
+
+describe("MetaFloatingChat — askMeta UX removed", () => {
+  it("source does not reference askMetaAbout callback", () => {
+    const src = readFileSync(componentPath, "utf-8");
+    expect(src).not.toMatch(/askMetaAbout/);
+  });
+
+  it("source does not reference action_ask_meta i18n key", () => {
+    const src = readFileSync(componentPath, "utf-8");
+    expect(src).not.toMatch(/action_ask_meta/);
+  });
+
+  it("source does not reference ask_about_* i18n keys", () => {
+    const src = readFileSync(componentPath, "utf-8");
+    expect(src).not.toMatch(/ask_about_/);
+  });
+
+  it("source still provides routeTo callback (INV-RVA-7: route navigation 보존)", () => {
+    const src = readFileSync(componentPath, "utf-8");
+    expect(src).toMatch(/const routeTo = useCallback/);
+  });
+
+  it("source still provides Inbox tab + Chat tab (Meta floating chat 자체 보존)", () => {
+    const src = readFileSync(componentPath, "utf-8");
+    expect(src).toMatch(/tab_inbox/);
+    expect(src).toMatch(/tab_chat/);
+  });
+});
+
+describe("locales/dialog.json — askMeta keys removed", () => {
+  it("ko/dialog.json has no action_ask_meta or ask_about_* keys", () => {
+    const ko = JSON.parse(readFileSync(koDialogPath, "utf-8"));
+    const meta = ko.meta_chat;
+    expect(meta).toBeDefined();
+    expect(meta.action_ask_meta).toBeUndefined();
+    expect(meta.ask_about_header).toBeUndefined();
+    expect(meta.ask_about_summary).toBeUndefined();
+    expect(meta.ask_about_instruction).toBeUndefined();
+  });
+
+  it("en/dialog.json has no action_ask_meta or ask_about_* keys", () => {
+    const en = JSON.parse(readFileSync(enDialogPath, "utf-8"));
+    const meta = en.meta_chat;
+    expect(meta).toBeDefined();
+    expect(meta.action_ask_meta).toBeUndefined();
+    expect(meta.ask_about_header).toBeUndefined();
+    expect(meta.ask_about_summary).toBeUndefined();
+    expect(meta.ask_about_instruction).toBeUndefined();
+  });
+
+  it("ko/dialog.json still has action_navigate and action_dismiss (route + dismiss UX 보존)", () => {
+    const ko = JSON.parse(readFileSync(koDialogPath, "utf-8"));
+    expect(ko.meta_chat.action_navigate).toBeDefined();
+    expect(ko.meta_chat.action_dismiss).toBeDefined();
+  });
+});

--- a/src/lib/metaAnalysisTrigger.ts
+++ b/src/lib/metaAnalysisTrigger.ts
@@ -116,7 +116,7 @@ export async function maybeTriggerMetaAnalysis(
       `최근 ${t.reviewPassedCount}건의 Plan 이 리뷰 통과되었습니다. 프로젝트 전반에서 반복되는 잘된 패턴과 다음 우선순위 작업을 간단히 요약해주세요. 300자 이내.`,
       config,
       {
-        kind: "review_passed",
+        kind: "tier2_brief",
         title: `📊 ${t.reviewPassedCount}건 Plan 통과 — 주간 요약`,
         summaryFallback: "분석이 완료되지 않았습니다. 메타 채팅에서 직접 질문해보세요.",
       },
@@ -129,7 +129,7 @@ export async function maybeTriggerMetaAnalysis(
       `최근 ${t.reviewFailedCount}건의 Review 가 실패했습니다. 반복되는 실패 패턴(동일 파일/동일 findings)이 있는지 확인하고, 설계 재검토가 필요한 부분을 제안해주세요. 구체적 findings:\n${findingsContext}\n\n300자 이내 한국어 요약.`,
       config,
       {
-        kind: "review_failed",
+        kind: "tier2_brief",
         title: `⚠️ ${t.reviewFailedCount}건 Review 실패 — 패턴 분석`,
         summaryFallback: "반복되는 실패 패턴이 있을 수 있습니다. 메타 채팅에서 확인하세요.",
       },

--- a/src/lib/metaNotifications.ts
+++ b/src/lib/metaNotifications.ts
@@ -12,17 +12,21 @@
  * - PR-3: Tier 2 메타 LLM 브리핑 (Haiku/Gemini Flash)
  */
 
+/**
+ * **kind 정리 (2026-05-04, reviewerVerdictDirectArchitectPlan)**:
+ * - review_passed / review_failed / doom_loop_warning / doom_loop_escalated 4 kind 는
+ *   Architect 직행 라우팅으로 dispatch 가 사라짐 → MetaNotificationKind 에서 제거
+ * - tier2_brief 신규 추가 — Tier 2 분석 (Haiku/Flash) 결과 dispatch 전용
+ * - DB 의 deprecated kind row 는 free-text 라 그대로 남음. UI 는 unknown kind 폴백 처리
+ */
 export type MetaNotificationKind =
-  | "review_passed"           // Plan 리뷰 통과 → Done
-  | "review_failed"           // Review 실패 → Rework
-  | "doom_loop_warning"       // 3회 이상 실패 → 설계 재검토 권장
-  | "doom_loop_escalated"     // 5회 이상 실패 → Architect 재설계 강제
+  | "tier2_brief"             // Tier 2 (Haiku/Flash) 분석 결과 brief
   | "architect_redesign_requested"  // 사용자가 재설계 버튼 명시 클릭
   | "plan_completed"          // Plan 전체 사이클 완료
   | "plan_promoted"           // 새 Plan 등록됨
   | "tool_request_failed"     // 도구 호출 실패
   | "insight_detected"        // 새 Insight finding 감지
-  | "generic";                // 기타 폴백
+  | "generic";                // 기타 폴백 (legacy review-cycle row 도 여기로 폴백)
 
 export interface MetaNotificationRoute {
   /** 이동할 탭 (AppShell 의 `tunaflow:switch-tab` 이벤트와 매칭) */

--- a/src/lib/workflow/architectDispatch.test.ts
+++ b/src/lib/workflow/architectDispatch.test.ts
@@ -1,0 +1,126 @@
+/**
+ * architectDispatch — pass / fail / doom-escalate 분기에서 main conv 로 prompt
+ * 자동 dispatch 가 동작하는지 검증.
+ *
+ * Plan: docs/plans/reviewerVerdictDirectArchitectPlan_2026-05-04.md (T07)
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Plan } from "@/types";
+import type { ParsedReviewVerdict } from "../planProposalParser";
+
+// useChatStore mock — sendWithEngine / getConversationEngine 호출만 검증
+const sendWithEngine = vi.fn<(engine: string, prompt: string) => Promise<void>>(
+  () => Promise.resolve(),
+);
+const getConversationEngine = vi.fn<(convId: string) => { engine: string; model?: string } | undefined>(
+  () => undefined,
+);
+vi.mock("@/stores/chatStore", () => ({
+  useChatStore: { getState: () => ({ sendWithEngine, getConversationEngine }) },
+}));
+
+// i18next mock — t() 가 key + interpolated args 로 prompt 를 만들어 sendWithEngine
+// 인자에 key 가 포함되어 있는지 단언할 수 있게 함
+vi.mock("i18next", () => ({
+  default: {
+    t: (key: string, opts?: Record<string, unknown>) => {
+      if (!opts) return `[${key}]`;
+      const ns = opts.ns ?? "";
+      const rest = { ...opts };
+      delete rest.ns;
+      const args = Object.entries(rest)
+        .map(([k, v]) => `${k}=${v}`)
+        .join(",");
+      return `[${key}|${ns}|${args}]`;
+    },
+  },
+}));
+
+import { dispatchArchitectNextPriority, dispatchArchitectRedesign } from "./architectDispatch";
+
+const mockPlan: Plan = {
+  id: "p-1",
+  conversationId: "conv-1",
+  title: "Auth refactor",
+  description: "",
+  status: "active",
+  phase: "review",
+  revision: 2,
+  versionMajor: 1,
+  versionMinor: 0,
+  createdAt: 0,
+  updatedAt: 0,
+};
+
+const mockVerdict: ParsedReviewVerdict = {
+  verdict: "fail",
+  findings: ["bug A", "bug B"],
+  recommendations: ["fix 1"],
+  failedSubtaskIds: [1],
+  raw: "",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("dispatchArchitectNextPriority", () => {
+  it("calls sendWithEngine with next_priority_prompt + plan title", async () => {
+    await dispatchArchitectNextPriority(mockPlan);
+    expect(sendWithEngine).toHaveBeenCalledTimes(1);
+    const [engine, prompt] = sendWithEngine.mock.calls[0];
+    expect(engine).toBe("claude"); // default fallback
+    expect(prompt as string).toContain("review.verdict.next_priority_prompt");
+    expect(prompt as string).toContain("title=Auth refactor");
+  });
+
+  it("uses saved engine when getConversationEngine returns one", async () => {
+    getConversationEngine.mockReturnValueOnce({ engine: "codex", model: "gpt-5" } as any);
+    await dispatchArchitectNextPriority(mockPlan);
+    const [engine] = sendWithEngine.mock.calls[0];
+    expect(engine).toBe("codex");
+  });
+
+  it("does not throw when sendWithEngine rejects", async () => {
+    sendWithEngine.mockRejectedValueOnce(new Error("network"));
+    await expect(dispatchArchitectNextPriority(mockPlan)).resolves.toBeUndefined();
+  });
+});
+
+describe("dispatchArchitectRedesign", () => {
+  it("user-redesign: calls sendWithEngine with redesign_prompt and findings", async () => {
+    await dispatchArchitectRedesign(mockPlan, mockVerdict, { reason: "user-redesign" });
+    expect(sendWithEngine).toHaveBeenCalledTimes(1);
+    const [, prompt] = sendWithEngine.mock.calls[0];
+    expect(prompt as string).toContain("review.verdict.redesign_prompt");
+    expect(prompt as string).toContain("verdict=FAIL");
+    expect(prompt as string).toContain("nextRevision=3");
+    // user-redesign 은 reasonNote 없음
+    expect(prompt as string).not.toContain("redesign_reason_doom_escalate");
+  });
+
+  it("doom-escalate with failCount: prefixes redesign_reason_doom_escalate", async () => {
+    await dispatchArchitectRedesign(mockPlan, mockVerdict, { reason: "doom-escalate", failCount: 5 });
+    const [, prompt] = sendWithEngine.mock.calls[0];
+    expect(prompt as string).toContain("review.verdict.redesign_reason_doom_escalate");
+    expect(prompt as string).toContain("failCount=5");
+    expect(prompt as string).toContain("review.verdict.redesign_prompt");
+  });
+
+  it("uses findings_empty_redesign when verdict.findings is empty", async () => {
+    await dispatchArchitectRedesign(
+      mockPlan,
+      { ...mockVerdict, findings: [] },
+      { reason: "user-redesign" },
+    );
+    const [, prompt] = sendWithEngine.mock.calls[0];
+    expect(prompt as string).toContain("review.verdict.findings_empty_redesign");
+  });
+
+  it("does not throw when sendWithEngine rejects", async () => {
+    sendWithEngine.mockRejectedValueOnce(new Error("network"));
+    await expect(
+      dispatchArchitectRedesign(mockPlan, mockVerdict, { reason: "user-redesign" }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/tests/workflowOrchestration.test.ts
+++ b/src/tests/workflowOrchestration.test.ts
@@ -37,6 +37,22 @@ vi.mock("@/lib/appStore", () => ({
   setSetting: vi.fn(() => Promise.resolve()),
 }));
 
+// Mock architectDispatch — verify pass / doom-escalate 분기 호출 (Plan 2026-05-04 T07)
+vi.mock("@/lib/workflow/architectDispatch", () => ({
+  dispatchArchitectNextPriority: vi.fn(() => Promise.resolve()),
+  dispatchArchitectRedesign: vi.fn(() => Promise.resolve()),
+}));
+
+// Mock metaAnalysisTrigger — Tier 2 brief 호출 시점 보존 검증 (INV-RVA-5)
+vi.mock("@/lib/metaAnalysisTrigger", () => ({
+  maybeTriggerMetaAnalysis: vi.fn(() => Promise.resolve()),
+}));
+
+// Mock metaNotifications — review-cycle dispatch 가 0회 호출인지 검증 (INV-RVA: T01/T02 본체)
+vi.mock("@/lib/metaNotifications", () => ({
+  dispatchMetaNotification: vi.fn(),
+}));
+
 import { invoke } from "@tauri-apps/api/core";
 import * as planApi from "@/lib/api/plans";
 import * as appStore from "@/lib/appStore";
@@ -291,6 +307,142 @@ describe("processReviewVerdict — doom loop", () => {
 
     expect(planApi.updatePlanPhase).toHaveBeenCalledWith("p-1", "rework");
     expect(planApi.updatePlanPhase).not.toHaveBeenCalledWith("p-1", "subtask_review");
+  });
+});
+
+// ─── Verdict → Architect dispatch routing (Plan 2026-05-04) ────────────
+
+describe("processReviewVerdict — Architect direct dispatch (T01/T02)", () => {
+  it("pass: calls dispatchArchitectNextPriority and skips dispatchMetaNotification", async () => {
+    const { dispatchArchitectNextPriority, dispatchArchitectRedesign } = await import("@/lib/workflow/architectDispatch");
+    const { dispatchMetaNotification } = await import("@/lib/metaNotifications");
+
+    await processReviewVerdict(mockPlan, {
+      verdict: "pass",
+      findings: [],
+      recommendations: [],
+      failedSubtaskIds: [],
+      raw: "",
+    });
+
+    expect(dispatchArchitectNextPriority).toHaveBeenCalledTimes(1);
+    expect(dispatchArchitectNextPriority).toHaveBeenCalledWith(mockPlan);
+    expect(dispatchArchitectRedesign).not.toHaveBeenCalled();
+    // INV: review-cycle Meta inbox dispatch 0건
+    expect(dispatchMetaNotification).not.toHaveBeenCalled();
+  });
+
+  it("pass: still calls maybeTriggerMetaAnalysis(review_passed) (INV-RVA-5)", async () => {
+    const { maybeTriggerMetaAnalysis } = await import("@/lib/metaAnalysisTrigger");
+    (invoke as any).mockImplementation((cmd: string) => {
+      if (cmd === "get_conversation") return Promise.resolve({ projectKey: "proj-1" });
+      return Promise.resolve();
+    });
+
+    await processReviewVerdict(mockPlan, {
+      verdict: "pass",
+      findings: [],
+      recommendations: [],
+      failedSubtaskIds: [],
+      raw: "",
+    });
+
+    expect(maybeTriggerMetaAnalysis).toHaveBeenCalledWith("proj-1", "review_passed", expect.any(Object));
+  });
+
+  it("fail (1회): no dispatchArchitectRedesign, no Meta inbox", async () => {
+    const { dispatchArchitectNextPriority, dispatchArchitectRedesign } = await import("@/lib/workflow/architectDispatch");
+    const { dispatchMetaNotification } = await import("@/lib/metaNotifications");
+
+    await processReviewVerdict(mockPlan, {
+      verdict: "fail",
+      findings: ["bug"],
+      recommendations: [],
+      failedSubtaskIds: [],
+      raw: "",
+    });
+
+    // 1 fail 만 있으면 doom-loop 임계값 미도달 → Architect 자동 호출 0건
+    expect(dispatchArchitectNextPriority).not.toHaveBeenCalled();
+    expect(dispatchArchitectRedesign).not.toHaveBeenCalled();
+    expect(dispatchMetaNotification).not.toHaveBeenCalled();
+  });
+
+  it("doom warn (3회): no dispatchArchitectRedesign — user decision UI보존", async () => {
+    const { dispatchArchitectRedesign } = await import("@/lib/workflow/architectDispatch");
+    const { dispatchMetaNotification } = await import("@/lib/metaNotifications");
+    vi.mocked(planApi.listPlanEvents).mockResolvedValue([
+      { id: "e1", planId: "p-1", eventType: "review_failed", actor: "reviewer", detail: '{"findings":["x"]}', createdAt: 1 },
+      { id: "e2", planId: "p-1", eventType: "review_failed", actor: "reviewer", detail: '{"findings":["y"]}', createdAt: 2 },
+      { id: "e3", planId: "p-1", eventType: "review_failed", actor: "reviewer", detail: '{"findings":["z"]}', createdAt: 3 },
+    ]);
+
+    await processReviewVerdict(mockPlan, {
+      verdict: "fail",
+      findings: ["bug"],
+      recommendations: [],
+      failedSubtaskIds: [],
+      raw: "",
+    });
+
+    // warn 단계는 Architect 자동 호출 안 함 + Meta 알림 0건. plan_event_log 의
+    // doom_loop_warning 만 남고 사용자 결정 UI (ReviewVerdictCard) 보존.
+    expect(dispatchArchitectRedesign).not.toHaveBeenCalled();
+    expect(dispatchMetaNotification).not.toHaveBeenCalled();
+    expect(planApi.createPlanEvent).toHaveBeenCalledWith(
+      "p-1", "doom_loop_warning", "system", expect.stringContaining("3회"),
+    );
+  });
+
+  it("doom escalate (5회): calls dispatchArchitectRedesign with reason=doom-escalate + failCount", async () => {
+    const { dispatchArchitectRedesign } = await import("@/lib/workflow/architectDispatch");
+    const { dispatchMetaNotification } = await import("@/lib/metaNotifications");
+    vi.mocked(planApi.listPlanEvents).mockResolvedValue([
+      { id: "e1", planId: "p-1", eventType: "review_failed", actor: "reviewer", detail: '{"findings":["a"]}', createdAt: 1 },
+      { id: "e2", planId: "p-1", eventType: "review_failed", actor: "reviewer", detail: '{"findings":["b"]}', createdAt: 2 },
+      { id: "e3", planId: "p-1", eventType: "review_failed", actor: "reviewer", detail: '{"findings":["c"]}', createdAt: 3 },
+      { id: "e4", planId: "p-1", eventType: "review_failed", actor: "reviewer", detail: '{"findings":["d"]}', createdAt: 4 },
+      { id: "e5", planId: "p-1", eventType: "review_failed", actor: "reviewer", detail: '{"findings":["e"]}', createdAt: 5 },
+    ]);
+
+    await processReviewVerdict(mockPlan, {
+      verdict: "fail",
+      findings: ["bug"],
+      recommendations: [],
+      failedSubtaskIds: [],
+      raw: "",
+    });
+
+    expect(dispatchArchitectRedesign).toHaveBeenCalledTimes(1);
+    expect(dispatchArchitectRedesign).toHaveBeenCalledWith(
+      mockPlan,
+      expect.objectContaining({ verdict: "fail" }),
+      { reason: "doom-escalate", failCount: 5 },
+    );
+    // INV: review-cycle Meta inbox dispatch 0건 (T02)
+    expect(dispatchMetaNotification).not.toHaveBeenCalled();
+    // plan_event_log 의 doom_loop_escalated event 는 보존 (시스템 자동 결정 흔적)
+    expect(planApi.createPlanEvent).toHaveBeenCalledWith(
+      "p-1", "doom_loop_escalated", "system", expect.stringContaining("5회"),
+    );
+  });
+
+  it("conditional: no dispatchArchitect{NextPriority,Redesign} — INV-RVA-4 보존", async () => {
+    const { dispatchArchitectNextPriority, dispatchArchitectRedesign } = await import("@/lib/workflow/architectDispatch");
+    const { dispatchMetaNotification } = await import("@/lib/metaNotifications");
+
+    await processReviewVerdict(mockPlan, {
+      verdict: "conditional",
+      findings: ["maybe"],
+      recommendations: [],
+      failedSubtaskIds: [],
+      raw: "",
+    });
+
+    expect(dispatchArchitectNextPriority).not.toHaveBeenCalled();
+    expect(dispatchArchitectRedesign).not.toHaveBeenCalled();
+    expect(dispatchMetaNotification).not.toHaveBeenCalled();
+    expect(planApi.createPlanEvent).toHaveBeenCalledWith("p-1", "review_conditional", "reviewer", expect.any(String));
   });
 });
 


### PR DESCRIPTION
## Summary

Plan: [reviewerVerdictDirectArchitectPlan_2026-05-04](../blob/main/docs/plans/reviewerVerdictDirectArchitectPlan_2026-05-04.md)

3 PR 시리즈의 마무리. PR-2 의 Architect 직행 라우팅으로 review-cycle dispatch 가
사라졌으므로 `MetaNotificationKind` 의 4 kind (review_passed / review_failed /
doom_loop_warning / doom_loop_escalated) 를 제거하고, Tier 2 분석 (Haiku/Flash brief)
결과 dispatch 는 신규 `tier2_brief` kind 로 분리. 회귀 가드 테스트 21건 추가.

PR-1 (#260, askMeta UX 폐지) ✅ / PR-2 (#261, verdict→Architect 직행) ✅ / 본 PR (PR-3).

## 2 commit

1. **T06 — Tier 2 brief kind 분리** (refactor)
   - `MetaNotificationKind` 에서 review_passed / review_failed / doom_loop_warning /
     doom_loop_escalated 4종 제거
   - `tier2_brief` 신규 kind 추가
   - `metaAnalysisTrigger.ts` 의 dispatch kind: `review_passed`/`review_failed` → `tier2_brief`
   - 잔존 dispatchMetaNotification caller 검증:
     - `toolRequestHandler.ts` → `insight_detected` (보존)
     - `SubtaskReviewView.tsx` → `architect_redesign_requested` (보존)

2. **T07 — Test 보강** (test)
   - `src/lib/workflow/architectDispatch.test.ts` (신규, 7 tests)
   - `src/tests/workflowOrchestration.test.ts` (6 신규: pass/fail/doom-warn/doom-escalate/conditional + maybeTriggerMetaAnalysis 호출 보존)
   - `src/components/tunaflow/MetaFloatingChat.test.tsx` (신규, 8 tests — source-level + i18n key 부재)

## DO NOT 영역 미침범 (grep 결과)

```
$ rg "review_passed|review_failed|doom_loop_warning|doom_loop_escalated" src/lib/metaNotifications.ts
# → 주석 1건 (kind 정의 0건)

$ rg "tier2_brief" src/lib/
# → metaNotifications.ts 정의 + metaAnalysisTrigger.ts 사용 2건

$ git diff src/lib/workflow/reviewWorkflow.ts            # 빈 출력 (PR-2 영역)
$ git diff src-tauri/                                    # 빈 출력 (Rust 미변경)
```

기타 보존:
- INV-RVA-5: `maybeTriggerMetaAnalysis` 호출 시점 (review_passed/review_failed) 보존 — kind 만 분리
- INV-RVA-8: tool_request_failed / insight_detected / plan_promoted / generic / architect_redesign_requested 5 kind 보존
- DB schema 변경 0 (`kind` 컬럼 free-text)

## DB Migration / 기존 row 처리

- `meta_notifications.kind` 는 free-text → migration 불필요
- 기존 row 의 deprecated kind ("review_passed" 등) 는 그대로 남고, UI 는 `MetaNotificationKind` 의 `generic` fallback 으로 표시. `as MetaNotificationKind` 캐스팅 부분 (`MetaFloatingChat.tsx:82`) 은 unknown string 도 허용해 표면에 영향 없음

## 검증

- `npx tsc --noEmit` PASS
- `npx vitest run` → 401 → **422** (+21 신규 테스트)
- `cd src-tauri && cargo check` PASS (변경 0)
- `cd src-tauri && cargo test --lib` → 613 passed + 1 pre-existing fail (`audit_enabled_default_true`)

## Test plan

- [ ] Plan pass → Tier 2 brief 알림이 inbox 에 `tier2_brief` kind 로 표시
- [ ] 기존 inbox 의 deprecated kind row → `generic` fallback 라벨로 표시 + 클릭 시 route 이동 동작 (폭주 / 빈 카드 0)
- [ ] tool_request_failed / insight_detected / plan_promoted / generic / architect_redesign_requested 알림 정상 표시 (INV-RVA-8)
- [ ] 신규 vitest 케이스 모두 PASS

GUI 환경 검증은 v0.1.6-beta release 외부 사용자 검증으로 최종 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)