### PR TITLE
feat(notification): SDK session window rotated toast (Task 02)

### DIFF
--- a/src-tauri/src/agents/anthropic_sdk.rs
+++ b/src-tauri/src/agents/anthropic_sdk.rs
@@ -161,6 +161,7 @@ where
         session_id: None,
         last_rate_limit: None,
         fresh_fallback: false,
+        window_rotated: None,
     })
 }
 

--- a/src-tauri/src/agents/claude.rs
+++ b/src-tauri/src/agents/claude.rs
@@ -179,6 +179,26 @@ pub struct RunOutput {
     /// revival 자동 발동, (c) frontend 에 `claude:fresh_fallback` event emit.
     /// claudeTransportFlipHardeningPlan T2 + T3.
     pub fresh_fallback: bool,
+    /// (claudeSdkSessionWindowGuardPlan Task 02) `Some((prior_tokens, threshold))`
+    /// = stream_run_sdk 진입 직후 SDK 누적 window guard 가 fresh-rotate trigger
+    /// 발동했음. finalize_engine_run 이 본 정보를 보고 frontend 에 Tauri event
+    /// `tunaflow:sdk-session-window-rotated` 발행 → sonner toast 알림. None 이면
+    /// rotate 미발생 (정상 path) — 이벤트 발행 안 함. cli/sdk path 모두 동일 필드
+    /// 사용 (cli path 는 항상 None).
+    pub window_rotated: Option<WindowRotatedInfo>,
+}
+
+/// (claudeSdkSessionWindowGuardPlan Task 02) fresh-rotate 발생 metadata.
+///
+/// SSOT: `docs/plans/claudeSdkSessionWindowGuardPlan_2026-05-09.md` Task 02.
+/// frontend toast 의 description 에 사용 (디버깅 / 사용자 인지 정보).
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WindowRotatedInfo {
+    /// rotate 직전 누적 input_tokens
+    pub prior_tokens: u64,
+    /// 적용된 임계값 (180K default / 900K `[1m]`)
+    pub threshold: u64,
 }
 
 /// claude API 에러를 사용자 친화 카테고리로 분류 (T7).
@@ -581,6 +601,8 @@ where
                     last_rate_limit: last_rate_limit.take(),
                     // T2: stream_run wrapper 가 retry 후 true 로 set. 1회 시도 자체는 false.
                     fresh_fallback: false,
+                    // cli `-p` path 는 본 plan scope 외 (sdk-url path 만 cumulative window guard 적용)
+                    window_rotated: None,
                 });
             }
             _ => {}
@@ -692,6 +714,8 @@ pub fn run(input: RunInput) -> Result<RunOutput, AppError> {
         // 못한다 (stream-json 전용). 항상 None.
         last_rate_limit: None,
         fresh_fallback: false,
+        // cli `-p` path 는 본 plan scope 외 (sdk-url path 만 cumulative window guard 적용)
+        window_rotated: None,
     })
 }
 

