### PR TITLE
fix(ui): #264 Windows 캡션바·드래그 문제 수정

### DIFF
--- a/src/components/tunaflow/AppShell.tsx
+++ b/src/components/tunaflow/AppShell.tsx
@@ -226,15 +226,22 @@ export function AppShell() {
   // 네이티브 캡션바를 제거한 상태이므로, splash / ProjectStartup 분기에서도
   // <TitleBar> 가 함께 마운트되어야 캡션·드래그·닫기 버튼이 보장된다. 마운트
   // 누락 시 사용자는 창 이동·종료 불가 상태에 갇힌다.
+  // PR #277 review (HIGH): splash 분기에서도 Toaster 마운트 — init() 단계
+  // 에서 fire 되는 toast (예: mobile_pairing migration toast, init catch
+  // 블록의 에러 알림) 가 사용자에게 표시되도록 함. 기존엔 splash 분기에
+  // Toaster 가 없어 invisible.
   if (!loaded) return (
-    <div className="flex flex-col h-screen w-screen overflow-hidden bg-sidebar text-foreground font-sans select-none">
-      <TitleBar />
-      <div className="flex-1 min-h-0 flex flex-col items-center justify-center gap-4">
-        <div className="w-10 h-10 rounded-full border-2 border-primary/20 border-t-primary animate-spin" />
-        <div className="text-foreground/60 text-[13px] font-medium">tunaFlow</div>
-        <div className="text-foreground/40 text-[11px]">{loadingStep}</div>
+    <>
+      <Toaster position="bottom-right" theme={themeMode} richColors closeButton />
+      <div className="flex flex-col h-screen w-screen overflow-hidden bg-sidebar text-foreground font-sans relative select-none">
+        <TitleBar />
+        <div className="flex-1 min-h-0 flex flex-col items-center justify-center gap-4">
+          <div className="w-10 h-10 rounded-full border-2 border-primary/20 border-t-primary animate-spin" />
+          <div className="text-foreground/60 text-[13px] font-medium">tunaFlow</div>
+          <div className="text-foreground/40 text-[11px]">{loadingStep}</div>
+        </div>
       </div>
-    </div>
+    </>
   );
 
   // Project-first startup: show selector if no project is selected.
@@ -251,7 +258,7 @@ export function AppShell() {
             initialSection={settingsInitialSection}
           />
         )}
-        <div className="flex flex-col h-screen w-screen overflow-hidden bg-sidebar text-foreground font-sans">
+        <div className="flex flex-col h-screen w-screen overflow-hidden bg-sidebar text-foreground font-sans relative">
           <TitleBar />
           <div className="flex-1 min-h-0">
             <ProjectStartup />

