### PR TITLE
fix(win): agent CLI 동작 정상화 — PATHEXT / no_console / cwd / args

### DIFF
--- a/src-tauri/src/commands/agent_detect.rs
+++ b/src-tauri/src/commands/agent_detect.rs
@@ -1,8 +1,9 @@
 //! Detect which AI agents are available on this machine.
 //!
 //! Used by the Meta Agent Selector modal shown during project onboarding.
-//! - CLI agents (claude / codex / gemini): probe via `which` + `--version`
-//! - HTTP agents (ollama / lmstudio): probe endpoint + list models live
+//! - CLI agents (claude / codex / gemini): probe PATH (cross-platform —
+//!   `which` on Unix, PATH + PATHEXT enumeration on Windows) + `--version`.
+//! - HTTP agents (ollama / lmstudio): probe endpoint + list models live.
 //! - 모든 탐지는 병렬로 수행. 각 항목은 1.5s timeout.
 
 use serde::{Deserialize, Serialize};
@@ -31,6 +32,61 @@ pub struct AgentDetection {
 
 // ─── CLI probing ─────────────────────────────────────────────────────────────
 
+/// PATH 에서 binary 의 절대 경로를 찾는다. Cross-platform.
+///
+/// - Windows: `which` 명령이 존재하지 않으므로 PATH (`;` 구분) 와 PATHEXT
+///   (`.EXE` / `.CMD` / `.BAT` / `.PS1` 등) 를 직접 enumerate. npm 으로
+///   글로벌 설치된 claude / codex / gemini CLI 는 보통 `<bin>.cmd` 형태로
+///   `%APPDATA%\npm\` 에 등록된다.
+/// - Unix: 시스템 `which` 에 위임 (기존 동작 보존).
+///
+/// 같은 repo 의 `resolve.rs::which_or` / `crg.rs` Windows 분기와 같은
+/// 철학이며, agent detection 은 PATHEXT 를 더 넓게 본다 (.cmd 까지).
+async fn find_in_path(bin: &str) -> Option<String> {
+    #[cfg(target_os = "windows")]
+    {
+        let path = std::env::var("PATH").ok()?;
+        let pathext = std::env::var("PATHEXT").unwrap_or_else(|_| ".COM;.EXE;.BAT;.CMD".into());
+        let exts: Vec<String> = pathext
+            .split(';')
+            .map(|e| e.trim().to_string())
+            .filter(|e| !e.is_empty())
+            .collect();
+        for dir in path.split(';') {
+            let dir = dir.trim();
+            if dir.is_empty() {
+                continue;
+            }
+            for ext in &exts {
+                let candidate = std::path::PathBuf::from(dir).join(format!("{}{}", bin, ext));
+                if candidate.is_file() {
+                    return Some(candidate.to_string_lossy().to_string());
+                }
+            }
+            // Drop-in binaries without extension (rare on Windows but possible).
+            let candidate = std::path::PathBuf::from(dir).join(bin);
+            if candidate.is_file() {
+                return Some(candidate.to_string_lossy().to_string());
+            }
+        }
+        None
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        let which_fut = Command::new("which").no_console().arg(bin).output();
+        let out = match timeout(Duration::from_millis(PROBE_TIMEOUT_MS), which_fut).await {
+            Ok(Ok(o)) => o,
+            _ => return None,
+        };
+        if !out.status.success() {
+            return None;
+        }
+        let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        if s.is_empty() { None } else { Some(s) }
+    }
+}
+
 async fn probe_cli(engine: &str, bin: &str, version_args: &[&str]) -> AgentDetection {
     let mut det = AgentDetection {
         engine: engine.to_string(),
@@ -43,27 +99,33 @@ async fn probe_cli(engine: &str, bin: &str, version_args: &[&str]) -> AgentDetec
         note: None,
     };
 
-    // `which <bin>`
-    let which_fut = Command::new("which").no_console().arg(bin).output();
-    let which_out = match timeout(Duration::from_millis(PROBE_TIMEOUT_MS), which_fut).await {
-        Ok(Ok(out)) => out,
-        Ok(Err(e)) => { det.note = Some(format!("which error: {e}")); return det; }
-        Err(_) => { det.note = Some("which timeout".into()); return det; }
+    let path = match find_in_path(bin).await {
+        Some(p) => p,
+        None => {
+            det.note = Some("not found in PATH".into());
+            return det;
+        }
     };
-    if !which_out.status.success() {
-        det.note = Some("not found in PATH".into());
-        return det;
-    }
-    let path = String::from_utf8_lossy(&which_out.stdout).trim().to_string();
-    if path.is_empty() {
-        det.note = Some("which returned empty".into());
-        return det;
-    }
     det.path = Some(path.clone());
     det.installed = true;
 
-    // `<bin> --version` (optional — 실패해도 installed 유지)
-    let ver_fut = Command::new(&path).no_console().args(version_args).output();
+    // `<bin> --version` (optional — 실패해도 installed 유지). Windows 에서
+    // `.cmd` / `.bat` / `.ps1` 은 std::Command 직접 실행이 불가능하므로 cmd
+    // /C 로 래핑. `.exe` 또는 Unix 는 직접 실행. 본 probe 가 실패해도
+    // detection 자체는 path 발견 시점에 이미 성공이라 사용자 UX 에 영향 없음
+    // (version 칸만 빈 채로 표시).
+    let lower = path.to_lowercase();
+    let is_windows_script = cfg!(target_os = "windows")
+        && (lower.ends_with(".cmd") || lower.ends_with(".bat") || lower.ends_with(".ps1"));
+    let ver_fut = if is_windows_script {
+        let mut c = Command::new("cmd");
+        c.no_console().arg("/C").arg(&path).args(version_args);
+        c.output()
+    } else {
+        let mut c = Command::new(&path);
+        c.no_console().args(version_args);
+        c.output()
+    };
     if let Ok(Ok(out)) = timeout(Duration::from_millis(PROBE_TIMEOUT_MS), ver_fut).await {
         if out.status.success() {
             let v = String::from_utf8_lossy(&out.stdout).lines().next().unwrap_or("").trim().to_string();

--- a/src-tauri/src/commands/agent_detect.rs
+++ b/src-tauri/src/commands/agent_detect.rs
@@ -35,7 +35,7 @@ pub struct AgentDetection {
 /// PATH 에서 binary 의 절대 경로를 찾는다. Cross-platform.
 ///
 /// - Windows: `which` 명령이 존재하지 않으므로 PATH (`;` 구분) 와 PATHEXT
-///   (`.EXE` / `.CMD` / `.BAT` / `.PS1` 등) 를 직접 enumerate. npm 으로
+///   (`.EXE` / `.CMD` / `.BAT` 등) 를 직접 enumerate. npm 으로
 ///   글로벌 설치된 claude / codex / gemini CLI 는 보통 `<bin>.cmd` 형태로
 ///   `%APPDATA%\npm\` 에 등록된다.
 /// - Unix: 시스템 `which` 에 위임 (기존 동작 보존).
@@ -110,13 +110,15 @@ async fn probe_cli(engine: &str, bin: &str, version_args: &[&str]) -> AgentDetec
     det.installed = true;
 
     // `<bin> --version` (optional — 실패해도 installed 유지). Windows 에서
-    // `.cmd` / `.bat` / `.ps1` 은 std::Command 직접 실행이 불가능하므로 cmd
-    // /C 로 래핑. `.exe` 또는 Unix 는 직접 실행. 본 probe 가 실패해도
-    // detection 자체는 path 발견 시점에 이미 성공이라 사용자 UX 에 영향 없음
-    // (version 칸만 빈 채로 표시).
+    // `.cmd` / `.bat` 은 std::Command 직접 실행이 불가능하므로 cmd /C 로
+    // 래핑. `.exe` 또는 Unix 는 직접 실행. `.ps1` 은 cmd 가 batch 로 해석
+    // 시도하다 fail 하므로 분기에서 제외 — npm 글로벌 CLI 는 .cmd / .bat
+    // 형태라 실용적 영향 없음 (PowerShell wrap 은 본 PR scope 외).
+    // 본 probe 가 실패해도 detection 자체는 path 발견 시점에 이미 성공이라
+    // 사용자 UX 에 영향 없음 (version 칸만 빈 채로 표시).
     let lower = path.to_lowercase();
     let is_windows_script = cfg!(target_os = "windows")
-        && (lower.ends_with(".cmd") || lower.ends_with(".bat") || lower.ends_with(".ps1"));
+        && (lower.ends_with(".cmd") || lower.ends_with(".bat"));
     let ver_fut = if is_windows_script {
         let mut c = Command::new("cmd");
         c.no_console().arg("/C").arg(&path).args(version_args);

--- a/src-tauri/src/commands/agent_detect.rs
+++ b/src-tauri/src/commands/agent_detect.rs
@@ -42,7 +42,7 @@ pub struct AgentDetection {
 ///
 /// 같은 repo 의 `resolve.rs::which_or` / `crg.rs` Windows 분기와 같은
 /// 철학이며, agent detection 은 PATHEXT 를 더 넓게 본다 (.cmd 까지).
-async fn find_in_path(bin: &str) -> Option<String> {
+pub(crate) async fn find_in_path(bin: &str) -> Option<String> {
     #[cfg(target_os = "windows")]
     {
         let path = std::env::var("PATH").ok()?;

--- a/src-tauri/src/commands/project_onboarding.rs
+++ b/src-tauri/src/commands/project_onboarding.rs
@@ -542,12 +542,17 @@ async fn await_cli_with_cancel(
         match rx.try_recv() {
             Ok(Ok(output)) => {
                 if !output.status.success() {
+                    // 일부 CLI 는 에러를 stderr 가 아닌 stdout 으로 출력하거나
+                    // 둘 다 비어 있을 수 있어, 진단성을 위해 양쪽 모두 capture.
                     let stderr_body = String::from_utf8_lossy(&output.stderr);
+                    let stdout_body = String::from_utf8_lossy(&output.stdout);
                     let stderr_trimmed = stderr_body.trim();
-                    let detail = if stderr_trimmed.is_empty() {
-                        "(no stderr)".to_string()
-                    } else {
-                        stderr_trimmed.to_string()
+                    let stdout_trimmed = stdout_body.trim();
+                    let detail = match (stderr_trimmed.is_empty(), stdout_trimmed.is_empty()) {
+                        (true, true) => "(no output)".to_string(),
+                        (true, false) => format!("(stdout) {}", stdout_trimmed),
+                        (false, true) => stderr_trimmed.to_string(),
+                        (false, false) => format!("{} | (stdout) {}", stderr_trimmed, stdout_trimmed),
                     };
                     return Err(format!(
                         "{engine} 분석 실패 (exit: {:?}): {}",
@@ -572,6 +577,7 @@ async fn call_cli_agent(
     bin: &str,
     prompt: &str,
     model: Option<&str>,
+    cwd: &str,
     cancel: &AtomicBool,
 ) -> Result<String, String> {
     use std::process::Stdio;
@@ -603,6 +609,10 @@ async fn call_cli_agent(
     // console 창에 attach 되어 (a) 사용자에게 보이고 (b) child stdout 이 부모
     // pipe 로 routing 되지 않아 즉시 exit 1 + stderr 빈 채로 실패.
     cmd.no_console();
+    // CLI 의 working directory 를 분석 대상 프로젝트로 설정. 미설정 시 child
+    // 가 tunaFlow.exe 의 install dir 등 무관한 곳에서 실행되어 codex 의
+    // "Not inside a trusted directory" / claude 의 silent exit 등 회귀.
+    cmd.current_dir(cwd);
     match engine {
         "claude" => {
             cmd.args(["-p", prompt, "--max-turns", "1", "--output-format", "text"]);
@@ -617,7 +627,11 @@ async fn call_cli_agent(
             cmd.stdin(Stdio::null());
         }
         "codex" => {
-            cmd.args(["exec", "--full-auto", "-"]);
+            // `--full-auto` 는 codex 최신 버전에서 deprecated → `--sandbox
+            // workspace-write` 로 대체. cwd 가 git repo 가 아닌 경우도 동작
+            // 하도록 `--skip-git-repo-check` 도 추가 (사용자 분석 대상이
+            // 비-git 디렉토리일 수 있음).
+            cmd.args(["exec", "--sandbox", "workspace-write", "--skip-git-repo-check", "-"]);
             if let Some(m) = model { cmd.args(["--model", m]); }
             cmd.stdin(Stdio::piped());
         }
@@ -761,11 +775,12 @@ async fn call_agent(
     model: Option<&str>,
     endpoint: Option<&str>,
     prompt: &str,
+    cwd: &str,
     cancel: &AtomicBool,
 ) -> Result<(String, String, Option<serde_json::Value>), String> {
     let text = match engine {
         "claude" | "codex" | "gemini" => {
-            call_cli_agent(engine, engine, prompt, model, cancel).await?
+            call_cli_agent(engine, engine, prompt, model, cwd, cancel).await?
         }
         "ollama" => {
             let ep = endpoint.unwrap_or("http://localhost:11434");
@@ -833,6 +848,7 @@ pub async fn analyze_project_for_onboarding(
         model.as_deref(),
         endpoint.as_deref(),
         &prompt,
+        &project_path,
         &cancel,
     ).await;
 

--- a/src-tauri/src/commands/project_onboarding.rs
+++ b/src-tauri/src/commands/project_onboarding.rs
@@ -3,6 +3,8 @@ use std::sync::{Arc, Mutex, OnceLock};
 use serde::Serialize;
 use tauri::{AppHandle, Emitter};
 
+use crate::no_console::NoConsole;
+
 use super::projects::detect_project_info;
 
 // ─── Cancellation flag ───────────────────────────────────────────────────────
@@ -575,6 +577,12 @@ async fn call_cli_agent(
     use std::process::Stdio;
 
     let mut cmd = tokio::process::Command::new(bin);
+    // Windows 에서 CREATE_NO_WINDOW flag 미적용 시 .cmd wrapper (npm 글로벌
+    // 설치 시 표준 형태) 가 새 cmd.exe console 창에 attach 되어 (a) 사용자
+    // 에게 보이고 (b) child stdout 이 부모 pipe 로 routing 되지 않아 즉시
+    // exit 1 + stderr 빈 채로 실패. no_console.rs 헤더의 invariant ("모든
+    // Command::new 직후 .no_console() chain 호출") 누락 회귀.
+    cmd.no_console();
     match engine {
         "claude" => {
             cmd.args(["-p", prompt, "--max-turns", "1", "--output-format", "text"]);

--- a/src-tauri/src/commands/project_onboarding.rs
+++ b/src-tauri/src/commands/project_onboarding.rs
@@ -615,7 +615,10 @@ async fn call_cli_agent(
     cmd.current_dir(cwd);
     match engine {
         "claude" => {
-            cmd.args(["-p", prompt, "--max-turns", "1", "--output-format", "text"]);
+            // `--max-turns 1` 은 noninteractive 단일 응답 의도였으나, claude
+            // 가 reasoning / tool use 시 1턴 초과로 "Reached max turns (1)"
+            // exit 1. onboarding 분석은 한 응답이면 충분하지만 여유 확보.
+            cmd.args(["-p", prompt, "--max-turns", "5", "--output-format", "text"]);
             if let Some(m) = model { cmd.args(["--model", m]); }
             // GUI 부모는 stdin 없음. claude 가 prompt 외 stdin 안 읽어야
             // 하지만 inherited stdin = invalid handle 회귀 회피 위해 명시.
@@ -632,7 +635,20 @@ async fn call_cli_agent(
             // 하도록 `--skip-git-repo-check` 도 추가 (사용자 분석 대상이
             // 비-git 디렉토리일 수 있음).
             cmd.args(["exec", "--sandbox", "workspace-write", "--skip-git-repo-check", "-"]);
-            if let Some(m) = model { cmd.args(["--model", m]); }
+            // codex 의 model 호환은 인증 type (ChatGPT account vs API key)
+            // 에 따라 다르다. ChatGPT account 는 `gpt-5-codex` / `gpt-4o-codex`
+            // 같은 codex 전용 모델을 거부 (invalid_request_error). frontend
+            // 의 CLI_DEFAULT_MODELS["codex"] 가 그런 codex 전용 default 를
+            // 자동 선택하므로, 사용자가 명시 변경 없이 그대로 보낸 경우
+            // (default 첫 항목 그대로) 는 model 인자를 전달하지 않고 codex
+            // 자체 default (인증 type 에 맞는) 를 신뢰. 사용자가 다른 모델로
+            // 변경한 경우만 명시 전달.
+            const CODEX_DEFAULT_MODELS_TO_SKIP: &[&str] = &["gpt-5-codex", "gpt-4o-codex"];
+            if let Some(m) = model {
+                if !CODEX_DEFAULT_MODELS_TO_SKIP.contains(&m) {
+                    cmd.args(["--model", m]);
+                }
+            }
             cmd.stdin(Stdio::piped());
         }
         _ => return Err(format!("지원하지 않는 CLI 엔진: {engine}")),

--- a/src-tauri/src/commands/project_onboarding.rs
+++ b/src-tauri/src/commands/project_onboarding.rs
@@ -592,12 +592,14 @@ async fn call_cli_agent(
         .ok_or_else(|| format!("{engine} CLI 를 PATH 에서 찾을 수 없습니다. 설치 후 PATH 등록을 확인하세요."))?;
     let lower = resolved_path.to_lowercase();
     let is_windows_script = cfg!(target_os = "windows")
-        && (lower.ends_with(".cmd") || lower.ends_with(".bat") || lower.ends_with(".ps1"));
+        && (lower.ends_with(".cmd") || lower.ends_with(".bat"));
 
-    // .cmd / .bat / .ps1 은 cmd /C 로 래핑 — Rust std Command 가 직접 spawn
-    // 시 stdin/stdout pipe 가 cmd.exe → 실제 child (node.exe) 까지 forward
+    // .cmd / .bat 은 cmd /C 로 래핑 — Rust std Command 가 직접 spawn 시
+    // stdin/stdout pipe 가 cmd.exe → 실제 child (node.exe) 까지 forward
     // 되는 동작이 환경 의존이라 보수적으로 cmd /C 명시. agent_detect 의
-    // version probe 와 동일 패턴.
+    // version probe 와 동일 패턴. `.ps1` 은 cmd 가 batch 로 해석 시도하다
+    // fail 하므로 분기에서 제외 — npm 글로벌 CLI 는 .cmd / .bat 형태라
+    // 실용적 영향 없음 (PowerShell wrap 은 본 PR scope 외).
     let mut cmd = if is_windows_script {
         let mut c = tokio::process::Command::new("cmd");
         c.arg("/C").arg(&resolved_path);

--- a/src-tauri/src/commands/project_onboarding.rs
+++ b/src-tauri/src/commands/project_onboarding.rs
@@ -576,21 +576,45 @@ async fn call_cli_agent(
 ) -> Result<String, String> {
     use std::process::Stdio;
 
-    let mut cmd = tokio::process::Command::new(bin);
-    // Windows 에서 CREATE_NO_WINDOW flag 미적용 시 .cmd wrapper (npm 글로벌
-    // 설치 시 표준 형태) 가 새 cmd.exe console 창에 attach 되어 (a) 사용자
-    // 에게 보이고 (b) child stdout 이 부모 pipe 로 routing 되지 않아 즉시
-    // exit 1 + stderr 빈 채로 실패. no_console.rs 헤더의 invariant ("모든
-    // Command::new 직후 .no_console() chain 호출") 누락 회귀.
+    // PATH 에서 절대 경로 resolve. caller 가 engine 이름 ("claude" / "codex"
+    // 등) 을 그대로 bin 으로 넘기는 흐름이라, Rust std Command::new("codex")
+    // 가 Windows 에서 PATHEXT 를 일관되게 검사 안 해 npm 글로벌 .cmd wrapper
+    // 를 못 찾는 케이스 발생 ("program not found"). agent_detect 의
+    // find_in_path 는 PATHEXT 를 모두 검사하므로 그 결과를 직접 사용.
+    let resolved_path = crate::commands::agent_detect::find_in_path(bin)
+        .await
+        .ok_or_else(|| format!("{engine} CLI 를 PATH 에서 찾을 수 없습니다. 설치 후 PATH 등록을 확인하세요."))?;
+    let lower = resolved_path.to_lowercase();
+    let is_windows_script = cfg!(target_os = "windows")
+        && (lower.ends_with(".cmd") || lower.ends_with(".bat") || lower.ends_with(".ps1"));
+
+    // .cmd / .bat / .ps1 은 cmd /C 로 래핑 — Rust std Command 가 직접 spawn
+    // 시 stdin/stdout pipe 가 cmd.exe → 실제 child (node.exe) 까지 forward
+    // 되는 동작이 환경 의존이라 보수적으로 cmd /C 명시. agent_detect 의
+    // version probe 와 동일 패턴.
+    let mut cmd = if is_windows_script {
+        let mut c = tokio::process::Command::new("cmd");
+        c.arg("/C").arg(&resolved_path);
+        c
+    } else {
+        tokio::process::Command::new(&resolved_path)
+    };
+    // Windows 에서 CREATE_NO_WINDOW flag 미적용 시 .cmd wrapper 가 새 cmd.exe
+    // console 창에 attach 되어 (a) 사용자에게 보이고 (b) child stdout 이 부모
+    // pipe 로 routing 되지 않아 즉시 exit 1 + stderr 빈 채로 실패.
     cmd.no_console();
     match engine {
         "claude" => {
             cmd.args(["-p", prompt, "--max-turns", "1", "--output-format", "text"]);
             if let Some(m) = model { cmd.args(["--model", m]); }
+            // GUI 부모는 stdin 없음. claude 가 prompt 외 stdin 안 읽어야
+            // 하지만 inherited stdin = invalid handle 회귀 회피 위해 명시.
+            cmd.stdin(Stdio::null());
         }
         "gemini" => {
             cmd.args(["-p", prompt]);
             if let Some(m) = model { cmd.args(["-m", m]); }
+            cmd.stdin(Stdio::null());
         }
         "codex" => {
             cmd.args(["exec", "--full-auto", "-"]);

--- a/src-tauri/src/commands/search/query_expand.rs
+++ b/src-tauri/src/commands/search/query_expand.rs
@@ -18,6 +18,7 @@ use rusqlite::{params, Connection};
 
 use crate::db::migrations::now_epoch_ms;
 use crate::errors::AppError;
+use crate::no_console::NoConsole;
 
 const CACHE_TTL_MS: i64 = 7 * 24 * 60 * 60 * 1000; // 7 days
 const HAIKU_MODEL: &str = "claude-haiku-4-5-20251001";
@@ -156,6 +157,7 @@ fn write_cache(conn: &Connection, key: &str, expanded: &str) -> Result<(), AppEr
 fn invoke_claude_haiku(query: &str) -> Result<String, AppError> {
     let prompt = build_expansion_prompt(query);
     let output = std::process::Command::new("claude")
+        .no_console()
         .args(["-p", &prompt, "--model", HAIKU_MODEL])
         .output()
         .map_err(|e| AppError::Agent(format!("claude subprocess: {e}")))?;


### PR DESCRIPTION
  ## Summary

  Windows 에서 외부 사용자가 클론·빌드 후 처음 사용할 때 메타 에이전트
  선택 화면 → ProjectOnboarding 분석 단계까지의 회귀를 수정합니다. 한
  가지 root cause 가 아니라 다섯 단계로 분리된 회귀들이 직렬로 사용자
  경험을 막고 있었습니다.

  본 PR 은 외부 사용자가 직접 분석·수정한 것입니다 (PR #277 과 동일 흐름).

  ## Root cause + Fix (5 commits)

  ### 1. CLI detection 실패 — `agent_detect.rs:47` 가 `which` 의존
  `Command::new("which")` 가 Windows 에 없음. `find_in_path` helper 추가:
  - Windows: `PATH` + `PATHEXT` (`.EXE`/`.CMD`/`.BAT`/`.PS1`) enumerate
  - Unix: 시스템 `which` 위임 (회귀 0)

  ### 2. spawn console 창 노출 / stdout 미캡처
  `project_onboarding.rs:577` 의 `call_cli_agent`, `query_expand.rs:158` 의
  `invoke_claude_haiku` 가 `no_console.rs` 헤더의 invariant ("`Command::new`
  직후 `.no_console()` chain") 위반. 두 사이트 모두 `cmd.no_console()` 추가.
  다른 모든 spawn 사이트는 audit 결과 이미 적용 중.

  ### 3. spawn `program not found` (codex) / `exit 1` (claude)
  caller 가 engine 이름 ("codex") 그대로 bin 으로 넘기면 Rust std Command
  의 PATHEXT 처리 일관성 부족으로 `.cmd` wrapper 못 찾음.
  - `agent_detect::find_in_path` 를 `pub(crate)` 로 노출 → 절대 경로 resolve
  - `.cmd`/`.bat`/`.ps1` 은 `cmd /C` 명시 래핑
  - claude/gemini stdin `Stdio::null()` 명시 (GUI 부모는 stdin 없음)

  ### 4. spawn cwd 미설정 + codex deprecated 옵션
  `call_cli_agent`/`call_agent` signature 가 cwd 를 받지 않아 child CLI 가
  tunaFlow.exe install dir 등 무관한 곳에서 실행 → codex 의 `Not inside a
  trusted directory`, claude 의 silent exit 1.
  - signature 에 `cwd: &str` 추가 + `cmd.current_dir(cwd)`
  - codex args: `--full-auto` (deprecated) → `--sandbox workspace-write`
    + `--skip-git-repo-check` 추가
  - `await_cli_with_cancel` 의 fail 메시지에 stdout 도 capture (silent
    exit 진단성 향상)

  ### 5. claude max-turns / codex default model 호환
  - claude `--max-turns 1` → `5` (reasoning 여유)
  - codex frontend default model (`gpt-5-codex`/`gpt-4o-codex`) 이 ChatGPT
    account 에서 거부됨. 사용자가 default 그대로인 경우 model 인자 미전달
    → codex 자체 default 신뢰 (인증-type 호환)

  ## macOS 영향

  코드 변경 대부분이 macOS 에도 적용되지만 cfg-gated 이거나 정상화 방향.
  보고 사용자가 macOS 에서 직접 검증한 결과 회귀 없음 — codex 의 ChatGPT
  계정 model 회귀는 main 에서도 재현되어 본 PR 의 default-model skip
  fallback 이 정확히 의도대로 동작.

  ## Out of scope

  - **rawq sidecar daemon 의 메인 chat 무한 대기** — daemon IPC 흐름의
    별개 root cause. 별도 PR 예정. (rawq 강제 종료 시 메인 chat 정상 동작
    확인됨)
  - **codex 응답 시간 / 토큰 사용량** — codex 자체 default model 의 quality
    특성. 본 PR 변경의 부산물이 아닌 codex CLI 자체 동작.
  - **`MetaAgentSelector.tsx` 의 Codex install hint 오류, docLink 404, 새로
    고침 메커니즘 부재** — 별도 후속 PR 예정.

  ## Test plan

  ### 자동 검증
  - [x] `cd src-tauri && cargo check` clean
  - [x] `cd src-tauri && cargo test --lib` — 635 passed

  ### 수동 검증 (Windows, 보고 사용자가 본인 환경에서)
  - [x] 메타 에이전트 화면에서 claude/codex/gemini 모두 detected 표시
  - [x] onboarding "프로젝트 분석 중..." 단계에서 터미널 창 안 뜸
  - [x] claude/codex/gemini 모두 onboarding 분석 정상 완료
  - [x] 메인 chat 에서도 터미널 창 안 뜨고 PTY 정상 동작
  - [ ] (rawq 강제 종료 시 메인 chat 응답 도착 확인 — 별도 이슈)

  ### 회귀 검증 (macOS)
  - [x] claude onboarding 분석 정상
  - [x] codex onboarding 분석 정상 (ChatGPT 계정에서 default-model skip
    fallback 으로 본 PR 의 fix 가 macOS 에서도 의도대로 동작)