### PR TITLE
fix(csp): broaden jsdelivr path to /gh/orioncactus/ — WebView2 strict matching (#264)

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -23,7 +23,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net/gh/orioncactus/; img-src 'self' data: blob: https://avatars.githubusercontent.com https://github.com; font-src 'self' data: https://cdn.jsdelivr.net/gh/orioncactus/; connect-src 'self' ipc: http://ipc.localhost https://cdn.dos.zone https://dos.zone; worker-src 'self' blob:"
+      "csp": "default-src 'self'; script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/; img-src 'self' data: blob: https://avatars.githubusercontent.com https://github.com; font-src 'self' data: https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/; connect-src 'self' ipc: http://ipc.localhost https://cdn.dos.zone https://dos.zone; worker-src 'self' blob:"
     }
   },
   "bundle": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -23,7 +23,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net/gh/orioncactus/pretendard/; img-src 'self' data: blob: https://avatars.githubusercontent.com https://github.com; font-src 'self' data: https://cdn.jsdelivr.net/gh/orioncactus/pretendard/; connect-src 'self' ipc: http://ipc.localhost https://cdn.dos.zone https://dos.zone; worker-src 'self' blob:"
+      "csp": "default-src 'self'; script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net/gh/orioncactus/; img-src 'self' data: blob: https://avatars.githubusercontent.com https://github.com; font-src 'self' data: https://cdn.jsdelivr.net/gh/orioncactus/; connect-src 'self' ipc: http://ipc.localhost https://cdn.dos.zone https://dos.zone; worker-src 'self' blob:"
     }
   },
   "bundle": {


### PR DESCRIPTION
## Symptom (devbug v0.1.7-beta-5)

```
Loading 'https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/...css'
violates "style-src ... https://cdn.jsdelivr.net/gh/orioncactus/pretendard/"
```

architect 환경 (Win 11 23H2) 에선 정상 동작했으나 devbug 환경 (Win 10 22H2) 에서 stylesheet 차단.

## Root cause — WebView2 CSP strict path matching

| 환경 | WebView2 | path matching |
|---|---|---|
| architect (Win 11 23H2) | 신버전 | spec 따름 — `pretendard/` 가 `pretendard@v1.3.9/...` 도 prefix 매칭으로 허용 |
| devbug (Win 10 22H2) | 구버전 | strict — `pretendard/` 다음 char 가 정확히 `/` 이어야 매칭. URL 의 `@` 가 차단 |

CSP spec (W3C): path 끝 slash 가 있으면 stripped 후 prefix 매칭이라 *spec 상* 통과해야 함. 그러나 WebView2 의 구현 차이.

## Fix

`tauri.conf.json:26` 의 csp path 를 broaden:
- `style-src ... https://cdn.jsdelivr.net/gh/orioncactus/pretendard/` → `https://cdn.jsdelivr.net/gh/orioncactus/`
- `font-src ... https://cdn.jsdelivr.net/gh/orioncactus/pretendard/` → `https://cdn.jsdelivr.net/gh/orioncactus/`

Gemini #272 review 의 *jsdelivr 도메인 전체 보다 좁힘* 의도는 *orioncactus org 한정* 으로 거의 충족 (jsdelivr/gh 의 다른 org 패키지는 차단 유지).

## Invariants
- INV-1 (cross-platform 안전): CSP path 가 *broader* 방향이라 모든 OS 회귀 0
- INV-3: 다른 영역 미변경
- INV-4: 단일 axis (CSP path), 1 파일 1줄

## Verification
- `cargo check --lib` ok
- 회귀 가드: connect-src / script-src / 다른 path 영역 모두 그대로

## Closes
v0.1.7-beta-6 release 후 devbug 환경 회복 검증 + WebView2 version 진단 요청 (혹시 다른 strict-matching 차단이 더 있을 가능성).