### PR TITLE
feat(api): mobile pairing toggle — default OFF + Settings UI + migration toast (#270)

### DIFF
--- a/docs/plans/windowsMobilePairingTogglePlan_2026-05-07.md
+++ b/docs/plans/windowsMobilePairingTogglePlan_2026-05-07.md
@@ -1,0 +1,91 @@
+---
+title: 모바일 페어링 LAN 노출 토글
+status: ready
+phase: planning
+priority: P2 (보안 강화 — devbug 외부 보고)
+created_at: 2026-05-07
+canonical: true
+related:
+  - src-tauri/src/http_api/mod.rs  # bind 주소 분기
+  - src-tauri/src/bootstrap/services.rs  # start_server 호출 + setting read
+  - src/components/tunaflow/settings/RuntimeSection.tsx  # 토글 UI
+  - src/locales/{ko,en}/settings.json  # i18n
+issue_source: GitHub #270 — devbug (2026-05-07)
+---
+
+# 모바일 페어링 LAN 노출 토글
+
+## 0. Context
+
+### 0.1 외부 사용자 보고 (devbug, GitHub #270)
+
+HTTP API 가 `0.0.0.0:19840` 으로 무조건 바인드 → 공공 Wi-Fi / 사내 IDS / 보안 정책 환경에서 attack surface 노출. 모바일 페어링 미사용자도 동일 영향.
+
+devbug 명시 권장: **기본값 OFF**, 토글로 사용자 능동 ON.
+
+## 1. Invariants
+
+| ID | 내용 |
+|---|---|
+| **INV-MP-1** | OFF 기본값 — 신규 + 기존 사용자 모두. 첫 startup 시 setting 키 부재면 OFF. |
+| **INV-MP-2** | 기존 모바일 페어링 사용자 회귀 안내 — 첫 startup 1회 toast (*"모바일 페어링 비활성, Settings → Runtime 에서 ON 가능"*). 사용자가 토글 변경 후엔 다시 안 보임. |
+| **INV-MP-3** | 토글 변경 시 즉시 효과 없음 — 다음 startup 부터 적용. UI 에 *"재시작 후 적용"* 명시. backend hot-rebind 별 PR 영역. |
+| **INV-MP-4** | macOS / Linux 영향 0 — bind 분기는 cross-platform 안전 (default OFF = `127.0.0.1`). 모바일 페어링 사용자가 macOS/Linux 에 있으면 동일 동작 (default OFF). |
+| **INV-MP-5** | DB / 사용자 데이터 영향 0 — settings.json 의 신규 키 1개 추가. |
+
+## 2. Subtasks
+
+### Task 01 — Backend bind 분기 + setting read [P2 fix 본체]
+
+- 파일: `src-tauri/src/http_api/mod.rs:126` + `src-tauri/src/bootstrap/services.rs:25`
+- 변경:
+  - `start_server` 시그니처에 `mobile_pairing_enabled: bool` 인자 추가.
+  - `bootstrap/services.rs` 가 startup 시 plugin-store 의 settings.json 을 직접 read (간단한 `fs::read_to_string + serde_json`) → `mobile_pairing_enabled` 추출 → `start_server` 에 전달. 키 부재 / 파싱 실패 → default false.
+  - bind 주소: enabled ? `[0, 0, 0, 0]` : `[127, 0, 0, 1]`.
+- INV-MP-1/4 충족.
+
+### Task 02 — Settings UI 토글 + i18n [P2]
+
+- 파일: `src/components/tunaflow/settings/RuntimeSection.tsx` 의 *Background Execution* 섹션 아래 새 row 또는 신규 *Mobile Pairing* sub-section
+- 변경:
+  - 토글 + "재시작 후 적용" 안내 + "이 옵션은 같은 Wi-Fi 의 다른 디바이스가 tunaFlow API 에 접근할 수 있도록 합니다" 한 줄 (devbug 권장 문구 그대로)
+  - getSetting/setSetting (`mobile_pairing_enabled`, default false)
+- i18n: ko/en `settings.json` 의 `runtime.mobile_pairing` namespace 신규
+- INV-MP-3 충족.
+
+### Task 03 — 1회 안내 toast (마이그레이션) [P2]
+
+- 파일: `src/components/tunaflow/AppShell.tsx` init 안에 1회 toast
+- 변경:
+  - `getSetting("mobile_pairing_migration_seen", false)` 검사 → false 면 toast (sonner) + setSetting true
+  - 메시지: *"모바일 페어링이 비활성화되었습니다. Settings → Runtime → Mobile Pairing 에서 다시 켤 수 있습니다."*
+- INV-MP-2 충족.
+
+## 3. Verification
+
+- `cargo check --lib` + `cargo test --lib` (회귀 가드: HTTP API 기존 테스트 모두 통과)
+- `npx tsc --noEmit` + `npx vitest run`
+- dev 모드 smoke: 첫 startup → toast 1회 + bind `127.0.0.1:19840` 확인 (`netstat -ano | grep :19840`). 토글 ON + 재시작 → bind `0.0.0.0:19840` 회복 확인.
+- macOS dev smoke: 동일 path (mobile pairing 환경 무관, default OFF 적용)
+
+## 4. Rollback
+
+- Task 01: bind 분기 revert → 기존 `0.0.0.0` 복귀
+- Task 02/03: UI / toast 영역, 단독 revert 가능
+
+destructive 영역 없음. setting 키 추가 + bind 분기만.
+
+## 5. Cross-cutting risks
+
+| 위험 | 대응 |
+|---|---|
+| plugin-store 의 settings.json 위치가 OS 별 다름 | tauri::Manager::path() 의 `app_config_dir()` 사용 — Tauri 가 OS 별 정확한 경로 제공 |
+| 기존 사용자 페어링 회귀 | INV-MP-2 의 1회 toast 마이그레이션 안내 |
+| settings.json 파일 read 실패 (corrupt / 권한) | default false 로 graceful — 안전 측 |
+| bind `127.0.0.1` 변경이 IDE/local automation 영향 | localhost 호출은 그대로 동작 (devbug 보고 §"페어링 OFF 상태에서도 IDE 확장·로컬 자동화 등 localhost 호출은 그대로 동작") |
+
+## 6. Follow-up axis (별 PR)
+
+- 토글 hot-rebind (재시작 없이 즉시 효과) — 현 PR 은 *재시작 후 적용* path 만
+- LAN 노출 인디케이터 (메뉴바 또는 페어링 화면의 작은 점) — 별 P3
+- 페어링된 디바이스 있을 때 OFF 회색 처리 — 별 P3 (페어링 디바이스 등록 인프라가 현재 어떻게 되어있는지 검토 필요)

--- a/src-tauri/src/bootstrap/services.rs
+++ b/src-tauri/src/bootstrap/services.rs
@@ -22,8 +22,21 @@ pub fn start_background_services(
     // 1. HTTP API server (E2E testing + mobile access + MCP)
     {
         let db_state = app.state::<DbState>().inner().clone();
-        let api_token = http_api::start_server(db_state, app.handle().clone(), cancel_arc);
-        eprintln!("[bootstrap/services] HTTP API token: {}", api_token);
+        // Mobile pairing setting (issue #270): default false → bind 127.0.0.1.
+        // 토글 변경은 plugin-store 의 settings.json 에 저장되며, 다음 startup
+        // 부터 적용 (현 PR 은 hot-rebind 미지원). read 실패 / 키 부재 / 파싱
+        // 실패 모두 graceful default false.
+        let mobile_pairing = read_mobile_pairing_setting(app);
+        let api_token = http_api::start_server(
+            db_state,
+            app.handle().clone(),
+            cancel_arc,
+            mobile_pairing,
+        );
+        eprintln!(
+            "[bootstrap/services] HTTP API token: {} (mobile_pairing={})",
+            api_token, mobile_pairing
+        );
     }
 
     // 2. Per-process state registration
@@ -75,4 +88,22 @@ pub fn start_background_services(
     }
 
     Ok(())
+}
+
+/// Read the user's `mobile_pairing_enabled` toggle from plugin-store's
+/// `settings.json`. Default false (localhost-only bind) when the file is
+/// missing, key is absent, or any read/parse step fails — *fail closed*
+/// is the security-correct default for LAN exposure (issue #270).
+fn read_mobile_pairing_setting(app: &tauri::App) -> bool {
+    let Ok(config_dir) = app.path().app_config_dir() else {
+        return false;
+    };
+    let settings_path = config_dir.join("settings.json");
+    let Ok(content) = std::fs::read_to_string(&settings_path) else {
+        return false;
+    };
+    serde_json::from_str::<serde_json::Value>(&content)
+        .ok()
+        .and_then(|v| v.get("mobile_pairing_enabled").and_then(|x| x.as_bool()))
+        .unwrap_or(false)
 }

--- a/src-tauri/src/http_api/mod.rs
+++ b/src-tauri/src/http_api/mod.rs
@@ -100,7 +100,16 @@ where
 
 /// Start the HTTP API server on a background tokio task.
 /// Returns the generated Bearer token for auth.
-pub fn start_server(db: DbState, app_handle: tauri::AppHandle, cancel: CancelArc) -> String {
+///
+/// `mobile_pairing_enabled` 가 true 일 때만 `0.0.0.0` 으로 바인드해 LAN
+/// 노출. 기본값(false)은 `127.0.0.1` 로 localhost-only — 공공 Wi-Fi /
+/// 사내 IDS 환경의 attack surface 차단 (issue #270, devbug 외부 보고).
+pub fn start_server(
+    db: DbState,
+    app_handle: tauri::AppHandle,
+    cancel: CancelArc,
+    mobile_pairing_enabled: bool,
+) -> String {
     let token = generate_token();
     let (event_tx, _) = broadcast::channel::<String>(256);
 
@@ -123,8 +132,12 @@ pub fn start_server(db: DbState, app_handle: tauri::AppHandle, cancel: CancelArc
 
     tauri::async_runtime::spawn(async move {
         let app = build_router(state);
-        let addr = std::net::SocketAddr::from(([0, 0, 0, 0], DEFAULT_PORT));
-        eprintln!("[http-api] starting on http://{}", addr);
+        let host: [u8; 4] = if mobile_pairing_enabled { [0, 0, 0, 0] } else { [127, 0, 0, 1] };
+        let addr = std::net::SocketAddr::from((host, DEFAULT_PORT));
+        eprintln!(
+            "[http-api] starting on http://{} (mobile_pairing={})",
+            addr, mobile_pairing_enabled
+        );
         let listener = match tokio::net::TcpListener::bind(addr).await {
             Ok(l) => l,
             Err(e) => {

--- a/src/components/tunaflow/AppShell.tsx
+++ b/src/components/tunaflow/AppShell.tsx
@@ -11,7 +11,8 @@ import { ProjectStartup } from "./ProjectStartup";
 // ResizeHandle removed — main area border serves as drag handle
 import { FileViewer } from "./chat/FileViewer";
 import { FileViewerContext } from "./chat/fileViewerContext";
-import { Toaster } from "sonner";
+import { Toaster, toast } from "sonner";
+import { useTranslation } from "react-i18next";
 import { CommandPalette } from "./CommandPalette";
 import { TitleBar } from "./TitleBar";
 import { MetaFloatingChat } from "./MetaFloatingChat";
@@ -32,6 +33,7 @@ const DRAWER_DEFAULT = 480;
 const clamp = (v: number, min: number, max: number) => Math.min(Math.max(v, min), max);
 
 export function AppShell() {
+  const { t } = useTranslation("settings");
   const { loadProjects, createProject, loadEngineModels, threadBranchId } = useChatStore();
   const drawerPinned = useChatStore((s) => s.drawerPinned);
 
@@ -74,6 +76,16 @@ export function AppShell() {
         invoke("cleanup_stale_jobs").catch((e) => console.debug("[cleanup]", e));
         // Clear in-memory running state (processes died on restart)
         useChatStore.setState({ runningThreadIds: [] });
+
+        // Issue #270 마이그레이션 안내 — 첫 v0.1.7-beta-5 startup 에서 1회.
+        // 기본값 변경 (HTTP API LAN 노출 OFF) 으로 페어링 사용자 회귀 가드.
+        // 사용자가 본 toast 후엔 다시 안 뜸 (sessionStorage 가 아닌 setting).
+        getSetting<boolean>("mobile_pairing_migration_seen", false).then(async (seen) => {
+          if (!seen) {
+            toast.info(t("runtime.mobile_pairing.migration_toast"), { duration: 8000 });
+            await setSetting("mobile_pairing_migration_seen", true);
+          }
+        });
 
         setLoadingStep("프로젝트 목록 로드 중...");
         await loadProjects();

--- a/src/components/tunaflow/settings/RuntimeSection.tsx
+++ b/src/components/tunaflow/settings/RuntimeSection.tsx
@@ -771,7 +771,58 @@ export function RuntimeSection() {
       </div>
 
       <ManualVerificationGateToggle />
+      <MobilePairingPanel />
       <AttachmentsCleanupPanel />
+    </div>
+  );
+}
+
+// ─── Mobile Pairing Toggle (issue #270) ─────────────────────────────────
+
+function MobilePairingPanel() {
+  const { t } = useTranslation("settings");
+  const [enabled, setEnabled] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const [touched, setTouched] = useState(false);
+
+  useEffect(() => {
+    let alive = true;
+    getSetting<boolean>("mobile_pairing_enabled", false).then((v) => {
+      if (alive) { setEnabled(v); setLoaded(true); }
+    });
+    return () => { alive = false; };
+  }, []);
+
+  const onToggle = async (next: boolean) => {
+    setEnabled(next);
+    setTouched(true);
+    await setSetting("mobile_pairing_enabled", next);
+  };
+
+  if (!loaded) return null;
+
+  return (
+    <div className="rounded-lg border border-border/30 bg-background/50 p-4 space-y-2">
+      <h3 className="text-[13px] font-medium text-foreground">{t("runtime.mobile_pairing.heading")}</h3>
+      <label className="flex items-center gap-2 text-[12px] text-foreground/80 cursor-pointer select-none">
+        <input
+          type="checkbox"
+          checked={enabled}
+          onChange={(e) => onToggle(e.target.checked)}
+          className="accent-primary"
+        />
+        {t("runtime.mobile_pairing.toggle_label")}
+      </label>
+      <p className="text-[11px] text-muted-foreground/70">
+        {enabled
+          ? t("runtime.mobile_pairing.on_hint")
+          : t("runtime.mobile_pairing.off_hint")}
+      </p>
+      {touched && (
+        <p className="text-[11px] text-amber-500/80">
+          ⚠ {t("runtime.mobile_pairing.restart_required")}
+        </p>
+      )}
     </div>
   );
 }

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -259,6 +259,14 @@
       "success": "Installed — restart to mark as ready",
       "venv_note": "The Python sidecar (code-review-graph) is installed via the first-run dialog or with an active venv."
     },
+    "mobile_pairing": {
+      "heading": "Mobile pairing (LAN exposure)",
+      "toggle_label": "Let mobile devices on the same Wi-Fi reach the tunaFlow API",
+      "on_hint": "ON: HTTP API binds to 0.0.0.0:19840 — every device on the same LAN can see port 19840 (token-auth still required).",
+      "off_hint": "OFF (recommended): HTTP API binds to 127.0.0.1:19840 (localhost-only); no LAN exposure.",
+      "restart_required": "The change takes effect on the next launch.",
+      "migration_toast": "Mobile pairing is disabled by default. Re-enable in Settings → Runtime → Mobile pairing if you need it."
+    },
     "workflow_skills": {
       "heading": "Workflow Skills",
       "description": "Skill sets per workflow phase. Combined with manual selection.",

--- a/src/locales/ko/settings.json
+++ b/src/locales/ko/settings.json
@@ -259,6 +259,14 @@
       "success": "설치 완료, 재시작 후 ready 로 전환",
       "venv_note": "Python 측 사이드카 (code-review-graph) 는 첫 실행 다이얼로그 또는 venv 활성 상태에서 별도 설치하세요."
     },
+    "mobile_pairing": {
+      "heading": "모바일 페어링 (LAN 노출)",
+      "toggle_label": "같은 Wi-Fi 의 모바일 디바이스가 tunaFlow API 에 접근하도록 허용",
+      "on_hint": "ON: HTTP API 가 0.0.0.0:19840 으로 바인드되어 같은 LAN 의 모든 디바이스가 19840 포트를 볼 수 있습니다 (인증 토큰 보호).",
+      "off_hint": "OFF (권장): HTTP API 가 127.0.0.1:19840 (localhost 전용) 으로 바인드되어 LAN 노출 차단.",
+      "restart_required": "변경 사항은 다음 실행부터 적용됩니다.",
+      "migration_toast": "모바일 페어링이 비활성화되었습니다. Settings → Runtime → 모바일 페어링 에서 다시 켤 수 있습니다."
+    },
     "workflow_skills": {
       "heading": "Workflow Skills",
       "description": "워크플로우 단계별 스킬 세트. 수동 선택과 합산됩니다.",


### PR DESCRIPTION
Closes #270

## Symptom
devbug 외부 보고 [#270](https://github.com/hang-in/tunaFlow/issues/270): HTTP API 가 `0.0.0.0:19840` 으로 무조건 바인드 → 모바일 페어링 미사용자도 LAN attack surface 노출. 공공 Wi-Fi / 사내 IDS 환경에서 보안 우려.

## Fix
plan ([windowsMobilePairingTogglePlan_2026-05-07.md](https://github.com/hang-in/tunaFlow/blob/main/docs/plans/windowsMobilePairingTogglePlan_2026-05-07.md)) 의 3 task 묶음.

| Task | 영역 |
|---|---|
| 01 | Backend bind 분기 (`http_api/mod.rs` + `bootstrap/services.rs`) |
| 02 | Settings UI 토글 + i18n (`RuntimeSection.tsx` + `locales/{ko,en}/settings.json`) |
| 03 | 1회 마이그레이션 toast (`AppShell.tsx`) |

## Default 결정 (devbug 권장 그대로)
- **기본값 OFF** — `127.0.0.1:19840` localhost-only. 신규 + 기존 사용자 모두.
- 기존 페어링 사용자 회귀 가드: 1회 toast (*"모바일 페어링이 비활성화되었습니다. Settings → Runtime → 모바일 페어링 에서 다시 켤 수 있습니다."*) + `mobile_pairing_migration_seen` setting 으로 한번만 노출.
- 토글 변경 시 즉시 효과 없음 — 다음 startup 부터 적용 (UI 에 *"재시작 후 적용"* 명시). hot-rebind 는 별 PR 영역.

## Invariants
- INV-MP-1 (default OFF / fail closed): `read_mobile_pairing_setting` 의 모든 fail path → false. 보안 측 기본값.
- INV-MP-2 (기존 사용자 마이그레이션): 1회 toast.
- INV-MP-3 (재시작 안내): 토글 옆 amber 문구.
- INV-MP-4 (mac/Linux 영향 0): cross-platform 안전.
- INV-MP-5 (DB / 사용자 데이터 영향 0): settings.json 키 1~2 개 추가.

## Verification
- `cargo check --lib` ok
- `cargo test --lib` (full) → **636 / 0** (baseline 그대로)
- `npx tsc --noEmit` clean
- `npx vitest run` → **422 passed** (baseline 그대로 — Settings UI e2e 영역)

## Test plan (수동 smoke — architect 영역)
- macOS dev: 토글 OFF (default) → `lsof -nP -iTCP:19840 -sTCP:LISTEN` → `127.0.0.1:19840` 만 (LAN 노출 없음)
- 토글 ON + dev 재시작 → `*:19840` 또는 `0.0.0.0:19840` (LAN 노출 회복)
- Windows: `netstat -ano | findstr :19840` 동일 검증
- 1회 toast 표시 (첫 startup 후) + 두 번째 startup 부터 부재

## Follow-up axis (별 PR)
- 토글 hot-rebind
- LAN 노출 인디케이터
- 페어링 디바이스 있을 때 OFF 회색 처리