### PR TITLE
test(rt): RT consensus integration + budget fix + docs (Task 05+06 / #263)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,58 @@ All notable changes to tunaFlow are recorded here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 versioning follows [SemVer](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+**Roundtable 합의 영구화 + RT marker 격리 + Architect ContextPack 인계** —
+외부 사용자 (devbug, [#263](https://github.com/hang-in/tunaFlow/issues/263))
+보고 회복. RT 환각/오동작 3 영역 (라운드 간 합의 망각 / main conv 단일
+dispatch 시 합의 무시 / Architect 가 RT 대화 내역 접근 못 함) 의 root cause
+3중 복합 fix. *"사용자 RT 사용 포기"* 단계 → 정상 사용 회복 path 도입.
+
+### Added
+
+- **`roundtable_consensus` 테이블** (DB migration v50) — RT round 간 axis
+  별 합의 항목을 영구 누적. 컬럼: id / conversation_id / round_index / axis /
+  decision / participants(json) / confidence / created_at. INDEX:
+  `idx_roundtable_consensus_conv_round`.
+- **합의 추출 helper** — synthesizer 응답에서 `<!-- tunaflow:consensus -->`
+  JSON fence (primary) 또는 `## Agreed axes` markdown bullet (fallback) 으로
+  axis 추출 후 `roundtable_consensus` row 누적.
+- **synthesizer prompt 의 *"## Consensus reached so far"* 섹션** — 라운드
+  N+1 의 synthesizer + 참여자 prompt 에 라운드 1~N 의 누적 합의 명시 포함.
+  같은 합의 재시도 환각 차단 (시나리오 B 회복 핵심 path).
+- **`messages.rt_round_index` 컬럼** (DB migration v51, nullable) — RT round
+  헤더 + 참여자 메시지 + synthesizer 헤더에 round_num 기록. 부분 INDEX
+  `idx_messages_rt_round`.
+- **`load_recent_messages_excluding_rt()` helper** — single agent dispatch
+  시 ContextPack 의 `current_messages` 가 RT round transcript 를 *주제별
+  컨텍스트* 로 prepend 하지 않음 (시나리오 A 회복 핵심 path).
+- **`build_rt_consensus_section()` helper** — Architect dispatch / single
+  agent dispatch 가 받는 ContextPack 에 *"## Roundtable Consensus"* 섹션
+  명시 인계. 라운드별 axis / decision / participants 누적 list (시나리오
+  C 회복 핵심 path). branch shadow conv 도 cover.
+
+### Fixed
+
+- **시나리오 A** (#263 보고 #1) — RT 진행 중 단일 에이전트 follow-up 질의
+  시 *라운드 재실행 흉내* / *합의 부정* 환각 회복. ContextPack 이 RT round
+  transcript 를 transcript 영역에서 제외하고 합의는 별 섹션으로 인계.
+- **시나리오 B** (#263 보고 #2) — RT 5 라운드 이상 진행 시 *같은 합의
+  재시도* / *3 fail 임계값 누적* / *사용자 fallback 영구 반복* 회복. 누적
+  합의가 synthesizer + 참여자 prompt 에 명시 등장.
+- **시나리오 C** (#263 보고 #3) — RT 종료 후 Architect dispatch 시 *마지막
+  라운드만 정리* 회복. 라운드별 누적 합의 + 참여자 의견 명시 인계.
+
+### Notes
+
+- DB migration v50 + v51 자동 진행. 기존 사용자 데이터 보존 (기존
+  `roundtable_brief` memo / messages 의 NULL `rt_round_index` 모두 그대로).
+- INV-RTC-1~8 모두 보존: round 본체 알고리즘 / Voting + MoA Synthesizer
+  본체 / conv 공유 정책 / 기존 ContextPack 섹션 / branchSessionPolicy
+  INV-1~5 / migration destructive 금지 / RT 미사용 영향 0.
+- Frontend 변경 0 (backend 영역). 사용자 가시 변화는 *RT 진행 동작 회복*
+  으로 표면됨.
+
 ## [0.1.6-beta] - 2026-05-04
 
 **Workflow architectural change** — Reviewer verdict 처리 책임이 Meta-agent inbox

--- a/docs/reference/dataModelRevised.md
+++ b/docs/reference/dataModelRevised.md
@@ -323,6 +323,40 @@ tools:
 
 ---
 
+### 1.11 RoundtableConsensus
+
+**정의**: Roundtable (RT) 라운드에서 도달한 axis 별 합의 항목. 라운드 간 누적 영구화.
+
+**책임**: 라운드 N+1 의 synthesizer + 참여자 prompt 에 *"이미 합의된 axis"* 명시 인계 + Architect dispatch 시 ContextPack 의 *"## Roundtable Consensus"* 섹션 인계 (devbug #263 회복).
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| id | string (PK) | UUID |
+| conversationId | string (FK→Conversation) | RT 진행 conv (또는 brand shadow `branch:<id>`) |
+| roundIndex | integer | 합의 도달 라운드 번호 (1..N) |
+| axis | string | 합의 주제 키워드 (예: *"compression"*, *"budget"*) |
+| decision | string | 1~3 문장 합의 요약 (synthesizer 추출) |
+| participants | string[] (JSON) | 합의 참여자 이름 list (예: `["claude","codex"]`) |
+| confidence | real (0.0-1.0) | synthesizer 의 합의 신뢰도 판단 |
+| createdAt | integer (epoch ms) | persist 시각 |
+
+**저장**: SQLite `roundtable_consensus` 테이블 (DB migration v50, 2026-05-07).
+INDEX: `idx_roundtable_consensus_conv_round (conversation_id, round_index)`.
+
+**관련 컬럼**: `messages.rt_round_index` (DB migration v51, nullable) — RT round
+헤더 + 참여자 메시지 + synthesizer 헤더에 round_num 기록. ContextPack 의
+`load_recent_messages_excluding_rt()` 가 `rt_round_index IS NULL` 만 collect →
+single agent dispatch 가 RT round transcript 를 *주제별 컨텍스트* 로 prepend
+하지 않음 (시나리오 A 회복).
+
+**근거**: `src-tauri/src/db/migrations.rs:apply_v50/apply_v51`,
+`src-tauri/src/commands/roundtable_helpers/persist.rs:save_consensus/load_consensus/extract_consensus_items`,
+`src-tauri/src/commands/agents_helpers/context_pack/db_queries.rs:build_rt_consensus_section`,
+Plan: `docs/plans/roundtableConsensusPersistencePlan_2026-05-07.md`,
+시나리오: `docs/reference/roundtableReproductionScenarios_2026-05-07.md`
+
+---
+
 ## 2. Relationship Model
 
 ```text
@@ -489,10 +523,11 @@ ContextPack                              (인메모리 조합, 실행 시점에 
 |--------|--------|------|-----------|
 | `projects` | Project | V1 | PK: key |
 | `conversations` | Conversation | V1 (+V2: resume_token) | (project_key), (updated_at DESC) |
-| `messages` | Message | V1 | (conversation_id, timestamp) |
+| `messages` | Message | V1 (+V51: rt_round_index) | (conversation_id, timestamp), (conversation_id, rt_round_index) WHERE NOT NULL |
 | `branches` | Branch | V1 | (conversation_id), (session_id) |
 | `messages_fts` | Message (검색) | V1 (스키마만, 미사용) | FTS5 가상 테이블 |
 | `memos` | Memo | V1 | (project_key), (message_id) |
+| `roundtable_consensus` | RoundtableConsensus | V50 | (conversation_id, round_index) |
 | `artifacts` | Artifact | V1 | (conversation_id) |
 | `trace_log` | TraceEntry | V1 (스키마만, 미사용) | (conversation_id) |
 | `schema_version` | 마이그레이션 추적 | V0 | PK: version |

--- a/docs/reference/roundtableReproductionScenarios_2026-05-07.md
+++ b/docs/reference/roundtableReproductionScenarios_2026-05-07.md
@@ -161,6 +161,22 @@ devbug 외부 사용자에게 진행 상황 안내:
 - 시나리오 검증 결과 (사용자 환경에서 재현되는지) 사용자 회신 받으면 plan §0.3 가설 확정/탈락 확정
 - 시나리오 자체에 *"환경 차이로 재현 안 되는 항목"* 발견 시 별 추가 issue 분기
 
-## 7. 변경 이력
+## 7. Fix 후 회복 결과 (PR-1 + PR-2 + PR-3 머지)
+
+| 시나리오 | Fix 진입점 | 회복 메커니즘 | 회귀 가드 unit test |
+|---|---|---|---|
+| **A** (단일 질의 시 합의 무시) | PR-2 Task 03 | `messages.rt_round_index` 컬럼 + `load_recent_messages_excluding_rt()` 가 single agent dispatch 시 RT round transcript 를 *주제별 컨텍스트* 영역에서 제외. 합의는 PR-2 Task 04 의 `build_rt_consensus_section()` 으로 별 섹션 인계 | `single_agent_dispatch_skips_rt_transcript`, `legacy_loader_includes_rt_messages`, `architect_context_pack_includes_consensus_section` |
+| **B** (라운드 길어지면 합의 망각) | PR-1 Task 02 | `roundtable_consensus` 테이블 영구화 + synthesizer 가 `<!-- tunaflow:consensus -->` JSON fence 또는 `## Agreed axes` markdown 으로 합의 추출 → `save_consensus()` row 누적 → 라운드 N+1 prompt 의 *"## Consensus reached so far"* 섹션이 라운드 1~N 합의 명시 포함 | `consensus_persisted_across_rounds`, `consensus_isolated_per_conversation`, `next_round_prompt_includes_prior_consensus`, `extract_consensus_from_json_marker`, `extract_consensus_from_markdown_fallback` |
+| **C** (Architect 가 RT 대화 내역 접근 못 함) | PR-2 Task 04 | `build_rt_consensus_section()` 이 `roundtable_consensus` 테이블 조회 → ContextPack assembly 의 findings 다음에 *"## Roundtable Consensus"* 섹션 push. branch shadow conv 도 부모 conv 검색에 cover | `architect_context_pack_includes_consensus_section`, `consensus_includes_branch_shadow_conversations`, `rt_consensus_section_assembled_into_prompt_and_meta` |
+
+회귀 가드 e2e (사용자 환경 검증으로 위임):
+- 시나리오 A 의 *실 동작 환각 표면* (단일 질의가 라운드 재실행 흉내) 가 fix 후 *"단일 에이전트가 합의 인지 + follow-up answer"* 로 회복되는지
+- 시나리오 B 의 *5 라운드 이상 진행 시* 같은 합의 재시도 환각이 사라지는지
+- 시나리오 C 의 *Architect 응답에 라운드 1~N 누적 합의 + 참여자 의견 등장* 하는지
+
+위 3 영역은 mcp 환경 차단으로 Architect 직접 e2e 캡처 불가 — v0.1.7-beta release 후 사용자 (devbug) 환경 e2e 검증으로 최종 확인 (Plan §6 / 핸드오프 §5).
+
+## 8. 변경 이력
 
 - 2026-05-07 초안 작성 (devbug #263 보고 직후, plan 작성 동시 시점)
+- 2026-05-07 PR-1 (#265) + PR-2 (#266) + PR-3 머지 후 §7 Fix 후 회복 결과 추가

--- a/src-tauri/src/commands/agents_helpers/send_common/prompt_assembly.rs
+++ b/src-tauri/src/commands/agents_helpers/send_common/prompt_assembly.rs
@@ -160,6 +160,9 @@ pub fn assemble_prompt(
         guardrail::SectionBudget { name: "plan",       content_len: data.plan_section.as_ref().map_or(0, |s| s.len()),     weight: 1.5, min_chars: 500,  max_chars: guardrail::MAX_PLAN_SECTION },
         guardrail::SectionBudget { name: "plan-doc",   content_len: data.plan_document.as_ref().map_or(0, |s| s.len()),    weight: 2.0, min_chars: 1000, max_chars: 6000 },
         guardrail::SectionBudget { name: "findings",   content_len: data.findings_section.as_ref().map_or(0, |s| s.len()), weight: 1.2, min_chars: 500,  max_chars: guardrail::MAX_FINDINGS_SECTION },
+        // RT consensus 는 findings 와 동일 weight + min_chars (devbug #263 Task 04).
+        // 라운드별 1줄 axis 누적 → 일반적으로 짧음, MAX_FINDINGS_SECTION 안에서 충분.
+        guardrail::SectionBudget { name: "rt-consensus", content_len: data.rt_consensus_section.as_ref().map_or(0, |s| s.len()), weight: 1.2, min_chars: 500, max_chars: guardrail::MAX_FINDINGS_SECTION },
         guardrail::SectionBudget { name: "artifacts",  content_len: data.artifacts_section.as_ref().map_or(0, |s| s.len()),weight: 1.0, min_chars: 300,  max_chars: guardrail::MAX_ARTIFACTS_SECTION },
         // Supplementary sources
         guardrail::SectionBudget { name: "skills",     content_len: if data.active_skills.is_empty() { 0 } else { 2000 },  weight: 0.8, min_chars: 500,  max_chars: guardrail::MAX_SKILLS_SECTION },
@@ -487,7 +490,7 @@ pub fn assemble_prompt(
         // (devbug #263 Task 04). 빈 결과는 None → 섹션 자체 skip (INV-RTC-7/8).
         if let Some(s) = guardrail::truncate_section(
             data.rt_consensus_section.clone(),
-            dyn_cap("findings"),
+            dyn_cap("rt-consensus"),
         ) {
             sections.push(s);
             included_sections.push("rt-consensus".into());
@@ -1141,5 +1144,68 @@ mod tests {
             "engine 만 있는 케이스에도 sender 줄 출력: {}", assembled
         );
         assert!(!assembled.contains("persona="));
+    }
+
+    // ─── RT consensus integration (devbug #263 Task 04+05) ─────────────────
+
+    /// Architect dispatch path 의 통합 검증: ContextData.rt_consensus_section
+    /// 이 채워져 있으면 prompt 본문에 *"## Roundtable Consensus"* 섹션 등장 +
+    /// `meta.sections` 에 `rt-consensus` 라벨 등장. 시나리오 C 회복 e2e 가드.
+    #[test]
+    fn rt_consensus_section_assembled_into_prompt_and_meta() {
+        let tmp = TempDir::new().unwrap();
+        let mut data = empty_context_data(Some(tmp.path().to_string_lossy().to_string()));
+        data.rt_consensus_section = Some(
+            "## Roundtable Consensus\n\n\
+             These axes are *already agreed* in roundtable rounds — Architect / single\n\
+             agent dispatch builds on top of these without re-litigating.\n\n\
+             - **R1** **compression** _(by claude, codex)_: Lite/Standard/Full automode\n\
+             - **R2** **budget** _(by gemini)_: dynamic per-section budget"
+                .into(),
+        );
+        data.context_mode_override = Some("standard".into());
+
+        let (assembled, _sys, meta) = assemble_prompt(&data, None);
+
+        assert!(
+            meta.sections.contains(&"rt-consensus".to_string()),
+            "meta.sections 에 rt-consensus 라벨 등장해야: {:?}", meta.sections,
+        );
+        assert!(
+            assembled.contains("## Roundtable Consensus"),
+            "prompt 본문에 RT 합의 섹션 헤딩 등장: {}", assembled,
+        );
+        assert!(
+            assembled.contains("**R1** **compression**"),
+            "라운드별 axis 누적 list 등장",
+        );
+        assert!(
+            assembled.contains("**R2** **budget**"),
+            "라운드 2 합의도 그대로 인계",
+        );
+        assert!(
+            assembled.contains("Lite/Standard/Full automode"),
+            "decision 본문 truncate 안 됨 (짧은 결정)",
+        );
+    }
+
+    /// rt_consensus_section None → meta 에 rt-consensus 부재 (INV-RTC-7/8 fast
+    /// path). RT 미사용 / 첫 라운드 영향 0.
+    #[test]
+    fn empty_rt_consensus_skips_section() {
+        let tmp = TempDir::new().unwrap();
+        let mut data = empty_context_data(Some(tmp.path().to_string_lossy().to_string()));
+        data.rt_consensus_section = None;
+        data.context_mode_override = Some("standard".into());
+
+        let (assembled, _sys, meta) = assemble_prompt(&data, None);
+        assert!(
+            !meta.sections.contains(&"rt-consensus".to_string()),
+            "rt-consensus 섹션 미등장 — RT 미사용 fast path",
+        );
+        assert!(
+            !assembled.contains("Roundtable Consensus"),
+            "prompt 본문에도 RT 합의 섹션 부재",
+        );
     }
 }


### PR DESCRIPTION
## Summary

devbug 외부 사용자 보고 [#263](https://github.com/hang-in/tunaFlow/issues/263) — RT 환각/오동작 3 영역 회복의 **PR-3 (Task 05+06)**. Plan B 의 마지막 PR — 통합 e2e 가드 + 사용자 가시 변화 docs.

- prompt_assembly 통합 unit test 2건 신규 + budget allocation fix (`rt-consensus` 항목 별 budget 분리)
- CHANGELOG.md `[Unreleased]` 섹션 — 사용자 가시 변화 4항목 (시나리오 A/B/C 회복 + DB migration)
- `docs/reference/dataModelRevised.md` §1.11 RoundtableConsensus 신규 + 테이블 카탈로그 갱신
- `docs/reference/roundtableReproductionScenarios_2026-05-07.md` §7 Fix 후 회복 결과 + §8 변경 이력

## 관련 문서

- Plan SSOT: [`docs/plans/roundtableConsensusPersistencePlan_2026-05-07.md`](https://github.com/hang-in/tunaFlow/blob/main/docs/plans/roundtableConsensusPersistencePlan_2026-05-07.md)
- 시나리오 SSOT: [`docs/reference/roundtableReproductionScenarios_2026-05-07.md`](https://github.com/hang-in/tunaFlow/blob/main/docs/reference/roundtableReproductionScenarios_2026-05-07.md)
- 핸드오프: [`docs/prompts/roundtableConsensusPersistenceDeveloperHandoff_2026-05-07.md`](https://github.com/hang-in/tunaFlow/blob/main/docs/prompts/roundtableConsensusPersistenceDeveloperHandoff_2026-05-07.md)
- Issue: Closes #263 (마지막 PR — *Closes* 키워드는 PR-3 에만)

## Verification (§4)

- `cargo check`: PASS
- `cargo test --lib`: 633 → 635 (+2 신규: rt_consensus_section_assembled / empty_rt_consensus_skips)
- `tsc --noEmit`: PASS
- `vitest run`: 422 (baseline 유지, frontend 미변경)

## Plan §3 Task 05 unit test 4건 매트릭스 (PR-1/2/3 통합)

| Plan §3 Task 05 명시 test | 추가된 PR | 위치 |
|---|---|---|
| `consensus_persisted_across_rounds` | PR-1 | `roundtable_helpers/persist.rs` |
| `next_round_prompt_includes_prior_consensus` | PR-1 | `roundtable_helpers/prompt.rs` |
| `single_agent_dispatch_skips_rt_transcript` | PR-2 | `commands/context_queries.rs` |
| `architect_context_pack_includes_consensus_section` | PR-2 | `agents_helpers/context_pack/db_queries.rs` |

추가 가드 (PR-1/2/3 합산 누적, 신규 Rust unit test 18건):
- PR-1: 9 (persist consensus 5 + prompt consensus 2 + migration v50 2)
- PR-2: 10 (rt_consensus_section 4 + rt_filter 4 + migration v51 2)
- PR-3: 2 (prompt_assembly integration 2)

## 회귀 grep 가드

- 신규 4 unit test 모두 PR-1/2 에서 등장 + PR-3 의 통합 test 2건 추가 → cargo test 가 모두 통과
- README.md / CLAUDE.md 변경 0 (cross-cutting docs 차단)
- `git diff src/`: 빈 출력 (frontend 미변경)

## DO NOT 영역 침범 없음

- INV-RTC-1~8 모두 PR-1/2 에서 보존 검증 통과
- src-tauri/src/commands/meta_agent/: diff 0
- src/ (frontend): diff 0
- README.md / CLAUDE.md: diff 0

## 다음 단계 (본 PR scope 외)

- v0.1.7-beta release publish (별 PR + tunaflow-release-cycle 스킬) — DB migration v50 + v51 + 사용자 가시 변화 4 항목 → minor bump
- devbug 외부 issue #263 회복 안내 댓글 (Architect 영역) — release publish 후

🤖 Generated with [Claude Code](https://claude.com/claude-code)