### PR TITLE
fix(tauri): platform-conditional titleBar config + WindowControls 진단 (#264)

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -19,8 +19,7 @@
         "minHeight": 480,
         "visible": false,
         "theme": "Dark",
-        "titleBarStyle": "Overlay",
-        "hiddenTitle": true
+        "decorations": true
       }
     ],
     "security": {

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "app": {
+    "windows": [
+      {
+        "titleBarStyle": "Overlay",
+        "hiddenTitle": true
+      }
+    ]
+  }
+}

--- a/src/components/tunaflow/TitleBar.tsx
+++ b/src/components/tunaflow/TitleBar.tsx
@@ -1,10 +1,17 @@
 import { useState, useEffect } from "react";
 import { invoke } from "@tauri-apps/api/core";
-import { isWindows as detectIsWindows } from "@/lib/platform";
+import { isWindows as detectIsWindows, detectPlatformDiagnostic } from "@/lib/platform";
 import { useChatStore } from "@/stores/chatStore";
 import { WindowControls } from "./WindowControls";
 
 const isWindows = detectIsWindows();
+
+// Issue #264 (Windows 캡션바 누락) 진단: PR #237 의 set_decorations(false) 가
+// 호출되면 native chrome 이 사라지고 그 자리를 WindowControls 가 차지해야 한다.
+// 사용자 환경에서 isWindows 가 false 로 평가되면 WindowControls 가 미마운트되어
+// 캡션 영역 통째로 공백. 첫 mount 시 1회 진단 dump 으로 webview UA 의 실제
+// 값과 detection 결과를 노출한다 (devtools console 에서 확인).
+console.warn("[TitleBar] platform diag", { isWindows, ...detectPlatformDiagnostic() });
 
 /**
  * Unified title bar (mac / Windows).

--- a/src/components/tunaflow/WindowControls.tsx
+++ b/src/components/tunaflow/WindowControls.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { Minus, Square, X, Copy } from "lucide-react";
+import { detectPlatformDiagnostic } from "@/lib/platform";
 
 /**
  * Custom Window Controls — Windows 11 native parity (46×32 sq buttons).
@@ -11,6 +12,13 @@ import { Minus, Square, X, Copy } from "lucide-react";
  * Decisions: Q-WT-1 (Windows native shape) / Q-WT-2 (status-rejected close hover)
  */
 export function WindowControls() {
+  // Issue #264 진단: WindowControls 가 mount 됐다는 사실 자체를 dev tools 에
+  // 노출. 보고된 캡션바 누락이 (a) 컴포넌트 미마운트 vs (b) 마운트는 됐으나
+  // 보이지 않음 중 어느 쪽인지 판단할 수 있게 한다. mount 1회만 fire.
+  useEffect(() => {
+    console.warn("[WindowControls] mounted", detectPlatformDiagnostic());
+  }, []);
+
   const [isMaximized, setIsMaximized] = useState(false);
 
   useEffect(() => {

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -12,20 +12,74 @@
  * Windows/Linux on `tauri-plugin-notification` (zero behavior change).
  */
 
-function detect(): "macos" | "windows" | "other" {
-  if (typeof navigator === "undefined") return "other";
-  const ua = navigator.userAgent || "";
-  if (/Mac|Macintosh|MacIntel/i.test(ua)) return "macos";
-  if (/Win/i.test(ua)) return "windows";
-  return "other";
+/**
+ * Detect host OS from the webview environment.
+ *
+ * Resolution order (most reliable first):
+ *  1. `navigator.userAgentData.platform` (modern UA-CH spec; "macOS",
+ *     "Windows", "Linux" tokens). Tauri 2 webview surfaces this on Win11
+ *     22H2+ and recent macOS / Linux.
+ *  2. `navigator.userAgent` regex (legacy fallback). Matches "Mac" /
+ *     "Macintosh" / "Win" / "Windows NT" tokens that every Tauri 2 webview
+ *     should emit.
+ *  3. `"other"` — neither source recognised the host. Caller is expected
+ *     to render a safe default (no platform-specific branch).
+ *
+ * The diagnostic snapshot exposed by `detectPlatformDiagnostic()` makes the
+ * decision visible to issue #264 reproduction (Windows captionbar missing).
+ */
+export type DetectedPlatform = "macos" | "windows" | "other";
+
+export interface PlatformDiagnostic {
+  detected: DetectedPlatform;
+  source: "userAgentData" | "userAgent" | "fallback";
+  userAgent: string;
+  userAgentDataPlatform: string | null;
 }
 
-const cached = detect();
+function snapshot(): PlatformDiagnostic {
+  if (typeof navigator === "undefined") {
+    return { detected: "other", source: "fallback", userAgent: "", userAgentDataPlatform: null };
+  }
+  const ua = navigator.userAgent || "";
+  // userAgentData is gated behind secure-context + recent Chromium; treat as
+  // optional. Tauri 2's webview2 surfaces it on Win11 22H2+.
+  const uaData = (navigator as Navigator & {
+    userAgentData?: { platform?: string };
+  }).userAgentData;
+  const uaDataPlatform = uaData?.platform ?? null;
+  if (uaDataPlatform) {
+    if (/mac/i.test(uaDataPlatform)) {
+      return { detected: "macos", source: "userAgentData", userAgent: ua, userAgentDataPlatform: uaDataPlatform };
+    }
+    if (/win/i.test(uaDataPlatform)) {
+      return { detected: "windows", source: "userAgentData", userAgent: ua, userAgentDataPlatform: uaDataPlatform };
+    }
+  }
+  if (/Mac|Macintosh|MacIntel/i.test(ua)) {
+    return { detected: "macos", source: "userAgent", userAgent: ua, userAgentDataPlatform: uaDataPlatform };
+  }
+  if (/Win/i.test(ua)) {
+    return { detected: "windows", source: "userAgent", userAgent: ua, userAgentDataPlatform: uaDataPlatform };
+  }
+  return { detected: "other", source: "fallback", userAgent: ua, userAgentDataPlatform: uaDataPlatform };
+}
+
+const cached = snapshot();
 
 export function isMacOS(): boolean {
-  return cached === "macos";
+  return cached.detected === "macos";
 }
 
 export function isWindows(): boolean {
-  return cached === "windows";
+  return cached.detected === "windows";
+}
+
+/**
+ * Returns the diagnostic snapshot computed at module load. Components can
+ * `console.warn` this when issue #264 (Windows captionbar missing) is being
+ * reproduced — surfaces the user-agent strings the gate actually saw.
+ */
+export function detectPlatformDiagnostic(): PlatformDiagnostic {
+  return cached;
 }


### PR DESCRIPTION
Closes #264

## Symptom (외부 사용자 devbug, 2026-05-06)
> "Windows 용을 설치하면 창에 캡션바나 닫기 버튼 최소화/최대화 버튼 등이 나타나지 않습니다. 따라서 창을 옮기거나 크기를 바꿀 수도 없습니다. 설정도 그렇고 어디에도 접근이 안 되며 Open Project만 가능합니다."

회귀 시점: v0.1.5-beta Windows 자산부터 잠재. v0.1.6-beta 첫 보고.

## 옵션 B 채택 사유
Plan (`windowsCaptionBarMissingPlan_2026-05-07.md`) 의 root-cause 가설은 macOS-only `titleBarStyle:"Overlay"` + `hiddenTitle:true` 의 cross-platform 영향 (가설 a/b). 그러나 PR #237 의 `bootstrap/window.rs::set_decorations(false)` 가 **명시적으로 native chrome 을 제거**하므로 config 단독은 부분 fix 일 수 있음. 진짜 root cause 가 (a) config + (b) frontend `WindowControls` 의 platform detection 둘 다 의심 영역이라 사용자 결정으로 동시 진행.

## Changes
**Task 01 — Tauri 2 platform-conditional config**
- `src-tauri/tauri.macos.conf.json` (신규): macOS 전용 `titleBarStyle: "Overlay"` + `hiddenTitle: true` 분리.
- `src-tauri/tauri.conf.json`: 위 두 키 제거 + `decorations: true` 명시 (Windows / Linux 의 native chrome 의도 표현).

**진단 보강 — `isWindows` gate 신뢰성**
- `src/lib/platform.ts`: 단일 userAgent regex → `userAgentData.platform` 우선 + userAgent regex 폴백 + `detectPlatformDiagnostic()` snapshot export. 두 source 결과 + UA 원문 dump.
- `src/components/tunaflow/TitleBar.tsx`: module-load 시 1회 `console.warn("[TitleBar] platform diag", ...)`.
- `src/components/tunaflow/WindowControls.tsx`: mount useEffect 에서 1회 `console.warn("[WindowControls] mounted", ...)` — 컴포넌트 마운트 자체가 일어났는지 사용자 devtools 에서 확인 가능. **(a) 미마운트 vs (b) 마운트는 됐으나 invisible 구분**.

## Plan Non-goals override 명시
Plan §2 / handoff §3 의 "TitleBar.tsx 변경 금지" (INV-WCB-4) 는 사용자 결정으로 *진단 console.warn 1줄 + import 1줄* 범위 안에서 의도적 override. 컴포넌트 로직 / 레이아웃 / 렌더 결과 영향 0. WindowControls.tsx 도 동일 — useEffect 1개 (mount log) 추가, 기존 동작 변경 0.

## Invariants
- **INV-WCB-1** (macOS overlay 보존): macOS override 에 두 키 유지. Tauri 2 의 platform-conditional merge 로 macOS dev 빌드에서 동일 효과.
- **INV-WCB-2** (Windows native control 회복): set_decorations(false) 가 여전히 호출되므로 config 단독으로는 native chrome 회복 안 됨. 진단 결과로 (a) detection 실패 확인되면 후속 PR 에서 gate 조정 또는 set_decorations 호출 조건 분기.
- **INV-WCB-3** (Linux 회귀 0): base 의 `decorations: true` 는 Linux default 와 동일.
- **INV-WCB-5** (window-state 영역 변경 0): tauri.conf.json 의 plugins / build / bundle 영역 미변경.

## Verification
- `npx tsc --noEmit` clean
- `cargo check --lib` ok
- `cargo test --lib` → **636 / 0** (baseline 그대로, 신규 테스트 없음)
- `npx vitest run` → **422 / 0** (baseline 그대로, 기존 `windowControls.test` 6/6 포함)
- 회귀 grep: `rg "titleBarStyle|hiddenTitle" src-tauri/` → `tauri.macos.conf.json` 에만 두 키, `tauri.conf.json` 0건. `bootstrap/window.rs` 의 코멘트 1줄은 무관.

## E2E 검증 (사용자 영역)
- **Windows 11/10**: `tunaFlow_<v>_x64-setup.exe` 재설치 후 실행 → 만약 devtools 를 열 수 있으면 (`Ctrl+Shift+I`) console 에 다음 로그 확인:
  - `[TitleBar] platform diag` — `isWindows: true` 가 정상. false 면 (a) detection 실패.
  - `[WindowControls] mounted` — 출력 안 되면 (a) 미마운트.
- 캡션바가 회복되면 config 분리만으로 fix 완료. 회복 안 되면 console 로그가 후속 PR 의 axis 결정 단서.

## 후속 PR 가능성
- 만약 `[WindowControls] mounted` 가 안 보이면 → `isWindows()` 로직 재설계 또는 WindowControls 의 isWindows gate 제거 (mac 영역 회귀 가드 동시 필요).
- 만약 마운트는 됐으나 invisible 이면 → z-index / styling / Tauri webview overlay 영역 진단.