### PR TITLE
feat(learn): gpt-local-tui standalone 3-role TUI demo

### DIFF
--- a/tunaflow/learn/gpt-local-tui/README.md
+++ b/tunaflow/learn/gpt-local-tui/README.md
@@ -1,0 +1,121 @@
+# gpt-local-tui
+
+A standalone learning example: a 3-role coding TUI in ~400 lines of Python.
+Uses **Codex CLI** (Architect + Reviewer) and **local Ollama** (Developer) to demonstrate
+how splitting roles across models saves tokens.
+
+This is **not** a tunaFlow consumer. It does not import tunaFlow. The point is the opposite:
+read this code, understand the pattern, then graduate to [tunaFlow](../../../README.md) when
+you outgrow a single file.
+
+## Why
+
+Long code generation eats tokens. Decomposition and verification do not.
+So run the cheap-but-smart parts on a paid model, and run the expensive-but-dumb part locally.
+
+| Role          | Model                  | Why                                                |
+| ------------- | ---------------------- | -------------------------------------------------- |
+| **Architect** | Codex CLI (`codex`)    | Decomposes the request into Developer instructions |
+| **Developer** | Local 27B via Ollama   | Generates code (token-heavy, runs free)            |
+| **Reviewer**  | Codex CLI (same thread)| Verifies output against criteria, decides retry    |
+
+The Reviewer **resumes the Architect's thread**, so the criteria the Architect wrote
+are already in context — no re-prompting cost.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Session: <thread_id>                          gpt-local-tui │
+├──────────────────────────┬──────────────────────────────────┤
+│ Architect / Reviewer     │ Developer (local 27B)            │
+│ (Codex CLI)              │                                  │
+│  > decomposing...        │  > generating...                 │
+│  > criteria: ...         │  > <code output>                 │
+│  > verifying...          │                                  │
+│  > verdict: pass         │                                  │
+├──────────────────────────┴──────────────────────────────────┤
+│ > type your request                                  [Send] │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Prerequisites
+
+1. **Codex CLI** (`codex-cli` 0.128+). Verify:
+
+   ```bash
+   codex --version              # codex-cli 0.128.x or newer
+   codex exec --json "say hi"   # should print JSONL events ending with turn.completed
+   ```
+
+   If `codex exec` errors on auth, run `codex login` first (Codex Plus subscription assumed).
+
+2. **Ollama** running locally with at least one chat model pulled. Verify:
+
+   ```bash
+   ollama --version
+   ollama list                  # must show a chat model (not just embeddings)
+   ```
+
+   The default config points at `gemma4:e4b` (the largest local model the author had on
+   hand). For a 27B-class model use `qwen2.5:32b`, `gemma2:27b`, `command-r:35b`, etc.
+   Whatever you set in `config.toml` must match `ollama list` output.
+
+3. **Python 3.10+** (3.11+ uses stdlib `tomllib`; 3.10 needs `tomli`).
+
+## Setup
+
+```bash
+cd tunaflow/learn/gpt-local-tui
+python3 -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+
+cp config.example.toml config.toml
+# edit config.toml — at minimum, set [developer].model to a model from `ollama list`
+```
+
+## Run
+
+```bash
+python app.py
+```
+
+On first launch the header shows `Session: (new)` until you submit a request.
+After the Architect call, it switches to the actual Codex thread id.
+
+Type a coding request in the footer input, press **Ctrl+Enter** to submit.
+Plain Enter inserts a newline (coding requests can be multi-line).
+
+The left panel streams Architect output, then Reviewer output.
+The right panel streams Developer output. Both panels scroll independently.
+
+## How to read this code
+
+The whole app is one file: [`app.py`](./app.py). Comments call out the pattern at each step.
+Start there, then read [`docs/how-it-works.md`](./docs/how-it-works.md) for the *why*.
+
+Key functions to follow in order:
+
+- `call_codex()` — subprocess wrapper around `codex exec` / `codex exec resume`
+- `call_ollama()` — thin wrapper around the `ollama` Python client
+- `run_workflow()` — the 3-role loop
+- `list_recent_sessions()` — picks up where Codex left off (the resume trick)
+
+## What this is NOT
+
+This is a **learning artifact**, not a production tool.
+
+- Single Developer (no multi-agent debate, no quorum, no parallel branches)
+- No tool-calling — Developer can't run tests against its own output
+- Subprocess capture, not streaming — output appears in chunks
+- Two retries max, then the user has to step in
+- One workflow at a time, no history view, no save/export
+
+If any of those limits start to bite, you have outgrown the learning example.
+That is the moment to switch to [tunaFlow](../../../README.md), which productionizes the
+same pattern with proper streaming, multi-agent RT, branch/adopt, ContextPack, and
+persistent state.
+
+## License
+
+AGPL-3.0, matching the parent tunaFlow repository.