--- a/src-tauri/src/agents/claude_sdk_session.rs
+++ b/src-tauri/src/agents/claude_sdk_session.rs
@@ -891,19 +891,22 @@ where
     G: FnMut(String) + Send,
     C: Fn() -> bool + Send,
 {
-    // (claudeSdkSessionWindowGuardPlan Task 01) SDK 누적 window guard.
+    // (claudeSdkSessionWindowGuardPlan Task 01+02) SDK 누적 window guard.
     //
     // 직전 turn 의 result event 가 stash 한 누적 input_tokens 를 read 해서
     // 임계 (default 180K / `[1m]` 900K) 도달이면 fresh-rotate 발동:
     //   1. kill_session_clear_resume — SESSIONS + RESUME_IDS + LAST_DELIVERED 모두 invalidate
     //   2. clear_window_guard_input_tokens — stash 도 reset
-    //   3. (PR-2) Tauri event emit `tunaflow:sdk-session-window-rotated`
+    //   3. window_rotated_pending 에 metadata stash → result event 에서 RunOutput
+    //      에 옮김 → finalize_engine_run 이 Tauri event `tunaflow:sdk-session-window-rotated`
+    //      발행 → frontend toast 알림 (PR-2 Task 02)
     //   4. 다음 줄의 get_or_create_session 이 fresh session 으로 spawn (INV-CSW-2)
     //
     // 회복 가시화: persistence.rs 가 LAST_DELIVERED 비어있음을 인지 →
     // is_session_continuation=false → ContextPack full mode + anchor 2 turns
     // → plan_doc / findings / RT consensus 재주입 (사용자 컨텍스트 회복).
     let pre_dispatch_key = session_key_for(conv_id);
+    let mut window_rotated_pending: Option<crate::agents::claude::WindowRotatedInfo> = None;
     if should_trigger_window_rotate(&pre_dispatch_key, input.model.as_deref()) {
         let prior_tokens = read_window_guard_input_tokens(&pre_dispatch_key);
         let threshold = crate::agents::claude_window_guard::current_window_guard_threshold(
@@ -920,8 +923,12 @@ where
         );
         kill_session_clear_resume(conv_id);
         clear_window_guard_input_tokens(&pre_dispatch_key);
-        // (PR-2 Task 02) Tauri event emit hook — frontend toast 알림.
-        // PR-1 단독 머지 시 silent 진행 (UX 마찰 ↑) but 회귀 차단은 즉시 발동.
+        // (PR-2 Task 02) frontend toast 발행을 위한 metadata stash.
+        // result event 가 RunOutput.window_rotated 에 옮긴다.
+        window_rotated_pending = Some(crate::agents::claude::WindowRotatedInfo {
+            prior_tokens,
+            threshold,
+        });
         emit_window_rotated_event(conv_id, prior_tokens, threshold);
     }
 
@@ -1155,6 +1162,9 @@ where
                     // sdk-session path 는 본 plan scope 외 — 호환성만 유지.
                     last_rate_limit: None,
                     fresh_fallback: false,
+                    // (claudeSdkSessionWindowGuardPlan Task 02) 진입부 fresh-rotate
+                    // 발생 시 metadata 를 옮김. None 이면 정상 path (rotate 미발생).
+                    window_rotated: window_rotated_pending.take(),
                 });
             }
             "control_request" => {

--- a/src-tauri/src/agents/codex.rs
+++ b/src-tauri/src/agents/codex.rs
@@ -212,6 +212,7 @@ pub fn run(input: RunInput) -> Result<RunOutput, AppError> {
         session_id: None,
         last_rate_limit: None,
         fresh_fallback: false,
+        window_rotated: None,
     })
 }
 
@@ -413,6 +414,7 @@ where
         session_id: None,
         last_rate_limit: None,
         fresh_fallback: false,
+        window_rotated: None,
     })
 }
 

--- a/src-tauri/src/agents/codex_app_server.rs
+++ b/src-tauri/src/agents/codex_app_server.rs
@@ -356,6 +356,7 @@ where
                     session_id: Some(thread_id),
                     last_rate_limit: None,
                     fresh_fallback: false,
+                    window_rotated: None,
                 });
             }
             // wire format: "error" (NOT "errorNotification"; codex v2 protocol common.rs:978)

--- a/src-tauri/src/agents/gemini.rs
+++ b/src-tauri/src/agents/gemini.rs
@@ -101,6 +101,7 @@ pub fn run(input: RunInput) -> Result<RunOutput, AppError> {
         session_id: None,
         last_rate_limit: None,
         fresh_fallback: false,
+        window_rotated: None,
     })
 }
 
@@ -321,5 +322,6 @@ where
         session_id,
         last_rate_limit: None,
         fresh_fallback: false,
+        window_rotated: None,
     })
 }

--- a/src-tauri/src/agents/gemini_sdk.rs
+++ b/src-tauri/src/agents/gemini_sdk.rs
@@ -163,6 +163,7 @@ where
         session_id: None,
         last_rate_limit: None,
         fresh_fallback: false,