--- a/src/components/tunaflow/AppShell.tsx
+++ b/src/components/tunaflow/AppShell.tsx
@@ -221,11 +221,19 @@ export function AppShell() {
   // Windows 첫 실행 + 기존 프로젝트 DB load 시 수십 초 걸릴 수 있어 spinner +
   // 단계 텍스트로 hang 인지 가시화. tauri.conf.json 의 visible: false 로 React
   // mount 전에는 창 자체가 안 보이고, mount 직후 본 splash 가 첫 화면.
+  //
+  // Issue #264: bootstrap/window.rs 가 Windows 에서 set_decorations(false) 로
+  // 네이티브 캡션바를 제거한 상태이므로, splash / ProjectStartup 분기에서도
+  // <TitleBar> 가 함께 마운트되어야 캡션·드래그·닫기 버튼이 보장된다. 마운트
+  // 누락 시 사용자는 창 이동·종료 불가 상태에 갇힌다.
   if (!loaded) return (
-    <div className="fixed inset-0 bg-sidebar flex flex-col items-center justify-center gap-4 select-none">
-      <div className="w-10 h-10 rounded-full border-2 border-primary/20 border-t-primary animate-spin" />
-      <div className="text-foreground/60 text-[13px] font-medium">tunaFlow</div>
-      <div className="text-foreground/40 text-[11px]">{loadingStep}</div>
+    <div className="flex flex-col h-screen w-screen overflow-hidden bg-sidebar text-foreground font-sans select-none">
+      <TitleBar />
+      <div className="flex-1 min-h-0 flex flex-col items-center justify-center gap-4">
+        <div className="w-10 h-10 rounded-full border-2 border-primary/20 border-t-primary animate-spin" />
+        <div className="text-foreground/60 text-[13px] font-medium">tunaFlow</div>
+        <div className="text-foreground/40 text-[11px]">{loadingStep}</div>
+      </div>
     </div>
   );
 
@@ -235,7 +243,6 @@ export function AppShell() {
   if (!selectedProjectKey) {
     return (
       <>
-        <ProjectStartup />
         <Toaster position="bottom-right" theme={themeMode} richColors closeButton />
         <FirstRunDependencyDialog />
         {settingsOpen && (
@@ -244,6 +251,12 @@ export function AppShell() {
             initialSection={settingsInitialSection}
           />
         )}
+        <div className="flex flex-col h-screen w-screen overflow-hidden bg-sidebar text-foreground font-sans">
+          <TitleBar />
+          <div className="flex-1 min-h-0">
+            <ProjectStartup />
+          </div>
+        </div>
       </>
     );
   }

--- a/src/components/tunaflow/ProjectStartup.tsx
+++ b/src/components/tunaflow/ProjectStartup.tsx
@@ -62,7 +62,7 @@ export function ProjectStartup() {
   };
 
   return (
-    <div className="flex items-center justify-center h-screen w-screen bg-sidebar text-foreground">
+    <div className="flex items-center justify-center h-full w-full bg-sidebar text-foreground">
       <div className="w-[400px] space-y-6">
         {/* Logo / Title */}
         <div className="text-center">

--- a/src/components/tunaflow/TitleBar.tsx
+++ b/src/components/tunaflow/TitleBar.tsx
@@ -66,30 +66,37 @@ export function TitleBar() {
         className={isWindows ? "h-full w-[12px] shrink-0" : "h-full w-[72px] shrink-0"}
       />
 
-      {/* Info row — left-aligned on both OSes (Q-WT-4) */}
-      <div data-tauri-drag-region className="h-full flex items-center gap-0 shrink-0">
-        <span data-tauri-drag-region className="text-[11px] font-bold text-foreground/70 tracking-wide">
-          tunaFlow
-        </span>
+      {/* Info row — selectedProjectKey 가 있을 때만 (즉 메인 AppShell 분기)
+          렌더. splash / ProjectStartup 화면에서는 카드 자체가 24px logo 를
+          이미 표시하므로 chrome 의 11px "tunaFlow" 가 redundant + 깔끔한
+          시작 화면 디자인 의도를 깨뜨려 숨긴다. 캡션바의 드래그 / 닫기 /
+          더블클릭 maximize 동작은 좌측 패딩 + 가운데 spacer + WindowControls
+          (Windows) 만으로 모두 보장된다 (#264 후속). */}
+      {selectedProjectKey && (
+        <div data-tauri-drag-region className="h-full flex items-center gap-0 shrink-0">
+          <span data-tauri-drag-region className="text-[11px] font-bold text-foreground/70 tracking-wide">
+            tunaFlow
+          </span>
 
-        {projectName && (
-          <>
-            <span data-tauri-drag-region className="mx-2 text-[6px] text-muted-foreground/30">●</span>
-            <span data-tauri-drag-region className="text-[11px] font-medium text-foreground/45 truncate max-w-[160px]">
-              {projectName}
-            </span>
-          </>
-        )}
+          {projectName && (
+            <>
+              <span data-tauri-drag-region className="mx-2 text-[6px] text-muted-foreground/30">●</span>
+              <span data-tauri-drag-region className="text-[11px] font-medium text-foreground/45 truncate max-w-[160px]">
+                {projectName}
+              </span>
+            </>
+          )}
 
-        {gitBranch && (
-          <>
-            <span data-tauri-drag-region className="mx-2 text-[6px] text-muted-foreground/25">●</span>
-            <span data-tauri-drag-region className="text-[10px] font-mono text-muted-foreground/35 truncate max-w-[180px]">
-              {gitBranch}
-            </span>
-          </>
-        )}
-      </div>
+          {gitBranch && (
+            <>
+              <span data-tauri-drag-region className="mx-2 text-[6px] text-muted-foreground/25">●</span>
+              <span data-tauri-drag-region className="text-[10px] font-mono text-muted-foreground/35 truncate max-w-[180px]">
+                {gitBranch}
+              </span>
+            </>
+          )}
+        </div>
+      )}
 
       {/* Center — large drag region. h-full 없으면 빈 div 의 height 0 →
           캡션바의 가장 큰 영역이 클릭 hit 0 이 되어 드래그·더블클릭 모두 실패. */}

--- a/src/components/tunaflow/TitleBar.tsx
+++ b/src/components/tunaflow/TitleBar.tsx
@@ -57,14 +57,17 @@ export function TitleBar() {
           중앙 spacer 각각의 sub-section 에만 attribute 부착해 button 영역은
           drag region 의 descendant 가 아니게 만든다. */}
 
-      {/* Left padding — reserves traffic-light area on mac, minimal on Windows */}
+      {/* Left padding — reserves traffic-light area on mac, minimal on Windows.
+          h-full 필수: outer 가 `flex items-center` 라 자식이 stretch 안 되어
+          명시 height 없으면 hit area 0 → drag.js 의 e.target 이 절대 본 div
+          가 못 됨. issue #264 후속 (Windows 캡션 hit area 누락). */}
       <div
         data-tauri-drag-region
-        className={isWindows ? "w-[12px] shrink-0" : "w-[72px] shrink-0"}
+        className={isWindows ? "h-full w-[12px] shrink-0" : "h-full w-[72px] shrink-0"}
       />
 
       {/* Info row — left-aligned on both OSes (Q-WT-4) */}
-      <div data-tauri-drag-region className="flex items-center gap-0 shrink-0">
+      <div data-tauri-drag-region className="h-full flex items-center gap-0 shrink-0">
         <span data-tauri-drag-region className="text-[11px] font-bold text-foreground/70 tracking-wide">
           tunaFlow
         </span>
@@ -88,8 +91,9 @@ export function TitleBar() {
         )}
       </div>
 
-      {/* Center — large drag region */}
-      <div data-tauri-drag-region className="flex-1" />
+      {/* Center — large drag region. h-full 없으면 빈 div 의 height 0 →
+          캡션바의 가장 큰 영역이 클릭 hit 0 이 되어 드래그·더블클릭 모두 실패. */}
+      <div data-tauri-drag-region className="h-full flex-1" />
 
       {/* Right side: Windows custom controls / mac empty padding */}
       {isWindows ? <WindowControls /> : <div className="w-[72px] shrink-0" />}


### PR DESCRIPTION
  ## Summary

  이슈 #264 ("Windows 캡션바 미표시") 의 실제 root cause 두 가지를 수정하고,
  그 부산물로 macOS 의 ProjectStartup 디자인 의도를 보존하기 위한 한 가지
  추가 조정을 포함합니다.

  ## 배경

  본 PR 은 이슈 보고자(외부 사용자) 가 직접 코드를 분석·수정한 것입니다.
  이슈 등록 이후 진행된 #268 / #269 / #272 등 일련의 PR 에서 capabilities /
  CSP / drag-region 트랙으로 수정이 시도되었으나 보고된 증상이 그대로 남아
  있었고, AI 보조 분석이 root cause 가 다른 영역에 있다는 단서 (이슈 본문의
  "**설정도 그렇고 어디에도 접근이 안 되며 Open Project 만 가능합니다**")
  를 반복적으로 놓치고 동일 트랙에서만 시도되고 있다고 판단되어, 보고자가
  직접 분석한 결과를 PR 로 정리합니다.

  핵심 단서는 *증상이 ProjectStartup 화면에서 발생한다는 것* 이었고, 그 화면
  에는 React 캡션바 컴포넌트가 마운트되지 않습니다. 이전 PR 들이 매달린
  capabilities / CSP / drag-region 은 그 컴포넌트가 마운트된 *후* 의 클릭/
  드래그 동작 이슈였고, 본 회귀와는 한 단계 위의 다른 문제입니다.

  ## Root cause

  ### 1. `<TitleBar>` 가 splash / ProjectStartup 분기에 마운트되지 않음

  `bootstrap/window.rs:22-27` 가 Windows 에서 `set_decorations(false)` 로
  네이티브 캡션바를 제거합니다. 그 자리는 React `<TitleBar>` 가 채워야 하는
  설계인데, `AppShell.tsx` 의 메인 분기 (`AppShell.tsx:259`) 에서만 마운트
  되고 splash (`!loaded`, 라인 224-230) 와 ProjectStartup
  (`!selectedProjectKey`, 라인 235-249) 에서는 누락. Windows 첫 실행
  사용자는 두 화면에서 캡션바 0 건 → 닫기·이동·리사이즈 모두 불가능.

  ### 2. drag-region div 의 hit area 가 0 px

  1번을 수정한 뒤 Windows 에서 검증해보니 캡션바는 표시되지만 "tunaFlow"
  텍스트 영역에서만 드래그가 동작. 가운데 spacer / 좌측 패딩 / 더블클릭
  maximize 모두 실패.

  원인: Tauri 2.10.3 `drag.js` 가 `e.target.getAttribute()` 기반
  (closest() 아님) 으로 검사. `<TitleBar>` 의 outer 가 `flex items-center`
  라 자식이 stretch 되지 않아 빈 div (`<div data-tauri-drag-region
  className="flex-1" />`) 의 height 가 0 → mousedown 의 e.target 이 절대
  그 div 가 되지 못함. "tunaFlow" span 만 텍스트 line-height 만큼 hit area
  가 있어 그곳에서만 동작했던 것.

  ### 3. macOS 디자인 의도 보존 (1번의 부산물)

  1번 fix 후 macOS ProjectStartup 화면에 카드 가운데 24px h1 "tunaFlow" 와
  TitleBar 정보 row 의 11px "tunaFlow" 가 동시 노출되어 redundant. 깔끔한
  logo + card 디자인 의도를 보존.

  ## 변경 사항

  3개 commit 으로 분리:

  1. **`fix(ui): mount TitleBar on splash and project startup screens (#264)`**
     `AppShell.tsx` 의 splash / ProjectStartup 분기를 메인 분기와 동일한
     `flex flex-col h-screen w-screen overflow-hidden` wrapper 로 통일하고
     `<TitleBar />` 를 마운트. `ProjectStartup.tsx` outer 의 `h-screen
     w-screen` → `h-full w-full` 로 변경.

  2. **`fix(ui): give drag-region elements full title bar height (#264)`**
     `TitleBar.tsx` 의 좌측 패딩 / Info row / 가운데 spacer 세 군데
     drag-region div 에 `h-full` 추가. hit height 를 32px 로 확보.

  3. **`fix(ui): hide TitleBar info row on splash and project startup (#264)`**
     정보 row (`tunaFlow ● projectName ● gitBranch`) 를 `selectedProjectKey`
     가 truthy 일 때만 렌더. 캡션바 자체 (좌측 패딩 / 가운데 spacer /
     WindowControls) 는 모든 분기에 그대로.

  ## macOS 영향

  코드는 macOS 에도 적용되지만 부정적 회귀 없음:

  - splash / ProjectStartup 에 32px TitleBar 가 새로 마운트되되, commit 3
    으로 정보 row 가 숨겨져 traffic-light overlay + 빈 32px 캡션바 모양이
    유지됨 (디자인 보존).
  - 새로 가능해진 동작: ProjectStartup 화면에서도 캡션바 드래그 / 더블클릭
    maximize.
  - traffic-light overlay 위치, 캡션 영역 width, 텍스트 폰트·정렬 변경 없음.

  > ProjectStartup 에서 양쪽 OS 모두 정보 row 를 숨긴 결정은 OS 일관성 +
  > 카드 logo redundancy 회피를 우선한 것입니다. Windows chrome 의 가운데
  > 영역이 비어 보이는 게 디자인 의도와 맞지 않으면 한 줄
  > (`isWindows || selectedProjectKey`) 조정으로 Windows 만 정보 row 를
  > 노출시킬 수 있습니다.

  ## Test plan

  ### 자동 검증
  - [x] `npx tsc --noEmit` 통과
  - [x] `npx vitest run` 41 files / 422 tests 통과

  ### 수동 검증 — Windows (이슈 보고자가 본인 환경에서 직접 빌드 후 확인)
  - [x] 첫 실행 splash 화면 32px 캡션바 영역 표시
  - [x] ProjectStartup 화면에서 닫기·최소화·최대화 동작
  - [x] 캡션바 가운데 spacer / 좌측 패딩 / 우측 WindowControls 외 영역
    에서도 드래그 동작
  - [x] 캡션바 더블클릭 maximize ↔ 이전 상태 토글
  - [x] 메인 화면 정보 row + WindowControls 회귀 없음

  ### 수동 검증 — macOS
  - [x] splash / ProjectStartup 양쪽 화면에서 traffic-light overlay 정상,
    정보 row 미노출 (디자인 보존)
  - [x] 메인 화면 정보 row + traffic-light overlay 회귀 없음

  Closes #264