### PR TITLE
feat(rt): RT marker + Architect ContextPack 인계 (Task 03+04 / #263)

### DIFF
--- a/src-tauri/src/commands/agents_helpers/context_pack/db_queries.rs
+++ b/src-tauri/src/commands/agents_helpers/context_pack/db_queries.rs
@@ -397,6 +397,82 @@ pub fn build_rt_inheritance_section(
     Some(format!("## Roundtable Context\n\n{}", parts.join("\n\n")))
 }
 
+/// Build a `## Roundtable Consensus` section from `roundtable_consensus` rows.
+///
+/// devbug #263 Task 04 — Architect 가 dispatch 받는 ContextPack 에 RT 누적
+/// 합의를 명시 인계하는 helper. 라운드별 합의 항목 (axis / decision /
+/// participants / round_index) 을 prompt 본문에 *"## Roundtable Consensus"*
+/// 섹션으로 조립.
+///
+/// 정책:
+/// - INV-RTC-7/8 (RT 미사용 영향 0): row 0건이면 None 반환 → caller 측 섹션
+///   skip → ContextPack 변경 0
+/// - INV-RTC-4 (기존 ContextPack 섹션 보존): build_findings_section 의
+///   `roundtable_brief` LIMIT 3 fallback 은 보조로 그대로 호출 — 본 helper 는
+///   *추가 섹션* 만, 기존 섹션 변경 0
+/// - 토큰 budget 가드: 라운드별 decision 600자 truncate, 한 conv 의 모든
+///   누적 합의를 보여주되 한 합의가 prompt 본문 잠식하지 않게
+/// - branch shadow conv 도 cover: `roundtable_consensus.conversation_id` 가
+///   `branch:<id>` 형식이면 부모 conv 의 합의도 collect (RT 가 brand session
+///   에서 진행된 케이스)
+pub fn build_rt_consensus_section(
+    conn: &rusqlite::Connection,
+    conversation_id: &str,
+) -> Option<String> {
+    // Collect from this conv + any branch-shadow convs whose parent is this conv.
+    let mut stmt = conn
+        .prepare(
+            "SELECT round_index, axis, decision, participants
+               FROM roundtable_consensus
+              WHERE conversation_id = ?1
+                 OR conversation_id IN (
+                    SELECT 'branch:' || id FROM branches WHERE conversation_id = ?1
+                 )
+              ORDER BY round_index ASC, created_at ASC",
+        )
+        .ok()?;
+
+    let rows: Vec<(i64, String, String, String)> = stmt
+        .query_map([conversation_id], |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+            ))
+        })
+        .ok()?
+        .filter_map(|r| r.ok())
+        .collect();
+
+    if rows.is_empty() {
+        return None;
+    }
+
+    let mut lines: Vec<String> = Vec::with_capacity(rows.len());
+    for (round_index, axis, decision, participants_json) in rows {
+        let decision_truncated = truncate_str(&decision, 600);
+        let participants: Vec<String> =
+            serde_json::from_str::<Vec<String>>(&participants_json).unwrap_or_default();
+        let by = if participants.is_empty() {
+            String::new()
+        } else {
+            format!(" _(by {})_", participants.join(", "))
+        };
+        lines.push(format!(
+            "- **R{}** **{}**{}: {}",
+            round_index, axis, by, decision_truncated
+        ));
+    }
+
+    Some(format!(
+        "## Roundtable Consensus\n\n\
+         These axes are *already agreed* in roundtable rounds — Architect / single\n\
+         agent dispatch builds on top of these without re-litigating.\n\n{}",
+        lines.join("\n")
+    ))
+}
+
 // ─── Layer A′ tests: brand-aware plan lookup ─────────────────────────────────
 
 #[cfg(test)]