+        window_rotated: None,
     })
 }
 

--- a/src-tauri/src/agents/openai_compat.rs
+++ b/src-tauri/src/agents/openai_compat.rs
@@ -381,6 +381,7 @@ where
         session_id: None,
         last_rate_limit: None,
         fresh_fallback: false,
+        window_rotated: None,
     })
 }
 

--- a/src-tauri/src/agents/openai_sdk.rs
+++ b/src-tauri/src/agents/openai_sdk.rs
@@ -166,6 +166,7 @@ where
         session_id: None,
         last_rate_limit: None,
         fresh_fallback: false,
+        window_rotated: None,
     })
 }
 

--- a/src-tauri/src/agents/opencode.rs
+++ b/src-tauri/src/agents/opencode.rs
@@ -135,5 +135,6 @@ pub fn run(input: RunInput) -> Result<RunOutput, AppError> {
         session_id: None,
         last_rate_limit: None,
         fresh_fallback: false,
+        window_rotated: None,
     })
 }

--- a/src-tauri/src/commands/agents_helpers/send_common/persistence.rs
+++ b/src-tauri/src/commands/agents_helpers/send_common/persistence.rs
@@ -483,6 +483,21 @@ pub fn finalize_engine_run(
                     "rateLimit": rl,
                 }));
             }