--- a/tunaflow/learn/gpt-local-tui/app.py
+++ b/tunaflow/learn/gpt-local-tui/app.py
@@ -1,0 +1,500 @@
+"""gpt-local-tui — a 3-role coding TUI in one file.
+
+Read top-to-bottom.  The point is the *pattern*, not the framework.
+
+Roles: Architect (Codex CLI) decomposes -> Developer (local Ollama) generates ->
+Reviewer (Codex CLI, *resuming Architect's thread*) decides pass/retry.
+Token-saving thesis: see `docs/how-it-works.md`.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable
+
+import ollama
+from textual.app import App, ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Footer, Header, Label, ListItem, ListView, RichLog, TextArea
+
+# tomllib is stdlib on 3.11+; fall back to the `tomli` PyPI package on 3.10.
+try:
+    import tomllib  # type: ignore[import-not-found]
+except ModuleNotFoundError:  # pragma: no cover - 3.10 fallback only
+    import tomli as tomllib  # type: ignore[import-not-found, no-redef]
+
+CONFIG_PATH, EXAMPLE_PATH = Path(__file__).parent / "config.toml", Path(__file__).parent / "config.example.toml"
+CODEX_SESSIONS_DIR = Path.home() / ".codex" / "sessions"
+
+
+# ===== config =================================================================
+@dataclass
+class Config:
+    architect_cmd: str
+    architect_timeout: int
+    developer_model: str
+    developer_host: str
+    developer_temperature: float
+    developer_num_ctx: int
+    developer_timeout: int
+    show_timing: bool
+    max_retries: int
+
+
+def load_config() -> Config:
+    """Load config.toml.  Bail early with a clear message if it is missing."""
+    if not CONFIG_PATH.exists():
+        sys.exit(
+            f"Missing {CONFIG_PATH.name}.\n"
+            f"Copy {EXAMPLE_PATH.name} to {CONFIG_PATH.name} and edit it first."
+        )
+    raw = tomllib.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+    a, d, u = raw.get("architect", {}), raw.get("developer", {}), raw.get("ui", {})
+    return Config(
+        architect_cmd=a.get("command", "codex"),
+        architect_timeout=int(a.get("timeout_seconds", 180)),
+        developer_model=d["model"],  # required — fail loud if missing
+        developer_host=d.get("host", "http://localhost:11434"),
+        developer_temperature=float(d.get("temperature", 0.3)),
+        developer_num_ctx=int(d.get("num_ctx", 8192)),
+        developer_timeout=int(d.get("timeout_seconds", 300)),
+        show_timing=bool(u.get("show_timing", True)),
+        max_retries=int(u.get("max_retries", 2)),
+    )
+
+
+# ===== prompts ================================================================
+# Short on purpose.  Architect forbids itself from writing code (cost-saving).
+# Developer is told to be dumb-but-productive.  Reviewer emits JSON so the
+# workflow can branch on it.
+ARCHITECT_PROMPT = """ROLE: Architect
+You are the Architect in a 3-role workflow.  A local 27B model does the coding;
+you decompose and verify.
+
+USER REQUEST:
+{user_input}
+
+YOUR JOB:
+1. Break the request into clear instructions for a Developer.
+2. Define objective verification criteria.
+3. Output ONLY valid JSON, no prose around it:
+{{
+  "developer_instructions": "Specific, self-contained task for the Developer.",
+  "verification_criteria": ["Criterion 1 (objective and checkable)", "Criterion 2"]
+}}
+Do NOT write the code yourself.  Be precise about what you want produced.
+"""
+
+DEVELOPER_PROMPT = """ROLE: Developer
+Your Architect has given you specific instructions.  Follow them exactly.
+
+INSTRUCTIONS:
+{developer_instructions}
+
+OUTPUT: Complete, working code (or content) — no snippets, no placeholders.
+Code only.  No explanations unless explicitly asked.
+"""
+
+REVIEWER_PROMPT = """ROLE: Reviewer (same thread as Architect — your earlier criteria are in context)
+The Developer has produced this output:
+```
+{developer_output}
+```
+Verify against the criteria you defined earlier.  Output ONLY valid JSON:
+{{
+  "verdict": "pass" | "retry" | "fail",
+  "reasons": ["Specific reason 1", "..."],
+  "retry_instructions": "If verdict is retry, concrete guidance.  Otherwise null."
+}}
+"""
+
+
+# ===== Codex CLI subprocess wrapper ==========================================
+# Reality from `codex --help` (codex-cli 0.128.0):
+#   - non-interactive: `codex exec [PROMPT] [--json] [-o FILE]`
+#   - resume:          `codex exec resume <SESSION_ID> [PROMPT]`
+#   - `--json` emits one JSON event per line; ends with `turn.completed`
+#   - first event:     `{"type":"thread.started","thread_id":"<uuid>"}`
+#   - final answer:    `{"type":"item.completed","item":{"type":"agent_message","text":"..."}}`
+# That `thread_id` is the resume token we keep — Codex stores history on disk for us.
+@dataclass
+class CodexResult:
+    text: str
+    thread_id: str
+    raw: list[dict]  # full JSONL event list, useful for debugging
+
+
+def call_codex(prompt: str, cfg: Config, *, session_id: str | None = None) -> CodexResult:
+    """Invoke `codex exec` (or `codex exec resume`) and parse the JSONL stream."""
+    args: list[str] = [cfg.architect_cmd, "exec", "--json", "--skip-git-repo-check"]
+    if session_id:
+        # `codex exec resume <SESSION_ID> -` reads prompt from stdin.
+        args += ["resume", session_id, "-"]
+    else:
+        # No session: prompt also via stdin (avoids quoting hell on long prompts).
+        args += ["-"]
+    proc = subprocess.run(
+        args, input=prompt, capture_output=True, text=True, timeout=cfg.architect_timeout
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"codex exec failed (exit {proc.returncode}):\n{proc.stderr or proc.stdout}"
+        )
+    events: list[dict] = []
+    final_text = ""
+    thread_id = session_id or ""
+    for line in proc.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            evt = json.loads(line)
+        except json.JSONDecodeError:
+            continue  # codex may print non-JSON warnings; skip them
+        events.append(evt)
+        etype = evt.get("type")
+        if etype == "thread.started":
+            thread_id = evt.get("thread_id", thread_id)
+        elif etype == "item.completed":
+            item = evt.get("item", {})
+            if item.get("type") == "agent_message":
+                final_text = item.get("text", "")
+    if not final_text:
+        raise RuntimeError("codex exec produced no agent_message.  Raw stdout:\n" + proc.stdout[:2000])
+    return CodexResult(text=final_text, thread_id=thread_id, raw=events)
+
+
+# ===== Ollama wrapper ========================================================
+# The Developer is the dumb, time-expensive part of the pipeline.
+# We use the blocking client and let the caller wrap it in `asyncio.to_thread`.
+def call_ollama(prompt: str, cfg: Config) -> str:
+    client = ollama.Client(host=cfg.developer_host, timeout=cfg.developer_timeout)
+    resp = client.chat(
+        model=cfg.developer_model,
+        messages=[{"role": "user", "content": prompt}],
+        options={"temperature": cfg.developer_temperature, "num_ctx": cfg.developer_num_ctx},
+    )
+    return resp["message"]["content"]
+
+
+# ===== JSON parsing helper ===================================================
+# Models sometimes wrap JSON in ``` fences or add a stray sentence.
+# Plain json.loads first, then a fenced-block fallback, then balanced-brace fallback.
+_FENCE_RE = re.compile(r"```(?:json)?\s*(\{.*?\})\s*```", re.DOTALL)
+
+
+def parse_json_blob(text: str) -> dict[str, Any]:
+    text = text.strip()
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        pass
+    m = _FENCE_RE.search(text)
+    if m:
+        return json.loads(m.group(1))
+    start, end = text.find("{"), text.rfind("}")
+    if start >= 0 and end > start:
+        return json.loads(text[start : end + 1])
+    raise ValueError(f"No JSON object found in: {text[:200]}...")
+
+
+# ===== Codex session listing (the resume feature) ============================
+# Codex stores sessions at ~/.codex/sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl
+# First JSONL line is `session_meta` with payload.id and payload.timestamp.
+# This is the simplest "externalized state" — no DB, no vector store; the
+# conversation history IS the resume token.
+@dataclass
+class SessionInfo:
+    session_id: str
+    started_at: str
+    first_user_prompt: str
+    path: Path
+
+
+def _extract_first_text(evt: dict) -> str:
+    payload = evt.get("payload") or evt.get("item") or {}
+    if isinstance(payload, dict):
+        for key in ("text", "content", "input"):
+            v = payload.get(key)
+            if isinstance(v, str) and v.strip():
+                return v
+    return ""
+
+
+def list_recent_sessions(limit: int = 10) -> list[SessionInfo]:
+    if not CODEX_SESSIONS_DIR.exists():
+        return []
+    files = sorted(
+        CODEX_SESSIONS_DIR.rglob("rollout-*.jsonl"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )[:limit]
+    out: list[SessionInfo] = []
+    for path in files:
+        try:
+            session_id = ""
+            started_at = ""
+            first_prompt = "(no prompt yet)"
+            with path.open("r", encoding="utf-8") as fh:
+                for line in fh:
+                    try:
+                        evt = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if evt.get("type") == "session_meta":
+                        payload = evt.get("payload", {})
+                        session_id = payload.get("id", "")
+                        started_at = payload.get("timestamp", "")
+                    elif first_prompt == "(no prompt yet)":
+                        text = _extract_first_text(evt)
+                        if text:
+                            first_prompt = text[:80].replace("\n", " ")
+                            break
+            if session_id:
+                out.append(SessionInfo(session_id, started_at, first_prompt, path))
+        except OSError:
+            continue
+    return out
+
+
+# ===== workflow ==============================================================
+# Three steps + a retry loop driven by the Reviewer's verdict.
+# UI updates are pushed via callbacks so the same logic can run headless.
+@dataclass
+class WorkflowEvent:
+    role: str  # "Architect" | "Developer" | "Reviewer" | "System"
+    body: str
+    duration_ms: int = 0
+    is_error: bool = False
+
+
+@dataclass
+class WorkflowState:
+    session_id: str | None = None
+    retries_left: int = 2
+    history: list[WorkflowEvent] = field(default_factory=list)
+
+
+async def run_workflow(
+    user_input: str, cfg: Config, state: WorkflowState, emit: Callable[[WorkflowEvent], None]
+) -> None:
+    """End-to-end 3-role flow.  `emit(event)` updates the UI (or stdout in tests)."""
+    state.retries_left = cfg.max_retries
+
+    # 1. Architect — decompose
+    arch_t0 = time.monotonic()
+    try:
+        arch = await asyncio.to_thread(
+            call_codex, ARCHITECT_PROMPT.format(user_input=user_input), cfg, session_id=state.session_id
+        )
+    except Exception as exc:
+        emit(WorkflowEvent("Architect", f"FAILED: {exc}", is_error=True))
+        return
+    arch_ms = int((time.monotonic() - arch_t0) * 1000)
+    state.session_id = arch.thread_id
+    try:
+        plan = parse_json_blob(arch.text)
+        instructions, criteria = plan["developer_instructions"], plan.get("verification_criteria", [])
+    except (ValueError, KeyError) as exc:
+        emit(WorkflowEvent("Architect", f"JSON parse error: {exc}\nRaw:\n{arch.text}",
+                           duration_ms=arch_ms, is_error=True))
+        return
+    emit(WorkflowEvent("Architect",
+                       "instructions:\n" + instructions + "\n\ncriteria:\n- " + "\n- ".join(criteria),
+                       duration_ms=arch_ms))
+
+    # 2. Developer + 3. Reviewer (retry loop)
+    dev_input = instructions
+    while True:
+        dev_t0 = time.monotonic()
+        try:
+            dev_output = await asyncio.to_thread(
+                call_ollama, DEVELOPER_PROMPT.format(developer_instructions=dev_input), cfg
+            )
+        except Exception as exc:
+            emit(WorkflowEvent("Developer", f"FAILED: {exc}", is_error=True))
+            return
+        dev_ms = int((time.monotonic() - dev_t0) * 1000)
+        emit(WorkflowEvent("Developer", dev_output, duration_ms=dev_ms))
+
+        rev_t0 = time.monotonic()
+        try:
+            rev = await asyncio.to_thread(
+                call_codex, REVIEWER_PROMPT.format(developer_output=dev_output), cfg,
+                session_id=state.session_id,  # resume! Architect criteria are in context.
+            )
+        except Exception as exc:
+            emit(WorkflowEvent("Reviewer", f"FAILED: {exc}", is_error=True))
+            return
+        rev_ms = int((time.monotonic() - rev_t0) * 1000)
+        try:
+            verdict_obj = parse_json_blob(rev.text)
+        except ValueError as exc:
+            emit(WorkflowEvent("Reviewer", f"JSON parse error: {exc}\nRaw:\n{rev.text}",
+                               duration_ms=rev_ms, is_error=True))
+            return
+        verdict = verdict_obj.get("verdict", "fail")
+        reasons = verdict_obj.get("reasons", [])
+        retry_instr = verdict_obj.get("retry_instructions") or ""
+        emit(WorkflowEvent(
+            "Reviewer", f"verdict: {verdict}\nreasons:\n- " + "\n- ".join(reasons),
+            duration_ms=rev_ms,
+        ))
+
+        if verdict == "pass":
+            return
+        if verdict == "fail" or state.retries_left <= 0:
+            emit(WorkflowEvent("System", "Workflow stopped.  User intervention needed.", is_error=True))
+            return
+        state.retries_left -= 1
+        emit(WorkflowEvent("System",
+                           f"Retrying ({cfg.max_retries - state.retries_left}/{cfg.max_retries})..."))
+        # Retry guidance is the only changing input; everything else is the same workflow.
+        dev_input = instructions + "\n\nADDITIONAL GUIDANCE FROM REVIEWER:\n" + retry_instr
+
+
+# ===== TUI ===================================================================
+# Two RichLogs (left + right) collect role output; a TextArea takes user input;
+# Ctrl+Enter submits.  We do not stream tokens — `codex exec` finishes a turn
+# before printing the agent_message, and the lesson is the pattern, not streaming.
+CSS = """
+Screen { layout: vertical; }
+#panes { height: 1fr; }
+#left, #right { width: 1fr; border: solid $primary; padding: 0 1; }
+#left { border-title-align: left; border-title-color: $accent; }
+#right { border-title-align: left; border-title-color: $success; }
+#input-row { height: 7; border-top: solid $secondary; padding: 0 1; }
+TextArea { height: 5; }
+"""
+
+
+class ResumeScreen(ModalScreen[str | None]):
+    """Pop-up listing recent Codex sessions; returns the chosen session id."""
+
+    BINDINGS = [Binding("escape", "dismiss", "Cancel")]
+
+    def __init__(self, sessions: list[SessionInfo]) -> None:
+        super().__init__()
+        self.sessions = sessions
+
+    def compose(self) -> ComposeResult:
+        yield Label("Pick a Codex session to resume (Esc to cancel)", id="resume-label")
+        items = [
+            ListItem(Label(f"{s.started_at}  {s.session_id[:8]}  {s.first_user_prompt}"), id=f"sess-{i}")
+            for i, s in enumerate(self.sessions)
+        ]
+        yield ListView(*items, id="resume-list")
+
+    def on_list_view_selected(self, event: ListView.Selected) -> None:
+        idx = int(event.item.id.split("-")[1])
+        self.dismiss(self.sessions[idx].session_id)
+
+    def action_dismiss(self) -> None:
+        self.dismiss(None)
+
+
+class GptLocalApp(App):
+    CSS = CSS
+    BINDINGS = [
+        Binding("ctrl+enter", "submit", "Send"),
+        Binding("ctrl+r", "open_resume", "Resume..."),
+        Binding("ctrl+n", "new_session", "New session"),
+        Binding("ctrl+q", "quit", "Quit"),
+    ]
+
+    def __init__(self, cfg: Config) -> None:
+        super().__init__()
+        self.cfg = cfg
+        self.state = WorkflowState(retries_left=cfg.max_retries)
+        self.title = "gpt-local-tui"
+        self.sub_title = "session: (new)"
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        with Horizontal(id="panes"):
+            self.left = RichLog(id="left", wrap=True, markup=False, highlight=False)
+            self.left.border_title = "Architect / Reviewer (Codex)"
+            self.right = RichLog(id="right", wrap=True, markup=False, highlight=False)
+            self.right.border_title = f"Developer ({self.cfg.developer_model})"
+            yield self.left
+            yield self.right
+        with Vertical(id="input-row"):
+            self.input = TextArea(id="input")
+            yield self.input
+        yield Footer()
+
+    def action_submit(self) -> None:
+        text = self.input.text.strip()
+        if not text:
+            return
+        self.input.clear()
+        self.left.write(f"\n>>> {text}\n")
+        self.run_worker(self._run_workflow(text), exclusive=True)
+
+    def action_new_session(self) -> None:
+        self.state = WorkflowState(retries_left=self.cfg.max_retries)
+        self.sub_title = "session: (new)"
+        self.left.write("\n[system] new session\n")
+
+    async def action_open_resume(self) -> None:
+        sessions = await asyncio.to_thread(list_recent_sessions, 10)
+        if not sessions:
+            self.left.write("\n[system] no recent Codex sessions found\n")
+            return
+        chosen = await self.push_screen_wait(ResumeScreen(sessions))
+        if chosen:
+            self.state.session_id = chosen
+            self.sub_title = f"session: {chosen[:8]}"
+            self.left.write(f"\n[system] resumed session {chosen[:8]}\n")
+
+    async def _run_workflow(self, user_input: str) -> None:
+        def emit(evt: WorkflowEvent) -> None:
+            self.call_from_thread(self._render_event, evt)
+        await run_workflow(user_input, self.cfg, self.state, emit)
+        if self.state.session_id:
+            self.sub_title = f"session: {self.state.session_id[:8]}"
+
+    def _render_event(self, evt: WorkflowEvent) -> None:
+        sink = self.right if evt.role == "Developer" else self.left
+        timing = f"  ({evt.duration_ms} ms)" if self.cfg.show_timing and evt.duration_ms else ""
+        prefix = f"\n[{evt.role}{timing}]" + (" ERROR" if evt.is_error else "")
+        sink.write(f"{prefix}\n{evt.body}\n")
+
+
+# ===== entry point ===========================================================
+def main() -> int:
+    cfg = load_config()
+    # Headless smoke-test: `python app.py --check` validates CLIs without launching the TUI.
+    if "--check" in sys.argv:
+        try:
+            r = subprocess.run([cfg.architect_cmd, "--version"], capture_output=True, text=True, timeout=10)
+            print("codex:", r.stdout.strip() or r.stderr.strip())
+        except FileNotFoundError:
+            print("codex: NOT FOUND on PATH (set [architect].command in config.toml)")
+            return 2
+        try:
+            client = ollama.Client(host=cfg.developer_host, timeout=10)
+            models = [m["model"] for m in client.list().get("models", [])]
+            print(f"ollama models: {', '.join(models) or '(none)'}")
+            if cfg.developer_model not in models:
+                print(f"WARNING: configured model '{cfg.developer_model}' not in ollama list")
+                return 3
+        except Exception as exc:
+            print(f"ollama: {exc}")
+            return 4
+        print("config OK")
+        return 0
+    GptLocalApp(cfg).run()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tunaflow/learn/gpt-local-tui/config.example.toml
+++ b/tunaflow/learn/gpt-local-tui/config.example.toml
@@ -1,0 +1,32 @@
+# Copy this file to config.toml and edit. The app refuses to start without config.toml.
+
+[architect]
+# Codex CLI command. Adjust if your binary is not on PATH or has a different name.
+command = "codex"
+
+# Per-call timeout for `codex exec` (seconds). Codex can be slow on cold cache.
+timeout_seconds = 180
+
+[developer]
+# Ollama model name — must match `ollama list` output exactly.
+# 27B-class models are the original spec target; pick whatever fits your VRAM.
+# Examples: "qwen2.5:32b", "gemma2:27b", "command-r:35b", "gemma4:e4b" (smaller fallback).
+model = "gemma4:e4b"
+
+# Ollama HTTP host. Default localhost is fine.
+host = "http://localhost:11434"
+
+# Generation parameters. Lower temperature = less creative, more reproducible.
+temperature = 0.3
+num_ctx = 8192
+
+# Per-call timeout (seconds). Local models can be slow on first load.
+timeout_seconds = 300
+
+[ui]
+# Show wall-clock duration after each role finishes.
+show_timing = true
+
+# Maximum retries when Reviewer says "retry". After this, the workflow gives up
+# and the user decides what to do.
+max_retries = 2

--- a/tunaflow/learn/gpt-local-tui/docs/how-it-works.md
+++ b/tunaflow/learn/gpt-local-tui/docs/how-it-works.md
@@ -1,0 +1,251 @@
+# How it works
+
+The point of `gpt-local-tui` is **not** to be useful. It is to be the smallest
+working version of a pattern that, once you understand it, makes you want
+something bigger. That bigger thing is [tunaFlow](../../../../README.md).
+
+This document walks the *why* behind each design choice in `app.py`. Read it
+with the file open.
+
+## 1. The token-saving thesis
+
+In a coding workflow, three things happen:
+
+1. **Decompose** the user's vague request into specific instructions.
+2. **Generate** the actual code (long output).
+3. **Verify** the output and decide whether to retry.
+
+Steps 1 and 3 need *judgment*. They are short prompts, short responses, but
+they need a model good enough to plan and to spot bugs.
+
+Step 2 is the opposite. It needs *throughput*. The prompt is short, but the
+output is long — every token counts against your budget.
+
+If you run all three on the same paid model, step 2 dominates the bill.
+The trick this demo encodes is: **run step 2 locally, free.** Local models
+are slow, but they don't bill per token. A 27B-class model on consumer
+hardware is fine for code generation when an Architect already told it
+exactly what to build.
+
+You only pay for short, smart steps. The long, dumb step is on your GPU.
+
+## 2. Why CLI subprocess instead of an API SDK
+
+Codex CLI is invoked with `subprocess.run`. That is deliberate.
+
+Three reasons:
+
+1. **No API key handling**. The user already logged into Codex CLI with
+   `codex login` for their Codex Plus subscription. We piggy-back on that.
+   If we used the OpenAI SDK, we would need a separate `OPENAI_API_KEY`
+   for the same models we are already paying for through the CLI.
+2. **Matches the actual workflow**. The author's day-to-day pattern is
+   driving Codex CLI from inside Python scripts and tunaFlow. Demo what
+   you do, not what reads cleanly in a tutorial.
+3. **The subprocess interface IS the contract**. Codex CLI is a stable
+   external binary. SDKs change versions; `codex exec --json` will keep
+   producing JSONL events even when the underlying model changes. The
+   wrapper in `call_codex()` is ~30 lines and outlives any SDK.
+
+The cost is no streaming. `subprocess.run` waits for the process to finish
+before we see output. For a learning demo this is fine; for production you
+would want to read the JSONL events as they arrive (this is what tunaFlow
+does — see its `claude_sdk_session` and `codex` engine wrappers).
+
+## 3. The session-resume trick
+
+This is the conceptual centerpiece. Open `call_codex` and notice the
+`session_id` parameter.
+
+When the Architect runs:
+
+```
+codex exec --json --skip-git-repo-check - <<< "<architect prompt>"
+```
+
+The first JSONL line is:
+
+```json
+{"type":"thread.started","thread_id":"019e0be4-95a8-7071-9ef6-0bc46fe5a3c9"}
+```
+
+We capture that `thread_id` and store it in `WorkflowState.session_id`.
+
+When the Reviewer runs, we use:
+
+```
+codex exec resume 019e0be4-95a8-... --json --skip-git-repo-check - <<< "<reviewer prompt>"
+```
+
+Codex loads the prior conversation from `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`
+and runs the Reviewer turn *with the Architect's criteria already in context*.
+
+We did not re-send the criteria. We did not stuff them into the prompt.
+We did not maintain our own history database. Codex CLI's session storage
+**is** our working memory.
+
+This is the simplest possible form of **externalized state across loops**.
+Tools like Tattoo and Gemento explore this in much more depth — durable
+memory, vector retrieval, plan-tree state, cross-loop adaptation. But the
+core idea is here: *the agent's state lives outside the agent's prompt, and
+the orchestrator's job is to point at the right state at the right time.*
+
+Once you internalize that, multi-agent orchestration stops feeling magic.
+It is just plumbing — knowing who needs what when.
+
+## 4. Prompt design walkthrough
+
+Three prompts in `app.py`, all short. Read them as a system, not in isolation.
+
+### Architect: "Don't write the code"
+
+```
+Do NOT write the code yourself. Be precise about what you want produced.
+```
+
+This is the cost-control sentence. Without it, the Architect — being good
+at coding — will happily produce 200 lines of Rust to demonstrate it
+understood the request. Those 200 lines are billed tokens we did not need.
+By forbidding it from coding, the Architect spends its capacity on
+decomposition, which is where its judgment is actually valuable.
+
+### Developer: "Be dumb"
+
+```
+- Provide complete, working code (or content) — no snippets, no placeholders.
+- Code only.  No explanations unless explicitly asked.
+- If instructions are unclear, do your best interpretation.
+```
+
+The Developer is told it has no judgment. It generates. If the instructions
+are bad, that is the Architect's fault, and the Reviewer will catch it.
+
+This is intentional. A local 27B model trying to "make better decisions"
+than its instructions said is a bad loop — it reasons in circles. Better
+to produce, fail review, retry with explicit guidance.
+
+### Reviewer: JSON output is not a stylistic choice
+
+```json
+{
+  "verdict": "pass" | "retry" | "fail",
+  "reasons": ["..."],
+  "retry_instructions": "..."
+}
+```
+
+The Reviewer outputs JSON because the workflow code branches on the
+verdict. JSON parsing means there is no ambiguity. The Architect's prompt
+also ends in JSON for the same reason — `developer_instructions` and
+`verification_criteria` are passed to other roles, so they have to be
+extractable.
+
+The lesson: **the prompt's output format is determined by who reads it
+next.** A human reads prose; another agent reads JSON; a tool reads
+function-call arguments. Decide by consumer.
+
+## 5. Where this falls short (honestly)
+
+This is a learning artifact. It deliberately omits things tunaFlow handles:
+
+- **No streaming.** `subprocess.run` waits for completion. If the Developer
+  takes 90 seconds, the right panel shows nothing for 90 seconds. Real
+  tools stream JSONL events as they arrive.
+- **No multi-agent debate.** One Developer per request. Real RT systems
+  let multiple agents argue, vote, or fall back to each other.
+- **No tool calling.** The Developer cannot run tests against its own
+  output, cannot search the codebase, cannot read files. The Reviewer
+  judges from text alone.
+- **No persistent state beyond Codex sessions.** Your project conventions,
+  past decisions, design docs — none of that is in the loop. The
+  Architect knows nothing about your codebase.
+- **Two retries, then give up.** Real systems escalate (different model,
+  different decomposition, ask the user, etc.).
+- **One workflow at a time.** No history view, no save/export, no
+  branching off a prior turn.
+- **JSON parse failures are not handled gracefully beyond surfacing the
+  error.** A real system would re-prompt with stricter instructions, or
+  use structured output features (`--output-schema` flag exists on
+  `codex exec`, but we did not wire it up — exercise for the reader).
+- **No cost tracking.** The whole point is to save tokens, but this demo
+  does not show you how many you saved. Adding usage parsing from the
+  `turn.completed` event would be ~20 lines.
+
+## 6. Where to go from here
+
+Three directions, in increasing seriousness:
+
+### Stay shallow, learn one more pattern
+
+- Hook the Developer to a code-execution sandbox. Let it run its own
+  output and feed errors back to itself before the Reviewer sees it.
+- Replace the Developer with two parallel local models (a quorum), and
+  have the Reviewer pick the better output.
+- Switch the Reviewer to a different paid model (e.g. Claude) to see
+  whether cross-model review catches different bug classes.
+
+### Productionize the pattern
+
+That is what [tunaFlow](../../../../README.md) does. Read its
+`docs/reference/architecture-detail.md`. The same Architect/Developer/
+Reviewer split is there, but with:
+
+- True streaming via Tauri events
+- ContextPack: per-request prompt assembly with budgets (Lite/Standard/Full)
+- Branch / Roundtable for multi-agent debate
+- SQLite-backed durable history
+- Skills, identity, memory, retrieval — externalized state at scale
+- Five engines (Claude / Codex / Gemini / Ollama / LM Studio) with parity
+
+If you keep adding features to `app.py`, you will reinvent tunaFlow
+poorly. That is the lesson `learn/` is supposed to deliver: the moment
+you want any of the bullet points above, switch.
+
+### Study the empirical question
+
+[Gemento](https://github.com/dghong/gemento) is the author's research
+project on which orchestration patterns actually pay off in practice —
+not on benchmarks, but on real coding work. The 3-role split this demo
+shows is a starting point; Gemento measures whether it is worth the
+extra round-trip vs single-model approaches.
+
+## 7. Reading order, one more time
+
+If you are still reading: open `app.py` and walk it in this order.
+
+1. `load_config()` — boring but required.
+2. The three prompt constants. Read them all together.
+3. `call_codex()` — the subprocess wrapper. This is the load-bearing
+   function in the whole demo.
+4. `call_ollama()` — the easy half.
+5. `parse_json_blob()` — defensive parsing because models lie about
+   pure-JSON output.
+6. `list_recent_sessions()` — the session resume picker. This is what
+   makes the demo feel like a real tool.
+7. `run_workflow()` — the actual loop. Map each step to the prompts
+   you already read.
+8. The Textual classes — UI plumbing. Skim, don't memorize.
+
+The other 60% of the file is wiring.
+
+## 8. Reality notes (Codex CLI 0.128.0)
+
+A few details that differ from typical "agent CLI" assumptions:
+
+- `codex -p` is **not** non-interactive prompt. `-p` is `--profile`. Use
+  `codex exec [PROMPT]` for non-interactive.
+- `--json` emits JSONL on stdout. Last meaningful line is
+  `{"type":"turn.completed","usage":{...}}`.
+- The agent's textual answer comes via
+  `{"type":"item.completed","item":{"type":"agent_message","text":"..."}}`.
+  Multiple `item.completed` events can occur for tool calls; we keep the
+  last `agent_message` for our final text.
+- Session id is `thread_id`, not `session_id`. They mean the same thing.
+  `codex exec resume <UUID>` accepts that UUID.
+- Sessions are stored at `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`.
+  First line is `session_meta` with `payload.id` and `payload.timestamp`.
+- `--skip-git-repo-check` lets us run outside a repo. The TUI is
+  intentionally repo-agnostic.
+
+If a future Codex CLI changes any of this, update this section first
+and `call_codex` second. Reality wins.

--- a/tunaflow/learn/gpt-local-tui/requirements.txt
+++ b/tunaflow/learn/gpt-local-tui/requirements.txt
@@ -1,0 +1,7 @@
+# gpt-local-tui dependencies
+# Keep this list short on purpose — the demo is meant to be readable, not feature-rich.
+textual>=0.85.0
+ollama>=0.4.0
+
+# tomllib is stdlib on 3.11+. Install tomli only on 3.10.
+tomli>=2.0.0; python_version < "3.11"


### PR DESCRIPTION
## Summary

Standalone Python TUI 학습 데모 추가. `tunaflow/learn/gpt-local-tui/` (소문자) 신규 디렉토리. tunaFlow 본 코드 (Rust/TS/Tauri) 영역 변경 0, tunaFlow 패키지 import 0.

3-role workflow: Architect (Codex CLI) → Developer (local Ollama) → Reviewer (Codex CLI, *resuming Architect's thread*).

Spec / Handoff: [`docs/prompts/gptLocalTuiLearnDeveloperHandoff_2026-05-09.md`](../blob/main/docs/prompts/gptLocalTuiLearnDeveloperHandoff_2026-05-09.md)

## Files (5)

| Path | LoC | Purpose |
|---|---:|---|
| `tunaflow/learn/gpt-local-tui/README.md` | 121 | User-facing setup + run guide |
| `tunaflow/learn/gpt-local-tui/app.py` | **500** | Single-file TUI (handoff §0/§17 ≤500) |
| `tunaflow/learn/gpt-local-tui/requirements.txt` | 7 | textual + ollama + tomli (3.10 fallback) |
| `tunaflow/learn/gpt-local-tui/config.example.toml` | 32 | Architect/Developer/UI config |
| `tunaflow/learn/gpt-local-tui/docs/how-it-works.md` | 251 | Walkthrough — the actual teaching |

## Reality-check memo (handoff §6/§17 — reality wins)

Findings from `codex --help` (codex-cli **0.128.0**):

- **`-p` is `--profile`, not non-interactive prompt.** Spec was wrong. Use `codex exec [PROMPT]` for non-interactive mode.
- **Resume**: `codex exec resume <SESSION_ID> [PROMPT]` (subcommand, not flag).
- **Session id event**: first JSONL line `{"type":"thread.started","thread_id":"<uuid>"}`. Field is `thread_id` (= session id).
- **Final answer**: `{"type":"item.completed","item":{"type":"agent_message","text":"..."}}`.
- **Sessions on disk**: `~/.codex/sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl`. First line `session_meta` carries `payload.id` + `payload.timestamp`.
- **`--skip-git-repo-check`** lets Codex run outside a repo. We use it so the demo works anywhere.

These corrections are documented in `app.py` `call_codex` comments + `docs/how-it-works.md` §8 "Reality notes".

### Ollama default

System inventory (via `ollama list`): `nomic-embed-text`, `bge-m3`, `gemma4:e4b` (9.6 GB), `qwen3.5:9b` (6.6 GB). No 27B-class model present.

Default in `config.example.toml`: **`gemma4:e4b`** (largest available). README + config comments instruct user to swap to `qwen2.5:32b` / `gemma2:27b` / `command-r:35b` if they have one pulled.

## §15 Validation checklist

| # | Check | Status |
|---:|---|---|
| 1 | Fresh venv → `pip install -r requirements.txt` succeeds | PASS |
| 2 | `python app.py` exits with clear error if `config.toml` missing | PASS (`load_config` early exit) |
| 3 | `python app.py --check` validates Codex + Ollama without launching TUI | PASS — output: `codex: codex-cli 0.128.0 / ollama models: nomic-embed-text:latest, bge-m3:latest, gemma4:e4b, qwen3.5:9b / config OK` |
| 4 | `call_codex()` real call returns `thread_id` + parsed JSON | PASS — `019e0beb...` thread, `{"ok":true}` parsed in 5.7s |
| 5 | `list_recent_sessions()` reads `~/.codex/sessions` correctly | PASS — 3 sessions surfaced with id/timestamp |
| 6 | Codex resume works (verified out-of-band: `cached_input_tokens=28416` on 2nd turn) | PASS |
| 7 | `app.py` ≤ 500 LoC | PASS — exactly 500 |
| 8 | `docs/how-it-works.md` reads coherently as standalone | PASS — 8 sections, ~250 lines |
| 9 | Workflow with intentionally-bad request → Reviewer catches → retry | USER (TUI live workflow not headless-testable) |
| 10 | Codex auth expired surfaces in panel | USER |
| 11 | Ollama not running shows clear error in panel | USER |

Items 9-11 require live TUI interaction (out of headless scope).

## Regression guard grep — all changes scoped to `tunaflow/learn/`

```
$ git diff --name-only main...HEAD
tunaflow/learn/gpt-local-tui/README.md
tunaflow/learn/gpt-local-tui/app.py
tunaflow/learn/gpt-local-tui/config.example.toml
tunaflow/learn/gpt-local-tui/docs/how-it-works.md
tunaflow/learn/gpt-local-tui/requirements.txt
```

Zero changes in `src-tauri/`, `src/`, `docs/agents/`, `docs/plans/`, `docs/reference/`, `package.json`, `Cargo.toml`. No tunaFlow imports. No new top-level dependencies in repo (Python deps live inside the learn folder, not the Rust/TS build).

## Test plan

- [x] `python app.py --check` against real Codex CLI 0.128.0 + Ollama
- [x] `call_codex()` round-trip — Codex returns valid JSON, thread_id captured
- [x] `list_recent_sessions()` parses real `~/.codex/sessions` rollout files
- [x] AST parse of `app.py` clean
- [ ] (USER) Run `python app.py` in a real terminal, submit a coding request, verify Architect → Developer → Reviewer panels render
- [ ] (USER) Click Resume button, pick a prior session, verify follow-up request inherits context
- [ ] (USER) Submit intentionally-vague request, observe Reviewer retry path

## CI policy

본 영역은 build/cargo/vitest 영역 영향 0 (Python 학습 artifact). 머지 정책: PR 직후 `gh pr merge --squash --delete-branch --admin` 즉시 머지. CI watch 불필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)