### PR TITLE
fix(csp): allow Tauri 2 IPC custom protocol + jsdelivr stylesheet (#264)

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -23,7 +23,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob: https://avatars.githubusercontent.com https://github.com; font-src 'self' data: https://cdn.jsdelivr.net; connect-src 'self' ipc: http://ipc.localhost http://tauri.localhost https://tauri.localhost https://cdn.dos.zone https://dos.zone; worker-src 'self' blob:"
+      "csp": "default-src 'self'; script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net/gh/orioncactus/pretendard/; img-src 'self' data: blob: https://avatars.githubusercontent.com https://github.com; font-src 'self' data: https://cdn.jsdelivr.net/gh/orioncactus/pretendard/; connect-src 'self' ipc: http://ipc.localhost https://cdn.dos.zone https://dos.zone; worker-src 'self' blob:"
     }
   },
   "bundle": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -23,7 +23,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://avatars.githubusercontent.com https://github.com; font-src 'self' data:; connect-src 'self' https://cdn.dos.zone https://dos.zone; worker-src 'self' blob:"
+      "csp": "default-src 'self'; script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob: https://avatars.githubusercontent.com https://github.com; font-src 'self' data: https://cdn.jsdelivr.net; connect-src 'self' ipc: http://ipc.localhost http://tauri.localhost https://tauri.localhost https://cdn.dos.zone https://dos.zone; worker-src 'self' blob:"
     }
   },
   "bundle": {


### PR DESCRIPTION
## Symptom (외부 사용자 devbug v0.1.7-beta-3 production)

```
Connecting to 'http://ipc.localhost/plugin:store|load' violates
"connect-src 'self' https://cdn.dos.zone https://dos.zone"

IPC custom protocol failed, Tauri will now use the postMessage interface instead
TypeError: Failed to fetch.

Loading the stylesheet 'https://cdn.jsdelivr.net/.../pretendard...css' violates
"style-src 'self' 'unsafe-inline'"
```

## Root cause (또 다른 layer)

PR #237 의 capabilities 누락 + `tauri.conf.json:26` 의 CSP `connect-src` 가 Tauri 2 의 IPC custom protocol (`http://ipc.localhost` Windows / `ipc:` macOS-Linux) 을 명시 안 함 → IPC 자체가 차단 → `plugin:store|load` (`appStore.getSetting` 모두) / `plugin:event|listen` 모두 fail → `lastProjectKey` / `convEngineMap` / `agentProfiles` 등 사용자 설정 전부 로드 실패 → 앱이 *"Open Project 만 가능"* 한 상태로 표시 (devbug 첫 보고의 직접 원인).

dev 모드 (`vite localhost:1420`) 는 일반 http 라 CSP 가 IPC 프로토콜 차단해도 frontend 가 *postMessage 폴백* 으로 정상 동작 → architect dev 검증에서는 표면 안 됨. **production NSIS 빌드만 CSP 가 적용** 되어 plugin 호출 모두 fail.

## Fix

`src-tauri/tauri.conf.json:26` 의 csp 한 줄:

| 영역 | 추가 |
|---|---|
| `connect-src` | `ipc:` / `http://ipc.localhost` / `http://tauri.localhost` / `https://tauri.localhost` |
| `style-src` | `https://cdn.jsdelivr.net` (pretendard 폰트 로드 회복) |
| `font-src` | `https://cdn.jsdelivr.net` (pretendard variable font 파일) |

## Invariants
- **INV-1** (cross-platform 안전): CSP 변경은 모든 OS 적용. mac/Linux 의 dev 모드는 postMessage 폴백 그대로 동작했고 production NSIS 도 동일 회귀였을 가능성. CSP 가 추가 token 만 허용하므로 *기존 허용 영역 (dos.zone / github / avatars / dataURI 등) 모두 보존*.
- **INV-3** (다른 영역 미변경): tauri.conf.json 의 csp 한 줄, 다른 build/bundle/window 항목 미변경.
- **INV-4** (단일 axis): CSP, 1 파일.

## Verification
- `cargo check --lib` ok
- 회귀 가드 grep: 다른 csp 키 영역 / windows[0] / bundle 미변경

## E2E (사용자 영역)
- v0.1.7-beta-4 release 후 devbug 자산 재설치 → 캡션바 + button click + 사용자 설정 로드 모두 회복
- console 의 *"http://ipc.localhost violates connect-src"* 에러 부재 확인

## Closes (issue #264, 3rd attempt)