+
+            // (claudeSdkSessionWindowGuardPlan Task 02) SDK 누적 window guard 가
+            // fresh-rotate 발동 시 frontend 에 toast 알림 발행. ClaudeFallbackEvents.tsx
+            // 의 listener 가 sonner toast 표시. 회귀 가드: window_rotated=None 이면
+            // 정상 path (rotate 미발생) — 이벤트 발행 안 함. claude / claude-code 외
+            // 엔진은 항상 None 이라 자연스럽게 skip.
+            if let Some(ref wr) = out.window_rotated {
+                let _ = app.emit("tunaflow:sdk-session-window-rotated", serde_json::json!({
+                    "messageId": msg_id,
+                    "conversationId": conversation_id,
+                    "engine": engine_key,
+                    "priorTokens": wr.prior_tokens,
+                    "threshold": wr.threshold,
+                }));
+            }
             insert_trace_log_with_context(conn, conversation_id, out.input_tokens, out.output_tokens, out.cost_usd, now,
                 &SpanInfo { trace_id: &new_trace_id(), span_id: new_span_id(), parent_span_id: None,
                     operation: "agent.stream", engine: engine_key, duration_ms: duration_ms as i64, status: "ok" },

--- a/src/components/tunaflow/ClaudeFallbackEvents.tsx
+++ b/src/components/tunaflow/ClaudeFallbackEvents.tsx
@@ -1,9 +1,11 @@
 /**
- * Claude transport flip hardening (T4) — UI 가시화.
+ * Claude transport flip hardening (T4) + SDK window guard (Task 02) — UI 가시화.
  *
- * SSOT: docs/plans/claudeTransportFlipHardeningPlan_2026-04-29.md Task 04.
+ * SSOT:
+ * - docs/plans/claudeTransportFlipHardeningPlan_2026-04-29.md Task 04
+ * - docs/plans/claudeSdkSessionWindowGuardPlan_2026-05-09.md Task 02
  *
- * Backend (T2+T3) 가 emit 하는 두 이벤트를 단일 컴포넌트에서 listen:
+ * Backend 가 emit 하는 세 이벤트를 단일 컴포넌트에서 listen:
  *
  *  - `claude:fresh_fallback` — stale resume_token detect 후 자동 fresh session
  *    fallback 발생. 사용자에게 "다음 응답부터 ContextPack revival" 안내 토스트
@@ -14,10 +16,16 @@
  *    상태로 보관. (status: ok/approaching/limit_reached + reset 시각 + overage
  *    상태)
  *
+ *  - `tunaflow:sdk-session-window-rotated` — SDK 누적 input_tokens 가 임계
+ *    (180K default / 900K `[1m]`) 도달 시 자동 fresh-rotate 발생. 사용자에게
+ *    "세션 컨텍스트 한계 도달, 새 세션으로 자동 전환" 안내 토스트 (info 레벨,
+ *    5초 자동 dismiss). conversation 별 sessionStorage flag 로 spam 차단 —
+ *    같은 conv 의 반복 rotate 마다 토스트 한 번만.
+ *
  * 회귀 가드:
  *  - 본 컴포넌트는 AppShell 안에 1회 mount → listener 가 앱 lifetime 한 번만 wire.
  *  - 기존 progress/chunk/completed/error listener (agentStreamHelper) 영향 0.
- *  - 다른 엔진의 같은 이름 이벤트 없음 (claude 한정 prefix) — 회귀 0.
+ *  - 다른 엔진의 같은 이름 이벤트 없음 (claude 한정 prefix + tunaflow: prefix) — 회귀 0.
  */
 import { useEffect } from "react";
 import { listen } from "@tauri-apps/api/event";
@@ -37,9 +45,27 @@ interface RateLimitPayload {
   rateLimit: ClaudeRateLimitInfo;
 }
 
+/**
+ * (claudeSdkSessionWindowGuardPlan Task 02) SDK 누적 window guard fresh-rotate
+ * 발생 시 backend → frontend payload. backend 의 `RunOutput.window_rotated` 가
+ * `Some(WindowRotatedInfo)` 일 때만 발행.
+ */
+interface WindowRotatedPayload {
+  messageId: string;
+  conversationId: string;
+  engine: string;
+  priorTokens: number;
+  threshold: number;
+}
+
 /** sessionStorage key — 같은 conversation 의 fallback 토스트 재표시 차단. */
 function fallbackToastKey(conversationId: string): string {
   return `tunaflow.claudeFreshFallbackShown.${conversationId}`;
+}
+
+/** sessionStorage key — 같은 conversation 의 window-rotated 토스트 재표시 차단. */
+function windowRotatedToastKey(conversationId: string): string {
+  return `tunaflow.sdkWindowRotatedShown.${conversationId}`;
 }
 
 /**
@@ -53,6 +79,7 @@ export function ClaudeFallbackEvents(): null {
   useEffect(() => {
     let unlistenFallback: (() => void) | null = null;
     let unlistenRateLimit: (() => void) | null = null;
+    let unlistenWindowRotated: (() => void) | null = null;
     let cancelled = false;
 
     (async () => {
@@ -95,6 +122,41 @@ export function ClaudeFallbackEvents(): null {
           setRateLimit(e.payload.conversationId, e.payload.rateLimit);
         },
       );
+
+      // (claudeSdkSessionWindowGuardPlan Task 02) SDK 누적 window guard
+      // fresh-rotate 발생 알림.
+      unlistenWindowRotated = await listen<WindowRotatedPayload>(
+        "tunaflow:sdk-session-window-rotated",
+        (e) => {
+          if (cancelled) return;
+          const { conversationId } = e.payload;
+          // Spam 차단 — 같은 conversation 의 첫 rotate 만 토스트.
+          let alreadyShown = false;
+          try {
+            alreadyShown =
+              sessionStorage.getItem(windowRotatedToastKey(conversationId)) === "1";
+          } catch {
+            /* sessionStorage unavailable */
+          }
+          if (alreadyShown) return;
+          try {
+            sessionStorage.setItem(windowRotatedToastKey(conversationId), "1");
+          } catch {
+            /* ignore */
+          }
+
+          toast.info(t("claude.windowRotated.title"), {
+            description: t("claude.windowRotated.body"),
+            duration: 5000,
+            action: {
+              label: t("claude.windowRotated.dismiss"),
+              onClick: () => {
+                /* sonner auto-dismiss — explicit 확인 액션만 */
+              },
+            },
+          });
+        },
+      );
     })().catch((err) => {
       console.warn("[claude-fallback] listener setup failed:", err);
     });
