### PR TITLE
fix(embedder): bge-m3 default pool size 1 — RSS 1.1GB 절감 (#271)

### DIFF
--- a/src-tauri/src/agents/embedder.rs
+++ b/src-tauri/src/agents/embedder.rs
@@ -40,9 +40,17 @@ pub struct BgeM3Embedder {
 
 #[allow(dead_code)]
 impl BgeM3Embedder {
-    /// Create with default pool size (2 sessions for desktop app).
+    /// Create with default pool size (1 session — single-user desktop).
+    ///
+    /// Pool size 1 인 이유 (issue #271, devbug 외부 보고 2026-05-07):
+    /// `EMBED_SEMAPHORE = Semaphore(1)` (`send_common/persistence.rs:10-22`) 가
+    /// 동시 임베딩 추론을 1로 직렬화하므로 pool size 2 가 throughput 을 살리지
+    /// 못한다. 반면 ONNX session 은 1.1GB weight 를 in-process 로 두 번 보유
+    /// → RSS +2.2GB 순수 비용. 8GB RAM 환경 / 다른 앱 jetsam 간접 유발 위험.
+    /// pool size 1 은 throughput 회귀 0 + RSS 약 1.1GB 절감.
+    /// RT 다중 임베딩 burst 케이스 등장 시 별 PR 로 with_pool_size 노출 검토.
     pub fn new(model_dir: &Path) -> Result<Self, AppError> {
-        Self::with_pool_size(model_dir, 2)
+        Self::with_pool_size(model_dir, 1)
     }
 
     pub fn with_pool_size(model_dir: &Path, pool_size: usize) -> Result<Self, AppError> {


### PR DESCRIPTION
Closes #271

## Symptom
devbug 외부 보고 [#271](https://github.com/hang-in/tunaFlow/issues/271): bge-m3 ONNX session 풀 사이즈 default 가 2 → 1.1GB 모델 weight 가 in-process 로 두 번 로드 → RSS 약 +2.2GB 가산. 8GB RAM 환경 / 다른 앱 jetsam 간접 유발 가능성.

## Root cause
`agents/embedder.rs:44` 의 `pub fn new` 가 `Self::with_pool_size(model_dir, 2)` 호출. 그러나 `EMBED_SEMAPHORE = Semaphore(1)` 가 동시 추론을 1로 직렬화하므로 pool size 2 가 *throughput 을 살리지 못하는* 순수 비용 상태.

## Fix
옵션 A (사용자 제안 + 채택): default pool size 2 → 1. `with_pool_size` 는 그대로 유지 (RT 다중 임베딩 burst 케이스 등장 시 별 PR 로 노출).

## Verification
- `cargo test --lib agents::embedder` → **9 passed** (`test_embedder_real` / `test_batch_embed_real` 등 실제 추론 회귀 0)
- `cargo test --lib` (full) → **636 passed / 0 failed** (baseline 그대로)

## Invariants
- INV-1 (cross-platform 안전): pool size 변경은 OS 무관.
- INV-3: macOS-specific 파일 미변경.
- INV-4: 단일 axis (#271 메모리 최적화), 1 파일 1줄.

## Follow-up axis (본 PR 외)
- 옵션 B: ONNX mmap 기반 weight 공유 (page cache 단일 인스턴스)
- 옵션 C: Settings 에 `bge_m3_pool_size` 노출