@@ -510,5 +586,111 @@ mod plan_isolation_tests {
 
         let r = lookup_plan_for_conversation(&conn, "conv-main").unwrap();
         assert_eq!(r.1, "main-plan");
+    }
+}
+
+// ─── RT consensus section tests (devbug #263 Task 04) ─────────────────────
+#[cfg(test)]
+mod rt_consensus_tests {
+    use super::*;
+    use rusqlite::Connection;
+
+    fn build_db_with_rt() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE conversations (id TEXT PRIMARY KEY);
+             CREATE TABLE branches (
+                id TEXT PRIMARY KEY,
+                conversation_id TEXT NOT NULL
+             );
+             CREATE TABLE roundtable_consensus (
+                id              TEXT    PRIMARY KEY,
+                conversation_id TEXT    NOT NULL,
+                round_index     INTEGER NOT NULL,
+                axis            TEXT    NOT NULL,
+                decision        TEXT    NOT NULL,
+                participants    TEXT    NOT NULL DEFAULT '[]',
+                confidence      REAL    NOT NULL DEFAULT 0.0,
+                created_at      INTEGER NOT NULL
+             );
+             INSERT INTO conversations (id) VALUES ('conv-main');
+             INSERT INTO conversations (id) VALUES ('conv-other');",
+        )
+        .unwrap();
+        conn
+    }
+
+    /// Architect dispatch 가 받는 ContextPack 에 RT 누적 합의가 *"## Roundtable
+    /// Consensus"* 섹션으로 등장 — Plan §3 Task 04 의 핵심 회귀 가드.
+    #[test]
+    fn architect_context_pack_includes_consensus_section() {
+        let conn = build_db_with_rt();
+        // 라운드 1, 2 에서 axis 별 합의 누적
+        conn.execute_batch(
+            "INSERT INTO roundtable_consensus
+                (id, conversation_id, round_index, axis, decision, participants, confidence, created_at)
+              VALUES
+                ('c1', 'conv-main', 1, 'compression', 'Lite/Standard/Full automode', '[\"claude\",\"codex\"]', 0.9, 100),
+                ('c2', 'conv-main', 2, 'budget', 'dynamic per-section budget', '[\"gemini\"]', 0.85, 200);",
+        ).unwrap();
+
+        let result = build_rt_consensus_section(&conn, "conv-main").unwrap();
+        assert!(result.starts_with("## Roundtable Consensus"));
+        assert!(result.contains("**R1** **compression**"));
+        assert!(result.contains("Lite/Standard/Full automode"));
+        assert!(result.contains("**R2** **budget**"));
+        assert!(result.contains("by claude, codex"));
+        assert!(result.contains("by gemini"));
+    }
+
+    /// 빈 결과 (RT 미진행 / 다른 conv) → None — Architect ContextPack 에서
+    /// 섹션 자체 skip (INV-RTC-7/8 fast path).
+    #[test]
+    fn empty_consensus_returns_none() {
+        let conn = build_db_with_rt();
+        // conv-other 는 합의 row 없음
+        let result = build_rt_consensus_section(&conn, "conv-other");
+        assert!(result.is_none());
+    }
+
+    /// 다른 conversation 의 합의가 누설되지 않음 — INV-RTC-7 격리.
+    #[test]
+    fn consensus_isolated_per_conversation() {
+        let conn = build_db_with_rt();
+        conn.execute_batch(
+            "INSERT INTO roundtable_consensus
+                (id, conversation_id, round_index, axis, decision, participants, confidence, created_at)
+              VALUES
+                ('c1', 'conv-main',  1, 'A', 'main A', '[]', 0.8, 100),
+                ('c2', 'conv-other', 1, 'B', 'other B', '[]', 0.8, 100);",
+        )
+        .unwrap();
+
+        let main_result = build_rt_consensus_section(&conn, "conv-main").unwrap();
+        assert!(main_result.contains("**A**"));
+        assert!(!main_result.contains("**B**"));
+
+        let other_result = build_rt_consensus_section(&conn, "conv-other").unwrap();
+        assert!(other_result.contains("**B**"));
+        assert!(!other_result.contains("**A**"));
+    }
+
+    /// branch shadow conv 의 RT 도 부모 conv 검색에 포함 — branch 에서 RT
+    /// 진행 후 main conv Architect dispatch 시 합의 인계.
+    #[test]
+    fn consensus_includes_branch_shadow_conversations() {
+        let conn = build_db_with_rt();
+        conn.execute_batch(
+            "INSERT INTO branches (id, conversation_id) VALUES ('br-1', 'conv-main');
+             INSERT INTO conversations (id) VALUES ('branch:br-1');
+             INSERT INTO roundtable_consensus
+                (id, conversation_id, round_index, axis, decision, participants, confidence, created_at)
+              VALUES
+                ('c1', 'branch:br-1', 1, 'branch-axis', 'branch decision', '[]', 0.7, 100);",
+        )
+        .unwrap();
+
+        let result = build_rt_consensus_section(&conn, "conv-main").unwrap();
+        assert!(result.contains("**branch-axis**"));
     }
 }

--- a/src-tauri/src/commands/agents_helpers/context_pack/mod.rs
+++ b/src-tauri/src/commands/agents_helpers/context_pack/mod.rs
@@ -33,6 +33,7 @@ pub use db_queries::{
     build_lite_context_prompt,
     build_thread_inheritance_section,
     build_rt_inheritance_section,
+    build_rt_consensus_section,
     lookup_plan_for_conversation,
     LITE_CONTEXT_MESSAGES_LIMIT,
 };

