### PR TITLE
test(claude-sdk): window guard 통합 e2e + v0.1.8-beta release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,58 @@ All notable changes to tunaFlow are recorded here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 versioning follows [SemVer](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.8-beta] - 2026-05-09
+
+🩹 **Reviewer 단계 *"Prompt is too long"* 회귀 자동 회복** —
+v0.1.7-beta release 후 사용자 본인 환경에서 표면화된 SDK 세션 누적
+window 한계 회귀. `MAX_TOTAL_PROMPT = 60,000` chars 가 *system 영역
+outgoing* 만 가드하고 claude SDK 세션의 cumulative input_tokens (200K
+default / 1M `[1m]`) 는 별 영역. Reviewer 가 빈번한 surface 인 이유는
+같은 conv 의 dev turn 누적 + plan_document 6K + verdict 반복으로 SDK
+누적 input_tokens 가 200K limit hit. Architect plan + 4 PR 묶음 fix.
+
+### Fixed
+
+- **SDK 누적 임계 도달 시 자동 fresh-rotate** ([PR #279](https://github.com/hang-in/tunaFlow/pull/279)) —
+  default 모드 180K tokens / `[1m]` variant 모드 900K tokens 도달 시
+  `claude_sdk_session::stream_run_sdk` 진입 직후 자동 fresh session
+  rotate. SESSIONS / RESUME_IDS / LAST_DELIVERED 모두 invalidate →
+  `is_session_continuation=false` → ContextPack full mode + anchor 2
+  turns → plan_doc / findings / RT consensus 재주입 (사용자 컨텍스트
+  회복). claudeTransportFlipHardeningPlan T9-a/T11 의 fresh-session
+  정책 패턴 재사용.
+- **fresh-rotate 사용자 가시화 토스트** ([PR #280](https://github.com/hang-in/tunaFlow/pull/280)) —
+  Tauri event `tunaflow:sdk-session-window-rotated` + ClaudeFallbackEvents
+  listener 가 sonner toast info 5초 dismiss 표시. ko/en i18n 분기 +
+  conversation 별 sessionStorage spam 차단 flag. 신규 컴포넌트 0,
+  기존 sonner 인프라 재사용 (INV-CSW-7).
+- **Reviewer specific squeeze** ([PR #281](https://github.com/hang-in/tunaFlow/pull/281)) —
+  `load_recent_messages_excluding_rt` LIMIT 20 → 10 (reviewer 만) +
+  `plan_document` cap 6,000 → 3,000 chars (reviewer 만). 다른 role
+  (Architect / Developer / Persona / single-agent) 영향 0 (INV-CSW-6).
+  PR-1 의 fresh-rotate trigger threshold 늦춤 보조 → fresh-rotate 빈도
+  감소. squeeze 영역은 verdict 정확도에 영향 미미 (rubric / findings /
+  RT consensus 는 별 섹션).
+
+### Notes
+
+- **`[1m]` variant 사용자 영향 0** (INV-CSW-5) — claude-opus-4-7-1m 등
+  1M context variant 사용자는 임계 900K 적용. 200K limit 영역 무관 →
+  default 사용자보다 5배 늦은 시점에 fresh-rotate 발동 (또는 거의 발동
+  안 됨).
+- **release notes 강조 항목**:
+  - *"Reviewer 단계 'Prompt is too long' 회귀 자동 회복 — 세션 누적
+     한계 도달 시 자동 fresh-rotate + toast 알림"*
+  - *"`[1m]` variant 사용자 (1M context 모드) 영향 0"*
+  - *"Reviewer specific squeeze — plan_document + recent messages 영역
+     압축으로 trigger 빈도 감소"*
+- **DB migration 영향 0** — `accumulated_input_tokens` 는 in-memory stash
+  (앱 재시작 시 reset). 영구 저장 (재시작 후에도 정확한 cap 적용) 는 별
+  P3 plan 영역.
+- **사용자 자가 회복 path** — v0.1.8-beta 자산 재설치 + Reviewer 진입 시
+  *"Prompt is too long"* 회귀 0 / 임계 도달 시 toast 알림 표시 / 새 세션
+  의 첫 turn 부터 ContextPack 재주입 동작 확인.
+
 ## [0.1.7-beta-6] - 2026-05-07
 
 🩹 **Win 10 22H2 WebView2 strict CSP path matching hotfix** —

--- a/docs/reference/sessionHistory.md
+++ b/docs/reference/sessionHistory.md
@@ -38,6 +38,7 @@ description: 세션별 전체 작업 이력. 새 세션 시작 시 또는 과거
 | 25 | 2026-04-12 | 버그 9건 수정 + UI 개선 4건 (MarkdownComponents h-tags/empty span/relative link, PTY persona+duration+label, PlanProposalCard reload, branch stale closure, Insight 이전분석 우측 패널, adopt 중 스트리밍 보존+결과 복원, 드로어 라운딩, 사이드바 가독성, 알림배지 오버랩) |
 | 26 | 2026-04-13 | 코드베이스 리팩토링 v3 Tier 1(부분)+Tier 2 — conversation_memory 3분리, vector_search 4분리, workflowOrchestration 5분리, InsightPanel 4분리, ptyTypes 추출. Rust/TS 테스트 전원 통과. |
 | 35 | 2026-04-13 | 구조개선 Sprint 2~3 (planWorkflowService 도메인 규칙, threadRtRunner 분리, silent catch 7건), PTY Enter 3중 수정, bge-m3 CPU 스파이크 수정(ONNX 스레드 제한+세마포어+점진적 인덱싱). 232 Rust + 188 TS tests. |
+| **v0.1.8-beta** | **2026-05-09** | **Reviewer "Prompt is too long" 회귀 자동 회복** — claudeSdkSessionWindowGuardPlan 4 PR (#279~#281 + test/docs PR-4). SDK 누적 input_tokens 임계 (180K default / 900K `[1m]`) 도달 시 자동 fresh-rotate + sonner toast + Reviewer specific squeeze (LIMIT 20→10 / plan_doc 6K→3K). claudeTransportFlipHardeningPlan T9-a 패턴 재사용. Rust 635 → 649 (+14 unit) / FE 422 → 426 (+4 listener). DB migration 영향 0 (in-memory stash). |
 
 ---
 

--- a/src-tauri/src/agents/claude_sdk_session.rs
+++ b/src-tauri/src/agents/claude_sdk_session.rs
@@ -1874,4 +1874,79 @@ mod tests {
             "model_id 없어도 stash 비어있으면 trigger 안 됨"
         );
     }
+
+    /// (claudeSdkSessionWindowGuardPlan Task 05) 통합 e2e — fresh-rotate 발동
+    /// 시 모든 side effect (SESSIONS / RESUME_IDS / LAST_DELIVERED / window
+    /// guard stash) 가 일관되게 invalidate 되는지 검증.
+    ///
+    /// 시나리오: dev turn 누적 → Reviewer 호출 (stash 가 임계 초과) → trigger
+    /// → kill_session_clear_resume → 다음 dispatch 진입 시 stash 0 + LAST_DELIVERED
+    /// 비어있음 → ContextPack full mode (INV-CSW-2) 자연 회복.
+    #[test]
+    fn sdk_window_guard_full_rotate_flow_invalidates_all_state() {
+        use crate::commands::agents_helpers::send_common::session_freshness::{
+            last_delivered_key, record_delivered_key,
+        };
+
+        let conv = unique_conv("wg-rotate-full-flow");
+        let key = session_key_for(&conv);
+
+        // 사전 상태: dev turn 누적 + 정상 SDK 세션 동작 중 imitating
+        RESUME_IDS.lock().insert(key.clone(), "sid-DEV-ACCUMULATED".into());
+        record_delivered_key(&conv, "claude-ws:sid-DEV-ACCUMULATED");
+        stash_window_guard_input_tokens(&key, 185_000);
+
+        // 사전 상태 검증
+        assert_eq!(read_window_guard_input_tokens(&key), 185_000);
+        assert!(RESUME_IDS.lock().contains_key(&key));
+        assert!(last_delivered_key(&conv).is_some());
+        assert!(should_trigger_window_rotate(&key, Some("claude-opus-4-7")));
+
+        // Reviewer 호출 시뮬레이션 — stream_run_sdk 진입부 trigger 발동 시 호출되는
+        // 두 cleanup 함수 (kill_session_clear_resume 가 둘 다 invoke)
+        kill_session_clear_resume(&conv);
+
+        // 사후 상태 검증 (INV-CSW-2 + INV-CSW-1 의 reset 영역)
+        assert_eq!(
+            read_window_guard_input_tokens(&key),
+            0,
+            "fresh-rotate 후 window guard stash 0 — 다음 send 가 정상 누적 시작"
+        );
+        assert!(
+            !RESUME_IDS.lock().contains_key(&key),
+            "fresh-rotate 후 RESUME_IDS 비어있음 — 다음 send 가 fresh session 으로 spawn"
+        );
+        assert!(
+            last_delivered_key(&conv).is_none(),
+            "fresh-rotate 후 LAST_DELIVERED 비어있음 — is_session_continuation=false → ContextPack full mode 자연 회복"
+        );
+        assert!(
+            !should_trigger_window_rotate(&key, Some("claude-opus-4-7")),
+            "fresh-rotate 후 trigger 자체 미발동 (stash 0 fast path)"
+        );
+    }
+
+    /// (claudeSdkSessionWindowGuardPlan Task 05) 시나리오: `[1m]` variant 사용
+    /// 자가 같은 dev turn 누적량 (200K) 을 받아도 fresh-rotate 미발동 확인.
+    /// INV-CSW-5 핵심 가드.
+    #[test]
+    fn sdk_window_guard_1m_variant_skips_rotate_in_full_flow() {
+        let conv = unique_conv("wg-1m-no-rotate-flow");
+        let key = session_key_for(&conv);
+
+        clear_window_guard_input_tokens(&key);
+        // 200K 누적 — default 모드면 trigger 됐을 양
+        stash_window_guard_input_tokens(&key, 200_000);
+
+        // default 모델: trigger 발동
+        assert!(should_trigger_window_rotate(&key, Some("claude-opus-4-7")));
+
+        // 1M variant: trigger 미발동 (INV-CSW-5)
+        assert!(
+            !should_trigger_window_rotate(&key, Some("claude-opus-4-7-1m")),
+            "1M variant 사용자는 200K 에서 미발동 (cap 900K)"
+        );
+
+        clear_window_guard_input_tokens(&key);
+    }
 }


### PR DESCRIPTION
## Summary

claudeSdkSessionWindowGuardPlan_2026-05-09 의 Task 05 (통합 e2e) + Task 06 (release notes). PR-1/2/3 의 분기별 unit test 외 *통합 시나리오* 검증 + v0.1.8-beta release 사용자 가시 변화 안내.

Plan SSOT: [`docs/plans/claudeSdkSessionWindowGuardPlan_2026-05-09.md`](https://github.com/hang-in/tunaFlow/blob/main/docs/plans/claudeSdkSessionWindowGuardPlan_2026-05-09.md) — Task 05 + 06.

PR-1 (#279) / PR-2 (#280) / PR-3 (#281) 머지 후 묶음 release 안내.

## Changes

### Task 05 (commit `c8e5794`) — 통합 e2e test
신규 통합 e2e test 2건 (`agents::claude_sdk_session::tests`):
- `sdk_window_guard_full_rotate_flow_invalidates_all_state` — 사전 상태 (185K 누적 + RESUME_IDS + LAST_DELIVERED) → kill_session_clear_resume → 모든 상태 invalidate (INV-CSW-2 통합 가드)
- `sdk_window_guard_1m_variant_skips_rotate_in_full_flow` — 같은 200K 누적량을 받아도 1M variant 사용자는 trigger 미발동 (INV-CSW-5 통합 가드)

### Task 06 (commit `3e27110`) — release notes
- `CHANGELOG.md` 의 `[0.1.8-beta] - 2026-05-09` 신규 섹션:
  - **Fixed**: PR #279 (fresh-rotate 본체) / #280 (toast) / #281 (Reviewer squeeze)
  - **Notes**: `[1m]` variant 영향 0 / 강조 3 항목 / DB migration 영향 0 / 사용자 자가 회복 path
- `docs/reference/sessionHistory.md` 의 세션 표 entry — Rust 635 → 649 (+14 unit) / FE 422 → 426 (+4 listener)

## Verification

```
cd src-tauri && cargo check --message-format=short  # PASS
cd src-tauri && cargo test --lib                     # 649 → 651 (+2)
npx tsc --noEmit                                     # PASS
npx vitest run                                       # 426 (변동 0)
```

전체 cycle (PR-1 + PR-2 + PR-3 + PR-4) 누적:
- Rust: 635 → **651** (+16, plan §4 baseline 의 +10 보다 +6 더 — fresh-rotate 분기 + 통합 e2e 추가)
- Frontend: 422 → **426** (+4 listener test, plan §4 baseline 의 +1~2 보다 +2~3 더 — spam 차단 case 더 검증)

## Test plan

- [x] cargo / tsc / vitest 통과
- [x] CHANGELOG `[0.1.8-beta]` 섹션 + 강조 3 항목 등장
- [x] sessionHistory 세션 표 entry 추가
- [x] 다른 docs (README / CLAUDE.md / 다른 reference docs) 변경 0
- [ ] e2e 사용자 환경 — v0.1.8-beta release 후 자가 회복 검증 (별 release cycle 영역)

## Release timing

본 PR 머지 후 v0.1.8-beta 묶음 release 가능 (4 PR 모두 같은 release cycle 안). 별 release cycle plan 은 Architect 영역 (tunaflow-release-cycle skill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)