@@ -103,6 +165,7 @@ export function ClaudeFallbackEvents(): null {
       cancelled = true;
       if (unlistenFallback) unlistenFallback();
       if (unlistenRateLimit) unlistenRateLimit();
+      if (unlistenWindowRotated) unlistenWindowRotated();
     };
   }, [setRateLimit, t]);
 

--- a/src/locales/en/runtime.json
+++ b/src/locales/en/runtime.json
@@ -7,6 +7,11 @@
       "learnMore": "Open Claude usage",
       "manualRestart": "Restart Claude session"
     },
+    "windowRotated": {
+      "title": "Claude session window limit reached",
+      "body": "Cumulative context approached the model's window limit, so the SDK session was rotated to a fresh one. Prior conversation context is re-attached via ContextPack — the first reply may be slightly slower.",
+      "dismiss": "Got it"
+    },
     "rateLimit": {
       "ok": "Claude usage OK",
       "approaching": "Approaching Claude's 5-hour limit",

--- a/src/locales/ko/runtime.json
+++ b/src/locales/ko/runtime.json
@@ -7,6 +7,11 @@
       "learnMore": "Claude 사용량 보기",
       "manualRestart": "Claude 세션 다시 시작"
     },
+    "windowRotated": {
+      "title": "Claude 세션 컨텍스트 한계 도달",
+      "body": "누적 컨텍스트가 한계에 가까워져 새 세션으로 자동 전환됐습니다. 이전 대화 맥락은 ContextPack 으로 재주입됩니다 — 첫 응답이 약간 느릴 수 있습니다.",
+      "dismiss": "확인"
+    },
     "rateLimit": {
       "ok": "Claude 사용량 정상",
       "approaching": "Claude 5시간 한도에 가까워졌습니다",

--- a/src/tests/claudeFallbackEvents.test.tsx
+++ b/src/tests/claudeFallbackEvents.test.tsx
@@ -1,0 +1,156 @@
+// ClaudeFallbackEvents — Tauri event listener test.
+//
+// SSOT:
+// - docs/plans/claudeTransportFlipHardeningPlan_2026-04-29.md Task 04 (claude:fresh_fallback)
+// - docs/plans/claudeSdkSessionWindowGuardPlan_2026-05-09.md Task 02 (tunaflow:sdk-session-window-rotated)
+//
+// 본 test 는 PR-2 의 SDK window guard toast listener 가:
+//  1. `tunaflow:sdk-session-window-rotated` 이벤트 수신 시 sonner toast.info 호출
+//  2. 같은 conversation 의 두 번째 이벤트는 sessionStorage flag 로 spam 차단
+//  3. 다른 conversation 은 별 flag 라 toast 표시
+// 를 검증한다.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render } from "@testing-library/react";
+import { ClaudeFallbackEvents } from "@/components/tunaflow/ClaudeFallbackEvents";
+
+// react-i18next mock — toast 의 t(key) 가 식별 가능하도록 identity 반환.
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "ko", changeLanguage: () => Promise.resolve() },
+  }),
+}));
+
+// claudeRateLimitStore — listener 가 호출하는 setRateLimit 의 spy.
+const setRateLimitSpy = vi.fn();
+vi.mock("@/stores/claudeRateLimitStore", () => ({
+  useClaudeRateLimitStore: (selector: (s: { setRateLimit: typeof setRateLimitSpy }) => unknown) =>
+    selector({ setRateLimit: setRateLimitSpy }),
+}));
+
+// sonner — toast.info / toast.error 의 spy.
+const toastInfoSpy = vi.fn();
+const toastErrorSpy = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    info: (...args: unknown[]) => toastInfoSpy(...args),
+    error: (...args: unknown[]) => toastErrorSpy(...args),
+  },
+}));
+
+// Tauri event listener — 이벤트 별로 callback 등록 + 외부에서 trigger 가능한 spy.
+type EventCallback<T> = (event: { payload: T }) => void;
+const eventListeners = new Map<string, EventCallback<unknown>>();
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: <T,>(eventName: string, callback: EventCallback<T>) => {
+    eventListeners.set(eventName, callback as EventCallback<unknown>);
+    return Promise.resolve(() => {
+      eventListeners.delete(eventName);
+    });
+  },
+}));
+
+beforeEach(() => {
+  setRateLimitSpy.mockClear();
+  toastInfoSpy.mockClear();
+  toastErrorSpy.mockClear();
+  eventListeners.clear();
+  // sessionStorage spam-flag 초기화 — 테스트 간 격리.
+  try {
+    sessionStorage.clear();
+  } catch {
+    /* noop */
+  }
+});
+
+afterEach(() => {
+  eventListeners.clear();
+});
+
+describe("ClaudeFallbackEvents — SDK window guard listener (Task 02)", () => {
+  it("registers a listener for tunaflow:sdk-session-window-rotated", async () => {
+    render(<ClaudeFallbackEvents />);
+    // useEffect 의 async (async () => {})() 가 listener 를 등록하기까지 대기.
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(eventListeners.has("tunaflow:sdk-session-window-rotated")).toBe(true);
+    expect(eventListeners.has("claude:fresh_fallback")).toBe(true);
+    expect(eventListeners.has("claude:rate_limit")).toBe(true);
+  });
+
+  it("shows sonner toast.info when window-rotated event fires", async () => {
+    render(<ClaudeFallbackEvents />);
+    await new Promise((r) => setTimeout(r, 0));
+
+    const callback = eventListeners.get("tunaflow:sdk-session-window-rotated")!;
+    callback({
+      payload: {
+        messageId: "msg-1",
+        conversationId: "conv-A",
+        engine: "claude-code",
+        priorTokens: 185_000,
+        threshold: 180_000,
+      },
+    });
+
+    expect(toastInfoSpy).toHaveBeenCalledTimes(1);
+    expect(toastInfoSpy).toHaveBeenCalledWith(
+      "claude.windowRotated.title",
+      expect.objectContaining({
+        description: "claude.windowRotated.body",
+        duration: 5000,
+      }),
+    );
+  });
+
+  it("dedupes repeat events per conversation via sessionStorage flag", async () => {
+    render(<ClaudeFallbackEvents />);
+    await new Promise((r) => setTimeout(r, 0));
+
+    const callback = eventListeners.get("tunaflow:sdk-session-window-rotated")!;
+    const payload = {
+      messageId: "msg-1",
+      conversationId: "conv-A",
+      engine: "claude-code",
+      priorTokens: 185_000,
+      threshold: 180_000,
+    };
+
+    callback({ payload });
+    callback({ payload });
+    callback({ payload });
+
+    // 첫 번째만 toast — 같은 conv 의 반복은 spam 차단.
+    expect(toastInfoSpy).toHaveBeenCalledTimes(1);
+    expect(sessionStorage.getItem("tunaflow.sdkWindowRotatedShown.conv-A")).toBe("1");
+  });
+
+  it("treats different conversations as separate spam-flag scopes", async () => {
+    render(<ClaudeFallbackEvents />);
+    await new Promise((r) => setTimeout(r, 0));
+
+    const callback = eventListeners.get("tunaflow:sdk-session-window-rotated")!;
+    callback({
+      payload: {
+        messageId: "msg-1",
+        conversationId: "conv-A",
+        engine: "claude-code",
+        priorTokens: 185_000,
+        threshold: 180_000,
+      },
+    });
+    callback({
+      payload: {
+        messageId: "msg-2",
+        conversationId: "conv-B",
+        engine: "claude-code",
+        priorTokens: 185_000,
+        threshold: 180_000,
+      },
+    });
+
+    // 다른 conv 는 별 flag → 각각 toast.
+    expect(toastInfoSpy).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary

PR-1 의 silent fresh-rotate 를 사용자 가시화. SDK 누적 input_tokens 가 임계 도달해 자동 rotate 발생 시 frontend sonner toast (info 레벨, 5초 dismiss) 알림 — 사용자가 *왜 갑자기 fresh* 인지 인지 가능. claudeTransportFlipHardeningPlan T4 의 freshFallback 토스트와 정확히 같은 패턴 (sessionStorage spam 차단 + i18n).

Plan SSOT: [`docs/plans/claudeSdkSessionWindowGuardPlan_2026-05-09.md`](https://github.com/hang-in/tunaFlow/blob/main/docs/plans/claudeSdkSessionWindowGuardPlan_2026-05-09.md) — Task 02.

PR-1 (#279, merge `63a5e00`) 의 후속 — fresh-rotate trigger 자체는 PR-1 에서 동작, 본 PR 은 *알림만*.

## Changes

### Backend
- `RunOutput.window_rotated: Option<WindowRotatedInfo>` 신규 필드 (`claude.rs`)
- `WindowRotatedInfo { prior_tokens: u64, threshold: u64 }` struct (frontend toast description 용 metadata)
- `claude_sdk_session.rs::stream_run_sdk` 진입부 fresh-rotate trigger 시점에 `window_rotated_pending` stash, result event 가 RunOutput 에 옮김
- 다른 11 RunOutput 생성지 (anthropic_sdk / openai_compat / openai_sdk / gemini_sdk / opencode / codex / codex_app_server / gemini / claude.rs `stream_run_once` + `run_json`) 에 `window_rotated: None` 호환성 채움 — 회귀 0
- `persistence.rs::finalize_engine_run` 에 `out.window_rotated` 분기 → Tauri event `tunaflow:sdk-session-window-rotated` emit (기존 `claude:fresh_fallback` / `claude:rate_limit` 와 정확히 같은 패턴)

### Frontend
- `ClaudeFallbackEvents.tsx` 에 신규 listener — sonner `toast.info` 5초 dismiss + sessionStorage spam 차단 flag (conv 별)
- `runtime.json` ko/en — `claude.windowRotated.{title,body,dismiss}` 추가
- 신규 frontend test 파일 `src/tests/claudeFallbackEvents.test.tsx` — 4 개 case

## Invariants 준수

- **INV-CSW-7**: 기존 sonner 인프라 (`ClaudeFallbackEvents`) 재사용 — 신규 컴포넌트 0, 신규 modal/banner/dialog 0
- **INV-CSW-8**: spam 차단 — 같은 conv 의 반복 rotate 마다 토스트 한 번만, 다른 conv 는 별 flag
- **Plan A (#264)**: 영역 침범 없음
- **RT 영역**: `roundtable.rs` / `roundtable_helpers/` / `db/migrations.rs` diff 0
- **신규 dependency**: 0 (sonner / Tauri event 모두 기존 인프라)

## Verification

```
cd src-tauri && cargo check --message-format=short  # PASS
cd src-tauri && cargo test --lib                     # 645 passed (변동 0)
npx tsc --noEmit                                     # PASS
npx vitest run                                       # 422 → 426 (+4)
```

신규 frontend test 4건:
- `registers a listener for tunaflow:sdk-session-window-rotated`
- `shows sonner toast.info when window-rotated event fires`
- `dedupes repeat events per conversation via sessionStorage flag`
- `treats different conversations as separate spam-flag scopes`

## Test plan

- [x] `cargo check` / `cargo test --lib` / `tsc --noEmit` / `vitest run`
- [x] 회귀 grep — Plan A / RT / DB 영역 diff 0
- [x] 11 RunOutput 생성지 모두 `window_rotated: None` 호환성 채움
- [ ] e2e 사용자 환경 — v0.1.8-beta release 후 ko/en toast 표시 검증 (별 release cycle 영역)

## Follow-up

- **PR-3** (`feat/reviewer-context-squeeze`): Reviewer role 분기 plan_doc cap 6K → 3K + recent messages LIMIT 20 → 10 (rotate trigger threshold 늦춤 보조)
- **PR-4** (`test/sdk-window-guard-coverage`): 통합 e2e (mocking) + Task 06 release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)