--- a/src-tauri/src/commands/agents_helpers/send_common/context_loading.rs
+++ b/src-tauri/src/commands/agents_helpers/send_common/context_loading.rs
@@ -422,6 +422,10 @@ pub struct ContextData {
     pub plan_document: Option<String>,
     pub findings_section: Option<String>,
     pub artifacts_section: Option<String>,
+    /// Roundtable consensus section (devbug #263 Task 04). Architect / single
+    /// agent dispatch 가 RT 누적 합의 (`roundtable_consensus` 테이블) 를 명시
+    /// 인계받게 한다. 빈 결과 시 None — RT 미사용 / 첫 라운드 경로 영향 0.
+    pub rt_consensus_section: Option<String>,
 
     // Retrieval
     pub retrieval_chunks: Vec<crate::commands::context_queries::RetrievedChunk>,
@@ -571,7 +575,19 @@ pub fn load_context_data(
     let has_active_plan: bool = isolated_plan.is_some();
 
     // Query 2: current messages — budget-based dynamic window + per-agent last-message guarantee
-    let current_messages = load_recent_messages_with_author(conn, conversation_id, 20);
+    //
+    // devbug #263 Task 03: RT round 메시지는 *raw transcript* 로 prepend 하지
+    // 않는다. RT 의 누적 합의는 `rt_consensus_section` 에 별 섹션으로 명시
+    // 인계되므로, single agent dispatch 가 RT 라운드 메시지를 *주제별 컨텍스트*
+    // 로 오인하지 않음 (시나리오 A 회복 핵심 path).
+    //
+    // INV-RTC-7/8 (RT 미사용 영향 0): RT 한번도 안 쓴 conv 는 모든 row 의
+    // rt_round_index = NULL → 출력이 기존 동작과 동일.
+    let current_messages = crate::commands::context_queries::load_recent_messages_excluding_rt(
+        conn,
+        conversation_id,
+        20,
+    );
 
     // Query 3: parent messages (branch: parent conv, scratchpad: main chat)
     let parent_messages: Vec<(String, String, Option<String>, Option<String>)> = if is_branch {
@@ -711,6 +727,13 @@ pub fn load_context_data(
 
     let findings_section = build_findings_section(conn, &plan_conv_id);
     let artifacts_section = build_artifact_handoff_section(conn, &plan_conv_id);
+    // RT consensus section (devbug #263 Task 04). Lookup against the live
+    // conversation_id (not plan_conv_id) so brand-shadow conv branches are
+    // covered too via `branch:<id>` JOIN inside the helper.
+    let rt_consensus_section = crate::commands::agents_helpers::context_pack::build_rt_consensus_section(
+        conn,
+        conversation_id,
+    );
 
     // Query 8-9: retrieval chunks (FTS5 + vector hybrid)
     let project_key: Option<String> = conn.query_row(
@@ -941,6 +964,7 @@ pub fn load_context_data(
         plan_document,
         findings_section,
         artifacts_section,
+        rt_consensus_section,
         retrieval_chunks,
         document_chunks,
         compressed_memory,
@@ -1250,6 +1274,7 @@ mod tests {
             plan_document: None,
             findings_section: None,
             artifacts_section: None,
+            rt_consensus_section: None,
             retrieval_chunks: vec![],
             document_chunks: vec![],
             compressed_memory: None,

--- a/src-tauri/src/commands/agents_helpers/send_common/mod.rs
+++ b/src-tauri/src/commands/agents_helpers/send_common/mod.rs
@@ -35,6 +35,7 @@ mod tests {
             plan_document: None,
             findings_section: None,
             artifacts_section: None,
+            rt_consensus_section: None,
             retrieval_chunks: vec![],
             document_chunks: vec![],
             compressed_memory: None,

--- a/src-tauri/src/commands/agents_helpers/send_common/prompt_assembly.rs
+++ b/src-tauri/src/commands/agents_helpers/send_common/prompt_assembly.rs
@@ -483,6 +483,15 @@ pub fn assemble_prompt(
             sections.push(s);
             included_sections.push("findings".into());
         }
+        // RT consensus — Architect dispatch 가 누적 합의를 명시 인계받는 경로
+        // (devbug #263 Task 04). 빈 결과는 None → 섹션 자체 skip (INV-RTC-7/8).
+        if let Some(s) = guardrail::truncate_section(
+            data.rt_consensus_section.clone(),
+            dyn_cap("findings"),
+        ) {
+            sections.push(s);
+            included_sections.push("rt-consensus".into());
+        }
         if let Some(s) = guardrail::truncate_section(
             data.artifacts_section.clone(),
             dyn_cap("artifacts"),
@@ -826,6 +835,7 @@ mod tests {
             plan_document: None,
             findings_section: None,
             artifacts_section: None,
+            rt_consensus_section: None,
             retrieval_chunks: vec![],
             document_chunks: vec![],
             compressed_memory: None,

--- a/src-tauri/src/commands/context_queries.rs
+++ b/src-tauri/src/commands/context_queries.rs
@@ -18,6 +18,10 @@ pub fn load_recent_messages(
 
 /// Load recent messages with author metadata.
 /// Returns `(role, content, engine, persona)` tuples.
+///
+/// devbug #263 Task 03 — RT 메시지 (rt_round_index IS NOT NULL) 도 그대로 포함.
+/// single agent dispatch 가 RT 라운드 안에 들어가지 않은 *순수 main conv* 메시지
+/// 만 받고 싶다면 [`load_recent_messages_excluding_rt`] 사용.
 pub fn load_recent_messages_with_author(
     conn: &Connection,
     conversation_id: &str,
@@ -29,6 +33,45 @@ pub fn load_recent_messages_with_author(
          ORDER BY timestamp DESC LIMIT ?2",
     ) else {
         return Vec::new();
+    };
+    let mut rows: Vec<(String, String, Option<String>, Option<String>)> = stmt
+        .query_map(params![conversation_id, limit], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, Option<String>>(2)?,
+                row.get::<_, Option<String>>(3)?,
+            ))
+        })
+        .map(|mapped| mapped.filter_map(|r| r.ok()).collect())
+        .unwrap_or_default();
+    rows.reverse();
+    rows
+}
+
+/// Load recent messages excluding RT round messages.
+///
+/// devbug #263 Task 03 — single agent dispatch (main conv 의 *모든 에이전트
+/// 선택 해제* 후 단일 질의) 시점에 ContextPack 이 RT round transcript 를
+/// *주제별 컨텍스트* 로 prepend 하지 않게 사용.
+///
+/// `rt_round_index IS NULL` row 만 collect — 컬럼 자체가 없는 v50 이전
+/// fixture 에서도 query 가 깨지지 않게 fallback (호출 측이 v51+ 가정).
+///
+/// INV-RTC-7/8 (RT 미사용 영향 0): RT 한번도 안 쓴 conv 는 모든 row 의
+/// rt_round_index = NULL → 출력이 `load_recent_messages_with_author` 와 동일.
+pub fn load_recent_messages_excluding_rt(
+    conn: &Connection,
+    conversation_id: &str,
+    limit: i64,
+) -> Vec<(String, String, Option<String>, Option<String>)> {
+    let Ok(mut stmt) = conn.prepare(
+        "SELECT role, content, engine, persona FROM messages
+         WHERE conversation_id = ?1 AND rt_round_index IS NULL
+         ORDER BY timestamp DESC LIMIT ?2",
+    ) else {
+        // 컬럼 부재 (구 fixture) 시 기존 동작으로 fallback
+        return load_recent_messages_with_author(conn, conversation_id, limit);
     };
     let mut rows: Vec<(String, String, Option<String>, Option<String>)> = stmt
         .query_map(params![conversation_id, limit], |row| {
@@ -438,4 +481,129 @@ pub fn project_path_for_conversation(conn: &Connection, conversation_id: &str) -
     )
     .ok()
     .flatten()
+}
+
+// ─── RT marker filter tests (devbug #263 Task 03) ──────────────────────────
+#[cfg(test)]
+mod rt_filter_tests {
+    use super::*;
+
+    fn build_db_with_messages() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE messages (
+                id              TEXT    PRIMARY KEY,
+                conversation_id TEXT    NOT NULL,
+                role            TEXT    NOT NULL,
+                content         TEXT    NOT NULL,
+                timestamp       INTEGER NOT NULL,
+                status          TEXT    NOT NULL DEFAULT 'done',
+                progress_content TEXT,
+                engine          TEXT,
+                model           TEXT,
+                persona         TEXT,
+                rt_round_index  INTEGER
+             );
+             -- Main conv 일반 user/assistant 메시지
+             INSERT INTO messages (id, conversation_id, role, content, timestamp, status, engine, persona, rt_round_index)
+             VALUES
+                ('m1', 'conv-1', 'user',      'main user msg 1',           100, 'done', NULL,         NULL,         NULL),
+                ('m2', 'conv-1', 'assistant', 'main assistant reply',      200, 'done', 'claude',     NULL,         NULL),
+                -- RT 라운드 1 헤더 + 참여자 응답
+                ('m3', 'conv-1', 'assistant', '--- Round 1 ... ---',       300, 'done', 'system',     NULL,         1),
+                ('m4', 'conv-1', 'assistant', 'rt round 1 claude reply',   400, 'done', 'claude-code','claude',     1),
+                ('m5', 'conv-1', 'assistant', 'rt round 1 codex reply',    500, 'done', 'codex',      'codex',      1),
+                -- 라운드 사이 단일 follow-up (RT 메시지 아님)
+                ('m6', 'conv-1', 'user',      'follow-up: clarify X',      600, 'done', NULL,         NULL,         NULL),
+                ('m7', 'conv-1', 'assistant', 'single agent answer',       700, 'done', 'claude',     NULL,         NULL);",
+        ).unwrap();
+        conn
+    }
+
+    /// Single agent dispatch 시 RT 라운드 메시지가 transcript 에서 제외 — Plan
+    /// §3 Task 03 의 시나리오 A 회복 핵심 가드.
+    #[test]
+    fn single_agent_dispatch_skips_rt_transcript() {
+        let conn = build_db_with_messages();
+        let rows = load_recent_messages_excluding_rt(&conn, "conv-1", 20);
+
+        // RT 라운드 1 메시지 (m3, m4, m5) 모두 제외
+        let contents: Vec<&str> = rows.iter().map(|(_, c, _, _)| c.as_str()).collect();
+        assert!(!contents.iter().any(|c| c.contains("Round 1")));
+        assert!(!contents.iter().any(|c| c.contains("rt round 1 claude")));
+        assert!(!contents.iter().any(|c| c.contains("rt round 1 codex")));
+
+        // 일반 main conv 메시지는 그대로 — m1, m2, m6, m7 4건
+        assert_eq!(rows.len(), 4);
+        assert!(contents.contains(&"main user msg 1"));
+        assert!(contents.contains(&"main assistant reply"));
+        assert!(contents.contains(&"follow-up: clarify X"));
+        assert!(contents.contains(&"single agent answer"));
+    }
+
+    /// 기존 helper 는 *모든* 메시지 그대로 — RT 본 흐름 (transcript 조립) 영역
+    /// 의 동작 보존.
+    #[test]
+    fn legacy_loader_includes_rt_messages() {
+        let conn = build_db_with_messages();
+        let rows = load_recent_messages_with_author(&conn, "conv-1", 20);
+        assert_eq!(rows.len(), 7, "기존 helper 는 모든 메시지 포함");
+    }
+
+    /// RT 미사용 conv (rt_round_index 모두 NULL) 의 두 helper 결과 동일 —
+    /// INV-RTC-7/8 fast path 검증.
+    #[test]
+    fn no_rt_usage_yields_identical_results() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE messages (
+                id              TEXT    PRIMARY KEY,
+                conversation_id TEXT    NOT NULL,
+                role            TEXT    NOT NULL,
+                content         TEXT    NOT NULL,
+                timestamp       INTEGER NOT NULL,
+                status          TEXT    NOT NULL DEFAULT 'done',
+                progress_content TEXT,
+                engine          TEXT,
+                model           TEXT,
+                persona         TEXT,
+                rt_round_index  INTEGER
+             );
+             INSERT INTO messages (id, conversation_id, role, content, timestamp, status, engine, persona, rt_round_index)
+             VALUES
+                ('m1', 'conv-x', 'user',      'msg 1', 100, 'done', NULL,     NULL, NULL),
+                ('m2', 'conv-x', 'assistant', 'msg 2', 200, 'done', 'claude', NULL, NULL);",
+        )
+        .unwrap();
+
+        let with_rt    = load_recent_messages_with_author(&conn, "conv-x", 20);
+        let without_rt = load_recent_messages_excluding_rt(&conn, "conv-x", 20);
+        assert_eq!(with_rt, without_rt);
+    }
+
+    /// 컬럼 부재 fixture 에서도 panic 없이 fallback (구 schema 호환).
+    #[test]
+    fn falls_back_when_rt_round_index_column_missing() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE messages (
+                id              TEXT    PRIMARY KEY,
+                conversation_id TEXT    NOT NULL,
+                role            TEXT    NOT NULL,
+                content         TEXT    NOT NULL,
+                timestamp       INTEGER NOT NULL,
+                status          TEXT    NOT NULL DEFAULT 'done',
+                progress_content TEXT,
+                engine          TEXT,
+                model           TEXT,
+                persona         TEXT
+             );
+             INSERT INTO messages (id, conversation_id, role, content, timestamp, status)
+             VALUES ('m1', 'conv-y', 'user', 'msg', 100, 'done');",
+        )
+        .unwrap();
+        // 컬럼 부재 → fallback 으로 일반 helper 결과
+        let rows = load_recent_messages_excluding_rt(&conn, "conv-y", 20);
+        assert_eq!(rows.len(), 1);
+    }
 }

--- a/src-tauri/src/commands/roundtable.rs
+++ b/src-tauri/src/commands/roundtable.rs
@@ -14,7 +14,7 @@ use super::roundtable_helpers::executor::{
     execute_round, RoundStrategy, RoundtableParticipant, SessionMap,
 };
 use super::roundtable_helpers::persist::{
-    archive_transcript, extract_consensus_items, load_consensus, persist_header,
+    archive_transcript, extract_consensus_items, load_consensus, persist_header_with_round,
     save_consensus, save_shared_brief,
 };
 use super::agents_helpers::trace_log::{insert_trace_log, new_trace_id, new_span_id, SpanInfo};
@@ -107,10 +107,14 @@ async fn run_synthesizer_after_round(
     };
 
     // Emit a header message to delimit the synthesizer output in the transcript.
+    // Synthesizer 는 round_num + 1 의 결과로 취급 — single dispatch 시 ContextPack
+    // 이 RT 메시지로 인지 가능 (devbug #263 Task 03).
     let header_content = format!("--- Synthesizer · {} reviewer verdicts ---", round_responses.len());
     let _ = {
         let conn = state.write.lock().ok()?;
-        super::roundtable_helpers::persist::persist_header(&conn, conversation_id, &header_content)
+        super::roundtable_helpers::persist::persist_header_with_round(
+            &conn, conversation_id, &header_content, Some(round_num + 1),
+        )
             .ok()
             .map(|h| {
                 let _ = app.emit("roundtable:progress", &h);
@@ -288,7 +292,7 @@ pub async fn roundtable_run(
         )?;
 
         let header = format!("--- Round 1 · {} · {} ---", mode_label, names);
-        let header_msg = persist_header(&conn, &input.conversation_id, &header)?;
+        let header_msg = persist_header_with_round(&conn, &input.conversation_id, &header, Some(1))?;
         let _ = app.emit("roundtable:progress", &header_msg);
         all_messages.push(header_msg);
     }
@@ -393,7 +397,7 @@ pub async fn roundtable_followup(
 
         round_num = next_round_number(&conn, &input.conversation_id);
         let header = format!("--- Round {} · {} · {} ---", round_num, mode_label, names);
-        let header_msg = persist_header(&conn, &input.conversation_id, &header)?;
+        let header_msg = persist_header_with_round(&conn, &input.conversation_id, &header, Some(round_num))?;
         let _ = app.emit("roundtable:progress", &header_msg);
         all_messages.push(header_msg);
     }
@@ -499,7 +503,7 @@ pub async fn start_roundtable_run(
         conn.execute("INSERT INTO messages (id, conversation_id, role, content, timestamp, status) VALUES (?1, ?2, 'user', ?3, ?4, 'done')", params![id, input.conversation_id, input.prompt, now])?;
 
         let header = format!("--- Round 1 · {} · {} ---", mode_label, names);
-        let header_msg = persist_header(&conn, &input.conversation_id, &header)?;
+        let header_msg = persist_header_with_round(&conn, &input.conversation_id, &header, Some(1))?;
         let _ = app.emit("roundtable:progress", &header_msg);
         (ep, pp, header_msg.id)
     };
@@ -614,7 +618,7 @@ pub async fn start_roundtable_followup(
 
         let rn = next_round_number(&conn, &input.conversation_id);
         let header = format!("--- Round {} · {} · {} ---", rn, mode_label, names);
-        let header_msg = persist_header(&conn, &input.conversation_id, &header)?;
+        let header_msg = persist_header_with_round(&conn, &input.conversation_id, &header, Some(rn))?;
         let _ = app.emit("roundtable:progress", &header_msg);
         (prior, rn, pp, header_msg.id)
     };

--- a/src-tauri/src/commands/roundtable_helpers/deliberative.rs
+++ b/src-tauri/src/commands/roundtable_helpers/deliberative.rs
@@ -13,7 +13,7 @@ use super::executor::{
 use super::prompt::{
     build_round_prompt_with_consensus, build_round_prompt_with_vector_context, PromptSources,
 };
-use super::persist::{load_consensus, persist_streaming_start, persist_streaming_done};
+use super::persist::{load_consensus, persist_streaming_start_with_round, persist_streaming_done};
 
 /// Deliberative: run all participants in parallel via tokio tasks, then persist results.
 /// Each sees prior-round context but not current-round peers.
@@ -62,8 +62,9 @@ pub async fn execute_parallel(
                 "ollama" => "ollama",
                 other => other,
             };
-            let streaming_msg = persist_streaming_start(
+            let streaming_msg = persist_streaming_start_with_round(
                 &conn, conversation_id, &p.name, engine_label, p.model.as_deref(), &sources_json,
+                Some(round_num),
             )?;
             msg_ids.push(streaming_msg.id.clone());
             let _ = app.emit("roundtable:progress", &streaming_msg);

--- a/src-tauri/src/commands/roundtable_helpers/persist.rs
+++ b/src-tauri/src/commands/roundtable_helpers/persist.rs
@@ -9,17 +9,32 @@ use crate::errors::AppError;
 use super::executor::ParticipantResult;
 
 /// Persist a round header (system message) and return it.
+///
+/// 기존 시그니처 보존 — `rt_round_index` NULL. RT 라운드 진행 안에서 호출
+/// 되는 callsite 는 `persist_header_with_round` 사용 (devbug #263 Task 03).
 pub fn persist_header(
     conn: &rusqlite::Connection,
     conversation_id: &str,
     text: &str,
 ) -> Result<Message, AppError> {
+    persist_header_with_round(conn, conversation_id, text, None)
+}
+
+/// Round-index aware variant — Task 03 path. RT round 헤더 / synthesizer
+/// 안내 메시지는 round_index 기록 → ContextPack 의 single agent dispatch 가
+/// 그 메시지를 *raw transcript* 로 prepend 하지 않게 helper 가 필터.
+pub fn persist_header_with_round(
+    conn: &rusqlite::Connection,
+    conversation_id: &str,
+    text: &str,
+    round_index: Option<u32>,
+) -> Result<Message, AppError> {
     let id = Uuid::new_v4().to_string();
     let now = now_epoch_ms();
     conn.execute(
-        "INSERT INTO messages (id, conversation_id, role, content, timestamp, status, engine)
-         VALUES (?1, ?2, 'assistant', ?3, ?4, 'done', 'system')",
-        params![id, conversation_id, text, now],
+        "INSERT INTO messages (id, conversation_id, role, content, timestamp, status, engine, rt_round_index)
+         VALUES (?1, ?2, 'assistant', ?3, ?4, 'done', 'system', ?5)",
+        params![id, conversation_id, text, now, round_index.map(|r| r as i64)],
     )?;
     Ok(Message {
         id,
@@ -37,7 +52,9 @@ pub fn persist_header(
 }
 
 /// Persist a streaming-start placeholder — empty message with status='streaming'.
-/// Returns the Message (with generated id) so callers can emit it and pass the id to chunk events.
+///
+/// 기존 시그니처 보존 — `rt_round_index` NULL. RT 라운드 안에서 참여자
+/// 메시지 저장 시 `persist_streaming_start_with_round` 사용 (Task 03).
 pub fn persist_streaming_start(
     conn: &rusqlite::Connection,
     conversation_id: &str,
@@ -46,15 +63,37 @@ pub fn persist_streaming_start(
     model: Option<&str>,
     sources_json: &str,
 ) -> Result<Message, AppError> {
+    persist_streaming_start_with_round(
+        conn,
+        conversation_id,
+        name,
+        engine_label,
+        model,
+        sources_json,
+        None,
+    )
+}
+
+/// Round-index aware variant — Task 03 path. 참여자 메시지에 rt_round_index
+/// 기록 → main conv 의 단일 dispatch 가 ContextPack 에서 RT 메시지 분리.
+pub fn persist_streaming_start_with_round(
+    conn: &rusqlite::Connection,
+    conversation_id: &str,
+    name: &str,
+    engine_label: &str,
+    model: Option<&str>,
+    sources_json: &str,
+    round_index: Option<u32>,
+) -> Result<Message, AppError> {
     let msg_id = Uuid::new_v4().to_string();
     let now = now_epoch_ms();
     let progress = if sources_json.is_empty() { None } else { Some(sources_json) };
 
     conn.execute(
         "INSERT INTO messages
-         (id, conversation_id, role, content, timestamp, status, progress_content, engine, model, persona)
-         VALUES (?1, ?2, 'assistant', '', ?3, 'streaming', ?4, ?5, ?6, ?7)",
-        params![msg_id, conversation_id, now, progress, engine_label, model, name],
+         (id, conversation_id, role, content, timestamp, status, progress_content, engine, model, persona, rt_round_index)
+         VALUES (?1, ?2, 'assistant', '', ?3, 'streaming', ?4, ?5, ?6, ?7, ?8)",
+        params![msg_id, conversation_id, now, progress, engine_label, model, name, round_index.map(|r| r as i64)],
     )?;
 
     Ok(Message {

--- a/src-tauri/src/commands/roundtable_helpers/sequential.rs
+++ b/src-tauri/src/commands/roundtable_helpers/sequential.rs
@@ -13,7 +13,7 @@ use super::executor::{
 use super::prompt::{
     build_round_prompt_with_consensus, build_round_prompt_with_vector_context, PromptSources,
 };
-use super::persist::{load_consensus, persist_streaming_start, persist_streaming_done};
+use super::persist::{load_consensus, persist_streaming_start_with_round, persist_streaming_done};
 
 /// Sequential: run participants one by one. Each sees prior-round + current-round context.
 pub async fn execute_sequential(
@@ -72,7 +72,15 @@ pub async fn execute_sequential(
 
         let streaming_msg = {
             let conn = state.write.lock().map_err(|_| AppError::Lock)?;
-            persist_streaming_start(&conn, conversation_id, &p.name, engine_label, p.model.as_deref(), &sources_json)?
+            persist_streaming_start_with_round(
+                &conn,
+                conversation_id,
+                &p.name,
+                engine_label,
+                p.model.as_deref(),
+                &sources_json,
+                Some(round_num),
+            )?
         };
         let msg_id = streaming_msg.id.clone();
         let _ = app.emit("roundtable:progress", &streaming_msg);

--- a/src-tauri/src/db/migrations.rs
+++ b/src-tauri/src/db/migrations.rs
@@ -175,6 +175,9 @@ pub fn run(conn: &mut Connection) -> Result<(), AppError> {
     if current < 50 {
         apply_v50(conn)?;
     }
+    if current < 51 {
+        apply_v51(conn)?;
+    }
     Ok(())
 }
 
@@ -1372,6 +1375,39 @@ fn apply_v50(conn: &Connection) -> Result<(), AppError> {
     Ok(())
 }
 
+/// v51 — Roundtable round marker on messages (devbug #263 Task 03).
+///
+/// 배경: RT 와 main conv 가 동일 conversation_id 를 공유 (INV-RTC-3). RT 가
+/// 진행 중일 때 main conv 에서 *모든 에이전트 선택 해제* 후 단일 에이전트
+/// dispatch 시, ContextPack 이 RT round 메시지 (synthesizer / 참여자 / round
+/// header) 를 *주제별 컨텍스트* 인지 *RT 라운드 안* 인지 구분 못 함 → 단일
+/// 에이전트가 *라운드 재실행 흉내* 응답 (시나리오 A 회귀).
+///
+/// 본 migration 은 `messages.rt_round_index` (nullable) 컬럼을 추가만 한다.
+/// RT 안에서 저장된 메시지는 round_num 기록 → ContextPack 의 *single agent
+/// dispatch* 가 그 메시지를 *raw transcript* 로 prepend 하지 않게 helper 가
+/// 필터 (Plan §3 Task 03).
+///
+/// 정책:
+/// - INV-RTC-3 (conv 공유 보존): 별 conv 분리 안 함
+/// - INV-RTC-7 (RT 미사용 영향 0): 컬럼 NULL 이면 기존 동작 그대로
+/// - 후방 호환: 기존 메시지 row 의 rt_round_index 는 NULL → ContextPack 이
+///   *main conv 메시지* 로 처리 (시나리오 A 회복 path 가 fix 후 RT 안에서
+///   저장되는 메시지부터 적용)
+fn apply_v51(conn: &Connection) -> Result<(), AppError> {
+    add_column_if_missing(conn, "messages", "rt_round_index", "INTEGER")?;
+    conn.execute_batch(
+        "CREATE INDEX IF NOT EXISTS idx_messages_rt_round
+            ON messages(conversation_id, rt_round_index)
+            WHERE rt_round_index IS NOT NULL;",
+    )?;
+    conn.execute(
+        "INSERT INTO schema_version (version, applied_at) VALUES (51, ?1)",
+        [now_epoch_ms()],
+    )?;
+    Ok(())
+}
+
 /// Milliseconds since Unix epoch (for Message.timestamp)
 pub fn now_epoch_ms() -> i64 {
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -2262,5 +2298,85 @@ mod tests {
         apply_v50(&conn).expect("apply_v50 on empty db");
         let cur = current_version(&conn).expect("current_version");
         assert_eq!(cur, 50);
+    }
+
+    // ─── v51 — messages.rt_round_index column (devbug #263 Task 03) ──────
+
+    /// `messages.rt_round_index` 컬럼이 nullable 로 추가되고 기존 row 가 NULL
+    /// 로 보존되는지. 후방 호환 검증.
+    #[test]
+    fn v51_adds_rt_round_index_nullable_and_preserves_existing_rows() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE schema_version (version INTEGER PRIMARY KEY, applied_at INTEGER NOT NULL);
+             CREATE TABLE conversations (id TEXT PRIMARY KEY);
+             CREATE TABLE messages (
+                id              TEXT    PRIMARY KEY,
+                conversation_id TEXT    NOT NULL,
+                role            TEXT    NOT NULL,
+                content         TEXT    NOT NULL,
+                timestamp       INTEGER NOT NULL,
+                status          TEXT    NOT NULL DEFAULT 'done',
+                progress_content TEXT,
+                engine          TEXT,
+                model           TEXT,
+                persona         TEXT
+             );
+             INSERT INTO conversations (id) VALUES ('conv-x');
+             INSERT INTO messages (id, conversation_id, role, content, timestamp, status)
+             VALUES ('m-old', 'conv-x', 'user', 'pre-v51 message', 100, 'done');",
+        )
+        .unwrap();
+
+        apply_v51(&conn).expect("apply_v51");
+
+        // 컬럼 존재 + 기존 row 의 rt_round_index 가 NULL
+        let rt_idx: Option<i64> = conn
+            .query_row(
+                "SELECT rt_round_index FROM messages WHERE id = 'm-old'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(rt_idx.is_none(), "기존 row 는 NULL");
+
+        // INDEX 존재
+        let index_exists: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = 'idx_messages_rt_round'",
+                [], |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(index_exists, 1);
+
+        let cur = current_version(&conn).expect("current_version");
+        assert_eq!(cur, 51);
+    }
+
+    /// idempotent: 두 번째 적용 시도 시 add_column_if_missing 가 panic 없이 skip
+    /// (run() 의 schema_version 가드와 별개로, 함수 자체의 안전성).
+    #[test]
+    fn v51_idempotent_when_column_already_exists() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE schema_version (version INTEGER PRIMARY KEY, applied_at INTEGER NOT NULL);
+             CREATE TABLE conversations (id TEXT PRIMARY KEY);
+             CREATE TABLE messages (
+                id              TEXT    PRIMARY KEY,
+                conversation_id TEXT    NOT NULL,
+                role            TEXT    NOT NULL,
+                content         TEXT    NOT NULL,
+                timestamp       INTEGER NOT NULL,
+                status          TEXT    NOT NULL DEFAULT 'done',
+                progress_content TEXT,
+                engine          TEXT,
+                model           TEXT,
+                persona         TEXT,
+                rt_round_index  INTEGER
+             );",
+        )
+        .unwrap();
+        // 컬럼이 이미 있는 상태에서 호출 → ALTER ADD COLUMN skip + version row insert
+        apply_v51(&conn).expect("apply_v51 on pre-existing column");
     }
 }


### PR DESCRIPTION
## Summary

devbug 외부 사용자 보고 [#263](https://github.com/hang-in/tunaFlow/issues/263) — RT 환각/오동작 3 영역 회복의 **PR-2 (Task 03+04)**. PR-1 의 schema foundation (v50) 위에 marker 격리 + Architect 인계.

- `messages.rt_round_index` (nullable) 컬럼 v51 + 부분 INDEX
- RT round 헤더 + 참여자 메시지 + synthesizer 헤더 모두 round_index 기록
- `load_recent_messages_excluding_rt()` 신규 helper — single agent dispatch 시 RT round transcript 제외 (시나리오 A 회복)
- `build_rt_consensus_section()` 신규 — `## Roundtable Consensus` 섹션 명시 주입 (시나리오 C 회복)
- ContextData 에 `rt_consensus_section` 필드 + prompt_assembly findings 다음에 push

## 관련 문서

- Plan SSOT: [`docs/plans/roundtableConsensusPersistencePlan_2026-05-07.md`](https://github.com/hang-in/tunaFlow/blob/main/docs/plans/roundtableConsensusPersistencePlan_2026-05-07.md)
- 시나리오 SSOT: [`docs/reference/roundtableReproductionScenarios_2026-05-07.md`](https://github.com/hang-in/tunaFlow/blob/main/docs/reference/roundtableReproductionScenarios_2026-05-07.md)
- 핸드오프: [`docs/prompts/roundtableConsensusPersistenceDeveloperHandoff_2026-05-07.md`](https://github.com/hang-in/tunaFlow/blob/main/docs/prompts/roundtableConsensusPersistenceDeveloperHandoff_2026-05-07.md)
- Issue: Refs #263 (부분 해소 — PR-3 에서 Closes)

## Verification (§4)

- `cargo check`: PASS
- `cargo test --lib`: 623 → 633 (+10 신규: rt_consensus_section 4 + rt_filter 4 + migration v51 2)
- `tsc --noEmit`: PASS
- `vitest run`: 422 (baseline 유지, frontend 미변경)

## 회귀 grep 가드

- `rg rt_round_index src-tauri/`: 컬럼 정의 + persist callsites + load_recent_messages_excluding_rt + ContextPack filter + migration v51
- `rg build_rt_consensus_section src-tauri/`: 신규 helper + Architect dispatch (context_loading.rs 호출) + mod.rs export
- `git diff src/`: 빈 출력 (frontend 미변경)
- `git diff src-tauri/src/commands/meta_agent/`: 빈 출력

## DO NOT 영역 침범 없음

- INV-RTC-1 (round 본체): round count / 참여자 / 모드 변경 0
- INV-RTC-2 (Voting + MoA Synthesizer): 응답 판단 알고리즘 변경 0
- INV-RTC-3 (conv 공유 보존): 별 conv 분리 안 함, marker 만으로 격리
- INV-RTC-4 (기존 ContextPack 섹션 보존): findings_section 의 brief LIMIT 3 fallback 그대로
- INV-RTC-5 (branchSessionPolicy INV-1~5): branchSession 영역 diff 0
- INV-RTC-6 (migration destructive 금지): v51 도 add_column_if_missing + INDEX 추가만
- INV-RTC-7/8 (RT 미사용 영향 0): rt_round_index = NULL 시 두 helper 결과 동일, 빈 결과 섹션 skip 모두 검증
- `src-tauri/src/commands/meta_agent/`: diff 0
- `src/` (frontend): diff 0
- README.md / CLAUDE.md: diff 0

## 다음 단계

- PR-3 (`test/rt-consensus-coverage-263`): Task 05+06 — Plan §3 명시 4 unit test 의 *부족분* 보강 (consensus_persisted_across_rounds / next_round_prompt_includes_prior_consensus / single_agent_dispatch_skips_rt_transcript / architect_context_pack_includes_consensus_section — PR-1/2 에서 이미 모두 추가됨, PR-3 는 통합 검증 + CHANGELOG / 시나리오 회복 / dataModel docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)