### PR TITLE
feat(claude-sdk): SDK 세션 누적 window guard + [1m] variant 분기

### DIFF
--- a/src-tauri/src/agents/claude_sdk_session.rs
+++ b/src-tauri/src/agents/claude_sdk_session.rs
@@ -128,6 +128,14 @@ impl Drop for SdkSession {
 type SessionRegistry = Arc<PlMutex<HashMap<String, Arc<SdkSession>>>>;
 /// conversation_id → 마지막 result session_id (세션 종료 후에도 --resume용으로 보존)
 type ResumeRegistry = Arc<PlMutex<HashMap<String, String>>>;
+/// (claudeSdkSessionWindowGuardPlan_2026-05-09) session_key → 마지막 result 의
+/// `accumulated_input_tokens` (cumulative SDK history 누적치). stream_run_sdk
+/// 의 result handler 가 turn 종료 시 stash, 다음 dispatch 진입 시 read 해서
+/// 임계 (180K default / 900K `[1m]`) 도달 여부 검사 → fresh-rotate.
+///
+/// in-memory stash — 앱 재시작 시 reset (DB persist 영역은 별 P3 plan, Plan §6
+/// 후속 plan 가능성).
+type WindowGuardRegistry = Arc<PlMutex<HashMap<String, u64>>>;
 /// `branch:<branch_id>` shadow conv → root main conversation_id 캐시.
 ///
 /// **의도** (`docs/plans/branchInheritsMainSessionPlan_2026-04-25.md`):
@@ -144,6 +152,63 @@ lazy_static::lazy_static! {
     static ref SESSIONS: SessionRegistry = Arc::new(PlMutex::new(HashMap::new()));
     static ref RESUME_IDS: ResumeRegistry = Arc::new(PlMutex::new(HashMap::new()));
     static ref BRANCH_ROOT_CACHE: BranchRootCache = Arc::new(PlMutex::new(HashMap::new()));
+    /// claudeSdkSessionWindowGuardPlan Task 01 — session_key → 누적 input_tokens.
+    static ref WINDOW_GUARD_INPUT_TOKENS: WindowGuardRegistry = Arc::new(PlMutex::new(HashMap::new()));
+}
+
+/// (claudeSdkSessionWindowGuardPlan Task 01) 누적 input_tokens 를 stash.
+///
+/// `stream_run_sdk` 의 result event 핸들러 끝에서 호출. 다음 dispatch 진입 시
+/// `take_window_guard_input_tokens` 가 read → 임계 비교 → fresh-rotate 결정.
+///
+/// **INV-CSW-1** (Plan §1): `accumulated_input_tokens` tracking 본체 (line 902~)
+/// 변경 0 — 본 helper 는 *additive*, 단순 stash 만.
+fn stash_window_guard_input_tokens(session_key: &str, tokens: u64) {
+    WINDOW_GUARD_INPUT_TOKENS
+        .lock()
+        .insert(session_key.to_string(), tokens);
+}
+
+/// (claudeSdkSessionWindowGuardPlan Task 01) 누적 input_tokens stash 를 read.
+///
+/// `stream_run_sdk` 진입 직후 호출 → 본 값이 임계 도달이면 fresh-rotate.
+/// 미존재 (첫 send) 시 0 반환 — 자연스러운 정상 path 흐름.
+fn read_window_guard_input_tokens(session_key: &str) -> u64 {
+    WINDOW_GUARD_INPUT_TOKENS
+        .lock()
+        .get(session_key)
+        .copied()
+        .unwrap_or(0)
+}
+
+/// (claudeSdkSessionWindowGuardPlan Task 01) fresh-rotate 후 stash reset.
+///
+/// `kill_session_clear_resume` 직후 호출 → 새 세션의 첫 turn 부터 정상 누적
+/// 시작. INV-CSW-2 (fresh-rotate 후 ContextPack 재주입) 의 일부.
+fn clear_window_guard_input_tokens(session_key: &str) {
+    WINDOW_GUARD_INPUT_TOKENS.lock().remove(session_key);
+}
+
+/// (claudeSdkSessionWindowGuardPlan Task 01) fresh-rotate trigger 발동 결정.
+///
+/// 누적 input_tokens 가 model_id 별 임계 (Task 04 helper) 도달 시 true.
+/// stream_run_sdk 진입 path 에서 호출 → true 면 `kill_session_clear_resume`
+/// + `clear_window_guard_input_tokens` + (PR-2 에서) Tauri event emit.
+///
+/// fresh-rotate 자체는 *현재 turn* 에 적용 — `kill_session_clear_resume` 이
+/// SESSIONS / RESUME_IDS / LAST_DELIVERED 모두 invalidate 하므로 그 직후의
+/// `get_or_create_session` 이 fresh session 으로 spawn (INV-CSW-2).
+pub(crate) fn should_trigger_window_rotate(
+    session_key: &str,
+    model_id: Option<&str>,
+) -> bool {
+    let accumulated = read_window_guard_input_tokens(session_key);
+    if accumulated == 0 {
+        return false; // 첫 send 또는 초기화 직후 — fast path
+    }
+    let threshold =
+        crate::agents::claude_window_guard::current_window_guard_threshold(model_id);
+    accumulated >= threshold
 }
 
 /// brand:* conv_id 를 root main conversation_id 로 normalize.
@@ -352,7 +417,35 @@ fn kill_session_with_resume(conv_id: &str, keep_resume: bool) {
     if key != conv_id {
         crate::commands::agents_helpers::send_common::session_freshness::clear_delivered_key(&key);
     }
+    // (claudeSdkSessionWindowGuardPlan Task 01) window guard stash 도 정리 —
+    // 다음 send 가 fresh session 으로 시작하는데 prior 누적치가 stash 에 남아
+    // 있으면 false trigger 위험. brand/main 양쪽 키 모두 정리.
+    clear_window_guard_input_tokens(&key);
+    if key != conv_id {
+        clear_window_guard_input_tokens(conv_id);
+    }
     // SdkSession Drop → _shutdown_tx 전송 → axum 서버 종료 → _monitor_abort 취소
+}
+
+/// (claudeSdkSessionWindowGuardPlan Task 02 hook) fresh-rotate 발생 시
+/// frontend toast 알림 발행 — PR-1 단계는 stub (silent 동작).
+///
+/// 본 함수는 PR-2 (Task 02) 에서 Tauri event `tunaflow:sdk-session-window-rotated`
+/// 를 발행하도록 확장. PR-1 단독 머지 시에도 회귀 차단 (fresh-rotate trigger
+/// 자체) 은 즉시 발동, 단 사용자 가시성 (toast) 은 PR-2 머지 후 활성화.
+///
+/// 매개변수:
+/// - `conv_id`: rotate 발생 conversation
+/// - `prior_tokens`: rotate 직전 누적 input_tokens
+/// - `threshold`: 적용된 임계값 (180K default / 900K `[1m]`)
+///
+/// stub 단계 — eprintln 만 발행 → release log 에 기록되어 디버깅 용이.
+fn emit_window_rotated_event(conv_id: &str, prior_tokens: u64, threshold: u64) {
+    // PR-2 에서 AppHandle.emit("tunaflow:sdk-session-window-rotated", payload) 로 확장
+    eprintln!(
+        "[sdk-window-guard:event] tunaflow:sdk-session-window-rotated conv={} prior_tokens={} threshold={} (PR-2 toast hook stub)",
+        conv_id, prior_tokens, threshold
+    );
 }
 
 /// 해당 conversation에 활성 SDK 세션이 있는지 확인한다.
@@ -798,6 +891,40 @@ where
     G: FnMut(String) + Send,
     C: Fn() -> bool + Send,
 {
+    // (claudeSdkSessionWindowGuardPlan Task 01) SDK 누적 window guard.
+    //
+    // 직전 turn 의 result event 가 stash 한 누적 input_tokens 를 read 해서
+    // 임계 (default 180K / `[1m]` 900K) 도달이면 fresh-rotate 발동:
+    //   1. kill_session_clear_resume — SESSIONS + RESUME_IDS + LAST_DELIVERED 모두 invalidate
+    //   2. clear_window_guard_input_tokens — stash 도 reset
+    //   3. (PR-2) Tauri event emit `tunaflow:sdk-session-window-rotated`
+    //   4. 다음 줄의 get_or_create_session 이 fresh session 으로 spawn (INV-CSW-2)
+    //
+    // 회복 가시화: persistence.rs 가 LAST_DELIVERED 비어있음을 인지 →
+    // is_session_continuation=false → ContextPack full mode + anchor 2 turns
+    // → plan_doc / findings / RT consensus 재주입 (사용자 컨텍스트 회복).
+    let pre_dispatch_key = session_key_for(conv_id);
+    if should_trigger_window_rotate(&pre_dispatch_key, input.model.as_deref()) {
+        let prior_tokens = read_window_guard_input_tokens(&pre_dispatch_key);
+        let threshold = crate::agents::claude_window_guard::current_window_guard_threshold(
+            input.model.as_deref(),
+        );
+        eprintln!(
+            "[sdk-window-guard] threshold reached: accumulated={} tokens >= {} (model={:?}) for conv={} key={} — \
+             rotating to fresh SDK session (clear SESSIONS+RESUME_IDS+LAST_DELIVERED)",
+            prior_tokens,
+            threshold,
+            input.model.as_deref().unwrap_or("<default>"),
+            conv_id,
+            pre_dispatch_key
+        );
+        kill_session_clear_resume(conv_id);
+        clear_window_guard_input_tokens(&pre_dispatch_key);
+        // (PR-2 Task 02) Tauri event emit hook — frontend toast 알림.
+        // PR-1 단독 머지 시 silent 진행 (UX 마찰 ↑) but 회귀 차단은 즉시 발동.
+        emit_window_rotated_event(conv_id, prior_tokens, threshold);
+    }
+
     // 세션 획득 (없으면 새로 생성, 모델 변경 시 재시작)
     let session = get_or_create_session(
         conv_id,
@@ -1011,6 +1138,14 @@ where
                     parsed.total_input_tokens.unwrap_or(0),
                     parsed.total_output_tokens.unwrap_or(0));
 
+                // (claudeSdkSessionWindowGuardPlan Task 01) cumulative input_tokens stash.
+                // 다음 dispatch 진입 시 stream_run_sdk 진입부 가드가 read → 임계
+                // 비교 → fresh-rotate 결정. INV-CSW-1: tracking 본체 변경 0,
+                // 단순 stash 만 추가.
+                if final_input > 0 {
+                    stash_window_guard_input_tokens(&session_key_owned, final_input as u64);
+                }
+
                 return Ok(RunOutput {
                     content: parsed.result.unwrap_or_default(),
                     cost_usd: parsed.total_cost_usd.or(parsed.cost_usd).unwrap_or(0.0),
@@ -1053,6 +1188,8 @@ pub fn shutdown_all_sessions() {
     }
     drop(sessions); // Drop triggers _monitor_abort → kill_on_drop
     RESUME_IDS.lock().clear();
+    // (claudeSdkSessionWindowGuardPlan Task 01) window guard stash 전체 reset.
+    WINDOW_GUARD_INPUT_TOKENS.lock().clear();
 }
 
 /// Kill any orphaned `claude --sdk-url` processes from previous app runs.
@@ -1586,5 +1723,145 @@ mod tests {
         // cleanup
         RESUME_IDS.lock().remove(&root);
         clear_branch_cache(&brand_conv);
+    }
+
+    // ─── claudeSdkSessionWindowGuardPlan Task 01 ───────────────────────────
+
+    /// 신규 stash/read/clear API 단위 검증 — 다른 테스트 격리를 위해 unique conv 사용.
+    #[test]
+    fn window_guard_stash_round_trip_persists_and_clears() {
+        let conv = unique_conv("wg-stash-roundtrip");
+        let key = session_key_for(&conv);
+
+        // 초기 stash 없음 → 0 반환 (fast path).
+        assert_eq!(read_window_guard_input_tokens(&key), 0);
+
+        stash_window_guard_input_tokens(&key, 175_000);
+        assert_eq!(read_window_guard_input_tokens(&key), 175_000);
+
+        clear_window_guard_input_tokens(&key);
+        assert_eq!(read_window_guard_input_tokens(&key), 0);
+    }
+
+    #[test]
+    fn sdk_window_guard_no_op_below_threshold() {
+        // accumulated < 임계 → fresh-rotate 미발동 (정상 path 보존).
+        // INV-CSW (G1): 정상 사용량 사용자 영향 0.
+        let conv = unique_conv("wg-below-default");
+        let key = session_key_for(&conv);
+
+        clear_window_guard_input_tokens(&key);
+        // 임계 직전 (179K, default 180K cap)
+        stash_window_guard_input_tokens(&key, 179_000);
+
+        assert!(
+            !should_trigger_window_rotate(&key, Some("claude-opus-4-7")),
+            "default 모델, 179K < 180K → rotate trigger 안 됨"
+        );
+
+        clear_window_guard_input_tokens(&key);
+    }
+
+    #[test]
+    fn sdk_window_guard_triggers_fresh_rotate_at_threshold() {
+        // accumulated >= 임계 → fresh-rotate 발동 (사용자 보고 fix 의도).
+        // INV-CSW (G1): "Prompt is too long" 회귀 차단의 핵심 분기.
+        let conv = unique_conv("wg-at-default");
+        let key = session_key_for(&conv);
+
+        clear_window_guard_input_tokens(&key);
+        // 임계 도달 (180K = default cap)
+        stash_window_guard_input_tokens(&key, 180_000);
+
+        assert!(
+            should_trigger_window_rotate(&key, Some("claude-opus-4-7")),
+            "default 모델, 180K >= 180K → rotate trigger 발동"
+        );
+
+        // 초과 (200K) 도 동일하게 trigger
+        stash_window_guard_input_tokens(&key, 200_000);
+        assert!(should_trigger_window_rotate(&key, Some("claude-sonnet-4-6")));
+
+        clear_window_guard_input_tokens(&key);
+    }
+
+    #[test]
+    fn sdk_window_guard_resets_after_kill_session_clear_resume() {
+        // INV-CSW-2: fresh-rotate 후 stash reset 되어 새 session 의 첫 turn 부터
+        // 정상 누적. kill_session_clear_resume 가 stash 도 정리하는지 확인.
+        let conv = unique_conv("wg-reset-after-kill");
+        let key = session_key_for(&conv);
+
+        // RESUME_IDS / stash 초기화
+        RESUME_IDS.lock().insert(key.clone(), "sid-OLD".into());
+        stash_window_guard_input_tokens(&key, 185_000);
+        assert_eq!(read_window_guard_input_tokens(&key), 185_000);
+
+        // kill_session_clear_resume — stash 도 함께 reset 되어야 함 (INV-CSW-2)
+        kill_session_clear_resume(&conv);
+        assert_eq!(
+            read_window_guard_input_tokens(&key),
+            0,
+            "kill_session_clear_resume 후 window guard stash 가 reset 되어야 함"
+        );
+    }
+
+    #[test]
+    fn sdk_window_guard_1m_variant_threshold_900k_not_triggered_at_180k() {
+        // INV-CSW-5: `[1m]` variant 사용자 (claude-opus-4-7-1m 등) 영향 0 — 200K
+        // limit 무관. 임계 900K 적용 → 200K 누적도 trigger 안 됨.
+        let conv = unique_conv("wg-1m-not-trigger");
+        let key = session_key_for(&conv);
+
+        clear_window_guard_input_tokens(&key);
+        // default 모델이면 trigger 됐을 양 (200K)
+        stash_window_guard_input_tokens(&key, 200_000);
+
+        assert!(
+            !should_trigger_window_rotate(&key, Some("claude-opus-4-7-1m")),
+            "1M variant: 200K < 900K → rotate 미발동 (INV-CSW-5)"
+        );
+        assert!(
+            !should_trigger_window_rotate(&key, Some("claude-haiku-4-5-1m")),
+            "1M variant 다른 family 도 동일"
+        );
+
+        clear_window_guard_input_tokens(&key);
+    }
+
+    #[test]
+    fn sdk_window_guard_1m_variant_triggers_at_900k() {
+        // 1M variant 도 임계 도달 시 (900K) trigger.
+        let conv = unique_conv("wg-1m-at-trigger");
+        let key = session_key_for(&conv);
+
+        clear_window_guard_input_tokens(&key);
+        stash_window_guard_input_tokens(&key, 900_000);
+
+        assert!(
+            should_trigger_window_rotate(&key, Some("claude-opus-4-7-1m")),
+            "1M variant: 900K >= 900K → rotate 발동"
+        );
+
+        clear_window_guard_input_tokens(&key);
+    }
+
+    #[test]
+    fn sdk_window_guard_no_op_with_zero_accumulated() {
+        // 첫 send (stash 비어있음) — fast path, threshold 비교 자체 skip.
+        // INV-CSW-8: RT 미사용 / Reviewer 미사용 conv 의 fast path 보존.
+        let conv = unique_conv("wg-fresh-zero");
+        let key = session_key_for(&conv);
+
+        clear_window_guard_input_tokens(&key);
+
+        assert!(
+            !should_trigger_window_rotate(&key, Some("claude-opus-4-7")),
+            "stash 비어있으면 trigger 안 됨"
+        );
+        assert!(
+            !should_trigger_window_rotate(&key, None),
+            "model_id 없어도 stash 비어있으면 trigger 안 됨"
+        );
     }
 }

--- a/src-tauri/src/agents/claude_window_guard.rs
+++ b/src-tauri/src/agents/claude_window_guard.rs
@@ -1,0 +1,134 @@
+//! Claude SDK 세션 누적 window guard — `[1m]` variant detection + cap 분기
+//!
+//! SSOT: `docs/plans/claudeSdkSessionWindowGuardPlan_2026-05-09.md` Task 04.
+//!
+//! Plan §0.3: `MAX_TOTAL_PROMPT = 60,000` chars 가 *system 영역 outgoing* 만
+//! 가드하고 claude SDK 세션 누적 history 미가드. v0.1.7-beta 이후 사용자 본인
+//! 환경에서 Reviewer 단계 *"Prompt is too long"* 회귀 표면화. Root cause = SDK
+//! 세션의 누적 input_tokens 가 200K (default) 또는 1M (`[1m]` variant) 한계
+//! 초과.
+//!
+//! 본 모듈은 *분기 인프라* — 모델별 임계값을 결정하는 helper 만 제공하고,
+//! 실제 fresh-rotate trigger 는 `claude_sdk_session.rs` 의 stream_run_sdk
+//! 진입 path 가 본 모듈의 `current_window_guard_threshold(model_id)` 를 호출.
+//!
+//! INV-CSW-5 (Plan §1): `[1m]` variant 사용자 (claude-opus-4-7-1m 등) 영향 0 —
+//! 1M 모드는 단일 turn 자체가 1M 까지 받으므로 임계 900K (90% 안전마진) 적용,
+//! default 모드는 200K limit 의 90% 인 180K 적용.
+
+/// default 모드 (200K context window) 의 임계값. Anthropic 공식 200,000 의 90%
+/// 안전마진. Reviewer 등 누적 turn 직전 에 cumulative input_tokens 가 본 값
+/// 도달하면 fresh-rotate 발동.
+pub const SDK_WINDOW_GUARD_TOKENS_DEFAULT: u64 = 180_000;
+
+/// `[1m]` variant 모드 (1M context window) 의 임계값. 1,000,000 의 90% 안전마진.
+/// 본 모드는 사용자가 명시적으로 1M variant 모델 (claude-opus-4-7-1m 등) 을
+/// 선택했을 때만 적용 — 일반 default 사용자는 영향 0 (INV-CSW-5).
+pub const SDK_WINDOW_GUARD_TOKENS_1M: u64 = 900_000;
+
+/// 모델 ID 가 1M context window variant 인지 판정.
+///
+/// 매칭 규칙 (둘 중 하나 true 면 variant):
+/// 1. `model_id.ends_with("-1m")` — Anthropic 공식 suffix 컨벤션
+/// 2. known list — 명시적으로 알려진 1M variant ID (suffix 컨벤션 외)
+///
+/// 신규 1M variant 추가 시 known list 갱신 별 PR (Architect 결정, Plan §3
+/// Task 04 위험 항목).
+///
+/// 안전한 판정 (false negative 우선) — 매칭 실패 시 default cap (180K) 적용.
+/// 1M variant 가 default 로 분류되면 사용자 UX 마찰만 (불필요한 fresh-rotate),
+/// 회귀는 0.
+pub fn is_1m_variant(model_id: &str) -> bool {
+    if model_id.ends_with("-1m") {
+        return true;
+    }
+    // Known 1M variant list — 미래 신규 variant 등록 시 갱신.
+    const KNOWN_1M_VARIANTS: &[&str] = &[
+        "claude-opus-4-7-1m",
+        "claude-haiku-4-5-1m",
+        "claude-sonnet-4-6-1m",
+    ];
+    KNOWN_1M_VARIANTS.contains(&model_id)
+}
+
+/// 모델 ID 에 맞는 SDK window guard 임계값을 반환.
+///
+/// `[1m]` variant 면 `SDK_WINDOW_GUARD_TOKENS_1M` (900K), 그 외엔
+/// `SDK_WINDOW_GUARD_TOKENS_DEFAULT` (180K).
+///
+/// `model_id` 가 None 또는 빈 문자열이면 default cap — 보수적 기본값.
+pub fn current_window_guard_threshold(model_id: Option<&str>) -> u64 {
+    match model_id {
+        Some(id) if !id.is_empty() && is_1m_variant(id) => SDK_WINDOW_GUARD_TOKENS_1M,
+        _ => SDK_WINDOW_GUARD_TOKENS_DEFAULT,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_1m_variant_detects_known_variants() {
+        // -1m suffix 컨벤션
+        assert!(is_1m_variant("claude-opus-4-7-1m"));
+        assert!(is_1m_variant("claude-haiku-4-5-1m"));
+        assert!(is_1m_variant("claude-sonnet-4-6-1m"));
+
+        // 미래 신규 variant — suffix 컨벤션 따른다고 가정 시 자동 인식
+        assert!(is_1m_variant("claude-opus-5-0-1m"));
+
+        // default 변종은 false
+        assert!(!is_1m_variant("claude-opus-4-7"));
+        assert!(!is_1m_variant("claude-sonnet-4-6"));
+        assert!(!is_1m_variant("claude-haiku-4-5"));
+        assert!(!is_1m_variant("claude-opus-4-7-20260417"));
+
+        // edge cases
+        assert!(!is_1m_variant(""));
+        assert!(!is_1m_variant("1m"));
+        assert!(!is_1m_variant("claude"));
+    }
+
+    #[test]
+    fn current_window_guard_threshold_returns_correct_value_per_variant() {
+        // 1M variant
+        assert_eq!(
+            current_window_guard_threshold(Some("claude-opus-4-7-1m")),
+            SDK_WINDOW_GUARD_TOKENS_1M,
+            "1M variant 는 900K 임계"
+        );
+        assert_eq!(
+            current_window_guard_threshold(Some("claude-haiku-4-5-1m")),
+            SDK_WINDOW_GUARD_TOKENS_1M,
+        );
+
+        // default
+        assert_eq!(
+            current_window_guard_threshold(Some("claude-opus-4-7")),
+            SDK_WINDOW_GUARD_TOKENS_DEFAULT,
+            "default 는 180K 임계"
+        );
+        assert_eq!(
+            current_window_guard_threshold(Some("claude-sonnet-4-6")),
+            SDK_WINDOW_GUARD_TOKENS_DEFAULT,
+        );
+
+        // None / 빈 문자열 → default (보수적)
+        assert_eq!(
+            current_window_guard_threshold(None),
+            SDK_WINDOW_GUARD_TOKENS_DEFAULT,
+        );
+        assert_eq!(
+            current_window_guard_threshold(Some("")),
+            SDK_WINDOW_GUARD_TOKENS_DEFAULT,
+        );
+    }
+
+    #[test]
+    fn threshold_constants_are_safe_margins() {
+        // Anthropic 공식 한도의 90% 이하
+        assert!(SDK_WINDOW_GUARD_TOKENS_DEFAULT <= 200_000 * 9 / 10);
+        assert!(SDK_WINDOW_GUARD_TOKENS_1M <= 1_000_000 * 9 / 10);
+    }
+}

--- a/src-tauri/src/agents/mod.rs
+++ b/src-tauri/src/agents/mod.rs
@@ -1,6 +1,7 @@
 pub mod anthropic_sdk;
 pub mod claude;
 pub mod claude_sdk_session;
+pub mod claude_window_guard;
 pub mod codex;
 pub mod codex_app_server;
 pub mod context_hub;


### PR DESCRIPTION
## Summary

사용자 본인 환경 회귀 *"[claude-code error] claude reported error: Prompt is too long"* (Reviewer 단계 진행 차단) 의 fix 본체. v0.1.7-beta release 후 표면화된 SDK 세션 누적 history 미가드 회귀 — `MAX_TOTAL_PROMPT = 60,000` chars 가 *system 영역 outgoing* 만 가드하고 claude SDK 세션의 cumulative input_tokens (200K / 1M context window) 는 별 영역.

Plan SSOT: [`docs/plans/claudeSdkSessionWindowGuardPlan_2026-05-09.md`](https://github.com/hang-in/tunaFlow/blob/main/docs/plans/claudeSdkSessionWindowGuardPlan_2026-05-09.md) — Task 01 + Task 04.

Architecture pattern: [`claudeTransportFlipHardeningPlan_2026-04-29`](https://github.com/hang-in/tunaFlow/blob/main/docs/plans/claudeTransportFlipHardeningPlan_2026-04-29.md) 의 T9-a/T11 fresh-session 정책 (`is_session_continuation=false` 강제 + 새 SDK 세션) 재사용.

## Changes

### Task 04 (commit `a42548a`) — `[1m]` variant detection helper
- 신규 모듈 `src-tauri/src/agents/claude_window_guard.rs`
- `SDK_WINDOW_GUARD_TOKENS_DEFAULT: u64 = 180_000` (200K limit 의 90% 안전마진)
- `SDK_WINDOW_GUARD_TOKENS_1M: u64 = 900_000` (1M limit 의 90% 안전마진)
- `is_1m_variant(model_id) -> bool` — `-1m` suffix + known list 매칭
- `current_window_guard_threshold(model_id: Option<&str>) -> u64`

### Task 01 (commit `038e888`) — 누적 임계 도달 시 자동 fresh-rotate
- `claude_sdk_session.rs` 에 `WINDOW_GUARD_INPUT_TOKENS` 전역 stash 추가
- `stream_run_sdk` result event 핸들러 끝에서 final_input 을 stash
- `stream_run_sdk` 진입 직후 `should_trigger_window_rotate` 체크 → 임계 도달 시:
  1. `kill_session_clear_resume(conv_id)` — SESSIONS + RESUME_IDS + LAST_DELIVERED 무효화
  2. `clear_window_guard_input_tokens(key)` — stash reset
  3. `emit_window_rotated_event(conv_id, prior_tokens, threshold)` — PR-2 의 Tauri event hook (현재 stub eprintln)
  4. 다음 줄 `get_or_create_session` 이 fresh session 으로 spawn

## Invariants 준수

- **INV-CSW-1**: `accumulated_input_tokens` tracking 본체 (line 902) 변경 0 — `git diff src-tauri/src/agents/claude_sdk_session.rs | grep -E '^-.*accumulated_input_tokens'` 결과 0 라인
- **INV-CSW-2**: fresh-rotate 후 LAST_DELIVERED 비어 있음 → `is_session_continuation=false` → ContextPack full mode + anchor 2 turns → plan_doc / findings / RT consensus 재주입 (사용자 컨텍스트 회복)
- **INV-CSW-3**: RT 영역 영향 0 (`roundtable.rs` / `roundtable_helpers/` / `db/migrations.rs` diff 0)
- **INV-CSW-5**: `[1m]` variant 사용자 영향 0 (Task 04 helper 가 900K cap 분기, 200K limit 무관)
- **Plan A (#264 Windows 캡션바)**: 영역 침범 없음 (`tauri.conf.json` / `bootstrap/window.rs` / `TitleBar.tsx` / `WindowControls.tsx` / `platform.ts` diff 0)
- **DB schema**: 변경 0 (in-memory stash, P3 영역에 영구화 별 plan)

## Verification

```
cd src-tauri && cargo check --message-format=short  # PASS
cd src-tauri && cargo test --lib                     # 635 → 645 (+10)
npx tsc --noEmit                                     # PASS
```

신규 unit test 10건:
- Task 04: `is_1m_variant_detects_known_variants`, `current_window_guard_threshold_returns_correct_value_per_variant`, `threshold_constants_are_safe_margins`
- Task 01: `window_guard_stash_round_trip_persists_and_clears`, `sdk_window_guard_no_op_below_threshold`, `sdk_window_guard_triggers_fresh_rotate_at_threshold`, `sdk_window_guard_resets_after_kill_session_clear_resume`, `sdk_window_guard_1m_variant_threshold_900k_not_triggered_at_180k`, `sdk_window_guard_1m_variant_triggers_at_900k`, `sdk_window_guard_no_op_with_zero_accumulated`

## Test plan

- [x] `cargo check`
- [x] `cargo test --lib` — 645 passed
- [x] `npx tsc --noEmit`
- [x] 회귀 grep — Plan A / RT / DB 영역 diff 0
- [x] INV-CSW-1 — `accumulated_input_tokens` 삭제 라인 0건
- [ ] e2e 사용자 환경 — v0.1.8-beta release 후 자가 회복 검증 (별 PR / release cycle 영역)

## Follow-up

- **PR-2** (`feat/sdk-rotate-toast-notification`): Tauri event 채널 `tunaflow:sdk-session-window-rotated` + frontend sonner toast — 현재 stub `emit_window_rotated_event` 를 실 emit 으로 확장
- **PR-3** (`feat/reviewer-context-squeeze`): Reviewer role 분기 plan_doc cap 6K → 3K + recent messages LIMIT 20 → 10
- **PR-4** (`test/sdk-window-guard-coverage`): 통합 e2e (mocking) + Task 06 release notes
- **P3** (별 plan): `accumulated_input_tokens` 영구 저장 (현재 in-memory, 앱 재시작 시 reset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)